### PR TITLE
2512-V85-Added-borders-KryptonRibbon-in-MS365-themes.-Adjusted-RibbonQATButton

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-10-25 - Build 2508 (Patch 9) - October 2025
+* Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`
 * Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.
 * Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -3901,6 +3901,11 @@ namespace Krypton.Toolkit
         LinearBorder,
 
         /// <summary>
+         /// Specifies linear gradient border from first to second color.
+        /// </summary>
+        LinearBorder2,
+
+        /// <summary>
         /// Specifies using colors to draw a application menu inner area.
         /// </summary>
         RibbonAppMenuInner,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -3386,9 +3386,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -3426,6 +3424,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -3502,7 +3501,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -3599,7 +3598,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -3711,7 +3710,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -3790,7 +3789,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -3884,7 +3883,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -166,14 +166,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // ToolStripBorder
             Color.FromArgb(47, 47, 47), // FormBorderActive
             Color.FromArgb(146, 146, 146), // FormBorderInactive
-            Color.FromArgb(77, 77, 77), // FormBorderActiveLight
-            Color.FromArgb(102, 102, 102), // FormBorderActiveDark
+            Color.FromArgb(10, 10, 10), // FormBorderActiveLight
+            Color.FromArgb(10, 10, 10), // FormBorderActiveDark
             Color.FromArgb(153, 153, 153), // FormBorderInactiveLight
             Color.FromArgb(171, 171, 171), // FormBorderInactiveDark
             Color.FromArgb(65, 65, 65), // FormBorderHeaderActive
             Color.FromArgb(154, 154, 154), // FormBorderHeaderInactive
-            Color.FromArgb(42, 43, 43), // FormBorderHeaderActive1
-            Color.FromArgb(74, 74, 74), // FormBorderHeaderActive2
+            Color.FromArgb(10, 10, 10), // FormBorderHeaderActive1
+            Color.FromArgb(10, 10, 10), // FormBorderHeaderActive2
             Color.FromArgb(146, 146, 146), // FormBorderHeaderInctive1
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive2
             Color.FromArgb(174, 209, 255), // FormHeaderShortActive
@@ -197,14 +197,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 90, 90), // LinkPressedOverridePanel
             Color.White, // TextLabelPanel
             Color.FromArgb(10, 10, 10), // RibbonTabTextNormal
-            Color.FromArgb(41, 41, 41), // RibbonTabTextChecked
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(199, 250, 254), // RibbonTabSelected2
-            Color.FromArgb(238, 239, 241), // RibbonTabSelected3
+            Color.FromArgb(100, 100, 100), // RibbonTabSelected2
+            Color.FromArgb(10, 10, 10), // RibbonTabSelected3
             Color.FromArgb(241, 241, 241), // RibbonTabSelected4
             Color.FromArgb(213, 217, 223), // RibbonTabSelected5
-            Color.FromArgb(159, 156, 150), // RibbonTabTracking1
-            Color.FromArgb(235, 194, 39), // RibbonTabTracking2
+            Color.FromArgb(187, 186, 186), // RibbonTabTracking1
+            Color.FromArgb(91, 91, 91), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -213,19 +213,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(180, 187, 197), // RibbonGroupsArea3
+            Color.FromArgb(98, 98, 98), // RibbonGroupsArea3
             Color.FromArgb(235, 235, 235), // RibbonGroupsArea4
             Color.FromArgb(215, 219, 224), // RibbonGroupsArea5
-            Color.FromArgb(174, 176, 180), // RibbonGroupBorder1
-            Color.FromArgb(132, 132, 132), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.FromArgb(182, 184, 184), // RibbonGroupTitle1
             Color.FromArgb(159, 160, 160), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
             Color.FromArgb(190, 190, 190), // RibbonGroupTitleContext1
             Color.FromArgb(161, 161, 161), // RibbonGroupTitleContext2
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
-            Color.FromArgb(235, 235, 235), // RibbonGroupDialogLight
+            Color.FromArgb(225, 225, 225), // RibbonGroupDialogDark
+            Color.FromArgb(42, 43, 43), // RibbonGroupDialogLight
             Color.FromArgb(170, 171, 171), // RibbonGroupTitleTracking1
             Color.FromArgb(109, 110, 110), // RibbonGroupTitleTracking2
             Color.FromArgb(79, 79, 79), // RibbonMinimizeBarDark
@@ -252,7 +252,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
             Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
             Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-            Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText         
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -262,9 +262,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(18, 18, 18), // FormButtonBorderCheck
             Color.FromArgb(33, 45, 57), // FormButtonBack1CheckTrack
             Color.FromArgb(136, 152, 170), // FormButtonBack2CheckTrack
-            Color.FromArgb(55, 55, 55), // RibbonQATMini1
-            Color.FromArgb(100, 100, 100), // RibbonQATMini2
-            Color.FromArgb(73, 73, 73), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(10, 10, 10), // RibbonQATMini2
+            Color.FromArgb(10, 10, 10), // RibbonQATMini3
             Color.FromArgb(12, Color.White), // RibbonQATMini4
             Color.FromArgb(14, Color.White), // RibbonQATMini5
             Color.FromArgb(100, 100, 100), // RibbonQATMini1I
@@ -272,32 +272,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-            Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-            Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-            Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-            Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(39, 39, 39), // RibbonQATFullbar1
+            Color.FromArgb(39, 39, 39), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
+            Color.FromArgb(100, 100, 100), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(10, 10, 10), // GridListNormal1
+            Color.FromArgb(41, 41, 41), // GridListNormal2
+            Color.FromArgb(41, 41, 41), // GridListPressed1
+            Color.FromArgb(61, 61, 61), // GridListPressed2
+            Color.FromArgb(33, 33, 33), // GridListSelected
+            Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+            Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2
             Color.FromArgb(91, 91, 91), // GridSheetColSelected1
             Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(61, 61, 61), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -333,14 +333,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(247, 247, 247), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking3
+            Color.FromArgb(129, 129, 129), // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
-            Color.Empty, // RibbonGroupBorder3
-            Color.Empty, // RibbonGroupBorder4
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             Color.Empty, // RibbonGroupBorder5
             Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
-            Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
-            Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
+            Color.FromArgb(42, 43, 43), // RibbonDropArrowLight
+            Color.FromArgb(235, 235, 235), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
             Color.FromArgb(125, 125, 125), // HeaderDockInactiveBack2
             Color.FromArgb(46, 46, 46), // ButtonNavigatorBorder
@@ -3989,9 +3989,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4029,6 +4027,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4105,7 +4104,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4202,7 +4201,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4314,7 +4313,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4393,7 +4392,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4487,7 +4486,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 
@@ -4565,7 +4564,7 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledText,
-                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextChecked],
+                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.Tracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextChecked],
                         _ => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextNormal]
                     };
                 case PaletteRibbonTextStyle.RibbonGroupCollapsedText:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -199,7 +199,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(10, 10, 10), // RibbonTabTextNormal
             Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(100, 100, 100), // RibbonTabSelected2
+            Color.FromArgb(79, 79, 79), // RibbonTabSelected2
             Color.FromArgb(10, 10, 10), // RibbonTabSelected3
             Color.FromArgb(241, 241, 241), // RibbonTabSelected4
             Color.FromArgb(213, 217, 223), // RibbonTabSelected5
@@ -272,8 +272,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(39, 39, 39), // RibbonQATFullbar1
-            Color.FromArgb(39, 39, 39), // RibbonQATFullbar2
+            Color.FromArgb(10, 10, 10), // RibbonQATFullbar1
+            Color.FromArgb(10, 10, 10), // RibbonQATFullbar2
             Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
             Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
             Color.FromArgb(100, 100, 100), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -197,8 +197,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(21, 66, 139), // RibbonTabTextNormal
             Color.FromArgb(21, 66, 139), // RibbonTabTextChecked
             Color.FromArgb(96, 150, 220), // RibbonTabSelected1
-            Color.FromArgb(211, 226, 245), // RibbonTabSelected2
-            Color.FromArgb(125, 136, 173), // RibbonTabSelected3
+            Color.FromArgb(167, 200, 240), // RibbonTabSelected2
+            Color.FromArgb(134, 179, 235), // RibbonTabSelected3
             Color.FromArgb(63, 122, 197), // RibbonTabSelected4
             Color.FromArgb(222, 232, 245), // RibbonTabSelected5
             Color.FromArgb(179, 209, 255), // RibbonTabTracking1
@@ -211,7 +211,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(116, 153, 203), // RibbonTabSeparatorColor
             Color.FromArgb(96, 150, 220), // RibbonGroupsArea1
             Color.FromArgb(63, 122, 197), // RibbonGroupsArea2
-            Color.FromArgb(191, 207, 227), // RibbonGroupsArea3
+            Color.FromArgb(167, 200, 240), // RibbonGroupsArea3
             Color.FromArgb(231, 242, 255), // RibbonGroupsArea4
             Color.FromArgb(219, 230, 244), // RibbonGroupsArea5
             Color.Empty, // RibbonGroupBorder1
@@ -270,8 +270,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
             Color.FromArgb(72, Color.White), // RibbonQATMini5I
-            Color.FromArgb(233, 241, 252), // RibbonQATFullbar1
-            Color.FromArgb(233, 241, 252), // RibbonQATFullbar2
+            Color.FromArgb(134, 179, 235), // RibbonQATFullbar1
+            Color.FromArgb(134, 179, 235), // RibbonQATFullbar2
             Color.FromArgb(63, 122, 197), // RibbonQATFullbar3
             Color.FromArgb(63, 122, 197), // RibbonQATButtonDark
             Color.FromArgb(134, 179, 236), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -165,15 +165,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(134, 179, 236), // FormBorderActive
             Color.FromArgb(179, 209, 247), // FormBorderInactive
             Color.FromArgb(134, 179, 236), // FormBorderActiveLight
-            Color.FromArgb(63, 122, 197), // FormBorderActiveDark
+            Color.FromArgb(134, 179, 236), // FormBorderActiveDark
             Color.FromArgb(179, 209, 247), // FormBorderInactiveLight
             Color.FromArgb(96, 150, 220), // FormBorderInactiveDark
             Color.FromArgb(134, 179, 236), // FormBorderHeaderActive
             Color.FromArgb(179, 209, 247), // FormBorderHeaderInactive
             Color.FromArgb(134, 179, 236), // FormBorderHeaderActive1
-            Color.FromArgb(63, 122, 197), // FormBorderHeaderActive2
+            Color.FromArgb(134, 179, 236), // FormBorderHeaderActive2
             Color.FromArgb(179, 209, 247), // FormBorderHeaderInctive1
-            Color.FromArgb(96, 150, 220), // FormBorderHeaderInctive2
+            Color.FromArgb(179, 209, 247), // FormBorderHeaderInctive2
             Color.FromArgb(21, 66, 139), // FormHeaderShortActive
             Color.FromArgb(160, 160, 160), // FormHeaderShortInactive
             Color.FromArgb(105, 112, 121), // FormHeaderLongActive
@@ -194,36 +194,36 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(21, 66, 139), // TextLabelPanel
-            Color.FromArgb(255, 255, 255), // RibbonTabTextNormal - Old value 21, 66, 139
+            Color.FromArgb(21, 66, 139), // RibbonTabTextNormal
             Color.FromArgb(21, 66, 139), // RibbonTabTextChecked
-            Color.FromArgb(134, 179, 236), // RibbonTabSelected1
-            Color.FromArgb(63, 122, 197), // RibbonTabSelected2
-            Color.FromArgb(134, 179, 236), // RibbonTabSelected3
+            Color.FromArgb(96, 150, 220), // RibbonTabSelected1
+            Color.FromArgb(211, 226, 245), // RibbonTabSelected2
+            Color.FromArgb(125, 136, 173), // RibbonTabSelected3
             Color.FromArgb(63, 122, 197), // RibbonTabSelected4
             Color.FromArgb(222, 232, 245), // RibbonTabSelected5
-            Color.FromArgb(153, 187, 232), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(179, 209, 255), // RibbonTabTracking1
+            Color.FromArgb(167, 199, 241), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
             Color.FromArgb(254, 209, 94), // RibbonTabHighlight4
             Color.FromArgb(205, 209, 180), // RibbonTabHighlight5
             Color.FromArgb(116, 153, 203), // RibbonTabSeparatorColor
-            Color.FromArgb(134, 179, 236), // RibbonGroupsArea1
+            Color.FromArgb(96, 150, 220), // RibbonGroupsArea1
             Color.FromArgb(63, 122, 197), // RibbonGroupsArea2
-            Color.FromArgb(201, 217, 237), // RibbonGroupsArea3
+            Color.FromArgb(191, 207, 227), // RibbonGroupsArea3
             Color.FromArgb(231, 242, 255), // RibbonGroupsArea4
             Color.FromArgb(219, 230, 244), // RibbonGroupsArea5
-            Color.FromArgb(197, 210, 223), // RibbonGroupBorder1
-            Color.FromArgb(158, 191, 219), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle1
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle2
             Color.FromArgb(202, 202, 202), // RibbonGroupBorderContext1
             Color.FromArgb(196, 196, 196), // RibbonGroupBorderContext2
             Color.FromArgb(223, 223, 245), // RibbonGroupTitleContext1
             Color.FromArgb(210, 221, 242), // RibbonGroupTitleContext2
-            Color.FromArgb(102, 142, 175), // RibbonGroupDialogDark
-            Color.FromArgb(254, 254, 255), // RibbonGroupDialogLight
+            Color.FromArgb(63, 122, 197), // RibbonGroupDialogDark
+            Color.FromArgb(193, 216, 242), // RibbonGroupDialogLight
             Color.FromArgb(200, 224, 255), // RibbonGroupTitleTracking1
             Color.FromArgb(214, 237, 255), // RibbonGroupTitleTracking2
             Color.FromArgb(155, 187, 227), // RibbonMinimizeBarDark
@@ -260,42 +260,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(158, 193, 241), // FormButtonBorderCheck
             Color.FromArgb(140, 184, 229), // FormButtonBack1CheckTrack
             Color.FromArgb(225, 241, 255), // FormButtonBack2CheckTrack
-            Color.FromArgb(154, 179, 213), // RibbonQATMini1
-            Color.FromArgb(219, 231, 247), // RibbonQATMini2
-            Color.FromArgb(195, 213, 236), // RibbonQATMini3
-            Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(63, 122, 197), // RibbonQATMini1
+            Color.FromArgb(134, 179, 236), // RibbonQATMini2
+            Color.FromArgb(134, 179, 236), // RibbonQATMini3
+            Color.FromArgb(28, Color.White), // RibbonQATMini4
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-            Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-            Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(233, 241, 252), // RibbonQATFullbar1
+            Color.FromArgb(233, 241, 252), // RibbonQATFullbar2
+            Color.FromArgb(63, 122, 197), // RibbonQATFullbar3
+            Color.FromArgb(63, 122, 197), // RibbonQATButtonDark
+            Color.FromArgb(134, 179, 236), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(63, 122, 197), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(134, 179, 236), // GridListNormal1
+            Color.FromArgb(63, 122, 197), // GridListNormal2
+            Color.FromArgb(63, 122, 197), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(170, 195, 240), // GridListSelected
+            Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+            Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(249, 217, 159), // GridSheetColSelected1
             Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -333,12 +333,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(215, 233, 251), // RibbonGalleryBack2
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
-            Color.Empty, // RibbonGroupBorder3
-            Color.Empty, // RibbonGroupBorder4
+            Color.FromArgb(63, 122, 197), // RibbonGroupBorder3
+            Color.FromArgb(63, 122, 197), // RibbonGroupBorder4
             Color.Empty, // RibbonGroupBorder5
-            Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
-            Color.Empty, // RibbonDropArrowLight
-            Color.Empty, // RibbonDropArrowDark
+            Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
+            Color.FromArgb(63, 122, 197), // RibbonDropArrowLight
+            Color.FromArgb(21, 66, 139), // RibbonDropArrowDark
             Color.FromArgb(208, 226, 248), // HeaderDockInactiveBack1
             Color.FromArgb(178, 196, 218), // HeaderDockInactiveBack2
             Color.FromArgb(133, 158, 191), // ButtonNavigatorBorder
@@ -349,7 +349,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         };
 
         #endregion
@@ -3963,9 +3963,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4003,6 +4001,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4079,7 +4078,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4176,7 +4175,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4288,7 +4287,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4367,7 +4366,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4461,7 +4460,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -274,8 +274,8 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(198, 210, 226),    // RibbonQATMini3I
                                                                 Color.FromArgb(128, Color.White), // RibbonQATMini4I
                                                                 Color.FromArgb(72, Color.White),  // RibbonQATMini5I
-                                                                Color.FromArgb(213, 228, 245),    // RibbonQATFullbar1
-                                                                Color.FromArgb(213, 228, 245),    // RibbonQATFullbar2
+                                                                Color.FromArgb(229, 238, 248),    // RibbonQATFullbar1
+                                                                Color.FromArgb(229, 238, 248),    // RibbonQATFullbar2
                                                                 Color.FromArgb(134, 179, 236),    // RibbonQATFullbar3
                                                                 Color.FromArgb(134, 179, 236),    // RibbonQATButtonDark
                                                                 Color.FromArgb(188, 213, 239),    // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -168,16 +168,16 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(111, 157, 217),    // ToolStripBorder
                                                                 Color.FromArgb( 59,  90, 130),    // FormBorderActive
                                                                 Color.FromArgb(192, 198, 206),    // FormBorderInactive
-                                                                Color.FromArgb(176, 203, 239),    // FormBorderActiveLight
-                                                                Color.FromArgb(194, 217, 247),    // FormBorderActiveDark
+                                                                Color.FromArgb(230, 239, 249),    // FormBorderActiveLight
+                                                                Color.FromArgb(230, 239, 249),    // FormBorderActiveDark
                                                                 Color.FromArgb(204, 216, 232),    // FormBorderInactiveLight
                                                                 Color.FromArgb(212, 222, 236),    // FormBorderInactiveDark
                                                                 Color.FromArgb(221, 233, 248),    // FormBorderHeaderActive
                                                                 Color.FromArgb(223, 229, 237),    // FormBorderHeaderInactive
-                                                                Color.FromArgb(176, 207, 247),    // FormBorderHeaderActive1
-                                                                Color.FromArgb(228, 239, 253),    // FormBorderHeaderActive2
+                                                                Color.FromArgb(230, 239, 249),    // FormBorderHeaderActive1
+                                                                Color.FromArgb(230, 239, 249),    // FormBorderHeaderActive2
                                                                 Color.FromArgb(204, 218, 236),    // FormBorderHeaderInctive1
-                                                                Color.FromArgb(227, 232, 239),    // FormBorderHeaderInctive2
+                                                                Color.FromArgb(204, 218, 236),    // FormBorderHeaderInctive2
                                                                 Color.FromArgb( 62, 106, 184),    // FormHeaderShortActive
                                                                 Color.FromArgb(160, 160, 160),    // FormHeaderShortInactive
                                                                 Color.FromArgb(105, 112, 121),    // FormHeaderLongActive
@@ -201,12 +201,12 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb( 21,  66, 139),    // RibbonTabTextNormal
                                                                 Color.FromArgb( 21,  66, 139),    // RibbonTabTextChecked
                                                                 Color.FromArgb(145, 180, 228),    // RibbonTabSelected1
-                                                                Color.FromArgb(209, 251, 255),    // RibbonTabSelected2
-                                                                Color.FromArgb(246, 250, 255),    // RibbonTabSelected3
+                                                                Color.FromArgb(248, 250, 255),    // RibbonTabSelected2
+                                                                Color.FromArgb(230, 239, 249),    // RibbonTabSelected3
                                                                 Color.FromArgb(239, 246, 254),    // RibbonTabSelected4
                                                                 Color.FromArgb(222, 232, 245),    // RibbonTabSelected5
-                                                                Color.FromArgb(153, 187, 232),    // RibbonTabTracking1
-                                                                Color.FromArgb(255, 180,  86),    // RibbonTabTracking2
+                                                                Color.FromArgb(160, 205, 240),    // RibbonTabTracking1
+                                                                Color.FromArgb(188, 213, 239),    // RibbonTabTracking2
                                                                 Color.FromArgb(255, 255, 189),    // RibbonTabHighlight1
                                                                 Color.FromArgb(249, 237, 198),    // RibbonTabHighlight2
                                                                 Color.FromArgb(218, 185, 127),    // RibbonTabHighlight3
@@ -214,20 +214,20 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(205, 209, 180),    // RibbonTabHighlight5
                                                                 Color.FromArgb(116, 153, 203),    // RibbonTabSeparatorColor
                                                                 Color.FromArgb(141, 178, 227),    // RibbonGroupsArea1
-                                                                Color.FromArgb(192, 249, 255),    // RibbonGroupsArea2
-                                                                Color.FromArgb(201, 217, 237),    // RibbonGroupsArea3
+                                                                Color.FromArgb(134, 179, 236),    // RibbonGroupsArea2
+                                                                Color.FromArgb(186, 209, 240),    // RibbonGroupsArea3
                                                                 Color.FromArgb(231, 242, 255),    // RibbonGroupsArea4
                                                                 Color.FromArgb(219, 230, 244),    // RibbonGroupsArea5
-                                                                Color.FromArgb(197, 210, 223),    // RibbonGroupBorder1
-                                                                Color.FromArgb(158, 191, 219),    // RibbonGroupBorder2
+                                                                Color.Empty,    // RibbonGroupBorder1
+                                                                Color.Empty,    // RibbonGroupBorder2
                                                                 Color.FromArgb(193, 216, 242),    // RibbonGroupTitle1
                                                                 Color.FromArgb(193, 216, 242),    // RibbonGroupTitle2
                                                                 Color.FromArgb(202, 202, 202),    // RibbonGroupBorderContext1
                                                                 Color.FromArgb(196, 196, 196),    // RibbonGroupBorderContext2
                                                                 Color.FromArgb(223, 223, 245),    // RibbonGroupTitleContext1
                                                                 Color.FromArgb(210, 221, 242),    // RibbonGroupTitleContext2
-                                                                Color.FromArgb(102, 142, 175),    // RibbonGroupDialogDark
-                                                                Color.FromArgb(254, 254, 255),    // RibbonGroupDialogLight
+                                                                Color.FromArgb(21, 66, 139),    // RibbonGroupDialogDark
+                                                                Color.FromArgb(199, 218, 243),    // RibbonGroupDialogLight
                                                                 Color.FromArgb(200, 224, 255),    // RibbonGroupTitleTracking1
                                                                 Color.FromArgb(214, 237, 255),    // RibbonGroupTitleTracking2
                                                                 Color.FromArgb(155, 187, 227),    // RibbonMinimizeBarDark
@@ -264,42 +264,42 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(158, 193, 241),    // FormButtonBorderCheck
                                                                 Color.FromArgb(140, 184, 229),    // FormButtonBack1CheckTrack
                                                                 Color.FromArgb(225, 241, 255),    // FormButtonBack2CheckTrack
-                                                                Color.FromArgb(154, 179, 213),    // RibbonQATMini1
-                                                                Color.FromArgb(219, 231, 247),    // RibbonQATMini2
-                                                                Color.FromArgb(195, 213, 236),    // RibbonQATMini3
-                                                                Color.FromArgb(128, Color.White), // RibbonQATMini4
-                                                                Color.FromArgb(72, Color.White),  // RibbonQATMini5                                                       
+                                                                Color.FromArgb(141, 178, 227),    // RibbonQATMini1
+                                                                Color.FromArgb(230, 239, 249),    // RibbonQATMini2
+                                                                Color.FromArgb(230, 239, 249),    // RibbonQATMini3
+                                                                Color.FromArgb(28, Color.White), // RibbonQATMini4
+                                                                Color.FromArgb(72, Color.White),  // RibbonQATMini5
                                                                 Color.FromArgb(153, 176, 206),    // RibbonQATMini1I
                                                                 Color.FromArgb(226, 233, 241),    // RibbonQATMini2I
                                                                 Color.FromArgb(198, 210, 226),    // RibbonQATMini3I
                                                                 Color.FromArgb(128, Color.White), // RibbonQATMini4I
-                                                                Color.FromArgb(72, Color.White),  // RibbonQATMini5I                                                      
-                                                                Color.FromArgb(178, 205, 237),    // RibbonQATFullbar1                                                      
-                                                                Color.FromArgb(170, 197, 234),    // RibbonQATFullbar2                                                      
-                                                                Color.FromArgb(126, 161, 205),    // RibbonQATFullbar3                                                      
-                                                                Color.FromArgb( 86, 125, 177),    // RibbonQATButtonDark                                                      
-                                                                Color.FromArgb(234, 242, 249),    // RibbonQATButtonLight                                                      
-                                                                Color.FromArgb(192, 220, 255),    // RibbonQATOverflow1                                                      
-                                                                Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2                                                      
-                                                                Color.FromArgb(140, 172, 211),    // RibbonGroupSeparatorDark                                                      
-                                                                Color.FromArgb(248, 250, 252),    // RibbonGroupSeparatorLight                                                      
-                                                                Color.FromArgb(192, 212, 241),    // ButtonClusterButtonBack1                                                      
-                                                                Color.FromArgb(200, 219, 238),    // ButtonClusterButtonBack2                                                      
-                                                                Color.FromArgb(155, 183, 224),    // ButtonClusterButtonBorder1                                                      
-                                                                Color.FromArgb(117, 150, 191),    // ButtonClusterButtonBorder2                                                      
-                                                                Color.FromArgb(213, 228, 242),    // NavigatorMiniBackColor                                                    
-                                                                Color.FromArgb(230, 239, 249),    // GridListNormal1                                                    
-                                                                Color.FromArgb(209, 226, 244),    // GridListNormal2                                                    
-                                                                Color.FromArgb(209, 226, 244),    // GridListPressed1                                                    
-                                                                Color.FromArgb(252, 253, 255),    // GridListPressed2                                                    
-                                                                Color.FromArgb(168, 200, 234),    // GridListSelected                                                    
-                                                                Color.FromArgb(230, 239, 249),    // GridSheetColNormal1                                                    
-                                                                Color.FromArgb(209, 226, 244),    // GridSheetColNormal2                                                    
-                                                                Color.FromArgb(223, 226, 228),    // GridSheetColPressed1                                                    
-                                                                Color.FromArgb(188, 197, 210),    // GridSheetColPressed2                                                    
+                                                                Color.FromArgb(72, Color.White),  // RibbonQATMini5I
+                                                                Color.FromArgb(213, 228, 245),    // RibbonQATFullbar1
+                                                                Color.FromArgb(213, 228, 245),    // RibbonQATFullbar2
+                                                                Color.FromArgb(134, 179, 236),    // RibbonQATFullbar3
+                                                                Color.FromArgb(134, 179, 236),    // RibbonQATButtonDark
+                                                                Color.FromArgb(188, 213, 239),    // RibbonQATButtonLight
+                                                                Color.FromArgb(192, 220, 255),    // RibbonQATOverflow1
+                                                                Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2
+                                                                Color.FromArgb(141, 178, 227),    // RibbonGroupSeparatorDark
+                                                                Color.Empty,    // RibbonGroupSeparatorLight
+                                                                Color.FromArgb(192, 212, 241),    // ButtonClusterButtonBack1
+                                                                Color.FromArgb(200, 219, 238),    // ButtonClusterButtonBack2
+                                                                Color.FromArgb(155, 183, 224),    // ButtonClusterButtonBorder1
+                                                                Color.FromArgb(117, 150, 191),    // ButtonClusterButtonBorder2
+                                                                Color.FromArgb(213, 228, 242),    // NavigatorMiniBackColor
+                                                                Color.FromArgb(230, 239, 249),    // GridListNormal1
+                                                                Color.FromArgb(209, 226, 244),    // GridListNormal2
+                                                                Color.FromArgb(209, 226, 244),    // GridListPressed1
+                                                                Color.FromArgb(252, 253, 255),    // GridListPressed2
+                                                                Color.FromArgb(168, 200, 234),    // GridListSelected
+                                                                Color.FromArgb(230, 239, 249),    // GridSheetColNormal1
+                                                                Color.FromArgb(209, 226, 244),    // GridSheetColNormal2
+                                                                Color.FromArgb(223, 226, 228),    // GridSheetColPressed1
+                                                                Color.FromArgb(188, 197, 210),    // GridSheetColPressed2
                                                                 Color.FromArgb(188, 213, 239),    // GridSheetColSelected1
                                                                 Color.FromArgb(168, 200, 234),    // GridSheetColSelected2
-                                                                Color.FromArgb(228, 236, 247),    // GridSheetRowNormal                                                   
+                                                                Color.FromArgb(228, 236, 247),    // GridSheetRowNormal
                                                                 Color.FromArgb(187, 196, 209),    // GridSheetRowPressed
                                                                 Color.FromArgb(255, 213, 141),    // GridSheetRowSelected
                                                                 Color.FromArgb(188, 195, 209),    // GridDataCellBorder
@@ -337,12 +337,12 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(215, 233, 251),    // RibbonGalleryBack2
                                                                 Color.Empty,                      // RibbonTabTracking3
                                                                 Color.Empty,                      // RibbonTabTracking4
-                                                                Color.Empty,                      // RibbonGroupBorder3
-                                                                Color.Empty,                      // RibbonGroupBorder4
+                                                                Color.FromArgb(141, 178, 227),    // RibbonGroupBorder3
+                                                                Color.FromArgb(141, 178, 227),    // RibbonGroupBorder4
                                                                 Color.Empty, // RibbonGroupBorder5
-                                                                Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
-                                                                Color.Empty,                      // RibbonDropArrowLight
-                                                                Color.Empty,                      // RibbonDropArrowDark
+                                                                Color.FromArgb(21, 66, 139),      // RibbonGroupTitleText
+                                                                Color.FromArgb(101, 147, 207),    // RibbonDropArrowLight
+                                                                Color.FromArgb(21, 66, 139),      // RibbonDropArrowDark
                                                                 Color.FromArgb(208, 226, 248),    // HeaderDockInactiveBack1
                                                                 Color.FromArgb(178, 196, 218),    // HeaderDockInactiveBack2
                                                                 Color.FromArgb(133, 158, 191),    // ButtonNavigatorBorder
@@ -353,7 +353,7 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(198, 214, 231),    // ButtonNavigatorPressed2
                                                                 Color.FromArgb(200, 219, 240),    // ButtonNavigatorChecked1
                                                                 Color.FromArgb(177, 201, 228),    // ButtonNavigatorChecked2
-                                                                Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+                                                                Color.FromArgb(201, 217, 239) // ToolTipBottom
         };
 
         #endregion
@@ -3967,9 +3967,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4007,6 +4005,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4083,7 +4082,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4180,7 +4179,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4292,7 +4291,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4371,7 +4370,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4465,7 +4464,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -168,15 +168,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(119, 132, 161), // FormBorderActive
             Color.FromArgb(83, 99, 136), // FormBorderInactive
             Color.FromArgb(119, 132, 161), // FormBorderActiveLight
-            Color.FromArgb(83, 99, 136), // FormBorderActiveDark
+            Color.FromArgb(119, 132, 161), // FormBorderActiveDark
             Color.FromArgb(119, 132, 161), // FormBorderInactiveLight
             Color.FromArgb(83, 99, 136), // FormBorderInactiveDark
             Color.FromArgb(119, 132, 161), // FormBorderHeaderActive
             Color.FromArgb(83, 99, 136), // FormBorderHeaderInactive
             Color.FromArgb(119, 132, 161), // FormBorderHeaderActive1
-            Color.FromArgb(83, 99, 136), // FormBorderHeaderActive2
+            Color.FromArgb(119, 132, 161), // FormBorderHeaderActive2
             Color.FromArgb(119, 132, 161), // FormBorderHeaderInctive1
-            Color.FromArgb(83, 99, 136), // FormBorderHeaderInctive2
+            Color.FromArgb(119, 132, 161), // FormBorderHeaderInctive2
             Color.FromArgb(255, 255, 255), // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
@@ -197,15 +197,15 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(255, 255, 255), // TextLabelPanel
-            Color.FromArgb(255, 255, 255), // RibbonTabTextNormal
-            Color.FromArgb(0, 0, 0), // RibbonTabTextChecked
+            Color.FromArgb(76, 83, 92), // RibbonTabTextNormal
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(198, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(247, 248, 249), // RibbonTabSelected3
+            Color.FromArgb(130, 140, 178), // RibbonTabSelected2
+            Color.FromArgb(118, 131, 160), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
-            Color.FromArgb(189, 190, 193), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(163, 179, 220), // RibbonTabTracking1
+            Color.FromArgb(102, 117, 161), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -214,19 +214,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(213, 219, 231), // RibbonGroupsArea3
+            Color.FromArgb(153, 159, 200), // RibbonGroupsArea3
             Color.FromArgb(249, 249, 249), // RibbonGroupsArea4
             Color.FromArgb(243, 245, 249), // RibbonGroupsArea5
-            Color.FromArgb(189, 191, 193), // RibbonGroupBorder1
-            Color.FromArgb(133, 133, 133), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitle1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitleContext1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitleContext2
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
-            Color.FromArgb(242, 242, 242), // RibbonGroupDialogLight
+            Color.FromArgb(242, 242, 242), // RibbonGroupDialogDark
+            Color.FromArgb(106, 123, 164), // RibbonGroupDialogLight
             Color.FromArgb(222, 226, 238), // RibbonGroupTitleTracking1
             Color.FromArgb(179, 185, 199), // RibbonGroupTitleTracking2
             Color.FromArgb(128, 128, 128), // RibbonMinimizeBarDark
@@ -253,7 +253,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -263,42 +263,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(119, 132, 161), // RibbonQATMini2
+            Color.FromArgb(119, 132, 161), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-            Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-            Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(84, 101, 138), // RibbonQATFullbar1
+            Color.FromArgb(84, 101, 138), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
+            Color.FromArgb(163, 179, 220), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(119, 132, 161), // GridListNormal1
+            Color.FromArgb(83, 99, 136), // GridListNormal2
+            Color.FromArgb(83, 99, 136), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(83, 99, 136), // GridListSelected
+            Color.FromArgb(119, 132, 161), // GridSheetColNormal1
+            Color.FromArgb(83, 99, 136), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(102, 117, 161), // GridSheetColSelected1
             Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -334,14 +334,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking3
+            Color.FromArgb(106, 123, 164), // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
-            Color.Empty, // RibbonGroupBorder3
-            Color.Empty, // RibbonGroupBorder4
+            Color.FromArgb(210, 210, 210), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             Color.Empty, // RibbonGroupBorder5
             Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
-            Color.Empty, // RibbonDropArrowLight
-            Color.Empty, // RibbonDropArrowDark
+            Color.FromArgb(222, 226, 236), // RibbonDropArrowLight
+            Color.FromArgb(255, 255, 255), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
@@ -352,7 +352,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         };
 
         #endregion
@@ -3968,9 +3968,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4008,6 +4006,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4084,7 +4083,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4181,7 +4180,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4293,7 +4292,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4372,7 +4371,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4466,7 +4465,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 
@@ -4544,7 +4543,7 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledText,
-                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextChecked],
+                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.Tracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextChecked],
                         _ => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextNormal]
                     };
                 case PaletteRibbonTextStyle.RibbonGroupCollapsedText:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -200,8 +200,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextNormal
             Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(130, 140, 178), // RibbonTabSelected2
-            Color.FromArgb(118, 131, 160), // RibbonTabSelected3
+            Color.FromArgb(153, 159, 200), // RibbonTabSelected2
+            Color.FromArgb(119, 132, 161), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
             Color.FromArgb(163, 179, 220), // RibbonTabTracking1
@@ -273,8 +273,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(84, 101, 138), // RibbonQATFullbar1
-            Color.FromArgb(84, 101, 138), // RibbonQATFullbar2
+            Color.FromArgb(119, 132, 161), // RibbonQATFullbar1
+            Color.FromArgb(119, 132, 161), // RibbonQATFullbar2
             Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
             Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
             Color.FromArgb(163, 179, 220), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -172,15 +172,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(224, 225, 231), // FormBorderActive
             Color.FromArgb(195, 198, 209), // FormBorderInactive
             Color.FromArgb(224, 225, 231), // FormBorderActiveLight
-            Color.FromArgb(195, 198, 209), // FormBorderActiveDark
+            Color.FromArgb(224, 225, 231), // FormBorderActiveDark
             Color.FromArgb(224, 225, 231), // FormBorderInactiveLight
             Color.FromArgb(195, 198, 209), // FormBorderInactiveDark
             Color.FromArgb(224, 225, 231), // FormBorderHeaderActive
             Color.FromArgb(195, 198, 209), // FormBorderHeaderInactive
             Color.FromArgb(224, 225, 231), // FormBorderHeaderActive1
-            Color.FromArgb(195, 198, 209), // FormBorderHeaderActive2
+            Color.FromArgb(224, 225, 231), // FormBorderHeaderActive2
             Color.FromArgb(224, 225, 231), // FormBorderHeaderInctive1
-            Color.FromArgb(195, 198, 209), // FormBorderHeaderInctive2
+            Color.FromArgb(224, 225, 231), // FormBorderHeaderInctive2
             Color.FromArgb(53, 110, 170), // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
@@ -204,12 +204,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextNormal
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(198, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(247, 248, 249), // RibbonTabSelected3
+            Color.FromArgb(248, 248, 248), // RibbonTabSelected2
+            Color.FromArgb(214, 216, 221), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
-            Color.FromArgb(189, 190, 193), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(232, 234, 244), // RibbonTabTracking1
+            Color.FromArgb(214, 216, 221), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -217,12 +217,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(205, 209, 180), // RibbonTabHighlight5
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
-            Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(213, 219, 231), // RibbonGroupsArea3
+            Color.FromArgb(170, 170, 170), // RibbonGroupsArea2
+            Color.FromArgb(234, 235, 235), // RibbonGroupsArea3
             Color.FromArgb(249, 249, 249), // RibbonGroupsArea4
             Color.FromArgb(243, 245, 249), // RibbonGroupsArea5
-            Color.FromArgb(189, 191, 193), // RibbonGroupBorder1
-            Color.FromArgb(133, 133, 133), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitle1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
@@ -257,7 +257,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -267,42 +267,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(224, 225, 231), // RibbonQATMini2
+            Color.FromArgb(224, 225, 231), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-            Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-            Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(196, 199, 209), // RibbonQATFullbar1
+            Color.FromArgb(196, 199, 209), // RibbonQATFullbar2
+            Color.FromArgb(170, 170, 170), // RibbonQATFullbar3
+            Color.FromArgb(150, 150, 150), // RibbonQATButtonDark
+            Color.FromArgb(228, 228, 234), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(224, 225, 231), // GridListNormal1
+            Color.FromArgb(195, 198, 209), // GridListNormal2
+            Color.FromArgb(195, 198, 209), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(195, 198, 209), // GridListSelected
+            Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+            Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -338,14 +338,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking3
+            Color.FromArgb(194, 197, 204), // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
-            Color.Empty, // RibbonGroupBorder3
-            Color.Empty, // RibbonGroupBorder4
+            Color.FromArgb(170, 170, 170), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             Color.Empty, // RibbonGroupBorder5
             Color.FromArgb(76, 83, 92), // RibbonGroupTitleText
-            Color.Empty, // RibbonDropArrowLight
-            Color.Empty, // RibbonDropArrowDark
+            Color.FromArgb(173, 177, 181), // RibbonDropArrowLight
+            Color.FromArgb(76, 83, 92), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
@@ -356,7 +356,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         };
 
         #endregion
@@ -3972,9 +3972,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4012,6 +4010,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4088,7 +4087,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4185,7 +4184,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4297,7 +4296,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4376,7 +4375,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4470,7 +4469,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
             Color.FromArgb(248, 248, 248), // RibbonTabSelected2
-            Color.FromArgb(214, 216, 221), // RibbonTabSelected3
+            Color.FromArgb(223, 224, 230), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
             Color.FromArgb(232, 234, 244), // RibbonTabTracking1
@@ -218,7 +218,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(170, 170, 170), // RibbonGroupsArea2
-            Color.FromArgb(234, 235, 235), // RibbonGroupsArea3
+            Color.FromArgb(248, 248, 248), // RibbonGroupsArea3
             Color.FromArgb(249, 249, 249), // RibbonGroupsArea4
             Color.FromArgb(243, 245, 249), // RibbonGroupsArea5
             Color.Empty, // RibbonGroupBorder1
@@ -277,8 +277,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(196, 199, 209), // RibbonQATFullbar1
-            Color.FromArgb(196, 199, 209), // RibbonQATFullbar2
+            Color.FromArgb(223, 224, 230), // RibbonQATFullbar1
+            Color.FromArgb(223, 224, 230), // RibbonQATFullbar2
             Color.FromArgb(170, 170, 170), // RibbonQATFullbar3
             Color.FromArgb(150, 150, 150), // RibbonQATButtonDark
             Color.FromArgb(228, 228, 234), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -204,8 +204,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(30, 57, 91), // RibbonTabTextNormal
             Color.FromArgb(30, 57, 91), // RibbonTabTextChecked
             Color.FromArgb(159, 178, 199), // RibbonTabSelected1
-            Color.FromArgb(187, 206, 230), // RibbonTabSelected2
-            Color.FromArgb(224, 236, 249), // RibbonTabSelected3
+            Color.FromArgb(224, 236, 249), // RibbonTabSelected2
+            Color.FromArgb(187, 206, 230), // RibbonTabSelected3
             Color.FromArgb(239, 246, 253), // RibbonTabSelected4
             Color.FromArgb(239, 246, 253), // RibbonTabSelected5
             Color.FromArgb(237, 201, 88), // RibbonTabTracking1
@@ -218,7 +218,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(182, 186, 191), // RibbonTabSeparatorColor
             Color.FromArgb(159, 178, 199), // RibbonGroupsArea1
             Color.FromArgb(114, 142, 173), // RibbonGroupsArea2
-            Color.FromArgb(239, 246, 253), // RibbonGroupsArea3
+            Color.FromArgb(224, 236, 249), // RibbonGroupsArea3
             Color.FromArgb(221, 234, 247), // RibbonGroupsArea4
             Color.FromArgb(216, 228, 242), // RibbonGroupsArea5
             Color.Empty, // RibbonGroupBorder1
@@ -277,8 +277,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
             Color.FromArgb(72, Color.White), // RibbonQATMini5I
-            Color.FromArgb(210, 225, 240), // RibbonQATFullbar1
-            Color.FromArgb(210, 225, 240), // RibbonQATFullbar2
+            Color.FromArgb(187, 206, 230), // RibbonQATFullbar1
+            Color.FromArgb(187, 206, 230), // RibbonQATFullbar2
             Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
             Color.FromArgb(114, 142, 173), // RibbonQATButtonDark
             Color.FromArgb(221, 234, 247), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -172,12 +172,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(144, 154, 166), // FormBorderActive
             Color.FromArgb(162, 173, 185), // FormBorderInactive
             Color.FromArgb(187, 206, 230), // FormBorderActiveLight
-            Color.FromArgb(212, 230, 245), // FormBorderActiveDark
+            Color.FromArgb(187, 206, 230), // FormBorderActiveDark
             Color.FromArgb(223, 235, 247), // FormBorderInactiveLight
             Color.FromArgb(223, 235, 247), // FormBorderInactiveDark
             Color.FromArgb(144, 154, 166), // FormBorderHeaderActive
             Color.FromArgb(162, 173, 185), // FormBorderHeaderInactive
-            Color.FromArgb(193, 212, 236), // FormBorderHeaderActive1
+            Color.FromArgb(187, 206, 230), // FormBorderHeaderActive1
             Color.FromArgb(187, 206, 230), // FormBorderHeaderActive2
             Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive1
             Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive2
@@ -204,12 +204,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(30, 57, 91), // RibbonTabTextNormal
             Color.FromArgb(30, 57, 91), // RibbonTabTextChecked
             Color.FromArgb(159, 178, 199), // RibbonTabSelected1
-            Color.FromArgb(245, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(239, 246, 253), // RibbonTabSelected3
+            Color.FromArgb(187, 206, 230), // RibbonTabSelected2
+            Color.FromArgb(224, 236, 249), // RibbonTabSelected3
             Color.FromArgb(239, 246, 253), // RibbonTabSelected4
             Color.FromArgb(239, 246, 253), // RibbonTabSelected5
-            Color.FromArgb(159, 178, 199), // RibbonTabTracking1
-            Color.FromArgb(237, 241, 247), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(159, 178, 199), // RibbonTabHighlight1
             Color.FromArgb(245, 250, 255), // RibbonTabHighlight2
             Color.FromArgb(239, 246, 253), // RibbonTabHighlight3
@@ -221,16 +221,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(239, 246, 253), // RibbonGroupsArea3
             Color.FromArgb(221, 234, 247), // RibbonGroupsArea4
             Color.FromArgb(216, 228, 242), // RibbonGroupsArea5
-            Color.FromArgb(235, 240, 246), // RibbonGroupBorder1
-            Color.FromArgb(240, 246, 252), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.Empty, // RibbonGroupTitle1
             Color.Empty, // RibbonGroupTitle2
             Color.Empty, // RibbonGroupBorderContext1
             Color.Empty, // RibbonGroupBorderContext2
             Color.Empty, // RibbonGroupTitleContext1
             Color.Empty, // RibbonGroupTitleContext2
-            Color.FromArgb(135, 142, 152), // RibbonGroupDialogDark
-            Color.FromArgb(165, 174, 183), // RibbonGroupDialogLight
+            Color.FromArgb(56, 78, 115), // RibbonGroupDialogDark
+            Color.FromArgb(221, 234, 247), // RibbonGroupDialogLight
             Color.Empty, // RibbonGroupTitleTracking1
             Color.Empty, // RibbonGroupTitleTracking2
             Color.FromArgb(139, 160, 188), // RibbonMinimizeBarDark
@@ -267,42 +267,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(158, 193, 241), // FormButtonBorderCheck
             Color.FromArgb(140, 184, 229), // FormButtonBack1CheckTrack
             Color.FromArgb(225, 241, 255), // FormButtonBack2CheckTrack
-            Color.FromArgb(154, 179, 213), // RibbonQATMini1
-            Color.FromArgb(219, 231, 247), // RibbonQATMini2
-            Color.FromArgb(195, 213, 236), // RibbonQATMini3
-            Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(114, 142, 173), // RibbonQATMini1
+            Color.FromArgb(187, 206, 230), // RibbonQATMini2
+            Color.FromArgb(187, 206, 230), // RibbonQATMini3
+            Color.FromArgb(10, Color.White), // RibbonQATMini4
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1                                                      
-            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2                                                      
-            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight                                                      
-            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1                                                      
-            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2                                                      
-            Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(244, 249, 255), // GridListNormal1                                                    
-            Color.FromArgb(218, 231, 245), // GridListNormal2                                                    
-            Color.FromArgb(198, 211, 225), // GridListPressed1                                                    
-            Color.FromArgb(244, 249, 255), // GridListPressed2                                                    
-            Color.FromArgb(160, 185, 230), // GridListSelected                                                    
-            Color.FromArgb(233, 246, 255), // GridSheetColNormal1                                                    
-            Color.FromArgb(213, 226, 240), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(210, 225, 240), // RibbonQATFullbar1
+            Color.FromArgb(210, 225, 240), // RibbonQATFullbar2
+            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
+            Color.FromArgb(114, 142, 173), // RibbonQATButtonDark
+            Color.FromArgb(221, 234, 247), // RibbonQATButtonLight
+            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1
+            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2
+            Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(244, 249, 255), // GridListNormal1
+            Color.FromArgb(218, 231, 245), // GridListNormal2
+            Color.FromArgb(198, 211, 225), // GridListPressed1
+            Color.FromArgb(244, 249, 255), // GridListPressed2
+            Color.FromArgb(160, 185, 230), // GridListSelected
+            Color.FromArgb(233, 246, 255), // GridSheetColNormal1
+            Color.FromArgb(213, 226, 240), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(218, 231, 245), // GridSheetRowNormal                                                   
+            Color.FromArgb(218, 231, 245), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -338,11 +338,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(242, 247, 252), // RibbonGalleryBackTracking
             Color.FromArgb(237, 245, 253), // RibbonGalleryBack1
             Color.FromArgb(206, 221, 237), // RibbonGalleryBack2
-            Color.FromArgb(214, 222, 234), // RibbonTabTracking3
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(200, 215, 233), // RibbonTabTracking4
             Color.FromArgb(147, 167, 195), // RibbonGroupBorder3
-            Color.FromArgb(226, 236, 247), // RibbonGroupBorder4
-            Color.FromArgb(251, 251, 252), // RibbonGroupBorder5
+            Color.FromArgb(147, 167, 195), // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
             Color.FromArgb(56, 78, 115), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
             Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
@@ -356,7 +356,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -179,14 +179,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(44, 44, 44), // ToolStripBorder
             Color.FromArgb(99, 99, 99), // FormBorderActive
             Color.FromArgb(119, 119, 119), // FormBorderInactive
-            Color.FromArgb(113, 113, 113), // FormBorderActiveLight
-            Color.FromArgb(131, 131, 131), // FormBorderActiveDark
+            Color.FromArgb(99, 99, 99), // FormBorderActiveLight
+            Color.FromArgb(99, 99, 99), // FormBorderActiveDark
             Color.FromArgb(158, 158, 158), // FormBorderInactiveLight
             Color.FromArgb(158, 158, 158), // FormBorderInactiveDark
             Color.FromArgb(65, 65, 65), // FormBorderHeaderActive
             Color.FromArgb(154, 154, 154), // FormBorderHeaderInactive
-            Color.FromArgb(121, 121, 121), // FormBorderHeaderActive1
-            Color.FromArgb(113, 113, 113), // FormBorderHeaderActive2
+            Color.FromArgb(99, 99, 99), // FormBorderHeaderActive1
+            Color.FromArgb(99, 99, 99), // FormBorderHeaderActive2
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive1
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive2
             Color.FromArgb(226, 226, 226), // FormHeaderShortActive
@@ -209,16 +209,15 @@ namespace Krypton.Toolkit
             Color.Violet, // LinkVisitedOverridePanel
             Color.FromArgb(255, 90, 90), // LinkPressedOverridePanel
             Color.White, // TextLabelPanel
-            //Color.FromArgb(226, 226, 226),    // RibbonTabTextNormal
-            Color.White, // RibbonTabTextNormal
-            Color.Black, // RibbonTabTextChecked
+            Color.FromArgb(10, 10, 10), // RibbonTabTextNormal
+            Color.White, // RibbonTabTextChecked
             Color.FromArgb(32, 32, 32), // RibbonTabSelected1
-            Color.FromArgb(201, 201, 201), // RibbonTabSelected2
-            Color.FromArgb(192, 192, 192), // RibbonTabSelected3
+            Color.FromArgb(113, 113, 113), // RibbonTabSelected2
+            Color.FromArgb(188, 188, 188), // RibbonTabSelected3
             Color.FromArgb(192, 192, 192), // RibbonTabSelected4
             Color.FromArgb(192, 192, 192), // RibbonTabSelected5
-            Color.FromArgb(32, 32, 32), // RibbonTabTracking1
-            Color.FromArgb(183, 183, 183), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(32, 32, 32), // RibbonTabHighlight1
             Color.FromArgb(201, 201, 201), // RibbonTabHighlight2
             Color.FromArgb(192, 192, 192), // RibbonTabHighlight3
@@ -227,19 +226,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(32, 32, 32), // RibbonGroupsArea1
             Color.FromArgb(50, 50, 50), // RibbonGroupsArea2
-            Color.FromArgb(32, 32, 32), // RibbonGroupsArea3
+            Color.FromArgb(110, 110, 110), // RibbonGroupsArea3
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea4
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea5
-            Color.FromArgb(159, 159, 159), // RibbonGroupBorder1
-            Color.FromArgb(194, 194, 194), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.Empty, // RibbonGroupTitle1
             Color.Empty, // RibbonGroupTitle2
             Color.Empty, // RibbonGroupBorderContext1
             Color.Empty, // RibbonGroupBorderContext2
             Color.Empty, // RibbonGroupTitleContext1
             Color.Empty, // RibbonGroupTitleContext2
-            Color.FromArgb(92, 92, 94), // RibbonGroupDialogDark
-            Color.FromArgb(123, 125, 125), // RibbonGroupDialogLight
+            Color.FromArgb(10, 10, 10), // RibbonGroupDialogDark
+            Color.FromArgb(212, 212, 212), // RibbonGroupDialogLight
             Color.Empty, // RibbonGroupTitleTracking1
             Color.Empty, // RibbonGroupTitleTracking2
             Color.FromArgb(78, 78, 78), // RibbonMinimizeBarDark
@@ -266,7 +265,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(167, 167, 168), // RibbonGroupFrameInside2
             Color.Empty, // RibbonGroupFrameInside3
             Color.Empty, // RibbonGroupFrameInside4
-            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText         
+            Color.FromArgb(0, 0, 0), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -276,9 +275,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(18, 18, 18), // FormButtonBorderCheck
             Color.FromArgb(33, 45, 57), // FormButtonBack1CheckTrack
             Color.FromArgb(136, 152, 170), // FormButtonBack2CheckTrack
-            Color.FromArgb(55, 55, 55), // RibbonQATMini1
-            Color.FromArgb(100, 100, 100), // RibbonQATMini2
-            Color.FromArgb(73, 73, 73), // RibbonQATMini3
+            Color.FromArgb(32, 32, 32), // RibbonQATMini1
+            Color.FromArgb(99, 99, 99), // RibbonQATMini2
+            Color.FromArgb(99, 99, 99), // RibbonQATMini3
             Color.FromArgb(12, Color.White), // RibbonQATMini4
             Color.FromArgb(14, Color.White), // RibbonQATMini5
             Color.FromArgb(100, 100, 100), // RibbonQATMini1I
@@ -286,32 +285,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1                                                      
-            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2                                                      
-            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
-            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
-            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
-            Color.FromArgb(166, 166, 166), // GridListNormal2                                                    
-            Color.FromArgb(166, 166, 166), // GridListPressed1                                                    
-            Color.FromArgb(205, 205, 205), // GridListPressed2                                                    
-            Color.FromArgb(150, 150, 150), // GridListSelected                                                    
-            Color.FromArgb(220, 220, 220), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 200, 200), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(170, 170, 170), // RibbonQATFullbar1
+            Color.FromArgb(170, 170, 170), // RibbonQATFullbar2
+            Color.FromArgb(50, 50, 50), // RibbonQATFullbar3
+            Color.FromArgb(50, 50, 50), // RibbonQATButtonDark
+            Color.FromArgb(190, 190, 190), // RibbonQATButtonLight
+            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1
+            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2
+            Color.FromArgb(32, 32, 32), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(205, 205, 205), // GridListNormal1
+            Color.FromArgb(166, 166, 166), // GridListNormal2
+            Color.FromArgb(166, 166, 166), // GridListPressed1
+            Color.FromArgb(205, 205, 205), // GridListPressed2
+            Color.FromArgb(150, 150, 150), // GridListSelected
+            Color.FromArgb(220, 220, 220), // GridSheetColNormal1
+            Color.FromArgb(200, 200, 200), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(205, 205, 205), // GridSheetRowNormal                                                   
+            Color.FromArgb(205, 205, 205), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -347,14 +346,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(193, 193, 193), // RibbonGalleryBackTracking
             Color.FromArgb(176, 176, 176), // RibbonGalleryBack1
             Color.FromArgb(150, 150, 150), // RibbonGalleryBack2
-            Color.FromArgb(148, 149, 151), // RibbonTabTracking3
-            Color.FromArgb(127, 127, 127), // RibbonTabTracking4
-            Color.FromArgb(82, 82, 82), // RibbonGroupBorder3
-            Color.FromArgb(176, 176, 176), // RibbonGroupBorder4
-            Color.FromArgb(178, 178, 178), // RibbonGroupBorder5
-            Color.FromArgb(36, 36, 36), // RibbonGroupTitleText
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
+            Color.Empty, // RibbonTabTracking4
+            Color.FromArgb(32, 32, 32), // RibbonGroupBorder3
+            Color.FromArgb(32, 32, 32), // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(0, 0, 0), // RibbonGroupTitleText
             Color.FromArgb(155, 157, 160), // RibbonDropArrowLight
-            Color.FromArgb(27, 29, 40), // RibbonDropArrowDark
+            Color.FromArgb(10, 10, 10), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
             Color.FromArgb(125, 125, 125), // HeaderDockInactiveBack2
             Color.FromArgb(46, 46, 46), // ButtonNavigatorBorder
@@ -365,7 +364,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
             Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
             Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 201, 201) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 201, 201) // ToolTipBottom
         };
 
         #endregion
@@ -4262,9 +4261,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4302,6 +4299,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4378,7 +4376,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4475,7 +4473,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4587,7 +4585,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4666,7 +4664,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4760,7 +4758,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -212,8 +212,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(10, 10, 10), // RibbonTabTextNormal
             Color.White, // RibbonTabTextChecked
             Color.FromArgb(32, 32, 32), // RibbonTabSelected1
-            Color.FromArgb(113, 113, 113), // RibbonTabSelected2
-            Color.FromArgb(188, 188, 188), // RibbonTabSelected3
+            Color.FromArgb(151, 151, 151), // RibbonTabSelected2
+            Color.FromArgb(99, 99, 99), // RibbonTabSelected3
             Color.FromArgb(192, 192, 192), // RibbonTabSelected4
             Color.FromArgb(192, 192, 192), // RibbonTabSelected5
             Color.FromArgb(237, 201, 88), // RibbonTabTracking1
@@ -226,7 +226,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(32, 32, 32), // RibbonGroupsArea1
             Color.FromArgb(50, 50, 50), // RibbonGroupsArea2
-            Color.FromArgb(110, 110, 110), // RibbonGroupsArea3
+            Color.FromArgb(151, 151, 151), // RibbonGroupsArea3
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea4
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea5
             Color.Empty, // RibbonGroupBorder1
@@ -285,8 +285,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(170, 170, 170), // RibbonQATFullbar1
-            Color.FromArgb(170, 170, 170), // RibbonQATFullbar2
+            Color.FromArgb(99, 99, 99), // RibbonQATFullbar1
+            Color.FromArgb(99, 99, 99), // RibbonQATFullbar2
             Color.FromArgb(50, 50, 50), // RibbonQATFullbar3
             Color.FromArgb(50, 50, 50), // RibbonQATButtonDark
             Color.FromArgb(190, 190, 190), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -212,7 +212,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(141, 141, 141), // RibbonGroupsArea1
             Color.FromArgb(160, 160, 160), // RibbonGroupsArea2
-            Color.FromArgb(181, 181, 181), // RibbonGroupsArea3
+            Color.FromArgb(221, 221, 221), // RibbonGroupsArea3
             Color.FromArgb(135, 135, 135), // RibbonGroupsArea4
             Color.FromArgb(130, 130, 130), // RibbonGroupsArea5
             Color.Empty, // RibbonGroupBorder1
@@ -271,8 +271,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(215, 214,214), // RibbonQATFullbar1
-            Color.FromArgb(215, 214,214), // RibbonQATFullbar2
+            Color.FromArgb(190, 187, 184), // RibbonQATFullbar1
+            Color.FromArgb(190, 187, 184), // RibbonQATFullbar2
             Color.FromArgb(160, 160, 160), // RibbonQATFullbar3
             Color.FromArgb(153, 153, 153), // RibbonQATButtonDark
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -165,16 +165,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(124, 124, 148), // ToolStripBorder
             Color.FromArgb(114, 120, 128), // FormBorderActive
             Color.FromArgb(180, 185, 192), // FormBorderInactive
-            Color.FromArgb(222, 221, 222), // FormBorderActiveLight
+            Color.FromArgb(187, 186, 186), // FormBorderActiveLight
             Color.FromArgb(187, 186, 186), // FormBorderActiveDark
-            Color.FromArgb(240, 240, 240), // FormBorderInactiveLight
-            Color.FromArgb(224, 224, 224), // FormBorderInactiveDark
+            Color.FromArgb(217, 219, 225), // FormBorderInactiveLight
+            Color.FromArgb(217, 219, 225), // FormBorderInactiveDark
             Color.FromArgb(172, 175, 183), // FormBorderHeaderActive
             Color.FromArgb(182, 181, 181), // FormBorderHeaderInactive
-            Color.FromArgb(192, 195, 202), // FormBorderHeaderActive1
-            Color.FromArgb(240, 243, 250), // FormBorderHeaderActive2
+            Color.FromArgb(187, 186, 186), // FormBorderHeaderActive1
+            Color.FromArgb(187, 186, 186), // FormBorderHeaderActive2
             Color.FromArgb(217, 219, 225), // FormBorderHeaderInctive1
-            Color.FromArgb(244, 247, 251), // FormBorderHeaderInctive2
+            Color.FromArgb(217, 219, 225), // FormBorderHeaderInctive2
             Color.FromArgb(53, 110, 170), // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
@@ -197,33 +197,33 @@ namespace Krypton.Toolkit
             Color.FromArgb(139, 136, 134), // TextLabelPanel
             Color.FromArgb(139, 136, 134), // RibbonTabTextNormal
             Color.FromArgb(139, 136, 134), // RibbonTabTextChecked
-            Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(198, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(247, 248, 249), // RibbonTabSelected3
+            Color.FromArgb(141, 141, 141), // RibbonTabSelected1
+            Color.FromArgb(221, 221, 221), // RibbonTabSelected2
+            Color.FromArgb(192, 192, 192), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
-            Color.FromArgb(189, 190, 193), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
             Color.FromArgb(254, 209, 94), // RibbonTabHighlight4
             Color.FromArgb(205, 209, 180), // RibbonTabHighlight5
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
-            Color.FromArgb(243, 243, 243), // RibbonGroupsArea1
-            Color.FromArgb(192, 192, 192), // RibbonGroupsArea2
-            Color.FromArgb(141, 141, 141), // RibbonGroupsArea3
+            Color.FromArgb(141, 141, 141), // RibbonGroupsArea1
+            Color.FromArgb(160, 160, 160), // RibbonGroupsArea2
+            Color.FromArgb(181, 181, 181), // RibbonGroupsArea3
             Color.FromArgb(135, 135, 135), // RibbonGroupsArea4
             Color.FromArgb(130, 130, 130), // RibbonGroupsArea5
-            Color.FromArgb(209, 209, 209), // RibbonGroupBorder1
-            Color.FromArgb(158, 158, 158), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitle1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitleContext1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitleContext2
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
+            Color.FromArgb(139, 136, 134), // RibbonGroupDialogDark
             Color.FromArgb(242, 242, 242), // RibbonGroupDialogLight
             Color.FromArgb(222, 226, 238), // RibbonGroupTitleTracking1
             Color.FromArgb(179, 185, 199), // RibbonGroupTitleTracking2
@@ -251,7 +251,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(139, 136, 134), // RibbonGroupCollapsedText         
+            Color.FromArgb(139, 136, 134), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -261,42 +261,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(153, 153, 153), // RibbonQATMini1
+            Color.FromArgb(186, 186, 186), // RibbonQATMini2
+            Color.FromArgb(186, 186, 186), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(215, 214,214), // RibbonQATFullbar1
+            Color.FromArgb(215, 214,214), // RibbonQATFullbar2
+            Color.FromArgb(160, 160, 160), // RibbonQATFullbar3
+            Color.FromArgb(153, 153, 153), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(160, 160, 160), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.FromArgb(212, 215, 219), // GridListNormal2
+            Color.FromArgb(210, 213, 218), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -332,10 +332,10 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking3
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
-            Color.Empty, // RibbonGroupBorder3
-            Color.Empty, // RibbonGroupBorder4
+            Color.FromArgb(160, 160, 160), // RibbonGroupBorder3
+            Color.FromArgb(160, 160, 160), // RibbonGroupBorder4
             Color.Empty, // RibbonGroupBorder5
             Color.FromArgb(139, 136, 134), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
@@ -350,7 +350,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -207,8 +207,8 @@ namespace Krypton.Toolkit
             Color.FromArgb(59, 59, 59), // RibbonTabTextNormal
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(182, 186, 191), // RibbonTabSelected1
-            Color.White, // RibbonTabSelected2
-            Color.FromArgb(246, 249, 251), // RibbonTabSelected3
+            Color.FromArgb(246, 249, 251), // RibbonTabSelected2
+            Color.FromArgb(226, 229, 231), // RibbonTabSelected3
             Color.White, // RibbonTabSelected4
             Color.White, // RibbonTabSelected5
             Color.FromArgb(237, 201, 88), // RibbonTabTracking1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -174,14 +174,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(147, 154, 163), // ToolStripBorder
             Color.FromArgb(101, 109, 117), // FormBorderActive
             Color.FromArgb(134, 139, 145), // FormBorderInactive
-            Color.FromArgb(228, 230, 232), // FormBorderActiveLight
-            Color.FromArgb(255, 255, 255), // FormBorderActiveDark
+            Color.FromArgb(227, 230, 232), // FormBorderActiveLight
+            Color.FromArgb(227, 230, 232), // FormBorderActiveDark
             Color.FromArgb(248, 247, 247), // FormBorderInactiveLight
             Color.FromArgb(248, 247, 247), // FormBorderInactiveDark
             Color.FromArgb(101, 109, 117), // FormBorderHeaderActive
             Color.FromArgb(134, 139, 145), // FormBorderHeaderInactive
-            Color.FromArgb(235, 237, 240), // FormBorderHeaderActive1
-            Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
+            Color.FromArgb(227, 230, 232), // FormBorderHeaderActive1
+            Color.FromArgb(227, 230, 232), // FormBorderHeaderActive2
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
             Color.FromArgb(59, 59, 59), // FormHeaderShortActive
@@ -208,11 +208,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(182, 186, 191), // RibbonTabSelected1
             Color.White, // RibbonTabSelected2
-            Color.White, // RibbonTabSelected3
+            Color.FromArgb(246, 249, 251), // RibbonTabSelected3
             Color.White, // RibbonTabSelected4
             Color.White, // RibbonTabSelected5
-            Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(248, 249, 249), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(182, 186, 191), // RibbonTabHighlight1
             Color.White, // RibbonTabHighlight2
             Color.White, // RibbonTabHighlight3
@@ -224,16 +224,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGroupsArea3
             Color.FromArgb(255, 255, 255), // RibbonGroupsArea4
             Color.FromArgb(229, 233, 238), // RibbonGroupsArea5
-            Color.FromArgb(255, 255, 255), // RibbonGroupBorder1
-            Color.FromArgb(253, 253, 253), // RibbonGroupBorder2
+            Color.Empty, // RibbonGroupBorder1
+            Color.Empty, // RibbonGroupBorder2
             Color.Empty, // RibbonGroupTitle1
             Color.Empty, // RibbonGroupTitle2
             Color.Empty, // RibbonGroupBorderContext1
             Color.Empty, // RibbonGroupBorderContext2
             Color.Empty, // RibbonGroupTitleContext1
             Color.Empty, // RibbonGroupTitleContext2
-            Color.FromArgb(148, 149, 152), // RibbonGroupDialogDark
-            Color.FromArgb(180, 182, 183), // RibbonGroupDialogLight
+            Color.FromArgb(76, 83, 92), // RibbonGroupDialogDark
+            Color.FromArgb(227, 230, 232), // RibbonGroupDialogLight
             Color.Empty, // RibbonGroupTitleTracking1
             Color.Empty, // RibbonGroupTitleTracking2
             Color.FromArgb(139, 144, 151), // RibbonMinimizeBarDark
@@ -260,7 +260,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
             Color.Empty, // RibbonGroupFrameInside3
             Color.Empty, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -270,42 +270,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(182, 186, 191), // RibbonQATMini1
+            Color.FromArgb(227, 230, 232), // RibbonQATMini2
+            Color.FromArgb(227, 230, 232), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(248, 252, 255), // GridListNormal1                                                    
-            Color.FromArgb(223, 227, 232), // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212), // GridListPressed1                                                    
-            Color.White, // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(231, 234, 238), // RibbonQATFullbar1
+            Color.FromArgb(231, 234, 238), // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
+            Color.FromArgb(135, 140, 146), // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
+            Color.FromArgb(182, 186, 191), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(248, 252, 255), // GridListNormal1
+            Color.FromArgb(223, 227, 232), // GridListNormal2
+            Color.FromArgb(203, 207, 212), // GridListPressed1
+            Color.White, // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -340,13 +340,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2           Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
-            Color.FromArgb(229, 231, 235), // RibbonTabTracking3
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
-            Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
-            Color.FromArgb(246, 247, 248), // RibbonGroupBorder4
-            Color.FromArgb(249, 250, 250), // RibbonGroupBorder5
-            Color.FromArgb(102, 109, 124), // RibbonGroupTitleText
+            Color.FromArgb(135, 140, 146), // RibbonGroupBorder3
+            Color.FromArgb(182, 186, 191), // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(59, 59, 59), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
             Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
@@ -359,7 +359,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -174,14 +174,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(147, 154, 163), // ToolStripBorder
             Color.FromArgb(0, 114, 198), // FormBorderActive -n
             Color.FromArgb(134, 139, 145), // FormBorderInactive
-            Color.FromArgb(228, 230, 232), // FormBorderActiveLight
+            Color.FromArgb(255, 255, 255), // FormBorderActiveLight
             Color.FromArgb(255, 255, 255), // FormBorderActiveDark
             Color.FromArgb(248, 247, 247), // FormBorderInactiveLight
             Color.FromArgb(248, 247, 247), // FormBorderInactiveDark
             Color.FromArgb(101, 109, 117), // FormBorderHeaderActive
             Color.FromArgb(134, 139, 145), // FormBorderHeaderInactive
-            Color.FromArgb(235, 237, 240), // FormBorderHeaderActive1
-            Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
+            Color.FromArgb(255, 255, 255), // FormBorderHeaderActive1
+            Color.FromArgb(255, 255, 255), // FormBorderHeaderActive2
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
             Color.FromArgb(59, 59, 59), // FormHeaderShortActive
@@ -204,15 +204,15 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(59, 59, 59), // TextLabelPanel
-            Color.FromArgb(102, 102, 102), // RibbonTabTextNormal -n
-            Color.FromArgb(0, 114, 198), // RibbonTabTextChecked -n
+            Color.FromArgb(90, 90, 90), // RibbonTabTextNormal -n
+            Color.FromArgb(59, 59, 59), // RibbonTabTextChecked -n
             Color.FromArgb(182, 186, 191), // RibbonTabSelected1
-            Color.White, // RibbonTabSelected2
+            Color.FromArgb(248, 247, 247), // RibbonTabSelected2
             Color.White, // RibbonTabSelected3
             Color.White, // RibbonTabSelected4
             Color.White, // RibbonTabSelected5
-            Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(248, 249, 249), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(182, 186, 191), // RibbonTabHighlight1
             Color.White, // RibbonTabHighlight2
             Color.White, // RibbonTabHighlight3
@@ -221,7 +221,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(182, 186, 191), // RibbonTabSeparatorColor
             Color.FromArgb(212, 212, 212), // RibbonGroupsArea1 -n
             Color.FromArgb(212, 212, 212), // RibbonGroupsArea2 -n
-            Color.White, // RibbonGroupsArea3 -n
+            Color.FromArgb(223, 223, 223), // RibbonGroupsArea3 -n
             Color.White, // RibbonGroupsArea4 -n
             Color.White, // RibbonGroupsArea5 -n
             Color.Empty, // RibbonGroupBorder1 -n
@@ -232,8 +232,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonGroupBorderContext2
             Color.Empty, // RibbonGroupTitleContext1
             Color.Empty, // RibbonGroupTitleContext2
-            Color.FromArgb(148, 149, 152), // RibbonGroupDialogDark
-            Color.FromArgb(180, 182, 183), // RibbonGroupDialogLight
+            Color.FromArgb(102, 109, 124), // RibbonGroupDialogDark
+            Color.FromArgb(240, 240, 240), // RibbonGroupDialogLight
             Color.Empty, // RibbonGroupTitleTracking1
             Color.Empty, // RibbonGroupTitleTracking2
             Color.FromArgb(139, 144, 151), // RibbonMinimizeBarDark
@@ -260,7 +260,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
             Color.Empty, // RibbonGroupFrameInside3
             Color.Empty, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -270,42 +270,42 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(176, 182, 188), // RibbonQATMini1
+            Color.FromArgb(255, 255, 255), // RibbonQATMini2
+            Color.FromArgb(255, 255, 255), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.White, // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212), // GridListPressed1                                                    
-            Color.White, // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(255, 255, 255), // RibbonQATFullbar1
+            Color.FromArgb(255, 255, 255), // RibbonQATFullbar2
+            Color.FromArgb(212, 212, 212), // RibbonQATFullbar3
+            Color.FromArgb(176, 182, 188), // RibbonQATButtonDark
+            Color.FromArgb(223, 223, 223), // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
+            Color.FromArgb(176, 182, 188), // RibbonGroupSeparatorDark
+            Color.Empty, // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.White, // GridListNormal2
+            Color.FromArgb(203, 207, 212), // GridListPressed1
+            Color.White, // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -340,15 +340,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2        Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
-            Color.FromArgb(229, 231, 235), // RibbonTabTracking3
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
-            Color.FromArgb(246, 247, 248), // RibbonGroupBorder4
-            Color.FromArgb(249, 250, 250), // RibbonGroupBorder5
-            Color.FromArgb(102, 109, 124), // RibbonGroupTitleText
+            Color.FromArgb(176, 182, 188), // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(90, 90, 90), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
-            Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
+            Color.FromArgb(99, 59, 59), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
@@ -359,7 +359,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2071,6 +2071,8 @@ namespace Krypton.Toolkit
                     return DrawRibbonLinear(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.LinearBorder:
                     return DrawRibbonLinearBorder(context, rect, state, palette, memento);
+                case PaletteRibbonColorStyle.LinearBorder2:
+                    return DrawRibbonLinearBorder2(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.RibbonAppMenuInner:
                     return DrawRibbonAppMenuInner(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.RibbonAppMenuOuter:
@@ -2997,20 +2999,20 @@ namespace Krypton.Toolkit
             // TODO: WagnerP - please provide a better way of doing this for Various themes and dpi's
             if (shape == PaletteRibbonShape.Office2010)
             {
-                context.Graphics.DrawLine(darkPen, displayRect.Left - 1, displayRect.Top, displayRect.Right + 1, displayRect.Top);
-                context.Graphics.DrawLine(lightPen, displayRect.Left - 1, displayRect.Top + 1, displayRect.Right + 1, displayRect.Top + 1);
+                context.Graphics.DrawLine(darkPen, displayRect.Left - 1, displayRect.Top, displayRect.Right + 2, displayRect.Top);
+                context.Graphics.DrawLine(lightPen, displayRect.Left - 1, displayRect.Top + 1, displayRect.Right + 2, displayRect.Top + 1);
             }
             else
             {
-                context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top, displayRect.Right, displayRect.Top);
-                context.Graphics.DrawLine(lightPen, displayRect.Left, displayRect.Top + 1, displayRect.Right, displayRect.Top + 1);
+                context.Graphics.DrawLine(darkPen, displayRect.Left - 2, displayRect.Top, displayRect.Right + 1, displayRect.Top);
+                context.Graphics.DrawLine(lightPen, displayRect.Left - 2, displayRect.Top + 1, displayRect.Right + 1, displayRect.Top + 1);
             }
 
-            context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top + 3, displayRect.Right, displayRect.Top + 3);
-            context.Graphics.DrawLine(darkPen, displayRect.Right - 1, displayRect.Top + 4, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4);
-            context.Graphics.DrawLine(darkPen, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4, displayRect.Left, displayRect.Top + 3);
-            context.Graphics.DrawLine(lightPen, displayRect.Left + 1, displayRect.Top + 5, displayRect.Left + displayRect.Width / 2 - 1, displayRect.Bottom - 5);
-            context.Graphics.DrawLine(lightPen, displayRect.Left + displayRect.Width / 2 + 1, displayRect.Bottom - 5, displayRect.Right - 1, displayRect.Top + 5);
+            context.Graphics.DrawLine(darkPen, displayRect.Left - 2, displayRect.Top + 3, displayRect.Right + 1, displayRect.Top + 3);
+            context.Graphics.DrawLine(darkPen, displayRect.Right, displayRect.Top + 4, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 1);
+            context.Graphics.DrawLine(darkPen, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 1, displayRect.Left - 1, displayRect.Top + 4);
+            context.Graphics.DrawLine(lightPen, displayRect.Left + 2, displayRect.Top + 8, displayRect.Left + displayRect.Width / 2 - 3, displayRect.Bottom - 3);
+            context.Graphics.DrawLine(lightPen, displayRect.Left + displayRect.Width / 2 + 1, displayRect.Bottom - 1, displayRect.Right, displayRect.Top + 5);
         }
 
         /// <summary>
@@ -11701,6 +11703,58 @@ namespace Krypton.Toolkit
                 }
 
                 context.Graphics.DrawPath(cache.LinearPen, cache.BorderPath);
+            }
+
+            return memento;
+        }
+
+        /// <summary>
+        /// Internal rendering method.
+        /// </summary>
+        protected virtual IDisposable? DrawRibbonLinearBorder2(RenderContext context,
+                                                             Rectangle rect,
+                                                             PaletteState state,
+                                                             IPaletteRibbonBack palette,
+                                                             IDisposable? memento)
+        {
+            if (rect is { Width: > 0, Height: > 0 })
+            {
+                Color c1 = palette.GetRibbonBackColor1(state);
+                Color c2 = palette.GetRibbonBackColor2(state);
+
+                var generate = true;
+                MementoRibbonLinearBorder cache;
+
+                // Access a cache instance and decide if cache resources need generating
+                if (memento is MementoRibbonLinearBorder border)
+                {
+                    cache = border;
+                    generate = !cache.UseCachedValues(rect, c1, c2);
+                }
+                else
+                {
+                    memento?.Dispose();
+
+                    cache = new MementoRibbonLinearBorder(rect, c1, c2);
+                    memento = cache;
+                }
+
+                // Do we need to generate the contents of the cache?
+                if (generate)
+                {
+                    // Dispose of existing values
+                    cache.Dispose();
+
+                    cache.LinearBrush = new LinearGradientBrush(new RectangleF(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 1), c1, c2, 90f);
+                    cache.LinearPen = new Pen(cache.LinearBrush);
+
+                    // Create the complete border
+                    var borderPath = new GraphicsPath();
+                    borderPath.AddRectangle(new Rectangle(rect.X, rect.Y, rect.Width, rect.Height - 1));
+                    cache.BorderPath = borderPath;
+                }
+
+                context.Graphics.DrawPath(cache.LinearPen!, cache.BorderPath!);
             }
 
             return memento;


### PR DESCRIPTION
Resolve [[Bug]: Tabs on Ribbon don't have borders. #2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512).

Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. 
Adjusted the design of the `RibbonQATButton`.

Before:
<img width="611" height="210" alt="image" src="https://github.com/user-attachments/assets/5147c4f0-6b02-4875-af2c-90ef6ee78cef" />

After:
<img width="666" height="238" alt="image" src="https://github.com/user-attachments/assets/766bb43a-261e-410d-9178-8dec9a30af1e" />

<img width="319" height="96" alt="image" src="https://github.com/user-attachments/assets/881e6f97-f36f-4147-b809-d5332ffeb782" />


