### PR TITLE
2512-V95-Added-borders-KryptonRibbon-in-MS365-themes.-Adjusted-RibbonQATButton

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-10-25 - Build 2508 (Patch 9) - October 2025
+* Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`
 * Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.
 * Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -3964,6 +3964,11 @@ namespace Krypton.Toolkit
         LinearBorder,
 
         /// <summary>
+        /// Specifies linear gradient border from first to second color.
+        /// </summary>
+        LinearBorder2,
+
+        /// <summary>
         /// Specifies using colors to draw a application menu inner area.
         /// </summary>
         RibbonAppMenuInner,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -3540,9 +3540,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -3583,6 +3581,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -3667,7 +3666,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -3768,7 +3767,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -3885,7 +3884,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -3967,7 +3966,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4064,7 +4063,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -23,9 +23,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(41, 41, 41);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(51, 51, 51);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(79, 79, 79);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(99, 99, 99);
 
         private static readonly Color _ribbonAppButtonTextColor = Color.White;
 
@@ -176,16 +176,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(139, 147, 158), // OverflowMiddle
             Color.FromArgb(76, 83, 92), // OverflowEnd
             Color.FromArgb(76, 83, 92), // ToolStripBorder
-            Color.FromArgb(10, 10, 10), //(47, 47, 47), // FormBorderActive
+            Color.FromArgb(10, 10, 10), // FormBorderActive
             Color.FromArgb(146, 146, 146), // FormBorderInactive
-            Color.FromArgb(41, 41, 41), //(77, 77, 77), // FormBorderActiveLight
-            Color.FromArgb(102, 102, 102), // FormBorderActiveDark
+            Color.FromArgb(10, 10, 10), // FormBorderActiveLight
+            Color.FromArgb(10, 10, 10), // FormBorderActiveDark
             Color.FromArgb(153, 153, 153), // FormBorderInactiveLight
             Color.FromArgb(171, 171, 171), // FormBorderInactiveDark
             Color.FromArgb(65, 65, 65), // FormBorderHeaderActive
             Color.FromArgb(100, 100, 100), // FormBorderHeaderInactive
-            Color.FromArgb(42, 43, 43), // FormBorderHeaderActive1
-            Color.FromArgb(74, 74, 74), // FormBorderHeaderActive2
+            Color.FromArgb(10, 10, 10), // FormBorderHeaderActive1
+            Color.FromArgb(10, 10, 10), // FormBorderHeaderActive2
             Color.FromArgb(146, 146, 146), // FormBorderHeaderInctive1
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive2
             Color.FromArgb(255, 255, 255), // FormHeaderShortActive
@@ -209,14 +209,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 90, 90), // LinkPressedOverridePanel
             Color.White, // TextLabelPanel
             Color.White, // RibbonTabTextNormal
-            Color.FromArgb(41, 41, 41), // RibbonTabTextChecked
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(199, 250, 254), // RibbonTabSelected2
-            Color.FromArgb(238, 239, 241), // RibbonTabSelected3
+            Color.FromArgb(100, 100, 100), // RibbonTabSelected2
+            Color.FromArgb(10, 10, 10), // RibbonTabSelected3
             Color.FromArgb(241, 241, 241), // RibbonTabSelected4
             Color.FromArgb(213, 217, 223), // RibbonTabSelected5
-            Color.FromArgb(159, 156, 150), // RibbonTabTracking1
-            Color.FromArgb(235, 194, 39), // RibbonTabTracking2
+            Color.FromArgb(187, 186, 186), // RibbonTabTracking1
+            Color.FromArgb(91, 91, 91), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -225,23 +225,23 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(180, 187, 197), // RibbonGroupsArea3
+            Color.FromArgb(65, 65, 65), // RibbonGroupsArea3
             Color.FromArgb(235, 235, 235), // RibbonGroupsArea4
             Color.FromArgb(215, 219, 224), // RibbonGroupsArea5
-            Color.FromArgb(174, 176, 180), // RibbonGroupBorder1
-            Color.FromArgb(132, 132, 132), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             Color.FromArgb(182, 184, 184), // RibbonGroupTitle1
             Color.FromArgb(159, 160, 160), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
             Color.FromArgb(190, 190, 190), // RibbonGroupTitleContext1
             Color.FromArgb(161, 161, 161), // RibbonGroupTitleContext2
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
-            Color.FromArgb(235, 235, 235), // RibbonGroupDialogLight
+            Color.FromArgb(225, 225, 225), // RibbonGroupDialogDark
+            Color.FromArgb(42, 43, 43), // RibbonGroupDialogLight
             Color.FromArgb(170, 171, 171), // RibbonGroupTitleTracking1
             Color.FromArgb(109, 110, 110), // RibbonGroupTitleTracking2
-            Color.FromArgb(10, 10, 10), // (79, 79, 79) // RibbonMinimizeBarDark
-            Color.FromArgb(41, 41, 41), // (98, 98, 98) // RibbonMinimizeBarLight
+            Color.FromArgb(10, 10, 10), // RibbonMinimizeBarDark
+            Color.FromArgb(41, 41, 41), // RibbonMinimizeBarLight
             Color.FromArgb(182, 183, 183), // RibbonGroupCollapsedBorder1
             Color.FromArgb(112, 112, 112), // RibbonGroupCollapsedBorder2
             Color.FromArgb(64, Color.White), // RibbonGroupCollapsedBorder3
@@ -264,7 +264,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
             Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
             Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText (Old value 70, 70, 70)
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -274,9 +274,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(18, 18, 18), // FormButtonBorderCheck
             Color.FromArgb(33, 45, 57), // FormButtonBack1CheckTrack
             Color.FromArgb(136, 152, 170), // FormButtonBack2CheckTrack
-            Color.FromArgb(55, 55, 55), // RibbonQATMini1
-            Color.FromArgb(100, 100, 100), // RibbonQATMini2
-            Color.FromArgb(73, 73, 73), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(10, 10, 10), // RibbonQATMini2
+            Color.FromArgb(10, 10, 10), // RibbonQATMini3
             Color.FromArgb(12, Color.White), // RibbonQATMini4
             Color.FromArgb(14, Color.White), // RibbonQATMini5
             Color.FromArgb(100, 100, 100), // RibbonQATMini1I
@@ -284,15 +284,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(10, 10, 10), // RibbonQATFullbar1
+            Color.FromArgb(10, 10, 10), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
+            Color.FromArgb(100, 100, 100), // RibbonQATButtonLight
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
-            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
-            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
             Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
             Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
@@ -345,14 +345,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(247, 247, 247), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
+            Color.FromArgb(129, 129, 129), // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
             Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
-            Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
-            Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
+            Color.FromArgb(42, 43, 43), // RibbonDropArrowLight
+            Color.FromArgb(235, 235, 235), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
             Color.FromArgb(125, 125, 125), // HeaderDockInactiveBack2
             Color.FromArgb(46, 46, 46), // ButtonNavigatorBorder
@@ -715,7 +715,7 @@ namespace Krypton.Toolkit
         private static readonly Color _buttonTextTracking = Color.Black;
         private static readonly Color _gridTextColor = Color.White;
         private static readonly Color _disabledText2 = Color.FromArgb(166, 166, 166);
-        private static readonly Color _disabledText = Color.FromArgb(32, 32, 32);
+        private static readonly Color _disabledText = Color.FromArgb(51, 51, 51);
         private static readonly Color _disabledBack = Color.FromArgb(102, 102, 102);
         private static readonly Color _disabledBack2 = Color.FromArgb(128, 128, 128);
         private static readonly Color _disabledBorder = Color.FromArgb(212, 212, 212);
@@ -4167,9 +4167,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4208,6 +4206,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4291,7 +4290,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4392,7 +4391,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4509,7 +4508,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4591,7 +4590,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4688,7 +4687,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -22,9 +22,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(31, 31, 31);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(51, 51, 51);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(69, 69, 69);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(99, 99, 99);
 
         private static readonly Color _ribbonAppButtonTextColor = Color.White;
 
@@ -180,14 +180,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // ToolStripBorder
             Color.FromArgb(47, 47, 47), // FormBorderActive
             Color.FromArgb(146, 146, 146), // FormBorderInactive
-            Color.FromArgb(77, 77, 77), // FormBorderActiveLight
-            Color.FromArgb(102, 102, 102), // FormBorderActiveDark
+            Color.FromArgb(31, 31, 31), // FormBorderActiveLight
+            Color.FromArgb(31, 31, 31), // FormBorderActiveDark
             Color.FromArgb(153, 153, 153), // FormBorderInactiveLight
             Color.FromArgb(171, 171, 171), // FormBorderInactiveDark
             Color.FromArgb(65, 65, 65), // FormBorderHeaderActive
             Color.FromArgb(154, 154, 154), // FormBorderHeaderInactive
-            Color.FromArgb(42, 43, 43), // FormBorderHeaderActive1
-            Color.FromArgb(74, 74, 74), // FormBorderHeaderActive2
+            Color.FromArgb(31, 31, 31), // FormBorderHeaderActive1
+            Color.FromArgb(31, 31, 31), // FormBorderHeaderActive2
             Color.FromArgb(146, 146, 146), // FormBorderHeaderInctive1
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive2
             Color.FromArgb(255, 255, 255), // FormHeaderShortActive
@@ -211,14 +211,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 90, 90), // LinkPressedOverridePanel
             Color.White, // TextLabelPanel
             Color.White, // RibbonTabTextNormal
-            Color.FromArgb(15, 15, 15), // RibbonTabTextChecked
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(199, 250, 254), // RibbonTabSelected2
-            Color.FromArgb(238, 239, 241), // RibbonTabSelected3
+            Color.FromArgb(91, 91, 91), // RibbonTabSelected2
+            Color.FromArgb(31, 31, 31), // RibbonTabSelected3
             Color.FromArgb(241, 241, 241), // RibbonTabSelected4
             Color.FromArgb(213, 217, 223), // RibbonTabSelected5
-            Color.FromArgb(159, 156, 150), // RibbonTabTracking1
-            Color.FromArgb(235, 194, 39), // RibbonTabTracking2
+            Color.FromArgb(187, 186, 186), // RibbonTabTracking1
+            Color.FromArgb(91, 91, 91), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -227,19 +227,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(180, 187, 197), // RibbonGroupsArea3
+            Color.FromArgb(77, 77, 77), // RibbonGroupsArea3
             Color.FromArgb(235, 235, 235), // RibbonGroupsArea4
             Color.FromArgb(215, 219, 224), // RibbonGroupsArea5
-            Color.FromArgb(174, 176, 180), // RibbonGroupBorder1
-            Color.FromArgb(132, 132, 132), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             Color.FromArgb(182, 184, 184), // RibbonGroupTitle1
             Color.FromArgb(159, 160, 160), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
             Color.FromArgb(190, 190, 190), // RibbonGroupTitleContext1
             Color.FromArgb(161, 161, 161), // RibbonGroupTitleContext2
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
-            Color.FromArgb(235, 235, 235), // RibbonGroupDialogLight
+            Color.FromArgb(225, 225, 225), // RibbonGroupDialogDark
+            Color.FromArgb(54, 54, 54), // RibbonGroupDialogLight
             Color.FromArgb(170, 171, 171), // RibbonGroupTitleTracking1
             Color.FromArgb(109, 110, 110), // RibbonGroupTitleTracking2
             Color.FromArgb(79, 79, 79), // RibbonMinimizeBarDark
@@ -266,7 +266,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
             Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
             Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText (Old value 70, 70, 70)
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -276,9 +276,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(18, 18, 18), // FormButtonBorderCheck
             Color.FromArgb(33, 45, 57), // FormButtonBack1CheckTrack
             Color.FromArgb(136, 152, 170), // FormButtonBack2CheckTrack
-            Color.FromArgb(55, 55, 55), // RibbonQATMini1
-            Color.FromArgb(100, 100, 100), // RibbonQATMini2
-            Color.FromArgb(73, 73, 73), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(31, 31, 31), // RibbonQATMini2
+            Color.FromArgb(31, 31, 31), // RibbonQATMini3
             Color.FromArgb(12, Color.White), // RibbonQATMini4
             Color.FromArgb(14, Color.White), // RibbonQATMini5
             Color.FromArgb(100, 100, 100), // RibbonQATMini1I
@@ -286,15 +286,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(31, 31, 31), // RibbonQATFullbar1
+            Color.FromArgb(31, 31, 31), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
+            Color.FromArgb(100, 100, 100), // RibbonQATButtonLight
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
-            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
-            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
             Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
             Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
@@ -347,14 +347,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(247, 247, 247), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
+            Color.FromArgb(129, 129, 129), // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
             Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
-            Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
-            Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
+            Color.FromArgb(103, 103, 103), // RibbonDropArrowLight
+            Color.FromArgb(235, 235, 235), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
             Color.FromArgb(125, 125, 125), // HeaderDockInactiveBack2
             Color.FromArgb(46, 46, 46), // ButtonNavigatorBorder
@@ -4094,9 +4094,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4135,6 +4133,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4218,7 +4217,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4319,7 +4318,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4436,7 +4435,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4518,7 +4517,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4615,7 +4614,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -25,9 +25,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(43, 74, 115);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(84, 158, 243);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(77, 132, 204);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(31, 72, 161);
 
         private static readonly Color _ribbonAppButtonTextColor = Color.White;
 
@@ -183,15 +183,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(134, 179, 236), // FormBorderActive
             Color.FromArgb(179, 209, 247), // FormBorderInactive
             Color.FromArgb(134, 179, 236), // FormBorderActiveLight
-            Color.FromArgb(63, 122, 197), // FormBorderActiveDark
+            Color.FromArgb(134, 179, 236), // FormBorderActiveDark
             Color.FromArgb(179, 209, 247), // FormBorderInactiveLight
             Color.FromArgb(96, 150, 220), // FormBorderInactiveDark
             Color.FromArgb(134, 179, 236), // FormBorderHeaderActive
             Color.FromArgb(179, 209, 247), // FormBorderHeaderInactive
             Color.FromArgb(134, 179, 236), // FormBorderHeaderActive1
-            Color.FromArgb(63, 122, 197), // FormBorderHeaderActive2
+            Color.FromArgb(134, 179, 236), // FormBorderHeaderActive2
             Color.FromArgb(179, 209, 247), // FormBorderHeaderInctive1
-            Color.FromArgb(96, 150, 220), // FormBorderHeaderInctive2
+            Color.FromArgb(179, 209, 247), // FormBorderHeaderInctive2
             Color.FromArgb(21, 66, 139), // FormHeaderShortActive
             Color.FromArgb(150, 143, 134), // FormHeaderShortInactive
             Color.FromArgb(105, 112, 121), // FormHeaderLongActive
@@ -212,36 +212,36 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(21, 66, 139), // TextLabelPanel
-            Color.FromArgb(255, 255, 255), // RibbonTabTextNormal - Old value 21, 66, 139
-            Color.FromArgb(21, 66, 139), // RibbonTabTextChecked
-            Color.FromArgb(134, 179, 236), // RibbonTabSelected1
-            Color.FromArgb(63, 122, 197), // RibbonTabSelected2
+            Color.FromArgb(21, 66, 139), // RibbonTabTextNormal
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
+            Color.FromArgb(96, 150, 220), // RibbonTabSelected1
+            Color.FromArgb(73, 132, 207), // RibbonTabSelected2
             Color.FromArgb(134, 179, 236), // RibbonTabSelected3
             Color.FromArgb(63, 122, 197), // RibbonTabSelected4
             Color.FromArgb(222, 232, 245), // RibbonTabSelected5
-            Color.FromArgb(153, 187, 232), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(179, 209, 255), // RibbonTabTracking1
+            Color.FromArgb(167, 199, 241), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
             Color.FromArgb(254, 209, 94), // RibbonTabHighlight4
             Color.FromArgb(205, 209, 180), // RibbonTabHighlight5
             Color.FromArgb(116, 153, 203), // RibbonTabSeparatorColor
-            Color.FromArgb(134, 179, 236), // RibbonGroupsArea1
+            Color.FromArgb(96, 150, 220), // RibbonGroupsArea1
             Color.FromArgb(63, 122, 197), // RibbonGroupsArea2
             Color.FromArgb(201, 217, 237), // RibbonGroupsArea3
             Color.FromArgb(231, 242, 255), // RibbonGroupsArea4
             Color.FromArgb(219, 230, 244), // RibbonGroupsArea5
-            Color.FromArgb(197, 210, 223), // RibbonGroupBorder1
-            Color.FromArgb(158, 191, 219), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle1
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle2
             Color.FromArgb(202, 202, 202), // RibbonGroupBorderContext1
             Color.FromArgb(196, 196, 196), // RibbonGroupBorderContext2
             Color.FromArgb(223, 223, 245), // RibbonGroupTitleContext1
             Color.FromArgb(210, 221, 242), // RibbonGroupTitleContext2
-            Color.FromArgb(102, 142, 175), // RibbonGroupDialogDark
-            Color.FromArgb(254, 254, 255), // RibbonGroupDialogLight
+            Color.FromArgb(63, 122, 197), // RibbonGroupDialogDark
+            Color.FromArgb(193, 216, 242), // RibbonGroupDialogLight
             Color.FromArgb(200, 224, 255), // RibbonGroupTitleTracking1
             Color.FromArgb(214, 237, 255), // RibbonGroupTitleTracking2
             Color.FromArgb(134, 179, 236), //(155, 187, 227), // RibbonMinimizeBarDark
@@ -278,25 +278,25 @@ namespace Krypton.Toolkit
             Color.FromArgb(158, 193, 241), // FormButtonBorderCheck
             Color.FromArgb(140, 184, 229), // FormButtonBack1CheckTrack
             Color.FromArgb(225, 241, 255), // FormButtonBack2CheckTrack
-            Color.FromArgb(154, 179, 213), // RibbonQATMini1
-            Color.FromArgb(219, 231, 247), // RibbonQATMini2
-            Color.FromArgb(195, 213, 236), // RibbonQATMini3
-            Color.FromArgb(128, Color.White), // RibbonQATMini4
+            Color.FromArgb(63, 122, 197), // RibbonQATMini1
+            Color.FromArgb(134, 179, 236), // RibbonQATMini2
+            Color.FromArgb(134, 179, 236), // RibbonQATMini3
+            Color.FromArgb(28, Color.White), // RibbonQATMini4
             Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
             Color.FromArgb(72, Color.White), // RibbonQATMini5I
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(134, 179, 236), // RibbonQATFullbar1
+            Color.FromArgb(134, 179, 236), // RibbonQATFullbar2
+            Color.FromArgb(63, 122, 197), // RibbonQATFullbar3
+            Color.FromArgb(63, 122, 197), // RibbonQATButtonDark
+            Color.FromArgb(193, 216, 242), // RibbonQATButtonLight
             Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
-            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
-            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(63, 122, 197), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
             Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
             Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
@@ -351,12 +351,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(215, 233, 251), // RibbonGalleryBack2
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(63, 122, 197), // RibbonGroupBorder3
+            Color.FromArgb(63, 122, 197), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
-            Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
+            Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
+            Color.FromArgb(63, 122, 197), // RibbonDropArrowLight
+            Color.FromArgb(21, 66, 139), // RibbonDropArrowDark
             Color.FromArgb(208, 226, 248), // HeaderDockInactiveBack1
             Color.FromArgb(178, 196, 218), // HeaderDockInactiveBack2
             Color.FromArgb(133, 158, 191), // ButtonNavigatorBorder
@@ -4032,9 +4032,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4073,6 +4071,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4156,7 +4155,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4257,7 +4256,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4374,7 +4373,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4456,7 +4455,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4553,7 +4552,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -25,9 +25,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(135, 145, 157);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(61, 112, 221);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(179, 193, 208);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(84, 178, 253);
 
         private static readonly Color _ribbonAppButtonTextColor = SystemColors.Control;
 
@@ -188,16 +188,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(111, 157, 217), // ToolStripBorder
             Color.FromArgb(59, 90, 130), // FormBorderActive
             Color.FromArgb(192, 198, 206), // FormBorderInactive
-            Color.FromArgb(176, 203, 239), // FormBorderActiveLight
-            Color.FromArgb(194, 217, 247), // FormBorderActiveDark
+            Color.FromArgb(230, 239, 249), // FormBorderActiveLight
+            Color.FromArgb(230, 239, 249), // FormBorderActiveDark
             Color.FromArgb(204, 216, 232), // FormBorderInactiveLight
             Color.FromArgb(212, 222, 236), // FormBorderInactiveDark
             Color.FromArgb(221, 233, 248), // FormBorderHeaderActive
             Color.FromArgb(223, 229, 237), // FormBorderHeaderInactive
-            Color.FromArgb(176, 207, 247), // FormBorderHeaderActive1
-            Color.FromArgb(228, 239, 253), // FormBorderHeaderActive2
+            Color.FromArgb(230, 239, 249), // FormBorderHeaderActive1
+            Color.FromArgb(230, 239, 249), // FormBorderHeaderActive2
             Color.FromArgb(204, 218, 236), // FormBorderHeaderInctive1
-            Color.FromArgb(227, 232, 239), // FormBorderHeaderInctive2
+            Color.FromArgb(204, 218, 236), // FormBorderHeaderInctive2
             Color.FromArgb(62, 106, 184), // FormHeaderShortActive
             Color.FromArgb(160, 160, 160), // FormHeaderShortInactive
             Color.FromArgb(105, 112, 121), // FormHeaderLongActive
@@ -221,12 +221,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(21, 66, 139), // RibbonTabTextNormal
             Color.FromArgb(21, 66, 139), // RibbonTabTextChecked
             Color.FromArgb(145, 180, 228), // RibbonTabSelected1
-            Color.FromArgb(209, 251, 255), // RibbonTabSelected2
-            Color.FromArgb(246, 250, 255), // RibbonTabSelected3
+            Color.FromArgb(248, 250, 255), // RibbonTabSelected2
+            Color.FromArgb(230, 239, 249), // RibbonTabSelected3
             Color.FromArgb(239, 246, 254), // RibbonTabSelected4
             Color.FromArgb(222, 232, 245), // RibbonTabSelected5
-            Color.FromArgb(153, 187, 232), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(160, 205, 240), // RibbonTabTracking1
+            Color.FromArgb(188, 213, 239), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -234,20 +234,20 @@ namespace Krypton.Toolkit
             Color.FromArgb(205, 209, 180), // RibbonTabHighlight5
             Color.FromArgb(116, 153, 203), // RibbonTabSeparatorColor
             Color.FromArgb(141, 178, 227), // RibbonGroupsArea1
-            Color.FromArgb(192, 249, 255), // RibbonGroupsArea2
-            Color.FromArgb(201, 217, 237), // RibbonGroupsArea3
+            Color.FromArgb(134, 179, 236), // RibbonGroupsArea2
+            Color.FromArgb(186, 209, 240), // RibbonGroupsArea3
             Color.FromArgb(231, 242, 255), // RibbonGroupsArea4
             Color.FromArgb(219, 230, 244), // RibbonGroupsArea5
-            Color.FromArgb(197, 210, 223), // RibbonGroupBorder1
-            Color.FromArgb(158, 191, 219), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle1
             Color.FromArgb(193, 216, 242), // RibbonGroupTitle2
             Color.FromArgb(202, 202, 202), // RibbonGroupBorderContext1
             Color.FromArgb(196, 196, 196), // RibbonGroupBorderContext2
             Color.FromArgb(223, 223, 245), // RibbonGroupTitleContext1
             Color.FromArgb(210, 221, 242), // RibbonGroupTitleContext2
-            Color.FromArgb(102, 142, 175), // RibbonGroupDialogDark
-            Color.FromArgb(254, 254, 255), // RibbonGroupDialogLight
+            Color.FromArgb(21, 66, 139), // RibbonGroupDialogDark
+            Color.FromArgb(199, 218, 243), // RibbonGroupDialogLight
             Color.FromArgb(200, 224, 255), // RibbonGroupTitleTracking1
             Color.FromArgb(214, 237, 255), // RibbonGroupTitleTracking2
             Color.FromArgb(155, 187, 227), // RibbonMinimizeBarDark
@@ -284,25 +284,25 @@ namespace Krypton.Toolkit
             Color.FromArgb(158, 193, 241), // FormButtonBorderCheck
             Color.FromArgb(140, 184, 229), // FormButtonBack1CheckTrack
             Color.FromArgb(225, 241, 255), // FormButtonBack2CheckTrack
-            Color.FromArgb(154, 179, 213), // RibbonQATMini1
-            Color.FromArgb(219, 231, 247), // RibbonQATMini2
-            Color.FromArgb(195, 213, 236), // RibbonQATMini3
-            Color.FromArgb(128, Color.White), // RibbonQATMini4
+            Color.FromArgb(141, 178, 227), // RibbonQATMini1
+            Color.FromArgb(230, 239, 249), // RibbonQATMini2
+            Color.FromArgb(230, 239, 249), // RibbonQATMini3
+            Color.FromArgb(28, Color.White), // RibbonQATMini4
             Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
             Color.FromArgb(72, Color.White), // RibbonQATMini5I
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(230, 239, 249), // RibbonQATFullbar1
+            Color.FromArgb(230, 239, 249), // RibbonQATFullbar2
+            Color.FromArgb(134, 179, 236), // RibbonQATFullbar3
+            Color.FromArgb(134, 179, 236), // RibbonQATButtonDark
+            Color.FromArgb(199, 218, 243), // RibbonQATButtonLight
             Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
-            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
-            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(141, 178, 227), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
             Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
             Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
@@ -357,12 +357,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(215, 233, 251), // RibbonGalleryBack2
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(141, 178, 227), // RibbonGroupBorder3
+            Color.FromArgb(141, 178, 227), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
-            Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
+            Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
+            Color.FromArgb(101, 147, 207), // RibbonDropArrowLight
+            Color.FromArgb(21, 66, 139), // RibbonDropArrowDark
             Color.FromArgb(208, 226, 248), // HeaderDockInactiveBack1
             Color.FromArgb(178, 196, 218), // HeaderDockInactiveBack2
             Color.FromArgb(133, 158, 191), // ButtonNavigatorBorder
@@ -4073,9 +4073,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4116,6 +4114,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4202,7 +4201,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4305,7 +4304,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4424,7 +4423,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4509,7 +4508,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4610,7 +4609,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -25,9 +25,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(84, 96, 125);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(84, 158, 243);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(109, 125, 163);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(31, 72, 161);
 
         private static readonly Color _ribbonAppButtonTextColor = Color.White;
 
@@ -184,15 +184,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(119, 132, 161), // FormBorderActive
             Color.FromArgb(83, 99, 136), // FormBorderInactive
             Color.FromArgb(119, 132, 161), // FormBorderActiveLight
-            Color.FromArgb(83, 99, 136), // FormBorderActiveDark
+            Color.FromArgb(119, 132, 161), // FormBorderActiveDark
             Color.FromArgb(119, 132, 161), // FormBorderInactiveLight
             Color.FromArgb(83, 99, 136), // FormBorderInactiveDark
             Color.FromArgb(119, 132, 161), // FormBorderHeaderActive
             Color.FromArgb(83, 99, 136), // FormBorderHeaderInactive
             Color.FromArgb(119, 132, 161), // FormBorderHeaderActive1
-            Color.FromArgb(83, 99, 136), // FormBorderHeaderActive2
+            Color.FromArgb(119, 132, 161), // FormBorderHeaderActive2
             Color.FromArgb(119, 132, 161), // FormBorderHeaderInctive1
-            Color.FromArgb(83, 99, 136), // FormBorderHeaderInctive2
+            Color.FromArgb(119, 132, 161), // FormBorderHeaderInctive2
             Color.FromArgb(255, 255, 255), // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
             Color.FromArgb(255, 255, 255), // FormHeaderLongActive
@@ -213,15 +213,15 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(255, 255, 255), // TextLabelPanel
-            Color.FromArgb(255, 255, 255), // RibbonTabTextNormal (Old value 255, 255, 255)
-            Color.FromArgb(0, 0, 0), // RibbonTabTextChecked
+            Color.FromArgb(255, 255, 255), // RibbonTabTextNormal
+            Color.FromArgb(255, 255, 255), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(198, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(247, 248, 249), // RibbonTabSelected3
+            Color.FromArgb(83, 99, 136), // RibbonTabSelected2
+            Color.FromArgb(119, 132, 161), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
-            Color.FromArgb(189, 190, 193), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(163, 179, 220), // RibbonTabTracking1
+            Color.FromArgb(102, 117, 161), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -230,19 +230,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(213, 219, 231), // RibbonGroupsArea3
+            Color.FromArgb(83, 99, 136), // RibbonGroupsArea3
             Color.FromArgb(249, 249, 249), // RibbonGroupsArea4
             Color.FromArgb(243, 245, 249), // RibbonGroupsArea5
-            Color.FromArgb(189, 191, 193), // RibbonGroupBorder1
-            Color.FromArgb(133, 133, 133), // RibbonGroupBorder2
-            Color.FromArgb(255, 255, 255), // RibbonGroupTitle1 (Old value 255, 255, 255)
-            Color.FromArgb(52, 52, 52), // RibbonGroupTitle2 (Old value 195, 199, 209)
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitle1 
+            Color.FromArgb(52, 52, 52), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
             Color.FromArgb(131, 131, 131), // RibbonGroupBorderContext2
-            Color.FromArgb(255, 255, 255), // RibbonGroupTitleContext1 (Old value 255, 255, 255)
-            Color.FromArgb(52, 52, 52), // RibbonGroupTitleContext2 (Old value 195, 199, 209)
-            Color.FromArgb(101, 104, 112), // RibbonGroupDialogDark
-            Color.FromArgb(242, 242, 242), // RibbonGroupDialogLight
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleContext1
+            Color.FromArgb(52, 52, 52), // RibbonGroupTitleContext2
+            Color.FromArgb(242, 242, 242), // RibbonGroupDialogDark
+            Color.FromArgb(106, 123, 164), // RibbonGroupDialogLight
             Color.FromArgb(222, 226, 238), // RibbonGroupTitleTracking1
             Color.FromArgb(179, 185, 199), // RibbonGroupTitleTracking2
             Color.FromArgb(119, 132, 161), // RibbonMinimizeBarDark
@@ -269,7 +269,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText (Old value 76, 83, 92)
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -279,9 +279,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(119, 132, 161), // RibbonQATMini2
+            Color.FromArgb(119, 132, 161), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
             Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
@@ -289,15 +289,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(119, 132, 161), // RibbonQATFullbar1
+            Color.FromArgb(119, 132, 161), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(210, 210, 210), // RibbonQATButtonDark
+            Color.FromArgb(163, 179, 220), // RibbonQATButtonLight
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
             Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
             Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
@@ -331,7 +331,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(51, 51, 51), // InputDropDownDisabled1
             Color.Transparent, // InputDropDownDisabled2
             Color.FromArgb(255, 255, 255), // ContextMenuHeading
-            Color.FromArgb(255, 255, 255), // ContextMenuHeadingText (Old value 76, 83, 92)
+            Color.FromArgb(255, 255, 255), // ContextMenuHeadingText
             Color.FromArgb(239, 239, 239), // ContextMenuImageColumn
             Color.FromArgb(119, 132, 161), // AppButtonBack1
             Color.FromArgb(83, 99, 136), // AppButtonBack2
@@ -350,14 +350,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
+            Color.FromArgb(106, 123, 164), // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
             Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
+            Color.FromArgb(222, 226, 236), // RibbonDropArrowLight
+            Color.FromArgb(255, 255, 255), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
@@ -4056,9 +4056,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4098,6 +4096,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4183,7 +4182,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4287,7 +4286,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4408,7 +4407,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4492,7 +4491,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4591,7 +4590,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -25,9 +25,9 @@ namespace Krypton.Toolkit
 
         #region Ribbon Specific Colors
 
-        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(147, 149, 158);
+        private static readonly Color _ribbonAppButtonDarkColor = Color.FromArgb(137, 139, 148);
 
-        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(195, 198, 209);
+        private static readonly Color _ribbonAppButtonLightColor = Color.FromArgb(175, 178, 189);
 
         private static readonly Color _ribbonAppButtonTextColor = Color.FromArgb(24, 24, 24);
 
@@ -188,15 +188,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(224, 225, 231), // FormBorderActive
             Color.FromArgb(195, 198, 209), // FormBorderInactive
             Color.FromArgb(224, 225, 231), // FormBorderActiveLight
-            Color.FromArgb(195, 198, 209), // FormBorderActiveDark
+            Color.FromArgb(224, 225, 231), // FormBorderActiveDark
             Color.FromArgb(224, 225, 231), // FormBorderInactiveLight
             Color.FromArgb(195, 198, 209), // FormBorderInactiveDark
             Color.FromArgb(224, 225, 231), // FormBorderHeaderActive
             Color.FromArgb(195, 198, 209), // FormBorderHeaderInactive
             Color.FromArgb(224, 225, 231), // FormBorderHeaderActive1
-            Color.FromArgb(195, 198, 209), // FormBorderHeaderActive2
+            Color.FromArgb(224, 225, 231), // FormBorderHeaderActive2
             Color.FromArgb(224, 225, 231), // FormBorderHeaderInctive1
-            Color.FromArgb(195, 198, 209), // FormBorderHeaderInctive2
+            Color.FromArgb(224, 225, 231), // FormBorderHeaderInctive2
             Color.FromArgb(53, 110, 170), // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
@@ -220,12 +220,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextNormal
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(190, 190, 190), // RibbonTabSelected1
-            Color.FromArgb(198, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(247, 248, 249), // RibbonTabSelected3
+            Color.FromArgb(248, 248, 248), // RibbonTabSelected2
+            Color.FromArgb(214, 216, 221), // RibbonTabSelected3
             Color.FromArgb(245, 245, 247), // RibbonTabSelected4
             Color.FromArgb(239, 234, 241), // RibbonTabSelected5
-            Color.FromArgb(189, 190, 193), // RibbonTabTracking1
-            Color.FromArgb(255, 180, 86), // RibbonTabTracking2
+            Color.FromArgb(232, 234, 244), // RibbonTabTracking1
+            Color.FromArgb(214, 216, 221), // RibbonTabTracking2
             Color.FromArgb(255, 255, 189), // RibbonTabHighlight1
             Color.FromArgb(249, 237, 198), // RibbonTabHighlight2
             Color.FromArgb(218, 185, 127), // RibbonTabHighlight3
@@ -234,11 +234,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(175, 176, 179), // RibbonTabSeparatorColor
             Color.FromArgb(190, 190, 190), // RibbonGroupsArea1
             Color.FromArgb(210, 210, 210), // RibbonGroupsArea2
-            Color.FromArgb(213, 219, 231), // RibbonGroupsArea3
+            Color.FromArgb(195, 198, 209), // RibbonGroupsArea3
             Color.FromArgb(249, 249, 249), // RibbonGroupsArea4
             Color.FromArgb(243, 245, 249), // RibbonGroupsArea5
-            Color.FromArgb(189, 191, 193), // RibbonGroupBorder1
-            Color.FromArgb(133, 133, 133), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             Color.FromArgb(223, 227, 239), // RibbonGroupTitle1
             Color.FromArgb(195, 199, 209), // RibbonGroupTitle2
             Color.FromArgb(183, 183, 183), // RibbonGroupBorderContext1
@@ -273,7 +273,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -283,9 +283,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(190, 190, 190), // RibbonQATMini1
+            Color.FromArgb(224, 225, 231), // RibbonQATMini2
+            Color.FromArgb(224, 225, 231), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
             Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
@@ -293,15 +293,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(224, 225, 231), // RibbonQATFullbar1
+            Color.FromArgb(224, 225, 231), // RibbonQATFullbar2
+            Color.FromArgb(210, 210, 210), // RibbonQATFullbar3
+            Color.FromArgb(186, 186, 186), // RibbonQATButtonDark
+            Color.FromArgb(238, 238, 244), // RibbonQATButtonLight
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
             Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
             Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
@@ -354,14 +354,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking3
+            Color.FromArgb(194, 197, 204), // RibbonTabTracking3
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder3
+            Color.FromArgb(190, 190, 190), // RibbonGroupBorder4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
             Color.FromArgb(76, 83, 92), // RibbonGroupTitleText
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
+            Color.FromArgb(173, 177, 181), // RibbonDropArrowLight
+            Color.FromArgb(76, 83, 92), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
@@ -4074,9 +4074,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return PaletteRibbonColorStyle.RibbonAppMenuOuter;
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.CheckedNormal
-                        ? PaletteRibbonColorStyle.RibbonQATMinibarDouble
-                        : PaletteRibbonColorStyle.RibbonQATMinibarSingle;
+                    return PaletteRibbonColorStyle.RibbonQATMinibarDouble;
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
                     return PaletteRibbonColorStyle.RibbonQATFullbarSquare;
@@ -4116,6 +4114,7 @@ namespace Krypton.Toolkit
                     {
                         case PaletteState.Normal:
                         case PaletteState.CheckedNormal:
+                            return PaletteRibbonColorStyle.LinearBorder2;
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextCheckedNormal:
                             return PaletteRibbonColorStyle.Empty;
@@ -4201,7 +4200,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
 
@@ -4304,7 +4303,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
 
@@ -4425,7 +4424,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
                     return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
 
@@ -4509,7 +4508,7 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
 
@@ -4608,7 +4607,7 @@ namespace Krypton.Toolkit
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
                     return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
-                    return state == PaletteState.Normal
+                    return state == PaletteState.CheckedNormal
                         ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
                         : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -188,12 +188,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(144, 154, 166), // FormBorderActive
             Color.FromArgb(162, 173, 185), // FormBorderInactive
             Color.FromArgb(187, 206, 230), // FormBorderActiveLight
-            Color.FromArgb(212, 230, 245), // FormBorderActiveDark
+            Color.FromArgb(187, 206, 230), // FormBorderActiveDark
             Color.FromArgb(223, 235, 247), // FormBorderInactiveLight
             Color.FromArgb(223, 235, 247), // FormBorderInactiveDark
             Color.FromArgb(144, 154, 166), // FormBorderHeaderActive
             Color.FromArgb(162, 173, 185), // FormBorderHeaderInactive
-            Color.FromArgb(193, 212, 236), // FormBorderHeaderActive1
+            Color.FromArgb(187, 206, 230), // FormBorderHeaderActive1
             Color.FromArgb(187, 206, 230), // FormBorderHeaderActive2
             Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive1
             Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive2
@@ -220,12 +220,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(30, 57, 91), // RibbonTabTextNormal
             Color.FromArgb(30, 57, 91), // RibbonTabTextChecked
             Color.FromArgb(159, 178, 199), // RibbonTabSelected1
-            Color.FromArgb(245, 250, 255), // RibbonTabSelected2
-            Color.FromArgb(239, 246, 253), // RibbonTabSelected3
+            Color.FromArgb(225, 237, 250), // RibbonTabSelected2
+            Color.FromArgb(187, 206, 230), // RibbonTabSelected3
             Color.FromArgb(239, 246, 253), // RibbonTabSelected4
             Color.FromArgb(239, 246, 253), // RibbonTabSelected5
-            Color.FromArgb(159, 178, 199), // RibbonTabTracking1
-            Color.FromArgb(237, 241, 247), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(159, 178, 199), // RibbonTabHighlight1
             Color.FromArgb(245, 250, 255), // RibbonTabHighlight2
             Color.FromArgb(239, 246, 253), // RibbonTabHighlight3
@@ -237,16 +237,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(239, 246, 253), // RibbonGroupsArea3
             Color.FromArgb(221, 234, 247), // RibbonGroupsArea4
             Color.FromArgb(216, 228, 242), // RibbonGroupsArea5
-            Color.FromArgb(235, 240, 246), // RibbonGroupBorder1
-            Color.FromArgb(240, 246, 252), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, //Color.FromArgb(235, 240, 246), // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, //Color.FromArgb(240, 246, 252), // RibbonGroupBorder2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext2
-            Color.FromArgb(135, 142, 152), // RibbonGroupDialogDark
-            Color.FromArgb(165, 174, 183), // RibbonGroupDialogLight
+            Color.FromArgb(56, 78, 115), // RibbonGroupDialogDark
+            Color.FromArgb(221, 234, 247), // RibbonGroupDialogLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking2
             Color.FromArgb(139, 160, 188), // RibbonMinimizeBarDark
@@ -283,25 +283,25 @@ namespace Krypton.Toolkit
             Color.FromArgb(158, 193, 241), // FormButtonBorderCheck
             Color.FromArgb(140, 184, 229), // FormButtonBack1CheckTrack
             Color.FromArgb(225, 241, 255), // FormButtonBack2CheckTrack
-            Color.FromArgb(154, 179, 213), // RibbonQATMini1
-            Color.FromArgb(219, 231, 247), // RibbonQATMini2
-            Color.FromArgb(195, 213, 236), // RibbonQATMini3
-            Color.FromArgb(128, Color.White), // RibbonQATMini4
+            Color.FromArgb(114, 142, 173), // RibbonQATMini1
+            Color.FromArgb(187, 206, 230), // RibbonQATMini2
+            Color.FromArgb(187, 206, 230), // RibbonQATMini3
+            Color.FromArgb(10, Color.White), // RibbonQATMini4
             Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
             Color.FromArgb(72, Color.White), // RibbonQATMini5I
-            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1
-            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2
+            Color.FromArgb(187, 206, 230), // RibbonQATFullbar1
+            Color.FromArgb(187, 206, 230), // RibbonQATFullbar2
             Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
-            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight
+            Color.FromArgb(114, 142, 173), // RibbonQATButtonDark
+            Color.FromArgb(221, 234, 247), // RibbonQATButtonLight
             Color.FromArgb(222, 236, 252), // RibbonQATOverflow1
             Color.FromArgb(123, 139, 156), // RibbonQATOverflow2
             Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark
-            Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
             Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
             Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
@@ -354,11 +354,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(242, 247, 252), // RibbonGalleryBackTracking
             Color.FromArgb(237, 245, 253), // RibbonGalleryBack1
             Color.FromArgb(206, 221, 237), // RibbonGalleryBack2
-            Color.FromArgb(214, 222, 234), // RibbonTabTracking3
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(200, 215, 233), // RibbonTabTracking4
             Color.FromArgb(147, 167, 195), // RibbonGroupBorder3
-            Color.FromArgb(226, 236, 247), // RibbonGroupBorder4
-            Color.FromArgb(251, 251, 252), // RibbonGroupBorder5
+            Color.FromArgb(147, 167, 195), // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
             Color.FromArgb(56, 78, 115), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
             Color.FromArgb(39, 49, 60), // RibbonDropArrowDark

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -196,14 +196,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(44, 44, 44), // ToolStripBorder
             Color.FromArgb(99, 99, 99), // FormBorderActive
             Color.FromArgb(119, 119, 119), // FormBorderInactive
-            Color.FromArgb(113, 113, 113), // FormBorderActiveLight
-            Color.FromArgb(131, 131, 131), // FormBorderActiveDark
+            Color.FromArgb(99, 99, 99), // FormBorderActiveLight
+            Color.FromArgb(99, 99, 99), // FormBorderActiveDark
             Color.FromArgb(158, 158, 158), // FormBorderInactiveLight
             Color.FromArgb(158, 158, 158), // FormBorderInactiveDark
             Color.FromArgb(65, 65, 65), // FormBorderHeaderActive
             Color.FromArgb(154, 154, 154), // FormBorderHeaderInactive
-            Color.FromArgb(121, 121, 121), // FormBorderHeaderActive1
-            Color.FromArgb(113, 113, 113), // FormBorderHeaderActive2
+            Color.FromArgb(99, 99, 99), // FormBorderHeaderActive1
+            Color.FromArgb(99, 99, 99), // FormBorderHeaderActive2
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive1
             Color.FromArgb(158, 158, 158), // FormBorderHeaderInctive2
             Color.FromArgb(226, 226, 226), // FormHeaderShortActive
@@ -226,16 +226,15 @@ namespace Krypton.Toolkit
             Color.Violet, // LinkVisitedOverridePanel
             Color.FromArgb(255, 90, 90), // LinkPressedOverridePanel
             Color.White, // TextLabelPanel
-            //Color.FromArgb(226, 226, 226),    // RibbonTabTextNormal
             Color.White, // RibbonTabTextNormal
-            Color.Black, // RibbonTabTextChecked
+            Color.White, // RibbonTabTextChecked
             Color.FromArgb(32, 32, 32),    // RibbonTabSelected1
-            Color.FromArgb(201, 201, 201), // RibbonTabSelected2
-            Color.FromArgb(192, 192, 192), // RibbonTabSelected3
+            Color.FromArgb(150, 150, 150), // RibbonTabSelected2
+            Color.FromArgb(99, 99, 99), // RibbonTabSelected3
             Color.FromArgb(192, 192, 192), // RibbonTabSelected4
             Color.FromArgb(192, 192, 192), // RibbonTabSelected5
-            Color.FromArgb(32, 32, 32),    // RibbonTabTracking1
-            Color.FromArgb(183, 183, 183), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88),    // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(32, 32, 32),    // RibbonTabHighlight1
             Color.FromArgb(201, 201, 201), // RibbonTabHighlight2
             Color.FromArgb(192, 192, 192), // RibbonTabHighlight3
@@ -244,18 +243,18 @@ namespace Krypton.Toolkit
             Color.FromArgb(54, 54, 54), // RibbonTabSeparatorColor
             Color.FromArgb(32, 32, 32), // RibbonGroupsArea1
             Color.FromArgb(50, 50, 50), // RibbonGroupsArea2
-            Color.FromArgb(32, 32, 32), // RibbonGroupsArea3
+            Color.FromArgb(54, 54, 54), // RibbonGroupsArea3
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea4
             Color.FromArgb(33, 33, 33), // RibbonGroupsArea5
-            Color.FromArgb(159, 159, 159), // RibbonGroupBorder1
-            Color.FromArgb(194, 194, 194), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext2
-            Color.FromArgb(92, 92, 94), // RibbonGroupDialogDark
+            Color.FromArgb(237, 237, 237), // RibbonGroupDialogDark
             Color.FromArgb(123, 125, 125), // RibbonGroupDialogLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking2
@@ -283,7 +282,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(167, 167, 168), // RibbonGroupFrameInside2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside4
-            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText         
+            Color.FromArgb(255, 255, 255), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -293,9 +292,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(18, 18, 18), // FormButtonBorderCheck
             Color.FromArgb(33, 45, 57), // FormButtonBack1CheckTrack
             Color.FromArgb(136, 152, 170), // FormButtonBack2CheckTrack
-            Color.FromArgb(55, 55, 55), // RibbonQATMini1
-            Color.FromArgb(100, 100, 100), // RibbonQATMini2
-            Color.FromArgb(73, 73, 73), // RibbonQATMini3
+            Color.FromArgb(32, 32, 32), // RibbonQATMini1
+            Color.FromArgb(99, 99, 99), // RibbonQATMini2
+            Color.FromArgb(99, 99, 99), // RibbonQATMini3
             Color.FromArgb(12, Color.White), // RibbonQATMini4
             Color.FromArgb(14, Color.White), // RibbonQATMini5
             Color.FromArgb(100, 100, 100), // RibbonQATMini1I
@@ -303,15 +302,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1
-            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2
-            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
-            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight
+            Color.FromArgb(99, 99, 99), // RibbonQATFullbar1
+            Color.FromArgb(99, 99, 99), // RibbonQATFullbar2
+            Color.FromArgb(50, 50, 50), // RibbonQATFullbar3
+            Color.FromArgb(50, 50, 50), // RibbonQATButtonDark
+            Color.FromArgb(140, 140, 140), // RibbonQATButtonLight
             Color.FromArgb(161, 161, 161), // RibbonQATOverflow1
             Color.FromArgb(68, 68, 68), // RibbonQATOverflow2
-            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark
-            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight
+            Color.FromArgb(32, 32, 32), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
             Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
             Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
@@ -364,14 +363,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(193, 193, 193), // RibbonGalleryBackTracking
             Color.FromArgb(176, 176, 176), // RibbonGalleryBack1
             Color.FromArgb(150, 150, 150), // RibbonGalleryBack2
-            Color.FromArgb(148, 149, 151), // RibbonTabTracking3
-            Color.FromArgb(127, 127, 127), // RibbonTabTracking4
-            Color.FromArgb(82, 82, 82), // RibbonGroupBorder3
-            Color.FromArgb(176, 176, 176), // RibbonGroupBorder4
-            Color.FromArgb(178, 178, 178), // RibbonGroupBorder5
-            Color.White, // FromArgb(36, 36, 36), // RibbonGroupTitleText
-            Color.FromArgb(155, 157, 160), // RibbonDropArrowLight
-            Color.FromArgb(27, 29, 40), // RibbonDropArrowDark
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
+            GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
+            Color.FromArgb(32, 32, 32), // RibbonGroupBorder3
+            Color.FromArgb(32, 32, 32), // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.White, // RibbonGroupTitleText
+            Color.FromArgb(157, 157, 160), // RibbonDropArrowLight
+            Color.FromArgb(237, 237, 237), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
             Color.FromArgb(125, 125, 125), // HeaderDockInactiveBack2
             Color.FromArgb(46, 46, 46), // ButtonNavigatorBorder

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -190,14 +190,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(147, 154, 163), // ToolStripBorder
             Color.FromArgb(101, 109, 117), // FormBorderActive
             Color.FromArgb(134, 139, 145), // FormBorderInactive
-            Color.FromArgb(228, 230, 232), // FormBorderActiveLight
-            Color.FromArgb(255, 255, 255), // FormBorderActiveDark
+            Color.FromArgb(227, 230, 232), // FormBorderActiveLight
+            Color.FromArgb(227, 230, 232), // FormBorderActiveDark
             Color.FromArgb(248, 247, 247), // FormBorderInactiveLight
             Color.FromArgb(248, 247, 247), // FormBorderInactiveDark
             Color.FromArgb(101, 109, 117), // FormBorderHeaderActive
             Color.FromArgb(134, 139, 145), // FormBorderHeaderInactive
-            Color.FromArgb(235, 237, 240), // FormBorderHeaderActive1
-            Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
+            Color.FromArgb(227, 230, 232), // FormBorderHeaderActive1
+            Color.FromArgb(227, 230, 232), // FormBorderHeaderActive2
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
             Color.FromArgb(59, 59, 59), // FormHeaderShortActive
@@ -224,11 +224,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(76, 83, 92), // RibbonTabTextChecked
             Color.FromArgb(182, 186, 191), // RibbonTabSelected1
             Color.White, // RibbonTabSelected2
-            Color.White, // RibbonTabSelected3
+            Color.FromArgb(227, 230, 232), // RibbonTabSelected3
             Color.White, // RibbonTabSelected4
             Color.White, // RibbonTabSelected5
-            Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(248, 249, 249), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(182, 186, 191), // RibbonTabHighlight1
             Color.White, // RibbonTabHighlight2
             Color.White, // RibbonTabHighlight3
@@ -240,16 +240,16 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGroupsArea3
             Color.FromArgb(255, 255, 255), // RibbonGroupsArea4
             Color.FromArgb(229, 233, 238), // RibbonGroupsArea5
-            Color.FromArgb(255, 255, 255), // RibbonGroupBorder1
-            Color.FromArgb(253, 253, 253), // RibbonGroupBorder2
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext2
-            Color.FromArgb(148, 149, 152), // RibbonGroupDialogDark
-            Color.FromArgb(180, 182, 183), // RibbonGroupDialogLight
+            Color.FromArgb(76, 83, 92), // RibbonGroupDialogDark
+            Color.FromArgb(227, 230, 232), // RibbonGroupDialogLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking2
             Color.FromArgb(139, 144, 151), // RibbonMinimizeBarDark
@@ -286,9 +286,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(182, 186, 191), // RibbonQATMini1
+            Color.FromArgb(227, 230, 232), // RibbonQATMini2
+            Color.FromArgb(227, 230, 232), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
             Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
@@ -296,15 +296,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
+            Color.FromArgb(227, 230, 232), // RibbonQATFullbar1
+            Color.FromArgb(227, 230, 232), // RibbonQATFullbar2
             Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(166, 172, 179), // RibbonQATButtonDark
             Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
-            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
-            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
+            Color.FromArgb(182, 186, 191), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
             Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
             Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
@@ -356,13 +356,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2 //Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
-            Color.FromArgb(229, 231, 235), // RibbonTabTracking3
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2 
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
-            Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
-            Color.FromArgb(246, 247, 248), // RibbonGroupBorder4
-            Color.FromArgb(249, 250, 250), // RibbonGroupBorder5
-            Color.FromArgb(102, 109, 124), // RibbonGroupTitleText
+            Color.FromArgb(182, 186, 191), // RibbonGroupBorder3
+            Color.FromArgb(182, 186, 191), // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(59, 59, 59), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
             Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -184,14 +184,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(147, 154, 163), // ToolStripBorder
             Color.FromArgb(0, 114, 198), // FormBorderActive -n
             Color.FromArgb(134, 139, 145), // FormBorderInactive
-            Color.FromArgb(228, 230, 232), // FormBorderActiveLight
+            Color.FromArgb(255, 255, 255), // FormBorderActiveLight
             Color.FromArgb(255, 255, 255), // FormBorderActiveDark
             Color.FromArgb(248, 247, 247), // FormBorderInactiveLight
             Color.FromArgb(248, 247, 247), // FormBorderInactiveDark
             Color.FromArgb(101, 109, 117), // FormBorderHeaderActive
             Color.FromArgb(134, 139, 145), // FormBorderHeaderInactive
-            Color.FromArgb(235, 237, 240), // FormBorderHeaderActive1
-            Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
+            Color.FromArgb(255, 255, 255), // FormBorderHeaderActive1
+            Color.FromArgb(255, 255, 255), // FormBorderHeaderActive2
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
             Color.FromArgb(59, 59, 59),    // FormHeaderShortActive
@@ -214,15 +214,15 @@ namespace Krypton.Toolkit
             Color.Purple, // LinkVisitedOverridePanel
             Color.Red, // LinkPressedOverridePanel
             Color.FromArgb(59, 59, 59), // TextLabelPanel
-            Color.FromArgb(102, 102, 102), // RibbonTabTextNormal -n
-            Color.FromArgb(0, 114, 198), // RibbonTabTextChecked -n
+            Color.FromArgb(90, 90, 90), // RibbonTabTextNormal -n
+            Color.FromArgb(59, 59, 59), // RibbonTabTextChecked -n
             Color.FromArgb(182, 186, 191), // RibbonTabSelected1
-            Color.White, // RibbonTabSelected2
+            Color.FromArgb(248, 247, 247), // RibbonTabSelected2
             Color.White, // RibbonTabSelected3
             Color.White, // RibbonTabSelected4
             Color.White, // RibbonTabSelected5
-            Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(248, 249, 249), // RibbonTabTracking2
+            Color.FromArgb(237, 201, 88), // RibbonTabTracking1
+            Color.FromArgb(248, 225, 135), // RibbonTabTracking2
             Color.FromArgb(182, 186, 191), // RibbonTabHighlight1
             Color.White, // RibbonTabHighlight2
             Color.White, // RibbonTabHighlight3
@@ -231,7 +231,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(182, 186, 191), // RibbonTabSeparatorColor
             Color.FromArgb(212, 212, 212), // RibbonGroupsArea1 -n
             Color.FromArgb(212, 212, 212), // RibbonGroupsArea2 -n
-            Color.White, // RibbonGroupsArea3 -n
+            Color.FromArgb(223, 223, 223), // RibbonGroupsArea3 -n
             Color.White, // RibbonGroupsArea4 -n
             Color.White, // RibbonGroupsArea5 -n
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1 -n
@@ -242,8 +242,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext2
-            Color.FromArgb(148, 149, 152), // RibbonGroupDialogDark
-            Color.FromArgb(180, 182, 183), // RibbonGroupDialogLight
+            Color.FromArgb(102, 109, 124), // RibbonGroupDialogDark
+            Color.FromArgb(240, 240, 240), // RibbonGroupDialogLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking2
             Color.FromArgb(207, 212, 218), // RibbonMinimizeBarDark
@@ -280,9 +280,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
             Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
             Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
+            Color.FromArgb(176, 182, 188), // RibbonQATMini1
+            Color.FromArgb(255, 255, 255), // RibbonQATMini2
+            Color.FromArgb(255, 255, 255), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
             Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
@@ -290,15 +290,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
             Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
+            Color.FromArgb(255, 255, 255), // RibbonQATFullbar1
+            Color.FromArgb(255, 255, 255), // RibbonQATFullbar2
+            Color.FromArgb(212, 212, 212), // RibbonQATFullbar3
+            Color.FromArgb(176, 182, 188), // RibbonQATButtonDark
+            Color.FromArgb(223, 223, 223), // RibbonQATButtonLight
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
-            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
-            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
+            Color.FromArgb(176, 182, 188), // RibbonGroupSeparatorDark
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupSeparatorLight
             Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
             Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
             Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
@@ -350,15 +350,15 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2                        //Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(229, 231, 235), // RibbonTabTracking3
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2
+            Color.FromArgb(251, 248, 224), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
-            Color.FromArgb(246, 247, 248), // RibbonGroupBorder4
-            Color.FromArgb(249, 250, 250), // RibbonGroupBorder5
-            Color.FromArgb(102, 109, 124), // RibbonGroupTitleText
+            Color.FromArgb(176, 182, 188), // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(90, 90, 90), // RibbonGroupTitleText
             Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
-            Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
+            Color.FromArgb(99, 59, 59), // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
             Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
             Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2055,6 +2055,8 @@ namespace Krypton.Toolkit
                     return DrawRibbonLinear(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.LinearBorder:
                     return DrawRibbonLinearBorder(context, rect, state, palette, memento);
+                case PaletteRibbonColorStyle.LinearBorder2:
+                    return DrawRibbonLinearBorder2(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.RibbonAppMenuInner:
                     return DrawRibbonAppMenuInner(context, rect, state, palette, memento);
                 case PaletteRibbonColorStyle.RibbonAppMenuOuter:
@@ -2978,20 +2980,20 @@ namespace Krypton.Toolkit
             // TODO: WagnerP - please provide a better way of doing this for Various themes and dpi's
             if (shape == PaletteRibbonShape.Office2010)
             {
-                context.Graphics.DrawLine(darkPen, displayRect.Left - 1, displayRect.Top, displayRect.Right + 1, displayRect.Top);
-                context.Graphics.DrawLine(lightPen, displayRect.Left - 1, displayRect.Top + 1, displayRect.Right + 1, displayRect.Top + 1);
-            }
-            else
-            {
-                context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top, displayRect.Right, displayRect.Top);
-                context.Graphics.DrawLine(lightPen, displayRect.Left, displayRect.Top + 1, displayRect.Right, displayRect.Top + 1);
-            }
+                context.Graphics.DrawLine(darkPen, displayRect.Left - 1, displayRect.Top, displayRect.Right, displayRect.Top);
+            context.Graphics.DrawLine(lightPen, displayRect.Left - 1, displayRect.Top + 1, displayRect.Right, displayRect.Top + 1);
+        }
+        else
+        {
+            context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top, displayRect.Right - 1 , displayRect.Top);
+            context.Graphics.DrawLine(lightPen, displayRect.Left, displayRect.Top + 1, displayRect.Right - 1, displayRect.Top + 1);
+        }
 
-            context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top + 3, displayRect.Right, displayRect.Top + 3);
-            context.Graphics.DrawLine(darkPen, displayRect.Right - 1, displayRect.Top + 4, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4);
-            context.Graphics.DrawLine(darkPen, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4, displayRect.Left, displayRect.Top + 3);
-            context.Graphics.DrawLine(lightPen, displayRect.Left + 1, displayRect.Top + 5, displayRect.Left + displayRect.Width / 2 - 1, displayRect.Bottom - 5);
-            context.Graphics.DrawLine(lightPen, displayRect.Left + displayRect.Width / 2 + 1, displayRect.Bottom - 5, displayRect.Right - 1, displayRect.Top + 5);
+        context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top + 3, displayRect.Right -1, displayRect.Top + 3);
+        context.Graphics.DrawLine(darkPen, displayRect.Right - 2, displayRect.Top + 4, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 5);
+        context.Graphics.DrawLine(darkPen, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 5, displayRect.Left + 1, displayRect.Top + 4);
+        context.Graphics.DrawLine(lightPen, displayRect.Left + 7, displayRect.Top + 5, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4);
+        context.Graphics.DrawLine(lightPen, displayRect.Left + displayRect.Width / 2, displayRect.Bottom - 4, displayRect.Right - 8, displayRect.Top + 5);
         }
 
         /// <summary>
@@ -11742,6 +11744,58 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left + 2, rect.Bottom - 1, rect.Left, rect.Bottom - 3);
                     borderPath.AddLine(rect.Left, rect.Bottom - 3, rect.Left, rect.Top + 2);
                     borderPath.AddLine(rect.Left, rect.Top + 2, rect.Left + 2, rect.Top);
+                    cache.BorderPath = borderPath;
+                }
+
+                context.Graphics.DrawPath(cache.LinearPen!, cache.BorderPath!);
+            }
+
+            return memento;
+        }
+
+        /// <summary>
+        /// Internal rendering method.
+        /// </summary>
+        protected virtual IDisposable? DrawRibbonLinearBorder2(RenderContext context,
+                                                             Rectangle rect,
+                                                             PaletteState state,
+                                                             IPaletteRibbonBack palette,
+                                                             IDisposable? memento)
+        {
+            if (rect is { Width: > 0, Height: > 0 })
+            {
+                Color c1 = palette.GetRibbonBackColor1(state);
+                Color c2 = palette.GetRibbonBackColor2(state);
+
+                var generate = true;
+                MementoRibbonLinearBorder cache;
+
+                // Access a cache instance and decide if cache resources need generating
+                if (memento is MementoRibbonLinearBorder border)
+                {
+                    cache = border;
+                    generate = !cache.UseCachedValues(rect, c1, c2);
+                }
+                else
+                {
+                    memento?.Dispose();
+
+                    cache = new MementoRibbonLinearBorder(rect, c1, c2);
+                    memento = cache;
+                }
+
+                // Do we need to generate the contents of the cache?
+                if (generate)
+                {
+                    // Dispose of existing values
+                    cache.Dispose();
+
+                    cache.LinearBrush = new LinearGradientBrush(new RectangleF(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 1), c1, c2, 90f);
+                    cache.LinearPen = new Pen(cache.LinearBrush);
+
+                    // Create the complete border
+                    var borderPath = new GraphicsPath();
+                    borderPath.AddRectangle(new Rectangle(rect.X, rect.Y, rect.Width, rect.Height - 1));
                     cache.BorderPath = borderPath;
                 }
 


### PR DESCRIPTION
Resolve [[Bug]: Tabs on Ribbon don't have borders. #2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512).

Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. 
Adjusted the design of the `RibbonQATButton`.

Before:
<img width="892" height="231" alt="image" src="https://github.com/user-attachments/assets/2afb42ae-7bbc-4df7-8e37-4d4ad37c82b7" />

After:
<img width="899" height="227" alt="image" src="https://github.com/user-attachments/assets/efaeea71-981d-465b-a554-fd1703d09767" />


<img width="526" height="180" alt="image" src="https://github.com/user-attachments/assets/75db91cb-d95e-4a4e-ba73-ce2f0a4aedda" />