### PR TITLE
* `KryptonForm` dimensions

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2525](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2525), `KryptonForm` dimensions
 * Resolved [#2461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2461), (feat) Add `KryptonCalcInput` edit+dropdown control.
 * Resolved [#2480](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2480). `KryptonForm`'s 'InternalPanel' designer issues
 * Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -516,7 +516,20 @@ public abstract class VisualForm : Form,
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Padding RealWindowBorders => CommonHelper.GetWindowBorders(CreateParams, this as KryptonForm);
+    public Padding RealWindowBorders
+    {
+        get
+        {
+            // During design mode, use stable border values to prevent dimension changes
+            if (DesignMode)
+            {
+                // Use standard Windows form border values for design mode stability
+                return new Padding(8, 31, 8, 8); // Standard Windows form borders
+            }
+            
+            return CommonHelper.GetWindowBorders(CreateParams, this as KryptonForm);
+        }
+    }
 
     /// <summary>
     /// Gets a count of the number of paints that have occurred.


### PR DESCRIPTION
* Resolves #2525 

<img width="674" height="126" alt="image" src="https://github.com/user-attachments/assets/ae90a162-38c8-4ad1-90d4-f85e0cac04c0" />

(Warnings unrelated to this PR)