### PR TITLE
* `KryptonForm` still displays part of the Title when `FormBorderStyle` is set to `None`

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
-* Resolved [#2454](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2454), `KryptonForm` still displays part of the Title when `FormBorderStyle` is set to ``None`
+* Resolved [#2454](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2454), `KryptonForm` still displays part of the Title when `FormBorderStyle` is set to `None`
 * Resolved [#2461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2461), (feat) Add `KryptonCalcInput` edit+dropdown control.
 * Resolved [#2480](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2480). `KryptonForm`'s 'InternalPanel' designer issues
 * Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2454](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2454), `KryptonForm` still displays part of the Title when `FormBorderStyle` is set to ``None`
 * Resolved [#2461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2461), (feat) Add `KryptonCalcInput` edit+dropdown control.
 * Resolved [#2480](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2480). `KryptonForm`'s 'InternalPanel' designer issues
 * Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1552,6 +1552,9 @@ public class KryptonForm : VisualForm,
         // correct initial size and position of the window when first shown
         base.OnLoad(e);
 
+        // Ensure title bar visibility is correctly set based on FormBorderStyle
+        OnFormBorderStyleChanged();
+
         // We only apply custom chrome when control is already created and positioned
         UpdateUseThemeFormChromeBorderWidthDecision();
 
@@ -2194,6 +2197,8 @@ public class KryptonForm : VisualForm,
                 MinimizeBox = false;
                 MaximizeBox = false;
                 CloseBox = false;
+                // Hide the title bar completely when FormBorderStyle is None
+                _headingFixedSize.Visible = false;
                 break;
 
             case FormBorderStyle.FixedSingle:
@@ -2204,6 +2209,8 @@ public class KryptonForm : VisualForm,
                 MinimizeBox = true;
                 MaximizeBox = true;
                 CloseBox = true;
+                // Show the title bar for all other border styles
+                _headingFixedSize.Visible = true;
                 break;
 
             case FormBorderStyle.FixedToolWindow:
@@ -2212,6 +2219,8 @@ public class KryptonForm : VisualForm,
                 MinimizeBox = false;
                 MaximizeBox = false;
                 CloseBox = true;
+                // Show the title bar for tool window styles
+                _headingFixedSize.Visible = true;
                 break;
         }
     }


### PR DESCRIPTION
* Resolved #2454 

<img width="667" height="120" alt="image" src="https://github.com/user-attachments/assets/430417ed-619b-4965-9f50-6e7705a5067e" />

(Warnings not related to this PR)