### PR TITLE
2548-V100-Fixed-color-assignment-in-PopulateFromBase

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548), Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.
 * Resolved [#2461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2461), (feat) Add `KryptonCalcInput` edit+dropdown control.
 * Resolved [#2480](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2480). `KryptonForm`'s 'InternalPanel' designer issues
 * Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
@@ -161,8 +161,8 @@ public class PaletteRibbonGeneral : Storage,
         TabSeparatorContextColor = GetRibbonTabSeparatorContextColor(PaletteState.Normal);
         TextFont = GetRibbonTextFont(PaletteState.Normal);
         TextHint = GetRibbonTextHint(PaletteState.Normal);
-        QATButtonDarkColor = GetRibbonGroupDialogDark(PaletteState.Normal);
-        QATButtonLightColor = GetRibbonGroupDialogLight(PaletteState.Normal);
+        QATButtonDarkColor = GetRibbonQATButtonDark(PaletteState.Normal);
+        QATButtonLightColor = GetRibbonQATButtonLight(PaletteState.Normal);
     }
     #endregion
 
@@ -535,8 +535,8 @@ public class PaletteRibbonGeneral : Storage,
             }
         }
     }
-    private void ResetGroupSeparatorLight() => GroupDialogLight = GlobalStaticValues.EMPTY_COLOR;
-    private bool ShouldSerializeGroupSeparatorLight() => GroupDialogLight != GlobalStaticValues.EMPTY_COLOR;
+    private void ResetGroupSeparatorLight() => GroupSeparatorLight = GlobalStaticValues.EMPTY_COLOR;
+    private bool ShouldSerializeGroupSeparatorLight() => GroupSeparatorLight != GlobalStaticValues.EMPTY_COLOR;
 
     /// <summary>
     /// Gets the color for the dialog launcher light.


### PR DESCRIPTION
Resolve [[Bug]: PopulateFromBase incorrectly assigns the GroupSeparatorLight, QATButtonDarkColor, and QATButtonLightColor colors. #2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548).

Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.

<img width="535" height="154" alt="image" src="https://github.com/user-attachments/assets/b9d7b3a9-9537-4b8c-a285-4415cb7b6b27" />
