### PR TITLE
1376-V100-Extending-KryptonTaskDialog

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler1.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler1.cs
@@ -9,7 +9,12 @@
 
 namespace Krypton.Toolkit;
 
-public class KryptonTaskDialogElementFreeWheeler : KryptonTaskDialogElementSingleLineControlBase,
+/// <summary>
+/// KryptonTaskDialogElementFreeWheeler1 exposes a FlowLayoutPanel with full access to it's properties.<br/>
+/// Here you can host a choice of controls within KryptonTaskDialog.<br/>
+/// Note: Some controls do not work well with a FlowLayoutPanel. For those use KryptonTaskDialogElementFreeWheeler2 which exposes TableLayoutPanel.
+/// </summary>
+public class KryptonTaskDialogElementFreeWheeler1 : KryptonTaskDialogElementSingleLineControlBase,
     IKryptonTaskDialogElementHeight
 {
     #region Fields
@@ -17,7 +22,7 @@ public class KryptonTaskDialogElementFreeWheeler : KryptonTaskDialogElementSingl
     #endregion
 
     #region Identity
-    public KryptonTaskDialogElementFreeWheeler(KryptonTaskDialogDefaults taskDialogDefaults) : base(taskDialogDefaults, 1)
+    public KryptonTaskDialogElementFreeWheeler1(KryptonTaskDialogDefaults taskDialogDefaults) : base(taskDialogDefaults, 1)
     {
         _flp = new();
         SetupPanel();
@@ -37,11 +42,11 @@ public class KryptonTaskDialogElementFreeWheeler : KryptonTaskDialogElementSingl
         _flp.SetDoubleBuffered(true);
         _flp.Padding = Defaults.NullPadding;
         _flp.Margin = Defaults.NullMargin;
-        _tlp.Dock = DockStyle.Fill;
         _flp.Size = _tlp.Size;
         _flp.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
     }
     #endregion
+
     #region Public
     /// <summary>
     /// The internal FlowLayoutPanel to add your controls to.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
@@ -55,7 +55,7 @@ public class KryptonTaskDialogElementFreeWheeler2 : KryptonTaskDialogElementSing
 
     #region Public
     /// <summary>
-    /// The internal FlowLayoutPanel to add your controls to.
+    /// The internal TableLayoutPanel to add your controls to.
     /// </summary>
     public TableLayoutPanel TableLayoutPanel => _tlpExposed;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
@@ -46,7 +46,7 @@ public class KryptonTaskDialogElementFreeWheeler2 : KryptonTaskDialogElementSing
         _tlpExposed.RowCount = 1;
         _tlpExposed.ColumnCount = 1;
 
-        _tlp.RowStyles.Clear();
+        _tlpExposed.RowStyles.Clear();
         _tlpExposed.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         _tlpExposed.RowStyles.Clear();
         _tlpExposed.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
@@ -48,7 +48,8 @@ public class KryptonTaskDialogElementFreeWheeler2 : KryptonTaskDialogElementSing
 
         _tlpExposed.RowStyles.Clear();
         _tlpExposed.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        _tlpExposed.RowStyles.Clear();
+
+        _tlpExposed.ColumnStyles.Clear();
         _tlpExposed.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
     }
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
@@ -42,6 +42,14 @@ public class KryptonTaskDialogElementFreeWheeler2 : KryptonTaskDialogElementSing
         _tlpExposed.Padding = Defaults.NullPadding;
         _tlpExposed.Margin = Defaults.NullMargin;
         _tlpExposed.Dock = DockStyle.Fill;
+
+        _tlpExposed.RowCount = 1;
+        _tlpExposed.ColumnCount = 1;
+
+        _tlp.RowStyles.Clear();
+        _tlpExposed.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        _tlpExposed.RowStyles.Clear();
+        _tlpExposed.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFreeWheeler2.cs
@@ -1,0 +1,70 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// KryptonTaskDialogElementFreeWheeler2 exposes a TableLayoutPanel with full access to it's properties.<br/>
+/// Here you can host a choice of controls within KryptonTaskDialog.<br/>
+/// </summary>
+public class KryptonTaskDialogElementFreeWheeler2 : KryptonTaskDialogElementSingleLineControlBase,
+    IKryptonTaskDialogElementHeight
+{
+    #region Fields
+    private TableLayoutPanel _tlpExposed;
+    #endregion
+
+    #region Identity
+    public KryptonTaskDialogElementFreeWheeler2(KryptonTaskDialogDefaults taskDialogDefaults) : base(taskDialogDefaults, 1)
+    {
+        _tlpExposed = new();
+        SetupPanel();
+    }
+    #endregion
+
+    #region Private
+    private void SetupPanel()
+    {
+        _tlp.SetDoubleBuffered(true);
+        _tlp.Controls.Add(_tlpExposed, 0, 0);
+        _tlp.Padding = Defaults.NullPadding;
+        _tlp.Margin = new Padding(Defaults.PanelLeft, Defaults.PanelTop, Defaults.PanelRight, Defaults.PanelBottom);
+        _tlp.CellBorderStyle = TableLayoutPanelCellBorderStyle.None;
+        _tlp.Dock = DockStyle.Fill;
+
+        _tlpExposed.SetDoubleBuffered(true);
+        _tlpExposed.Padding = Defaults.NullPadding;
+        _tlpExposed.Margin = Defaults.NullMargin;
+        _tlpExposed.Dock = DockStyle.Fill;
+    }
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// The internal FlowLayoutPanel to add your controls to.
+    /// </summary>
+    public TableLayoutPanel TableLayoutPanel => _tlpExposed;
+
+    /// <inheritdoc/>
+    public int ElementHeight 
+    { 
+        get => Panel.Height; 
+        set
+        {
+            if (Panel.Height != value)
+            {
+                Panel.Height = value;
+                LayoutDirty = true;
+                OnSizeChanged();
+            }
+        }
+    }
+    #endregion
+
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
@@ -40,6 +40,10 @@ public class KryptonTaskDialog : IDisposable
     /// </summary>
     public KryptonTaskDialog(int dialogWidth = 0)
     {
+        if (dialogWidth <= 0)
+        {
+            dialogWidth = 600;
+        }
         _taskDialogDefaults = new(dialogWidth);
 
         // Border-Fixes: filler panel to compensate for the border problems 
@@ -68,13 +72,17 @@ public class KryptonTaskDialog : IDisposable
         // Instantiate the Dialog form properties
         Dialog = new KryptonTaskDialogFormProperties(_form, _elements, _taskDialogDefaults);
 
+        // Default to center screen 
+        Dialog.Form.StartPosition = FormStartPosition.CenterScreen;
+
         // Instantiante all elements
-        Heading            = new KryptonTaskDialogElementHeading(_taskDialogDefaults);
+        Heading = new KryptonTaskDialogElementHeading(_taskDialogDefaults);
         Content            = new KryptonTaskDialogElementContent(_taskDialogDefaults);
         //ContentTest   = new KryptonTaskDialogElementContentTest((_taskDialogDefaults);
         Expander           = new KryptonTaskDialogElementContent(_taskDialogDefaults);
         RichTextBox        = new KryptonTaskDialogElementRichTextBox(_taskDialogDefaults);
-        FreeWheeler        = new KryptonTaskDialogElementFreeWheeler(_taskDialogDefaults);
+        FreeWheeler1       = new KryptonTaskDialogElementFreeWheeler1(_taskDialogDefaults);
+        FreeWheeler2       = new KryptonTaskDialogElementFreeWheeler2(_taskDialogDefaults);
         CommandLinkButtons = new KryptonTaskDialogElementCommandLinkButtons(_taskDialogDefaults);
         CheckBox           = new KryptonTaskDialogElementCheckBox(_taskDialogDefaults);
         HyperLink          = new KryptonTaskDialogElementHyperLink(_taskDialogDefaults);
@@ -90,7 +98,8 @@ public class KryptonTaskDialog : IDisposable
         //_elements.Add(ContentTest);
         _elements.Add(Expander);
         _elements.Add(RichTextBox);
-        _elements.Add(FreeWheeler);
+        _elements.Add(FreeWheeler1);
+        _elements.Add(FreeWheeler2);
 
         //_elements.Add(ElementEmpty);
 
@@ -152,10 +161,19 @@ public class KryptonTaskDialog : IDisposable
     public KryptonTaskDialogElementRichTextBox RichTextBox { get; }
 
     /// <summary>
-    /// The FreeWheeler element exposes only a FlowLayoutPanel (and all it's properties) to which you can add and configure your own set of controls.<br/>
+    /// The FreeWheeler1 element exposes only a FlowLayoutPanel (and all it's properties) to which you can add and configure your own set of controls.<br/>
+    /// Here you can host a choice of controls within KryptonTaskDialog.<br/>
+    /// Note: Some controls do not work well with a FlowLayoutPanel, for those use KryptonTaskDialogElementFreeWheeler2 which exposes TableLayoutPanel.
     /// </summary>
     [TypeConverter(typeof(ExpandableObjectConverter))]
-    public KryptonTaskDialogElementFreeWheeler FreeWheeler { get; }
+    public KryptonTaskDialogElementFreeWheeler1 FreeWheeler1 { get; }
+
+    /// <summary>
+    /// The FreeWheeler2 element exposes only a TableLayoutPanel (and all it's properties) to which you can add and configure your own set of controls.<br/>
+    /// Here you can host a choice of controls within KryptonTaskDialog.<br/>
+    /// </summary>
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public KryptonTaskDialogElementFreeWheeler2 FreeWheeler2 { get; }
 
     /// <summary>
     /// Contains the properties for the CommandLinkButtons element.<br/>
@@ -215,17 +233,33 @@ public class KryptonTaskDialog : IDisposable
     /// <param name="owner">The parent window that launched this dialog.</param>
     public void Show(IWin32Window? owner = null)
     {
-        UpdateFormSizing();
-        UpdateFormPosition(owner);
-        ResetFormDialogResult();
-
-        if (owner is not null)
+        if (!Dialog.Visible)
         {
-            _form.Show(owner);
+            UpdateFormSizing();
+            UpdateFormPosition(owner);
+            ResetFormDialogResult();
+
+            if (owner is not null)
+            {
+                _form.Show(owner);
+            }
+            else
+            {
+                _form.Show();
+            }
         }
         else
         {
-            _form.Show();
+            KryptonMessageBox.Show(
+                "The form is already visible and Show() cannot be called again.",
+                "KryptonTaskDialog",
+                KryptonMessageBoxButtons.OK,
+                KryptonMessageBoxIcon.Exclamation);
+
+            if (!_form.TopMost)
+            {
+                _form.BringToFront();
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogDefaults.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogDefaults.cs
@@ -16,8 +16,8 @@ public record struct KryptonTaskDialogDefaults
         ClientWidth = clientWidth;
         ClientHeight = 600;
         PanelLeft = 10;
-        PanelTop = 5;
-        PanelBottom = 5;
+        PanelTop = 10;
+        PanelBottom = 10;
         PanelRight = 10;
         ComponentSpace = 10;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
@@ -337,9 +337,9 @@ public class KryptonTaskDialogFormProperties
     }
     #endregion
 
-    /// <summary>
-    /// TODO Will be removed in the final version
-    /// </summary>
+    ///// <summary>
+    ///// TODO Will be removed in the final version
+    ///// </summary>
     //public KryptonTaskDialogKryptonForm KryptonForm => _form;
 
     #region Public properties


### PR DESCRIPTION
- Issue: #1376
- Fixes: Show could be called while the dialog was visible already. Also in that case the dialog is brought to front.
- Fixes: KryptonTaskDialog dialog width now defaults to 600 when no width is given.
- Changed: Changed Defaults PanelTop & PanelBottom from 5 to 10 to enlarge the space between elements.
- Changed: Dialog.Form.StartPosition now defaults to CenterScreen.
- Renamed: FreeWheeler element to FreeWheeler1.
- Added: FreeWheeler2 which contains and exposes a TableLayoutPanel.
- For details see #1376

<img width="268" height="165" alt="compile-results" src="https://github.com/user-attachments/assets/cfd9c193-b183-41a0-85ce-f07374c32294" />
