### PR TITLE
2548-V95-Fixed-color-assignment-in-PopulateFromBase

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2025-10-25 - Build 2508 (Patch 9) - October 2025
 
+* Resolved [#2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548), Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.
 * Resolved [#2460](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2460) `KryptonDataGridView` column headers are always bold.
 * Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`
 * Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
@@ -161,8 +161,8 @@ namespace Krypton.Toolkit
             TabSeparatorContextColor = GetRibbonTabSeparatorContextColor(PaletteState.Normal);
             TextFont = GetRibbonTextFont(PaletteState.Normal);
             TextHint = GetRibbonTextHint(PaletteState.Normal);
-            QATButtonDarkColor = GetRibbonGroupDialogDark(PaletteState.Normal);
-            QATButtonLightColor = GetRibbonGroupDialogLight(PaletteState.Normal);
+            QATButtonDarkColor = GetRibbonQATButtonDark(PaletteState.Normal);
+            QATButtonLightColor = GetRibbonQATButtonLight(PaletteState.Normal);
         }
         #endregion
 
@@ -535,8 +535,8 @@ namespace Krypton.Toolkit
                 }
             }
         }
-        private void ResetGroupSeparatorLight() => GroupDialogLight = GlobalStaticValues.EMPTY_COLOR;
-        private bool ShouldSerializeGroupSeparatorLight() => GroupDialogLight != GlobalStaticValues.EMPTY_COLOR;
+        private void ResetGroupSeparatorLight() => GroupSeparatorLight = GlobalStaticValues.EMPTY_COLOR;
+        private bool ShouldSerializeGroupSeparatorLight() => GroupSeparatorLight != GlobalStaticValues.EMPTY_COLOR;
 
         /// <summary>
         /// Gets the color for the dialog launcher light.


### PR DESCRIPTION
Resolve [[Bug]: PopulateFromBase incorrectly assigns the GroupSeparatorLight, QATButtonDarkColor, and QATButtonLightColor colors. #2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548).

Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.

<img width="446" height="131" alt="image" src="https://github.com/user-attachments/assets/57dfbe2f-3af0-42e0-b219-26af771118dd" />
