### PR TITLE
2508-V100-Add-internal-InDesignMode-extension-methods-to-Control-and-Components

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/General/Extensions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Extensions.cs
@@ -11,17 +11,7 @@ namespace Krypton.Toolkit;
 
 internal static class Extensions
 {
-    #region Control.InDesignMode & Component.InDesignMode
-    /// <summary>
-    /// Returns if the control is in desigmode.
-    /// </summary>
-    /// <param name="control">The control instance to operate on.</param>
-    /// <returns></returns>
-    internal static bool InDesignMode(this Control control)
-    {
-        return control.Site?.DesignMode ?? false;
-    }
-
+    #region Component.InDesignMode
     /// <summary>
     /// Returns if the component is in desigmode.
     /// </summary>


### PR DESCRIPTION
- Issue: #2508
- Removes the extension on control, since control derives from Component.
- No changelog since functionality is maintained.

<img width="260" height="191" alt="compile-results" src="https://github.com/user-attachments/assets/350c02c9-dcba-4834-a387-a89fd865f806" />
