### PR TITLE
2542-V100-KryptonForm-cannot-be-resized-by-dragging-upper-corners

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
 
+* Resolved [#2542](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2542), `KryptonForm` cannot be resized by dragging upper corners.
 * Implemented [#2575](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2575), **[Breaking Change]** `CommonHelper.DesignMode()` behaviour changed, see issue for details.
 * Implemented [#2559](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2559), Allow `release.yml` to automatically push packages
 * Implemented [#331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/331), Make the "No Tab in a ribbon Solution" An Actual Designer Tool

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1903,23 +1903,8 @@ public class KryptonForm : VisualForm,
         // Scan up the view hierarchy until a recognized element is found
         while (mouseView != null)
         {
-            // Is mouse over the caption bar?
-            if (mouseView == _drawHeading)
-            {
-                // Always allow moving when over the title bar area
-                // The title bar should be treated as a caption area for moving
-                return new IntPtr(PI.HT.CAPTION);
-            }
-
-            // Additional check: if the mouse is in the top area of the form (title bar region)
-            // and we haven't identified a specific view, still allow moving
-            if (pt.Y < _drawHeading.ClientRectangle.Height)
-            {
-                return new IntPtr(PI.HT.CAPTION);
-            }
-
             // Is mouse over one of the borders?
-            if (isResizable && mouseView == _drawDocker)
+            if (isResizable && (mouseView == _drawDocker || pt.Y < _drawHeading.ClientRectangle.Height))
             {
                 // Is point over the left border?
                 if ((borders.Left > 0) && (pt.X <= borders.Left))
@@ -1964,6 +1949,13 @@ public class KryptonForm : VisualForm,
 
                     return pt.X >= (Width - HT_CORNER) ? new IntPtr(PI.HT.TOPRIGHT) : new IntPtr(PI.HT.TOP);
                 }
+            }
+
+            // Additional check: if the mouse is in the top area of the form (title bar region)
+            // and we haven't identified a specific view, still allow moving
+            if (mouseView == _drawHeading || pt.Y < _drawHeading.ClientRectangle.Height)
+            {
+                return new IntPtr(PI.HT.CAPTION);
             }
 
             // Mouse up another level


### PR DESCRIPTION
- Issue: #2542
- Reorder hit testing, borders first.
- And the changelog.

Warnings are not from this PR.
<img width="329" height="399" alt="image" src="https://github.com/user-attachments/assets/2b5ec087-9a76-4477-9dc5-19eb1ccf8a94" />
