### PR TITLE
2542-V95-KryptonForm-cannot-be-resized-by-dragging-upper-corners

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,12 +3,12 @@
 =======
 
 # 2025-10-20 - Build 2508 (Patch 9) - October 2025
-
+* Resolved [#2542](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2542), `KryptonForm` cannot be resized by dragging upper corners.
 * Resolved [#2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548), Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.
-* Resolved [#2460](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2460) `KryptonDataGridView` column headers are always bold.
-* Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`
-* Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.
-* Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related
+* Resolved [#2460](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2460), `KryptonDataGridView` column headers are always bold.
+* Resolved [#2512](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2512), Added borders with straight corners (`LinearBorder2`) and adjusted the colors in the `KryptonRibbon` in the `Microsoft365` themes. Adjusted the design of the `RibbonQATButton`.
+* Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524), `KryptonRibbon` tab title malformed when using long strings.
+* Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related.
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 
 =======

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1341,23 +1341,8 @@ namespace Krypton.Toolkit
             // Scan up the view hierarchy until a recognized element is found
             while (mouseView != null)
             {
-                // Is mouse over the caption bar?
-                if (mouseView == _drawHeading)
-                {
-                    // Always allow moving when over the title bar area
-                    // The title bar should be treated as a caption area for moving
-                    return new IntPtr(PI.HT.CAPTION);
-                }
-
-                // Additional check: if the mouse is in the top area of the form (title bar region)
-                // and we haven't identified a specific view, still allow moving
-                if (pt.Y < _drawHeading.ClientRectangle.Height)
-                {
-                    return new IntPtr(PI.HT.CAPTION);
-                }
-
                 // Is mouse over one of the borders?
-                if (mouseView == _drawDocker)
+                if (mouseView == _drawDocker || pt.Y < _drawHeading.ClientRectangle.Height)
                 {
                     // Is point over the left border?
                     if ((borders.Left > 0) && (pt.X <= borders.Left))
@@ -1402,6 +1387,13 @@ namespace Krypton.Toolkit
 
                         return pt.X >= (Width - HT_CORNER) ? new IntPtr(PI.HT.TOPRIGHT) : new IntPtr(PI.HT.TOP);
                     }
+                }
+
+                // Additional check: if the mouse is in the top area of the form (title bar region)
+                // and we haven't identified a specific view, still allow moving
+                if (mouseView == _drawHeading || pt.Y < _drawHeading.ClientRectangle.Height)
+                {
+                    return new IntPtr(PI.HT.CAPTION);
                 }
 
                 // Mouse up another level


### PR DESCRIPTION
- Issue: #2542
- Reorder hit testing, borders first.
- And the changelog.

<img width="253" height="236" alt="image" src="https://github.com/user-attachments/assets/3dae8c64-b788-4a20-984f-6d318439a256" />