### PR TITLE
1376-V100-Extending-KryptonTaskDialog

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBar.cs
@@ -198,7 +198,7 @@ public partial class KryptonTaskDialogElementFooterBar : KryptonTaskDialogElemen
         if (sender is KryptonButton button)
         {
             _form.DialogResult = button.DialogResult;
-            _form.Hide();
+            _form.Close();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
@@ -260,9 +260,18 @@ public class KryptonTaskDialog : IDisposable
         UpdateFormPosition(owner);
         ResetFormDialogResult();
 
-        return owner is not null
-            ? _form.ShowDialog(owner)
-            : _form.ShowDialog();
+        // The standard form's DialogResult property always returns Cancel when e.Cancel is set to true.<br/>
+        // Before that happens the DialogResult is stored in DialogResultInternal.
+        if (owner is not null)
+        {
+            _form.ShowDialog(owner);
+        }
+        else
+        {
+            _form.ShowDialog();
+        }
+
+        return Dialog.DialogResult;
     }
 
     /// <summary>
@@ -446,6 +455,7 @@ public class KryptonTaskDialog : IDisposable
         _form.Padding = _taskDialogDefaults.NullPadding;
         _form.MaximizeBox = false;
         _form.ControlBox = true;
+        _form.SystemMenuValues.Enabled = false;
 
         SetupTableLayoutPanel();
 
@@ -459,6 +469,7 @@ public class KryptonTaskDialog : IDisposable
     private void ResetFormDialogResult()
     {
         _form.DialogResult = DialogResult.None;
+        _form.DialogResultInternal = DialogResult.None;
     }
 
     private void SetupTableLayoutPanel()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
@@ -366,7 +366,7 @@ public class KryptonTaskDialogFormProperties
     /// </summary>
     public DialogResult DialogResult 
     {
-        get => _form.DialogResult;
+        get => _form.DialogResultInternal;
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogKryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogKryptonForm.cs
@@ -33,6 +33,15 @@ public class KryptonTaskDialogKryptonForm : KryptonForm
     }
     #endregion
 
+    #region Internal
+    /// <summary>
+    /// The standard form's DialogResult property always returns Cancel when e.Cancel is set to true.<br/>
+    /// Before that happens the DialogResult is stored in DialogResultInternal.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    internal DialogResult DialogResultInternal { get; set; }
+    #endregion
+
     #region Protected override
     /// <inheritdoc/>>
     protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
@@ -47,12 +56,11 @@ public class KryptonTaskDialogKryptonForm : KryptonForm
         // Else let it close itself.
         if (Visible && e.CloseReason == CloseReason.UserClosing)
         {
-            e.Cancel = false;
+            // The standard form's DialogResult property always returns Cancel when e.Cancel is set to true.<br/>
+            // Before that happens the DialogResult is stored in DialogResultInternal.
+            DialogResultInternal = DialogResult;
+            e.Cancel = true;
             Hide();
-        }
-        else
-        {
-            DialogResult = DialogResult.None;
         }
 
         base.OnFormClosing(e);


### PR DESCRIPTION
- Issue: #1376
- Fix incorrect DialogResult value returned on dialog closing.
- No changelog entry needed.

<img width="197" height="183" alt="image" src="https://github.com/user-attachments/assets/76ffafee-022d-4cdc-9bfd-35546d9446a9" />
