### PR TITLE
2653-V105-KryptonTaskDialog-add-switch-for-KryptonSystemMenu

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,9 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
-* Resolves [#2649]https://github.com/Krypton-Suite/Standard-Toolkit/issues/2649), `KryptonSytemMenu` duplicates menu entries.
+
+* Implemented [#2653](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2653), Adds a property to `KryptonTaskDialog` to toggle the `KryptonSystemMenu`.
+* Resolves [#2649](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2649), `KryptonSytemMenu` duplicates menu entries.
 * Resolved [#2641](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2641), `KryptonForm` based minimised MDI Child Windows do not react when hosted in a `KryptonForm` parent container.
 * Support for .NET 11
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
@@ -455,7 +455,7 @@ public class KryptonTaskDialog : IDisposable
         _form.Padding = _taskDialogDefaults.NullPadding;
         _form.MaximizeBox = false;
         _form.ControlBox = true;
-        _form.SystemMenuValues.Enabled = false;
+        _form.SystemMenuValues.Enabled = true;
 
         SetupTableLayoutPanel();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialogFormProperties.cs
@@ -194,6 +194,21 @@ public class KryptonTaskDialogFormProperties
             get => _form.Icon;
             set => _form.Icon = value;
         }
+
+        /// <summary>
+        /// Enable/disable the themed Krypton system menu.
+        /// </summary>
+        public bool KryptonSystemMenu
+        {
+            get => _form.SystemMenuValues.Enabled;
+            set
+            {
+                if (_form.SystemMenuValues.Enabled != value)
+                {
+                    _form.SystemMenuValues.Enabled = value;
+                }
+            }
+        }
         #endregion
 
         #region Public override


### PR DESCRIPTION
- Issue: #2653
- Add a switch to KTaskDialog for KSystemMenu
- And the changelog

<img width="339" height="163" alt="image" src="https://github.com/user-attachments/assets/f6a7de10-d9dc-441e-ab73-5a9a5ab21f02" />
