### PR TITLE
* Automatically assign users to new pull requests

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -1,0 +1,40 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2025 - 2026. All rights reserved.
+
+name: Auto-assign PR author
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR author
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            let assignee = context.actor;
+
+            if (branch.startsWith('dependabot/')) {
+              assignee = owner;
+            }
+
+            if (!pr.assignees?.length) {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pr.number,
+                assignees: [assignee],
+              });
+            }


### PR DESCRIPTION
This must be pushed to `master` for **both** V105 and V110. Tested in the test repo.

* Implements #2622, future additions will include auto syncing labels and milestones