### PR TITLE
2629-V110-toggleswitch-shows-incorrect-text

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,9 +3,9 @@
 ====
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
-
+* Resolved [#2629](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2629), `KryptonToggleSwitch` text repaint fails when the `Checked` property is toggled.
 * Implemented [#2658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2658), Achieve 100% parity with WinForms controls
-	- Implemented [#2673](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2673), `KryptonToolStripContainer` - Part of #2658
+* Implemented [#2673](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2673), `KryptonToolStripContainer` - Part of #2658
 * Implemented [#2609](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2609), Improve the layout of Discord push notifications
 * Implemented [#2653](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2653), Adds a property to `KryptonTaskDialog` to toggle the `KryptonSystemMenu`.
 * Implemented [#2586](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2586), One combined NuGet package

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
@@ -119,9 +119,10 @@ public class KryptonToggleSwitch : Control, IContentValues
                 _checked = value;
 
                 _animationTimer.Start();
+                StartAnimation();
+                Invalidate();
 
                 CheckedChanged?.Invoke(this, EventArgs.Empty);
-                StartAnimation();
             }
         }
     }
@@ -424,10 +425,15 @@ public class KryptonToggleSwitch : Control, IContentValues
     /// <summary>Gets the state of the current.</summary>
     private IPaletteTriple GetCurrentState()
     {
-        return !Enabled ? StateDisabled :
-            _isPressed ? StatePressed :
-            _isTracking ? StateTracking :
-            (StateNormal != null ? StateNormal : StateCommon);
+        return !Enabled 
+            ? StateDisabled 
+            : _isPressed 
+                ? StatePressed 
+                : _isTracking 
+                    ? StateTracking 
+                    : (StateNormal != null 
+                        ? StateNormal 
+                        : StateCommon);
     }
 
     /// <summary>Gets the knob rectangle.</summary>


### PR DESCRIPTION
- Issue: #2629
- Fixes text repaint
- And the change log

<img width="231" height="145" alt="image" src="https://github.com/user-attachments/assets/8252f173-af56-459e-8504-a82b1b6d2db1" />
