### PR TITLE
2629-V105-toggleswitch-shows-incorrect-text

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
-
+* Resolved [#2629](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2629), `KryptonToggleSwitch` text repaint fails when the `Checked` property is toggled.
 * Implemented [#2622](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2622), Automatically assign users to new pull requests
 * Implemented [#2617](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2617), Move GitHub templates to YAML
 * Implemented [#2653](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2653), Adds a property to `KryptonTaskDialog` to toggle the `KryptonSystemMenu`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
@@ -119,9 +119,10 @@ public class KryptonToggleSwitch : Control, IContentValues
                 _checked = value;
 
                 _animationTimer.Start();
+                StartAnimation();
+                Invalidate();
 
                 CheckedChanged?.Invoke(this, EventArgs.Empty);
-                StartAnimation();
             }
         }
     }
@@ -424,10 +425,15 @@ public class KryptonToggleSwitch : Control, IContentValues
     /// <summary>Gets the state of the current.</summary>
     private IPaletteTriple GetCurrentState()
     {
-        return !Enabled ? StateDisabled :
-            _isPressed ? StatePressed :
-            _isTracking ? StateTracking :
-            (StateNormal != null ? StateNormal : StateCommon);
+        return !Enabled 
+            ? StateDisabled 
+            : _isPressed 
+                ? StatePressed 
+                : _isTracking 
+                    ? StateTracking 
+                    : (StateNormal != null 
+                        ? StateNormal 
+                        : StateCommon);
     }
 
     /// <summary>Gets the knob rectangle.</summary>


### PR DESCRIPTION
- Issue: #2629
- Fixes text repaint
- And the change log

<img width="279" height="155" alt="image" src="https://github.com/user-attachments/assets/13e4eb97-486b-4414-bd38-1c62d120b740" />
