### PR TITLE
2682-V105-KryptonForm-does-not-close-on-ALT+F4-when-borderstyle-is-none

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,8 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+
+* Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2682), `KryptonForm` does not close when `FormBorderStyle` is set to none at design time.
 * Resolved [#2629](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2629), `KryptonToggleSwitch` text repaint fails when the `Checked` property is toggled.
 * Implemented [#2622](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2622), Automatically assign users to new pull requests
 * Implemented [#2617](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2617), Move GitHub templates to YAML

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -2758,16 +2758,12 @@ public class KryptonForm : VisualForm,
             // a drop shadow around the form
             CreateParams cp = base.CreateParams;
 
-#pragma warning disable CS0618 // Type or member is obsolete
+            #pragma warning disable CS0618 // Type or member is obsolete
             if (UseDropShadow)
             {
                 cp.ClassStyle |= CS_DROPSHADOW;
             }
-#pragma warning restore CS0618 // Type or member is obsolete
-            if (!CloseBox)
-            {
-                cp.ClassStyle |= CP_NOCLOSE_BUTTON;
-            }
+            #pragma warning restore CS0618 // Type or member is obsolete
 
             return cp;
         }


### PR DESCRIPTION
- Issue: #2682
- Remove CP_NOCLOSE_BUTTON option form KForm CreateParams
- and the change log

<img width="304" height="148" alt="image" src="https://github.com/user-attachments/assets/10ef2784-ee64-4f89-9d75-1f7e98dab271" />
