### PR TITLE
2682-V85-KryptonForm-does-not-close-on-ALT+F4-when-borderstyle-is-none

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,12 @@
 
 =======
 
+# 2026-02-30 - Build 2602 (Patch 10) - February 2025
+* Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2682), `KryptonForm` does not close when `FormBorderStyle` is set to none at design time.
+* Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2604), `KryptonContextMenu` items editor does not restore items when cancelled.
+
+=======
+
 # 2025-10-20 - Build 2508 (Patch 9) - October 2025
 * Resolved [#2542](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2542), `KryptonForm` cannot be resized by dragging upper corners.
 * Resolved [#2548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2548), Fixed color assignment for `GroupSeparatorLight`, `QATButtonDarkColor` and `QATButtonLightColor` in `PopulateFromBase`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -2254,16 +2254,12 @@ namespace Krypton.Toolkit
                 // a drop shadow around the form
                 CreateParams cp = base.CreateParams;
 
-#pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0618 // Type or member is obsolete
                 if (UseDropShadow)
                 {
                     cp.ClassStyle |= CS_DROPSHADOW;
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
-                if (!CloseBox)
-                {
-                    cp.ClassStyle |= CP_NOCLOSE_BUTTON;
-                }
+                #pragma warning restore CS0618 // Type or member is obsolete
 
                 return cp;
             }


### PR DESCRIPTION
- Issue: #2682
- Remove CP_NOCLOSE_BUTTON option form KForm CreateParams
- and the change log

<img width="265" height="122" alt="image" src="https://github.com/user-attachments/assets/12b0555c-a4a3-4f59-bf32-e90071d10e33" />
