### PR TITLE
2681-V105-KryptonDataGridView-column-headers-do-not-repaint-on-scroll

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+* Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2681), `KryptonDataGridView` column headers do repaint correctly on horizontal mouse scroll.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2604), `KryptonContextMenu` items editor does not restore items when cancelled.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2682), `KryptonForm` does not close when `FormBorderStyle` is set to none at design time.
 * Resolved [#2629](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2629), `KryptonToggleSwitch` text repaint fails when the `Checked` property is toggled.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1782,6 +1782,21 @@ public class KryptonDataGridView : DataGridView
         // Let base class layout child controls
         base.OnLayout(levent);
     }
+
+    protected override void OnScroll(ScrollEventArgs e)
+    {
+        // #2681 - Columns headers do not repaint correctly on horizontal scrollbar move by the mouse.
+        if (((MouseButtons & MouseButtons.Left) == MouseButtons.Left || (MouseButtons & MouseButtons.Right) == MouseButtons.Right)
+            && e.ScrollOrientation == ScrollOrientation.HorizontalScroll)
+        {
+            for (int i = 0; i < Columns.Count; i++)
+            {
+                InvalidateCell(Columns[i].HeaderCell);
+            }
+        }
+
+        base.OnScroll(e);
+    }
     #endregion
 
     #region Internal


### PR DESCRIPTION
- Issue: #2681
- Adds an OnScroll override that selectively repaints the column headers on horizontal mouse scroll
- And the change log

<img width="238" height="147" alt="image" src="https://github.com/user-attachments/assets/f3ab3014-2eca-43d3-aaf1-e272c92b654d" />
