### PR TITLE
2704-V85-KryptonCustomPaletteBase-has-missing-case-statement

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2026-02-30 - Build 2602 (Patch 10) - February 2025
+* Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2704), Add a missing case statement to `KryptonCustomPaletteBase`.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2682), `KryptonForm` does not close when `FormBorderStyle` is set to none at design time.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2604), `KryptonContextMenu` items editor does not restore items when cancelled.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -4270,6 +4270,8 @@ namespace Krypton.Toolkit
                     return ButtonSpecs.RibbonMinimize;
                 case PaletteButtonSpecStyle.RibbonExpand:
                     return ButtonSpecs.RibbonExpand;
+                case PaletteButtonSpecStyle.Undo:
+                    return ButtonSpecs.Previous;
                 default:
                     // Should never happen!
                     Debug.Assert(false);


### PR DESCRIPTION
- Issue: #2704
- Add the missing case
- And the change log

<img width="242" height="141" alt="image" src="https://github.com/user-attachments/assets/e0aea691-e25a-4a3d-be5a-5484f515a494" />


