### PR TITLE
2681-V105-KryptonDataGridView-column-headers-do-not-repaint-on-scroll

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1317,6 +1317,7 @@ public class KryptonDataGridView : DataGridView
         }
 
         var rtl = RightToLeftInternal;
+        bool isHandled = true;
 
         // Use an offscreen bitmap to draw onto before blitting it to the screen
         var tempCellBounds = e.CellBounds with { X = 0, Y = 0 };
@@ -1327,6 +1328,8 @@ public class KryptonDataGridView : DataGridView
                 using (var renderContext = new RenderContext(this, tempG, tempCellBounds, Renderer!))
                 {
                     bool isHeaderCell = e.RowIndex == -1 && e.ColumnIndex >= 0;
+                    isHandled = !isHeaderCell;
+
                     Rectangle headerContentBounds = Rectangle.Empty;
 
                     // Force the border to have a specified maximum border edge
@@ -1706,7 +1709,7 @@ public class KryptonDataGridView : DataGridView
         }
 
         // Prevent base class from doing the standard drawing
-        e!.Handled = true;
+        e!.Handled = isHandled;
 
         base.OnCellPainting(e);
     }
@@ -1781,21 +1784,6 @@ public class KryptonDataGridView : DataGridView
 
         // Let base class layout child controls
         base.OnLayout(levent);
-    }
-
-    protected override void OnScroll(ScrollEventArgs e)
-    {
-        // #2681 - Columns headers do not repaint correctly on horizontal scrollbar move by the mouse.
-        if (((MouseButtons & MouseButtons.Left) == MouseButtons.Left || (MouseButtons & MouseButtons.Right) == MouseButtons.Right)
-            && e.ScrollOrientation == ScrollOrientation.HorizontalScroll)
-        {
-            for (int i = 0; i < Columns.Count; i++)
-            {
-                InvalidateCell(Columns[i].HeaderCell);
-            }
-        }
-
-        base.OnScroll(e);
     }
     #endregion
 


### PR DESCRIPTION
- Issue: #2681
- Reverts PR2687 and alters OnCellPaiting tot solve this issue.
- Change log was already intact.

<img width="264" height="170" alt="image" src="https://github.com/user-attachments/assets/319e7a1f-a19f-4fa5-9419-912495c6a208" />
