### PR TITLE
2631-V105-KryptonForm-FormBorderStyle-None-produces-incorrect-results

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,9 +3,10 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+* Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2631), `KryptonFrom` draws the custom border when `FormBorderStyle` is `None`.
 * Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2704), Add a missing case statement to `KryptonCustomPaletteBase`.
 * Resolved [#2455](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2455), `KryptonForm` does not close when the system icon is double clicked.
-* Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2681), `KryptonDataGridView` column headers do repaint correctly on horizontal mouse scroll.
+* Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2681), `KryptonDataGridView` column headers do not repaint correctly on horizontal mouse scroll.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2604), `KryptonContextMenu` items editor does not restore items when cancelled.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2682), `KryptonForm` does not close when `FormBorderStyle` is set to none at design time.
 * Resolved [#2629](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2629), `KryptonToggleSwitch` text repaint fails when the `Checked` property is toggled.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -157,7 +157,7 @@ public class PaletteBorder : Storage,
     [Description(@"Should border be drawn.")]
     [DefaultValue(InheritBool.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
-    public InheritBool Draw
+    public virtual InheritBool Draw
     {
         get => _storage?.BorderDraw ?? InheritBool.Inherit;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteFormBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteFormBorder.cs
@@ -36,6 +36,32 @@ public class PaletteFormBorder : PaletteBorder
     internal bool UseThemeFormChromeBorderWidth { get; set; } = true;
 
     /// <summary>
+    /// Gets a value indicating if border should be drawn.
+    /// </summary>
+    [KryptonPersist(false)]
+    [Category(@"Visuals")]
+    [Description(@"Should the border be drawn.")]
+    [DefaultValue(InheritBool.Inherit)]
+    [RefreshProperties(RefreshProperties.All)]
+    public override InheritBool Draw
+    {
+        get
+        {
+            return _ownerForm.FormBorderStyle != FormBorderStyle.None
+                ? base.Draw
+                : InheritBool.False;
+        }
+
+        set
+        {
+            if (base.Draw != value)
+            {
+                base.Draw = value;
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets and sets the border width.
     /// </summary>
     [KryptonPersist(false)]


### PR DESCRIPTION
- Issue: #2631
- Override the `PaletteFormBorder` `draw` property to return false when `FormBorderStyle` is none
- And the change log

<img width="268" height="164" alt="image" src="https://github.com/user-attachments/assets/eaf29f3e-aea1-46ea-a5be-18e800747490" />
