### PR TITLE
2638-V110-Buttons-with-Rounded-Edges-not-repainting-correctly

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
+* Resolved [#2638](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2638), `KryptonButton` with rouding, draws incorrect background when pressed.
 * Resolved [#2455](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2455), `KryptonForm` does not close when the system icon is double clicked.
 * Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2704), Add a missing case statement to `KryptonCustomPaletteBase`.
 * Implemented [#2612](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2612), Implement a 'nightly' workflow

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -594,19 +594,7 @@ public class PaletteBorder : Storage,
     /// </summary>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>Border width.</returns>
-    //public int GetBorderWidth(PaletteState state) => Width != -1 ? Width : _inherit.GetBorderWidth(state);
-    public int GetBorderWidth(PaletteState state)
-    {
-        if (Width > 0)
-        {
-            return Width;
-        }
-        else
-        {
-            int width = _inherit.GetBorderWidth(state);
-            return width > 0 ? width : 0;
-        }
-    }
+    public int GetBorderWidth(PaletteState state) => Width != -1 ? Width : _inherit.GetBorderWidth(state);
     #endregion
 
     #region Rounding


### PR DESCRIPTION
- Issue: #2638
- Corrects the painting issue.
- And the change log.

Warnings not from here.
<img width="316" height="405" alt="image" src="https://github.com/user-attachments/assets/d6c0b76c-1d89-455e-b691-04765538073f" />
