### PR TITLE
2638-V105-Buttons-with-Rounded-Edges-not-repainting-correctly

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 # 2026-02-30 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+* Resolved [#2638](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2638), `KryptonButton` with rouding, draws incorrect background when pressed.
 * Resolved [#2631](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2631), `KryptonFrom` draws the custom border when `FormBorderStyle` is `None`.
 * Resolved [#2681](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2704), Add a missing case statement to `KryptonCustomPaletteBase`.
 * Resolved [#2455](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2455), `KryptonForm` does not close when the system icon is double clicked.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -594,19 +594,7 @@ public class PaletteBorder : Storage,
     /// </summary>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>Border width.</returns>
-    //public int GetBorderWidth(PaletteState state) => Width != -1 ? Width : _inherit.GetBorderWidth(state);
-    public int GetBorderWidth(PaletteState state)
-    {
-        if (Width > 0)
-        {
-            return Width;
-        }
-        else
-        {
-            int width = _inherit.GetBorderWidth(state);
-            return width > 0 ? width : 0;
-        }
-    }
+    public int GetBorderWidth(PaletteState state) => Width != -1 ? Width : _inherit.GetBorderWidth(state);
     #endregion
 
     #region Rounding


### PR DESCRIPTION
- Issue: #2638
- Corrects the painting issue.
- And the change log.

<img width="318" height="171" alt="image" src="https://github.com/user-attachments/assets/e4264e87-a541-4829-9066-fff598d83288" />
