### PR TITLE
2681-V105-KryptonDataGridView-column-headers-do-not-repaint-on-scroll

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1071,8 +1071,27 @@ public class KryptonDataGridView : DataGridView
     }
     #endregion
 
-
     #region Protected Override
+    /// <inheritdoc/>
+    protected override void OnScroll(ScrollEventArgs e)
+    {
+        base.OnScroll(e);
+
+        // #2681 - work-around
+        // Headers not correctly repainted on horizontal mouse scroll
+        if (e.ScrollOrientation == ScrollOrientation.HorizontalScroll
+            && (MouseButtons & MouseButtons.Left) == MouseButtons.Left)
+        {
+            for (int i = 0; i < Columns.Count; i++)
+            {
+                if (Columns[i].Displayed)
+                {
+                    InvalidateCell(Columns[i].HeaderCell);
+                }
+            }
+        }
+    }
+
     /// <inheritdoc/>
     protected override void OnDataBindingComplete(DataGridViewBindingCompleteEventArgs e)
     {
@@ -1317,7 +1336,6 @@ public class KryptonDataGridView : DataGridView
         }
 
         var rtl = RightToLeftInternal;
-        bool isHandled = true;
 
         // Use an offscreen bitmap to draw onto before blitting it to the screen
         var tempCellBounds = e.CellBounds with { X = 0, Y = 0 };
@@ -1328,7 +1346,6 @@ public class KryptonDataGridView : DataGridView
                 using (var renderContext = new RenderContext(this, tempG, tempCellBounds, Renderer!))
                 {
                     bool isHeaderCell = e.RowIndex == -1 && e.ColumnIndex >= 0;
-                    isHandled = !isHeaderCell;
 
                     Rectangle headerContentBounds = Rectangle.Empty;
 
@@ -1709,7 +1726,7 @@ public class KryptonDataGridView : DataGridView
         }
 
         // Prevent base class from doing the standard drawing
-        e!.Handled = isHandled;
+        e!.Handled = true;
 
         base.OnCellPainting(e);
     }


### PR DESCRIPTION
- Issue: #2681
- Reinstate scroll work-around.
- Change log already up-to-date.

<img width="220" height="178" alt="image" src="https://github.com/user-attachments/assets/ae3b7f11-be92-4dd9-85ba-b99728727739" />
