### PR TITLE
2681-V105-KryptonDataGridView-column-headers-do-not-repaint-on-scroll

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1074,6 +1074,26 @@ public class KryptonDataGridView : DataGridView
 
     #region Protected Override
     /// <inheritdoc/>
+    protected override void OnScroll(ScrollEventArgs e)
+    {
+        base.OnScroll(e);
+
+        // #2681 - work-around
+        // Headers not correctly repainted on horizontal mouse scroll
+        if (e.ScrollOrientation == ScrollOrientation.HorizontalScroll
+            && (MouseButtons & MouseButtons.Left) == MouseButtons.Left)
+        {
+            for (int i = 0; i < Columns.Count; i++)
+            {
+                if (Columns[i].Displayed)
+                {
+                    InvalidateCell(Columns[i].HeaderCell);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc/>
     protected override void OnDataBindingComplete(DataGridViewBindingCompleteEventArgs e)
     {
         base.OnDataBindingComplete(e);
@@ -1317,7 +1337,6 @@ public class KryptonDataGridView : DataGridView
         }
 
         var rtl = RightToLeftInternal;
-        bool isHandled = true;
 
         // Use an offscreen bitmap to draw onto before blitting it to the screen
         var tempCellBounds = e.CellBounds with { X = 0, Y = 0 };
@@ -1328,7 +1347,6 @@ public class KryptonDataGridView : DataGridView
                 using (var renderContext = new RenderContext(this, tempG, tempCellBounds, Renderer!))
                 {
                     bool isHeaderCell = e.RowIndex == -1 && e.ColumnIndex >= 0;
-                    isHandled = !isHeaderCell;
 
                     Rectangle headerContentBounds = Rectangle.Empty;
 
@@ -1709,7 +1727,7 @@ public class KryptonDataGridView : DataGridView
         }
 
         // Prevent base class from doing the standard drawing
-        e!.Handled = isHandled;
+        e!.Handled = true;
 
         base.OnCellPainting(e);
     }


### PR DESCRIPTION
- Issue: #2681
- Reinstate scroll work-around.
- Change log already up-to-date.

<img width="269" height="143" alt="image" src="https://github.com/user-attachments/assets/075a5905-6934-4ff8-8273-ffddccea700e" />
