### PR TITLE
2753-V110-Add-a-helper-class-to-close-menus-when-they-should-lose-focus

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/General/FocusLostMenuHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/FocusLostMenuHelper.cs
@@ -128,12 +128,18 @@ public static class FocusLostMenuHelper
     private static void ProcessStandardItems()
     {
         // Only process items implementing IFocusLostMenuItem
-        _items.ForEach(item => item?.ProcessItem());
+        for (int i = 0; i < _items.Count; i++)
+        {
+            _items[i]?.ProcessItem();
+        }
     }
 
     private static void ProcessWinformsContextMenus()
     {
-        _winformsContextMenus.ForEach(item => item?.Close(ToolStripDropDownCloseReason.AppFocusChange));
+        for (int i = 0; i < _winformsContextMenus.Count; i++)
+        {
+            _winformsContextMenus[i]?.Close(ToolStripDropDownCloseReason.AppFocusChange);
+        }
     }
 
     private static void ProcessWinformsToolStrips()


### PR DESCRIPTION
- Issue: #2753
- Updates PR 2755: Linq ForEach loops seem to process queued message which can affect the collection being processed and are replaced with standard for loops.
- Changelog has been updated already.

<img width="256" height="157" alt="image" src="https://github.com/user-attachments/assets/b0a86187-9c9c-4ebf-9d09-3248d9b8b6dd" />
