### PR TITLE
2570-V105-Added-Tab-scrolling-with-mouse-over-Ribbon's-GroupsArea

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 # 2026-02-27 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+* Implemented [#2570](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2570), Added Tab scrolling with mouse over Ribbon's GroupsArea - ScrollTabGroupArea for #331.
 * Implemented [#2753](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2753), Adds helper class that aids in closing menus at will, which don't repsond to losing focus.
 * Implemented [#2728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2728), Ability for developers to set the highlight colour - Part of #2720
 * Resolved [#2745](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2745b), `VisualMultilineStringEditorForm` only saving last line

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -83,6 +83,7 @@ public class KryptonRibbon : VisualSimple,
     // Properties
     private bool _minimizedMode;
     private bool _showMinimizeButton;
+    private bool _scrollTabGroupArea;
     private string _selectedContext;
     private Size _hideRibbonSize;
     private QATLocation _qatLocation;
@@ -921,6 +922,25 @@ public class KryptonRibbon : VisualSimple,
     }
 
     /// <summary>
+    /// Gets and sets a value indicating whether scrolling over the RibbonGroupArea changes the ribbon tab.
+    /// </summary>
+    [Category(@"Values")]
+    [Description(@"Does scrolling over the RibbonGroupArea change the ribbon tab.")]
+    [DefaultValue(true)]
+    public bool ScrollTabGroupArea
+    {
+        get => _scrollTabGroupArea;
+
+        set
+        {
+            if (_scrollTabGroupArea != value)
+            {
+                _scrollTabGroupArea = value;
+            }
+        }
+    }
+
+    /// <summary>
     /// Resets the ShowMinimizeButton property to its default value.
     /// </summary>
     public void ResetShowMinimizeButton() => ShowMinimizeButton = true;
@@ -1106,11 +1126,33 @@ public class KryptonRibbon : VisualSimple,
                             };
 
                             // Only interested if over the tabs area
-                            if (TabsArea.ClientRectangle.Contains(PointToClient(pt)))
+                            if (TabsArea.ClientRectangle.Contains(PointToClient(pt)) || (_scrollTabGroupArea && GroupsArea.ClientRectangle.Contains(PointToClient(pt))))
                             {
-                                var delta = (short)PI.HIWORD((int)m.WParam.ToInt64());
-                                TabsArea.LayoutTabs.ProcessMouseWheel(delta < 0);
-                                return true;
+                                if (MouseControlFinder.ControlUnderMouse() is Control control && control.Enabled)
+                                {
+                                    if (control is ComboBox or KryptonTrackBar or VisualPopupAppMenu or VisualContextMenu || control.Parent is DomainUpDown or NumericUpDown)
+                                    {
+                                        return false;
+                                    }
+                                    else if (control is TextBox textBox
+                                        && textBox.Multiline
+                                        && textBox.ScrollBars is ScrollBars.Both or ScrollBars.Vertical or ScrollBars.Horizontal)
+                                    {
+                                        return false;
+                                    }
+                                    else if (control is RichTextBox richTextBox
+                                        && richTextBox.Multiline
+                                        && richTextBox.ScrollBars is RichTextBoxScrollBars.Vertical or RichTextBoxScrollBars.ForcedVertical or RichTextBoxScrollBars.Both or RichTextBoxScrollBars.ForcedBoth)
+                                    {
+                                        return false;
+                                    }
+                                    else
+                                    {
+                                        var delta = (short)PI.HIWORD((int)m.WParam.ToInt64());
+                                        TabsArea.LayoutTabs.ProcessMouseWheel(delta < 0);
+                                        return true;
+                                    }
+                                }
                             }
                         }
                     }
@@ -1706,6 +1748,33 @@ public class KryptonRibbon : VisualSimple,
     /// <param name="e">An EventArgs containing event data.</param>
     protected virtual void OnMinimizedModeChanged(EventArgs e) => MinimizedModeChanged?.Invoke(this, e);
 
+    #endregion
+
+    #region WIN32 Calls
+    public static class MouseControlFinder
+    {
+        // Returns the HWND under the current mouse cursor (screen coordinates).
+        public static IntPtr HwndUnderMouse()
+        {
+            return PI.WindowFromPoint(Cursor.Position);
+        }
+
+        // Returns the WinForms Control under the mouse or null if none found.
+        public static Control? ControlUnderMouse()
+        {
+            IntPtr hwnd = HwndUnderMouse();
+            while (hwnd != IntPtr.Zero)
+            {
+                Control? control = FromHandle(hwnd);
+                if (control != null)
+                {
+                    return control;
+                }
+                hwnd = PI.GetParent(hwnd);
+            }
+            return null;
+        }
+    }
     #endregion
 
     #region Internal
@@ -2532,6 +2601,7 @@ public class KryptonRibbon : VisualSimple,
         MinimizedMode = false;
         ScrollerStyle = ButtonStyle.Standalone;
         ShowMinimizeButton = true;
+        ScrollTabGroupArea = true;
         QATLocation = QATLocation.Above;
         QATUserChange = true;
         LostFocusLosesKeyboard = true;


### PR DESCRIPTION
Add in [[Bug]: KryptonRibbon tab not scroll bar #2570](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2570)

Added Tab scrolling with mouse over Ribbon's GroupsArea.

The ScrollTabGroupArea property has also been added, so that when ["No Tab" #331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/331) is deployed, setting it to false disables scrolling.

<img width="674" height="235" alt="image" src="https://github.com/user-attachments/assets/40a85696-fce0-4e3e-83ae-9172e52aad8a" />
