### PR TITLE
2716-V110-Adjustin-the-width-of-the-KryptonRibbonGroupButton

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2716](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2716), Adjusting the width of the `KryptonRibbonGroupButton` to avoid cutting off the text
 * Implemented [#2764](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2764), Bug reporting tool
 * Implemented [#2570](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2570), Added Tab scrolling with mouse over Ribbon's GroupsArea - ScrollTabGroupArea for #331.
 * Implemented [#2749](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2749), Usage of native Krypton controls, i.e. TreeView & RichTextBox - Part of #2720

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonText.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonText.cs
@@ -135,8 +135,8 @@ internal class ViewDrawRibbonGroupButtonText : ViewLeaf,
             _heightExtra = (_ribbon.CalculatedValues.DrawFontHeight - _ribbon.CalculatedValues.RawFontHeight) * 2;
             _preferredSize.Height -= _heightExtra;
 
-            // Reduce width by a fixed 1 pixel as Graphics.DrawString always measures longer than needed
-            _preferredSize.Width -= 1;
+            // Increase by 1 pixel so the text isn't cut off
+            _preferredSize.Width += 1;
 
             // If the text is actually empty, then force it to be zero width
             if (string.IsNullOrEmpty(GetShortText()))


### PR DESCRIPTION
Resolved [[Bug]: How to change default PaletteTextTrim.EllipsisCharacter in KryptonRibbonGroup?](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2716)
#2716 

Adjusting the `_preferredSize.Width` of the `KryptonRibbonGroupButton` to avoid cutting off the text.

<img width="504" height="171" alt="image" src="https://github.com/user-attachments/assets/7cd496a3-bcd7-46d9-aa7b-e1ba7732a97a" />
