### PR TITLE
2716-V105-Adjustin-the-width-of-the-KryptonRibbonGroupButton

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,8 @@
 ====
 
 # 2026-02-27 - Build 2502 (Version 105-LTS - Patch 1) - February 2026
+
+* Resolved [#2716](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2716), Adjusting the width of the `KryptonRibbonGroupButton` to avoid cutting off the text*
 * Implemented [#2570](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2570), Added Tab scrolling with mouse over Ribbon's GroupsArea - ScrollTabGroupArea for #331.
 * Implemented [#2753](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2753), Adds helper class that aids in closing menus at will, which don't repsond to losing focus.
 * Implemented [#2728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2728), Ability for developers to set the highlight colour - Part of #2720

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonText.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonText.cs
@@ -135,8 +135,8 @@ internal class ViewDrawRibbonGroupButtonText : ViewLeaf,
             _heightExtra = (_ribbon.CalculatedValues.DrawFontHeight - _ribbon.CalculatedValues.RawFontHeight) * 2;
             _preferredSize.Height -= _heightExtra;
 
-            // Reduce width by a fixed 1 pixel as Graphics.DrawString always measures longer than needed
-            _preferredSize.Width -= 1;
+            // Increase by 1 pixel so the text isn't cut off
+            _preferredSize.Width += 1;
 
             // If the text is actually empty, then force it to be zero width
             if (string.IsNullOrEmpty(GetShortText()))


### PR DESCRIPTION
Resolved [[Bug]: How to change default PaletteTextTrim.EllipsisCharacter in KryptonRibbonGroup?](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2716)
#2716 

Adjusting the `_preferredSize.Width` of the `KryptonRibbonGroupButton` to avoid cutting off the text.3

<img width="514" height="182" alt="image" src="https://github.com/user-attachments/assets/871ef45a-b21e-458f-b222-983a19b41b7b" />
