### PR TITLE
* Button badge fixes

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Values/Badge/BadgeContentValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/Badge/BadgeContentValues.cs
@@ -258,10 +258,10 @@ public class BadgeContentValues : Storage
     private bool ShouldSerializeAnimation() => Animation != BadgeAnimation.None;
 
     /// <summary>
-    /// Gets and sets the badge diameter (for circle shape only). 0 means auto-size based on content.
+    /// Gets and sets the badge size (diameter for circle, side length for square). 0 means auto-size based on content.
     /// </summary>
     [Category(@"Visuals")]
-    [Description(@"The diameter of the badge when Shape is Circle. 0 means auto-size based on content.")]
+    [Description(@"The size of the badge: diameter when Shape is Circle, side length when Shape is Square. 0 means auto-size based on content.")]
     [RefreshProperties(RefreshProperties.All)]
     [DefaultValue(0)]
     public int BadgeDiameter

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawBadge.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawBadge.cs
@@ -170,8 +170,9 @@ public class ViewDrawBadge : ViewLeaf
     #region Implementation
     private Size CalculateBadgeSize(ViewLayoutContext context)
     {
-        // If shape is Circle and BadgeDiameter is specified, use it
-        if (_badgeValues.BadgeContentValues.Shape == BadgeShape.Circle && _badgeValues.BadgeContentValues.BadgeDiameter > 0)
+        // If BadgeDiameter is specified, use it for Circle and Square shapes
+        if (_badgeValues.BadgeContentValues.BadgeDiameter > 0 && 
+            (_badgeValues.BadgeContentValues.Shape == BadgeShape.Circle || _badgeValues.BadgeContentValues.Shape == BadgeShape.Square))
         {
             return new Size(_badgeValues.BadgeContentValues.BadgeDiameter, _badgeValues.BadgeContentValues.BadgeDiameter);
         }


### PR DESCRIPTION
# Fix Badge Size Not Updating When Changing Shape from Circle to Square

## Description
Fixes an issue where changing the `Shape` property from `Circle` to `Square` (or vice versa) doesn't respect the `BadgeDiameter` value, causing the badge size to change unexpectedly.

## Related Issue
Fixes #2783 (comment: https://github.com/Krypton-Suite/Standard-Toolkit/issues/2783#issuecomment-3724771337)

## Problem
When `BadgeDiameter` was set and the badge `Shape` was changed from `Circle` to `Square`, the badge size calculation would ignore the `BadgeDiameter` value and fall back to auto-sizing based on text content. This caused the badge to change size unexpectedly when switching shapes.

## Solution
Updated the `CalculateBadgeSize` method in `ViewDrawBadge.cs` to respect `BadgeDiameter` for both `Circle` and `Square` shapes. The property documentation was also updated to clarify that `BadgeDiameter` represents the diameter for circles and the side length for squares.

## Changes Made
- **`ViewDrawBadge.cs`**: Modified `CalculateBadgeSize()` to check for `BadgeDiameter` when shape is either `Circle` or `Square`
- **`BadgeContentValues.cs`**: Updated XML documentation and property description to reflect that `BadgeDiameter` applies to both Circle and Square shapes

## Testing
To verify the fix:
1. Create a badge with `Shape = Circle` and set `BadgeDiameter` to a specific value (e.g., 24)
2. Change `Shape` to `Square`
3. Verify that the badge maintains the same size (24x24 pixels)
4. Change `Shape` back to `Circle`
5. Verify that the badge size remains consistent

## Breaking Changes
None. This is a bug fix that restores expected behavior.