### PR TITLE
* Double ribbon drawn

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2921](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2921), Double ribbon drawn; form close button unresponsive when ribbon injects into caption (`CustomCaptionArea` overlapping min/max/close); design-time composition right border not re-injected when revoking
 * Implemented [#2925](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2925), Controlbox Touchscreen support
 * Implemented [#2916](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2916), Taskbar Thumbnail Button support
 * Resolved [#2914](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2914), White bar is shown in a `KryptonForm` Sizable without buttons and text

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonCaptionArea.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonCaptionArea.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -547,6 +547,9 @@ internal class ViewDrawRibbonCaptionArea : ViewDrawDocker
                         _compoRightInjected = true;
                     }
 
+                    // Issue #2921: Remove from CaptionArea before injecting so the view is not in two
+                    // hierarchies (form caption and ribbon). Otherwise both can layout/draw it → double ribbon.
+                    Remove(_contextTiles);
                     _kryptonForm.InjectViewElement(_contextTiles, ViewDockStyle.Fill);
                 }
                 else
@@ -554,12 +557,13 @@ internal class ViewDrawRibbonCaptionArea : ViewDrawDocker
                     _captionAppButton.OwnerForm = null;
                     _captionQAT.OwnerForm = null;
                     _kryptonForm.RevokeViewElement(_contextTiles, ViewDockStyle.Fill);
+                    Add(_contextTiles, ViewDockStyle.Fill);
 
                     // At runtime under vista we do not remove the compo right border
                     if (_ribbon.InDesignMode)
                     {
                         _kryptonForm.RevokeViewElement(_compRightBorder, ViewDockStyle.Right);
-                        _compoRightInjected = true;
+                        _compoRightInjected = false;
                     }
 
                     _kryptonForm.RevokeViewElement(_captionAppButton, ViewDockStyle.Left);


### PR DESCRIPTION
# Fix double ribbon drawn and close button unresponsive (#2921)

## Summary

Fixes [issue #2921](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2921): double ribbon drawn, form close button losing focus / not closing when the ribbon injects into the caption, and a design-time bug with the composition right border.

## Problem

1. **Double ribbon** – When `KryptonRibbon` integrates with a `KryptonForm` caption, the context-titles view (`_contextTiles`) was both injected into the form *and* left as a child of the ribbon’s `ViewDrawRibbonCaptionArea`. It lived in two view hierarchies, so it could be laid out and drawn twice.
2. **Close button unresponsive** – `WindowChromeHitTest` checked `CustomCaptionArea` before the min/max/close button rects. When the ribbon’s custom caption overlapped those buttons, hit-test returned `HT_CAPTION` and the close (and min/max) buttons never received hits.
3. **Design-time composition border** – When revoking the composition right border at design time, `_compoRightInjected` was set to `true` instead of `false`, so the border was never re-injected when toggling design/runtime.

## Solution

### 1. Hit-test order (`KryptonForm.cs`)

- **Check form buttons first**, then `CustomCaptionArea`.
- When the cursor is over close → return `HT_CLOSE`; over max → `HT_MAXBUTTON` (Win11) or `HT_ZOOM`; over min → `HT_REDUCE`.
- Only if not over any button, and the point is in `CustomCaptionArea`, return `HT_CAPTION`.

This keeps min/max/close clickable even when the ribbon’s custom caption overlaps them.

### 2. Single parentage for context tiles (`ViewDrawRibbonCaptionArea.cs`)

- **Before inject:** `Remove(_contextTiles)` from the caption area, then inject into the form.
- **After revoke:** Revoke from the form, then `Add(_contextTiles, ViewDockStyle.Fill)` back into the caption area.

`_contextTiles` now has a single parent at any time, so the double-ribbon effect is removed.

### 3. `_compoRightInjected` when revoking (`ViewDrawRibbonCaptionArea.cs`)

- When revoking the composition right border at design time, set `_compoRightInjected = false` (instead of `true`) so it can be re-injected correctly.

## Files changed

| File | Changes |
|------|---------|
| `Krypton.Toolkit/Controls Toolkit/KryptonForm.cs` | Reorder hit-test: buttons before `CustomCaptionArea`; return `HT_CLOSE` / `HT_ZOOM` / `HT_REDUCE` / `HT_MAXBUTTON` when over respective buttons | | `Krypton.Ribbon/View Draw/ViewDrawRibbonCaptionArea.cs` | Fix `_compoRightInjected` on revoke; remove `_contextTiles` from caption before inject, add back after revoke |

## Testing

- **Double ribbon:** `KryptonForm` + `KryptonRibbon` (e.g. TestForm ribbon scenarios or WinFormResizeBar-style layout). Confirm only one ribbon strip is drawn when integrated.
- **Close button:** No-resize form with ribbon. Confirm the X button closes the window even when the ribbon injects into the caption.
- **Design time:** Toggle design/runtime with a form that has an integrated ribbon; confirm the composition right border behaves correctly.

## Changelog

- [x] `Documents/Changelog/Changelog.md` updated with a Resolved [#2921](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2921) entry.

## Breaking changes / TFM impact

- None.