### PR TITLE
* Some `Utilities` project fixes

### DIFF
--- a/Source/Krypton Components/Krypton.Utilities/Krypton.Utilities.csproj
+++ b/Source/Krypton Components/Krypton.Utilities/Krypton.Utilities.csproj
@@ -158,11 +158,12 @@
 	<!-- For .NET 8+: only define when SDK files exist OR when package references can be resolved -->
 	<!-- Use a target to check if references are available before defining the constant -->
 	<Target Name="CheckWebView2Availability" BeforeTargets="CoreCompile" Condition="'$(TargetFramework)' == 'net8.0-windows' Or '$(TargetFramework)' == 'net9.0-windows' Or '$(TargetFramework)' == 'net10.0-windows'">
+		<!-- Check if SDK files exist first (highest priority) -->
 		<PropertyGroup Condition="Exists('$(WebView2CoreDll)')">
 			<DefineConstants>$(DefineConstants);WEBVIEW2_AVAILABLE</DefineConstants>
 		</PropertyGroup>
-		<!-- Check if WebView2 references are available from package -->
-		<ItemGroup>
+		<!-- Check if WebView2 references are available from package (only when SDK files don't exist) -->
+		<ItemGroup Condition="!Exists('$(WebView2CoreDll)')">
 			<_WebView2Refs Include="@(ReferencePath)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core' Or '%(Filename)' == 'Microsoft.Web.WebView2.WinForms'" />
 		</ItemGroup>
 		<PropertyGroup Condition="'@(_WebView2Refs)' != '' And !Exists('$(WebView2CoreDll)')">


### PR DESCRIPTION
* Some `Utilities` project fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MSBuild logic changes can affect restore/build behavior across multiple TFMs, and mistakes may surface as missing references or incorrect conditional compilation (`WEBVIEW2_AVAILABLE`) in consumers.
> 
> **Overview**
> Improves `Krypton.Utilities.csproj` WebView2 dependency handling across target frameworks, especially for .NET 8+ builds when the local `WebView2SDK` folder is missing.
> 
> It changes the WebView2 package version syntax to a proper range, adds `IncludeAssets=all` to ensure assemblies are available, and introduces an MSBuild target (`AddWebView2References`) that locates the restored WebView2 DLLs (including `lib_manual`) and adds explicit references. It also replaces unconditional .NET 8+ `WEBVIEW2_AVAILABLE` definition with a pre-compile check that only defines it when SDK files or resolved references are actually present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392e32246be06faf5f79671e336d209efb0d4832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->