### PR TITLE
* Bundle WebView2 DLLs with Krypton.Standard.Toolkit NuGet package

### DIFF
--- a/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
+++ b/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	
 	<!--
 		Krypton.Standard.Toolkit - Combined Package Project
@@ -14,6 +14,10 @@
 	
 		All referenced DLLs, XML documentation files, and PDB symbol files are included in the package
 		for each target framework, allowing consumers to use the complete toolkit from a single package.
+
+		When WebView2 DLLs are present in Krypton.Utilities\Lib\WebView2 (after running
+		Scripts\WebVew2\Populate-BundledWebView2.cmd), the package also includes the WebView2 managed
+		DLLs and native loader so consumers get WebView2 support without a separate package reference.
 	-->
 
 	<PropertyGroup>
@@ -58,10 +62,21 @@
 		-->
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 	</PropertyGroup>
+	<!-- WebView2: path to bundled DLLs in Krypton.Utilities (same as used by Utilities build). Run Scripts\WebVew2\Populate-BundledWebView2.cmd to populate. -->
+	<PropertyGroup>
+		<WebView2LibPath>$(MSBuildThisFileDirectory)..\Krypton.Utilities\Lib\WebView2</WebView2LibPath>
+	</PropertyGroup>
+
 	<ItemGroup>
 	  <Content Include="Krypton.ico">
 	    <Pack>false</Pack>
 	  </Content>
+	</ItemGroup>
+
+	<!-- WebView2 native loader: include in runtimes so consuming apps get the correct native DLL. Only included when bundled WebView2 is populated. -->
+	<ItemGroup Condition="Exists('$(WebView2LibPath)\WebView2Loader.dll')">
+		<Content Include="$(WebView2LibPath)\WebView2Loader.dll" Pack="true" PackagePath="runtimes\win-x64\native\WebView2Loader.dll" />
+		<Content Include="$(WebView2LibPath)\WebView2Loader.dll" Pack="true" PackagePath="runtimes\win-x86\native\WebView2Loader.dll" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -162,6 +177,14 @@
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
 			<TfmSpecificPackageFile Include="..\..\..\Bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll" Condition="Exists('..\..\..\Bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+
+			<!-- WebView2 managed DLLs (bundled from Krypton.Utilities\Lib\WebView2). Only included when bundled WebView2 is populated. -->
+			<TfmSpecificPackageFile Include="$(WebView2LibPath)\Microsoft.Web.WebView2.Core.dll" Condition="Exists('$(WebView2LibPath)\Microsoft.Web.WebView2.Core.dll')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(WebView2LibPath)\Microsoft.Web.WebView2.WinForms.dll" Condition="Exists('$(WebView2LibPath)\Microsoft.Web.WebView2.WinForms.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
 


### PR DESCRIPTION
# Bundle WebView2 DLLs with Krypton.Standard.Toolkit NuGet package

## Summary
Bundles the WebView2 managed and native DLLs into the **Krypton.Standard.Toolkit** NuGet package so consumers get WebView2 support (including `KryptonWebView2`) without adding a separate `Microsoft.Web.WebView2` package reference.

## Changes
- **Krypton.Standard.Toolkit.csproj**
  - Added `WebView2LibPath` pointing to `Krypton.Utilities\Lib\WebView2` (same source used by Krypton.Utilities and by `Scripts\WebVew2\Populate-BundledWebView2.cmd`).
  - **Managed DLLs:** `Microsoft.Web.WebView2.Core.dll` and `Microsoft.Web.WebView2.WinForms.dll` are included in `lib/<tfm>/` for each target framework via the existing `AddReferencedAssembliesToPackage` target (only when the files exist).
  - **Native loader:** When present, `WebView2Loader.dll` is packed into `runtimes\win-x64\native\` and `runtimes\win-x86\native\` so the correct native loader is used on 64-bit and 32-bit Windows.
  - All WebView2 inclusions are conditional on `Exists(...)` so the project still builds and packs when WebView2 has not been populated (e.g. fresh clone without running the populate script).
  - Documented WebView2 bundling in the project header comments.

## Behaviour
- **When WebView2 is populated** (e.g. after running `Scripts\WebVew2\Populate-BundledWebView2.cmd` or in CI, which already runs “Populate WebView2 (latest)” before build/pack): the produced Krypton.Standard.Toolkit package contains the WebView2 managed DLLs and the native loader; consumers get WebView2 without an extra package.
- **When WebView2 is not populated**: the package builds and packs as before; it simply does not include WebView2 DLLs.

## CI / Workflows
No workflow changes. **build.yml**, **release.yml**, and **nightly.yml** already populate `Krypton.Utilities/Lib/WebView2` before Restore/Build/Pack, so the Standard.Toolkit package built in CI will include WebView2 when these workflows run.

## Testing
- [ ] Build and pack Krypton.Standard.Toolkit locally with WebView2 populated (`Populate-BundledWebView2.cmd`), then inspect the `.nupkg` (e.g. with `dotnet pack` and unzip or NuGet Package Explorer): verify `lib/<tfm>/` contains the two WebView2 managed DLLs and `runtimes/win-x64/native/` and `runtimes/win-x86/native/` contain `WebView2Loader.dll`.
- [ ] (Optional) Create a small app that references the built package and uses `KryptonWebView2`; confirm it runs without adding `Microsoft.Web.WebView2`.