### PR TITLE
* Maximized MDI window form border is drawn on the second monitor (V105)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#2935](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2935), Maximized MDI window form border drawn on wrong monitor (secondary monitor); `DropSolidWindow` now uses screen coordinates for `DesktopBounds`; non-client border painting uses a DC compatible with the window's monitor
 * Resolved [#2103](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2103), Ensure that `KryptonForm` properly supports RTL/LTR
 * Resolved [#2914](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2914), White bar is shown in a `KryptonForm` Sizable without buttons and text
 * Resolved [#2910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2910), `KryptonComboBox` override Font property causes form designer error

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1524,29 +1524,39 @@ public abstract class VisualForm : Form,
                         // If we managed to get a compatible bitmap
                         if (hBitmap != IntPtr.Zero)
                         {
-                            // Must use the screen device context for the bitmap when drawing into the
-                            // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                            // Select the new bitmap into the screen DC
-                            IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                            // Use a DC compatible with the window's monitor so border draws on the correct
+                            // screen when the form is on a secondary monitor (fixes #2935).
+                            IntPtr memDC = PI.CreateCompatibleDC(hDC);
+                            IntPtr oldBitmap = memDC != IntPtr.Zero
+                                ? PI.SelectObject(memDC, hBitmap)
+                                : PI.SelectObject(_screenDC, hBitmap);
 
                             try
                             {
+                                IntPtr drawDC = memDC != IntPtr.Zero ? memDC : _screenDC;
+
                                 // Drawing is easier when using a Graphics instance
-                                using (Graphics g = Graphics.FromHdc(_screenDC))
+                                using (Graphics g = Graphics.FromHdc(drawDC))
                                 {
                                     WindowChromePaint(g, windowBounds);
                                 }
 
-                                // Now blit from the bitmap to the screen
-                                PI.BitBlt(hDC, 0, 0, windowBounds.Width, windowBounds.Height, _screenDC, 0, 0, PI.SRCCOPY);
+                                // Now blit from the bitmap to the window
+                                PI.BitBlt(hDC, 0, 0, windowBounds.Width, windowBounds.Height, drawDC, 0, 0, PI.SRCCOPY);
                             }
                             finally
                             {
-                                // Restore the original bitmap
-                                PI.SelectObject(_screenDC, oldBitmap);
+                                // Cleanup resources
+                                PI.SelectObject(memDC != IntPtr.Zero ? memDC : _screenDC, oldBitmap);
 
-                                // Delete the temporary bitmap
+                                // Delete resources we created
                                 PI.DeleteObject(hBitmap);
+
+                                // Delete memory DC if used
+                                if (memDC != IntPtr.Zero)
+                                {
+                                    PI.DeleteDC(memDC);
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
# Fix maximized MDI window form border drawn on wrong monitor (#2935) - V105 - LTS

## Summary

Resolves [#2935](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2935): when an MDI child (KryptonForm) is maximized on a secondary monitor, the form border/frame was incorrectly drawn on the primary (left) monitor instead of on the same monitor as the form content.

## Root cause and changes

### 1. **DropSolidWindow** (Krypton.Navigator)

- **Cause:** In the `SolidRect` setter, position was computed as `value.Location - (Size)area.Location` with `area = Screen.GetWorkingArea(this)`. When the drop-indicator window was already on a secondary monitor, `area` was that monitor’s working area, so the result was relative to that screen. That rectangle was then assigned to `DesktopBounds`, which is in **screen** coordinates, so the window was drawn on the primary monitor.
- **Fix:** Set `DesktopBounds = value` directly. `SolidRect` / `DrawRect` are already in screen coordinates, so no conversion is needed.

**File:** `Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs`

### 2. **VisualForm non-client (border) painting** (Krypton.Toolkit)

- **Cause:** Non-client (border) painting used a single cached DC created with `CreateCompatibleDC(IntPtr.Zero)`, i.e. compatible with the primary monitor. For a maximized MDI child on a secondary monitor, drawing through that DC could tie the border to the primary monitor.
- **Fix:** In `OnNonClientPaint`, create a compatible DC from the window’s DC: `memDC = CreateCompatibleDC(hDC)` (where `hDC` is from `GetWindowDC(Handle)`). Use `memDC` for the offscreen bitmap and `WindowChromePaint`, then BitBlt from `memDC` to `hDC`. In `finally`, restore the previous bitmap, delete the bitmap, and call `DeleteDC(memDC)` when non-zero. If `CreateCompatibleDC(hDC)` fails, fall back to the existing cached `_screenDC` behaviour.

**File:** `Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs`

### 3. **TestForm demo** (Bug 2935 MDI multi-monitor)

- Added a dedicated demo to reproduce and verify the fix:
  - **Bug2935MdiMultiMonitorDemo** – MDI parent with instructions, “New MDI Child”, “Move to secondary monitor” (when multiple screens), and Tile/Cascade/Arrange icons.
  - Instructions explain: move window to second monitor → open MDI child → maximize → confirm border is on the same monitor as the form.
- Registered in StartScreen as **“Bug 2935 MDI multi-monitor”**.

**Files:**
`Source/Krypton Components/TestForm/Bug2935MdiMultiMonitorDemo.cs` `Source/Krypton Components/TestForm/Bug2935MdiMultiMonitorDemo.Designer.cs` `Source/Krypton Components/TestForm/Bug2935MdiMultiMonitorDemo.resx` `Source/Krypton Components/TestForm/StartScreen.cs`

### 4. **Changelog**

- Added a “Resolved” entry for [#2935](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2935) in the 2026-11-xx (V110 Nightly) section.

**File:** `Documents/Changelog/Changelog.md`

## How to verify

1. Build and run TestForm (e.g. from the solution or `dotnet run` for TestForm).
2. On the start screen, open **“Bug 2935 MDI multi-monitor”**.
3. **With two monitors:**
   - Click **“Move to secondary monitor”** (or drag the window to the second display).
   - Click **“New MDI Child”**.
   - Maximize the MDI child (maximize button or double-click title bar).
   - **Expected:** The form border is drawn on the **same** monitor as the form content (secondary). No border appears on the primary monitor.
4. **Optional:** In an app that uses drag-drop with a solid drop indicator (e.g. Navigator), drag on the secondary monitor and confirm the drop-indicator window appears on that monitor, not on the primary.

## Checklist

- [x] Fixes [#2935](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2935)
- [x] No new compiler warnings from these changes
- [x] Changelog updated
- [x] Demo added in TestForm for manual verification