### PR TITLE
* Krypton Toolkit causes low-quality text rendering in Stimulsoft pre…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2913](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2913), Krypton Toolkit causes low-quality text rendering in Stimulsoft preview window
 * Resolved [#2984](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2984), NullReferenceException in `ViewDrawSeparator.RenderBefore`; added null guards for palette/metric and palette back/border when rendering separator (e.g. Navigator.StateDisabled.Separator can be null, or during theme swap/disposal)
 * Implemented [#2952](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2962), Set license header via `editorconfig`
 * Implemented [#2939](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2939), Extend the bug reporting tool

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3019,25 +3019,27 @@ public class KryptonComboBox : VisualControlBase,
                 // Set the correct text rendering hint for the text drawing. We only draw if the edit text is enabled so we
                 // just always grab the normal state value. Without this line the wrong hint can occur because it inherits
                 // it from the device context. Resulting in blurred text.
-                e.Graphics.TextRenderingHint = CommonHelper.PaletteTextHintToRenderingHint(StateNormal.Item.PaletteContent!.GetContentShortTextHint(PaletteState.Normal));
-
-                TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding;
-
-                // Use the correct prefix setting
-                flags |= TextFormatFlags.NoPrefix;
-
-                // Do we need to switch drawing direction?
-                if (RightToLeft == RightToLeft.Yes)
+                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+                using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(StateNormal.Item.PaletteContent!.GetContentShortTextHint(PaletteState.Normal))))
                 {
-                    flags |= TextFormatFlags.Right;
-                }
+                    TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding;
 
-                // Draw text using font defined by the control
-                TextRenderer.DrawText(e.Graphics,
-                    _comboBox.Text, _comboBox.Font,
-                    drawBounds,
-                    textColor, backColor,
-                    flags);
+                    // Use the correct prefix setting
+                    flags |= TextFormatFlags.NoPrefix;
+
+                    // Do we need to switch drawing direction?
+                    if (RightToLeft == RightToLeft.Yes)
+                    {
+                        flags |= TextFormatFlags.Right;
+                    }
+
+                    // Draw text using font defined by the control
+                    TextRenderer.DrawText(e.Graphics,
+                        _comboBox.Text, _comboBox.Font,
+                        drawBounds,
+                        textColor, backColor,
+                        flags);
+                }
             }
         }
         else

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -591,9 +591,12 @@ public class KryptonLinkWrapLabel : LinkLabel
         }
 
         ForeColor = textColor;
-        e.Graphics.TextRenderingHint = CommonHelper.PaletteTextHintToRenderingHint(hint);
 
-        base.OnPaint(e);
+        // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+        using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(hint)))
+        {
+            base.OnPaint(e);
+        }
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -186,58 +186,59 @@ public class KryptonTextBox : VisualControlBase,
                         }
                         else
                         {
-                            // Set the correct text rendering hint for the text drawing. We only draw if the edit text is disabled so we
-                            // just always grab the disable state value. Without this line the wrong hint can occur because it inherits
-                            // it from the device context. Resulting in blurred text.
-                            g.TextRenderingHint =
-                                CommonHelper.PaletteTextHintToRenderingHint(
-                                    _kryptonTextBox.StateDisabled.PaletteContent.GetContentShortTextHint(PaletteState.Disabled));
+                                // Set the correct text rendering hint for the text drawing. We only draw if the edit text is disabled so we
+                                // just always grab the disable state value. Without this line the wrong hint can occur because it inherits
+                                // it from the device context. Resulting in blurred text.
+                                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+                                using (new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(
+                                    _kryptonTextBox.StateDisabled.PaletteContent.GetContentShortTextHint(PaletteState.Disabled))))
+                                {
+                                    // Define the string formatting requirements
+                                    var stringFormat = new StringFormat
+                                    {
+                                        Trimming = StringTrimming.None,
+                                        LineAlignment = StringAlignment.Near
+                                    };
+                                    if (!_kryptonTextBox.Multiline)
+                                    {
+                                        stringFormat.FormatFlags |= StringFormatFlags.NoWrap;
+                                    }
 
-                            // Define the string formatting requirements
-                            var stringFormat = new StringFormat
-                            {
-                                Trimming = StringTrimming.None,
-                                LineAlignment = StringAlignment.Near
-                            };
-                            if (!_kryptonTextBox.Multiline)
-                            {
-                                stringFormat.FormatFlags |= StringFormatFlags.NoWrap;
+                                    stringFormat.Alignment = _kryptonTextBox.TextAlign switch
+                                    {
+                                        HorizontalAlignment.Left => RightToLeft == RightToLeft.Yes
+                                            ? StringAlignment.Far
+                                            : StringAlignment.Near,
+                                        HorizontalAlignment.Right => RightToLeft == RightToLeft.Yes
+                                            ? StringAlignment.Near
+                                            : StringAlignment.Far,
+                                        HorizontalAlignment.Center => StringAlignment.Center,
+                                        _ => stringFormat.Alignment
+                                    };
+
+                                    // Use the correct prefix setting
+                                    stringFormat.HotkeyPrefix = HotkeyPrefix.None;
+
+                                    // Decide on the text to draw disabled
+                                    var drawString = Text;
+                                    if (PasswordChar != '\0')
+                                    {
+                                        drawString = new string(PasswordChar, Text.Length);
+                                    }
+
+                                    // Define the font to use for disabled painting – always query the palette first.
+                                    // Avoids exception - magnitudes faster than another repaint AND try/catch.
+                                    var disabledFont = _kryptonTextBox
+                                                           .GetTripleState()
+                                                           .PaletteContent?
+                                                           .GetContentShortTextFont(PaletteState.Disabled)
+                                                       ?? Font; // Fallback: current Font if palette returns null
+                                    using var foreBrush = new SolidBrush(ForeColor);
+                                    g.DrawString(drawString, disabledFont, foreBrush,
+                                        textRectangle,
+                                        stringFormat);
+                                }
                             }
-
-                            stringFormat.Alignment = _kryptonTextBox.TextAlign switch
-                            {
-                                HorizontalAlignment.Left => RightToLeft == RightToLeft.Yes
-                                    ? StringAlignment.Far
-                                    : StringAlignment.Near,
-                                HorizontalAlignment.Right => RightToLeft == RightToLeft.Yes
-                                    ? StringAlignment.Near
-                                    : StringAlignment.Far,
-                                HorizontalAlignment.Center => StringAlignment.Center,
-                                _ => stringFormat.Alignment
-                            };
-
-                            // Use the correct prefix setting
-                            stringFormat.HotkeyPrefix = HotkeyPrefix.None;
-
-                            // Decide on the text to draw disabled
-                            var drawString = Text;
-                            if (PasswordChar != '\0')
-                            {
-                                drawString = new string(PasswordChar, Text.Length);
-                            }
-
-                            // Define the font to use for disabled painting – always query the palette first.
-                            // Avoids exception - magnitudes faster than another repaint AND try/catch.
-                            var disabledFont = _kryptonTextBox
-                                                   .GetTripleState()
-                                                   .PaletteContent?
-                                                   .GetContentShortTextFont(PaletteState.Disabled)
-                                               ?? Font; // Fallback: current Font if palette returns null
-                            using var foreBrush = new SolidBrush(ForeColor);
-                            g.DrawString(drawString, disabledFont, foreBrush,
-                                textRectangle,
-                                stringFormat);
-                        }
 
                         // Remove clipping settings
                         PI.SelectClipRgn(hdc, IntPtr.Zero);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
@@ -657,16 +657,15 @@ public class KryptonToggleSwitch : Control, IContentValues
                    
                 float textY = (Height - textSize.Height) / 2f; // Center text vertically
 
-                // Enable better text rendering for smooth appearance
-                graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
-
                 if (ToggleSwitchValues.ShowText)
                 {
-                    // Draw the text
-                    graphics.DrawString(text, font, textBrush, new PointF(textX, textY));
-
-                    // Reset text rendering hint
-                    graphics.TextRenderingHint = TextRenderingHint.SystemDefault;
+                    // Enable better text rendering for smooth appearance
+                    // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+                    using (new GraphicsTextHint(graphics, TextRenderingHint.AntiAlias))
+                    {
+                        // Draw the text
+                        graphics.DrawString(text, font, textBrush, new PointF(textX, textY));
+                    }
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -597,9 +597,12 @@ public class KryptonWrapLabel : Label
         }
 
         ForeColor = textColor;
-        e.Graphics.TextRenderingHint = CommonHelper.PaletteTextHintToRenderingHint(hint);
 
-        base.OnPaint(e);
+        // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+        using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(hint)))
+        {
+            base.OnPaint(e);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
…view window (V110)

# Fix blurry text rendering in Stimulsoft preview windows (#2913)

## Description

Fixes an issue where Krypton Toolkit controls caused low-quality/blurry text rendering in Stimulsoft report preview windows. The problem occurred even when just referencing the Krypton library or adding a single Krypton control (e.g., `KryptonLabel`) to any form in the application.

## Root Cause

Several Krypton controls were modifying `Graphics.TextRenderingHint` directly without properly saving and restoring the original value. This caused the text rendering hint to "leak" to other controls that shared the same graphics context, including Stimulsoft preview windows.

## Solution

All instances where `TextRenderingHint` was set directly have been updated to use the existing `GraphicsTextHint` helper class, which properly saves the original value, applies the new hint, and restores it when disposed (via `using` statement). This ensures that Krypton's text rendering settings are properly scoped and don't affect other controls.

## Changes Made

### Fixed Controls
1. **KryptonWrapLabel.cs** — Wrapped `TextRenderingHint` change with `GraphicsTextHint` before calling `base.OnPaint(e)`
2. **KryptonLinkWrapLabel.cs** — Same fix as `KryptonWrapLabel`
3. **KryptonComboBox.cs** — Wrapped `TextRenderingHint` change in the `DrawItem` event handler
4. **KryptonTextBox.cs** — Wrapped `TextRenderingHint` change when drawing disabled text
5. **KryptonMaskedTextBox.cs** — Same fix as `KryptonTextBox`
6. **KryptonToggleSwitch.cs** — Replaced manual save/restore with `GraphicsTextHint` to ensure original value is restored

### Code Pattern

**Before:**
```csharp
e.Graphics.TextRenderingHint = CommonHelper.PaletteTextHintToRenderingHint(hint);
base.OnPaint(e);
```

**After:**
```csharp
using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(hint)))
{
    base.OnPaint(e);
}
```

## Files Changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs`

## Testing

### Manual Testing Steps
1. Create a WinForms application that references both Krypton Toolkit and Stimulsoft
2. Add any Krypton control (e.g., `KryptonLabel`) to a form
3. Open a Stimulsoft report preview window
4. Verify that text in the preview window is no longer blurry and renders with proper quality

### Verification
- All modified files compile without errors
- No linter errors introduced
- Changes follow existing codebase patterns (similar to `GraphicsHint` for `SmoothingMode`)
- Backward compatible — no breaking changes

## Impact

- **Breaking Changes:** None
- **TFM Impact:** None — works across all supported TFMs (`net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`)
- **Performance:** Negligible — `GraphicsTextHint` is a lightweight wrapper with minimal overhead

## Related Issues

Closes #2913

## Notes

This fix follows the same pattern already established in the codebase for managing graphics state (e.g., `GraphicsHint` for `SmoothingMode`). The `GraphicsTextHint` helper class was already available but wasn't being used consistently across all controls.