### PR TITLE
`Office 2013` & `Microsoft 365` control box items are not 'flat' (V85…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-02-23 - Build 2602 (Patch 10) - February 2025
 
+* Resolved [#972](https://github.com/Krypton-Suite/Standard-Toolkit/issues/972), `Office 2013` & `Microsoft 365` control box items are not 'flat' – control box buttons (minimize, maximize, close) now use solid flat fills instead of gradients to match the official Office 2013 appearance
 * Resolved [#2913](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2913), Krypton Toolkit causes low-quality text rendering in Stimulsoft preview window
 * Resolved [#2935](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2935), Maximized MDI window form border drawn on wrong monitor (secondary monitor); `DropSolidWindow` now uses screen coordinates for `DesktopBounds`; non-client border painting uses a DC compatible with the window's monitor
 * Resolved [#2745](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2745b), `VisualMultilineStringEditorForm` only saving last line

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -964,12 +964,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -1543,12 +1543,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -1543,12 +1543,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -183,11 +183,11 @@ namespace Krypton.Toolkit
                                                                 Color.FromArgb(105, 112, 121),    // FormHeaderLongActive
                                                                 Color.FromArgb(160, 160, 160),    // FormHeaderLongInactive
                                                                 Color.FromArgb(158, 193, 241),    // FormButtonBorderTrack
-                                                                Color.FromArgb(210, 228, 254),    // FormButtonBack1Track
-                                                                Color.FromArgb(255, 255, 255),    // FormButtonBack2Track
+                                                                Color.FromArgb(213, 224, 241),    // FormButtonBack1Track
+                                                                Color.FromArgb(213, 224, 241),    // FormButtonBack2Track
                                                                 Color.FromArgb(162, 191, 227),    // FormButtonBorderPressed
-                                                                Color.FromArgb(132, 178, 233),    // FormButtonBack1Pressed
-                                                                Color.FromArgb(192, 231, 252),    // FormButtonBack2Pressed
+                                                                Color.FromArgb(163, 189, 227),    // FormButtonBack1Pressed
+                                                                Color.FromArgb(163, 189, 227),    // FormButtonBack2Pressed
                                                                 Color.FromArgb( 21,  66, 139),    // TextButtonFormNormal
                                                                 Color.FromArgb( 21,  66, 139),    // TextButtonFormTracking
                                                                 Color.FromArgb( 21,  66, 139),    // TextButtonFormPressed
@@ -1547,12 +1547,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -1548,12 +1548,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -186,11 +186,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(189, 199, 212), // FormButtonBorderTrack
-            Color.FromArgb(222, 230, 242), // FormButtonBack1Track
-            Color.FromArgb(255, 255, 255), // FormButtonBack2Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack1Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack2Track
             Color.FromArgb(149, 154, 160), // FormButtonBorderPressed
-            Color.FromArgb(125, 131, 140), // FormButtonBack1Pressed
-            Color.FromArgb(213, 226, 233), // FormButtonBack2Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack1Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack2Pressed
             Color.Black, // TextButtonFormNormal
             Color.Black, // TextButtonFormTracking
             Color.Black, // TextButtonFormPressed
@@ -1552,12 +1552,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -1455,12 +1455,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -189,11 +189,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(59, 59, 59), // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(166, 172, 179), // FormButtonBorderTrack
-            Color.FromArgb(255, 255, 255), // FormButtonBack1Track
-            Color.FromArgb(228, 228, 229), // FormButtonBack2Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack1Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack2Track
             Color.FromArgb(166, 172, 179), // FormButtonBorderPressed
-            Color.FromArgb(223, 228, 235), // FormButtonBack1Pressed
-            Color.FromArgb(188, 193, 200), // FormButtonBack2Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack1Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack2Pressed
             Color.Black, // TextButtonFormNormal
             Color.Black, // TextButtonFormTracking
             Color.Black, // TextButtonFormPressed

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -189,11 +189,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(59, 59, 59), // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(166, 172, 179), // FormButtonBorderTrack
-            Color.FromArgb(255, 255, 255), // FormButtonBack1Track
-            Color.FromArgb(228, 228, 229), // FormButtonBack2Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack1Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack2Track
             Color.FromArgb(166, 172, 179), // FormButtonBorderPressed
-            Color.FromArgb(223, 228, 235), // FormButtonBack1Pressed
-            Color.FromArgb(188, 193, 200), // FormButtonBack2Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack1Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack2Pressed
             Color.Black, // TextButtonFormNormal
             Color.Black, // TextButtonFormTracking
             Color.Black, // TextButtonFormPressed

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -942,12 +942,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -123,11 +123,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(92, 98, 106), // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(189, 199, 212), // FormButtonBorderTrack
-            Color.FromArgb(222, 230, 242), // FormButtonBack1Track
-            Color.FromArgb(255, 255, 255), // FormButtonBack2Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack1Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack2Track
             Color.FromArgb(149, 154, 160), // FormButtonBorderPressed
-            Color.FromArgb(125, 131, 140), // FormButtonBack1Pressed
-            Color.FromArgb(213, 226, 233), // FormButtonBack2Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack1Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack2Pressed
             Color.Black, // TextButtonFormNormal
             Color.Black, // TextButtonFormTracking
             Color.Black, // TextButtonFormPressed

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -128,11 +128,11 @@ namespace Krypton.Toolkit
             Color.FromArgb(59, 59, 59), // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(166, 172, 179), // FormButtonBorderTrack
-            Color.FromArgb(255, 255, 255), // FormButtonBack1Track
-            Color.FromArgb(228, 228, 229), // FormButtonBack2Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack1Track
+            Color.FromArgb(213, 224, 241), // FormButtonBack2Track
             Color.FromArgb(166, 172, 179), // FormButtonBorderPressed
-            Color.FromArgb(223, 228, 235), // FormButtonBack1Pressed
-            Color.FromArgb(188, 193, 200), // FormButtonBack2Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack1Pressed
+            Color.FromArgb(163, 189, 227), // FormButtonBack2Pressed
             Color.Black, // TextButtonFormNormal
             Color.Black, // TextButtonFormTracking
             Color.Black, // TextButtonFormPressed
@@ -1309,12 +1309,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -931,12 +931,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -933,12 +933,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorHighProfile => PaletteColorStyle.RoundedTopLight,
                 PaletteBackStyle.SeparatorHighInternalProfile => PaletteColorStyle.Linear,
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
-                PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
-                    _ => throw new ArgumentOutOfRangeException(nameof(state))
-                },
+            PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
+            {
+                PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => PaletteColorStyle.Solid,


### PR DESCRIPTION
… LTS)

# Fix Office 2013 & Microsoft 365 control box items not flat (#972)

## Summary

Control box buttons (minimize, maximize, close) in Office 2013 and Microsoft 365 themes now use flat, solid fills instead of gradients, matching the official Office 2013 appearance. White themes use updated tracking and pressed colors for consistent feedback.

## Problem

Office 2013 and Microsoft 365 control box items used `PaletteColorStyle.Linear` and `PaletteColorStyle.LinearShadow`, which created gradients and made them appear raised instead of flat like the official Office 2013 control box.

## Solution

1. **Flat appearance:** Updated `GetBackColorStyle` for `ButtonForm` and `ButtonFormClose` to use `PaletteColorStyle.Solid` for all states instead of `Linear` and `LinearShadow`.
2. **White theme tracking color:** Set `FormButtonBack1Track` and `FormButtonBack2Track` to RGB(213, 224, 241) for white themes.
3. **White theme pressed color:** Set `FormButtonBack1Pressed` and `FormButtonBack2Pressed` to RGB(163, 189, 227) for white themes.

## Files Changed

### Palette color style (flat appearance)

| Location | Files |
|----------|-------|
| Office 2013 | `PaletteOffice2013Base.cs`, `PaletteOffice2013White.cs` | | Microsoft 365 | `PaletteMicrosoft365Base.cs`, `PaletteMicrosoft365Black.cs`, `PaletteMicrosoft365SilverLightMode.cs`, `PaletteMicrosoft365SilverDarkMode.cs`, `PaletteMicrosoft365BlueLightMode.cs`, `PaletteMicrosoft365BlueDarkMode.cs`, `PaletteMicrosoft365BlackDarkMode.cs` | | Visual Studio | `PaletteVisualStudio2010With365Base.cs`, `PaletteVisualStudio2010With2013Base.cs` |

### White theme colors (tracking & pressed)

| Location | Files |
|----------|-------|
| Office 2013 | `PaletteOffice2013White.cs`, `PaletteOffice2013LightGray.cs` | | Microsoft 365 | `PaletteMicrosoft365White.cs`, `PaletteMicrosoft365Silver.cs`, `PaletteMicrosoft365SilverLightMode.cs`, `PaletteMicrosoft365BlueLightMode.cs` |

### Documentation

| Location | File |
|----------|------|
| Changelog | `Documents\Help\Changelog.md` |

## Testing

- Run TestForm with Office 2013 or Microsoft 365 themes
- Verify control box buttons appear flat (no gradient)
- Hover (tracking): white themes should show RGB(213, 224, 241)
- Press: white themes should show RGB(163, 189, 227)

## Links

- Closes #972