### PR TITLE
* Space between form close button and right edge of the form (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#3012](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3012), Space between form close button and right edge of the form – introduced `PaletteMetricInt.HeaderButtonEdgeInsetFormRight` (returns 0) so the close button aligns with the form edge; top-right corner is now clickable for easy closing
 * Resolved [#972](https://github.com/Krypton-Suite/Standard-Toolkit/issues/972), Office 2013 & Microsoft 365 control box items are not 'flat' – control box buttons (minimize, maximize, close) now use solid flat fills instead of gradients to match the official Office 2013 appearance
 * Resolved [#2913](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2913), Krypton Toolkit causes low-quality text rendering in Stimulsoft preview window
 * Implemented [#2129](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2129), Drop Down Arrows: base size reduced from 16 to 10 logical pixels; size scales by DPI; added `PaletteMetricInt.DropDownArrowBaseSize` and `KryptonPaletteNavigatorStateBar.DropDownArrowBaseSize` for theme-based configuration

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerDraw.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerDraw.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -46,7 +46,7 @@ public class ButtonSpecManagerDraw : ButtonSpecManagerBase
         GetToolStripRenderer getRenderer,
         NeedPaintHandler needPaint)
         : this(control, redirector, variableSpecs, fixedSpecs,
-            viewDockers, viewMetrics, viewMetricInt, viewMetricInt,
+            viewDockers, viewMetrics, viewMetricInt, null, viewMetricInt,
             viewMetricPaddings, getRenderer, needPaint)
     {
     }
@@ -61,6 +61,7 @@ public class ButtonSpecManagerDraw : ButtonSpecManagerBase
     /// <param name="viewDockers">Array of target view dockers.</param>
     /// <param name="viewMetrics">Array of target metric providers.</param>
     /// <param name="viewMetricIntOutside">Array of target metrics for outside spacer size.</param>
+    /// <param name="viewMetricIntOutsideRight">Optional array of target metrics for right outside spacer size. When null, left value is used for both.</param>
     /// <param name="viewMetricIntInside">Array of target metrics for inside spacer size.</param>
     /// <param name="viewMetricPaddings">Array of target metrics for button padding.</param>
     /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
@@ -72,12 +73,13 @@ public class ButtonSpecManagerDraw : ButtonSpecManagerBase
         [DisallowNull] ViewDrawDocker[] viewDockers,
         IPaletteMetric[] viewMetrics,
         PaletteMetricInt[] viewMetricIntOutside,
+        PaletteMetricInt[]? viewMetricIntOutsideRight,
         PaletteMetricInt[] viewMetricIntInside,
         PaletteMetricPadding[] viewMetricPaddings,
         GetToolStripRenderer getRenderer,
         NeedPaintHandler needPaint)
         : base(control, redirector, variableSpecs, fixedSpecs,
-            viewMetrics, viewMetricIntOutside, viewMetricIntInside,
+            viewMetrics, viewMetricIntOutside, viewMetricIntOutsideRight, viewMetricIntInside,
             viewMetricPaddings, getRenderer, needPaint)
     {
         Debug.Assert(viewDockers != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -1136,6 +1136,7 @@ public class KryptonCustomPaletteBase : PaletteBase
         PaletteMetricInt.HeaderButtonEdgeInsetDockInactive => HeaderStyles.HeaderDockInactive.StateCommon.GetMetricInt(owningForm, state, metric),
         PaletteMetricInt.HeaderButtonEdgeInsetDockActive => HeaderStyles.HeaderDockActive.StateCommon.GetMetricInt(owningForm, state, metric),
         PaletteMetricInt.HeaderButtonEdgeInsetForm => HeaderStyles.HeaderForm.StateCommon.GetMetricInt(owningForm, state, metric),
+        PaletteMetricInt.HeaderButtonEdgeInsetFormRight => HeaderStyles.HeaderForm.StateCommon.GetMetricInt(owningForm, state, metric),
         PaletteMetricInt.HeaderButtonEdgeInsetCustom1 => HeaderStyles.HeaderCustom1.StateCommon.GetMetricInt(owningForm, state, metric),
         PaletteMetricInt.HeaderButtonEdgeInsetCustom2 => HeaderStyles.HeaderCustom2.StateCommon.GetMetricInt(owningForm, state, metric),
         PaletteMetricInt.HeaderButtonEdgeInsetCustom3 => HeaderStyles.HeaderCustom3.StateCommon.GetMetricInt(owningForm, state, metric),

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -287,6 +287,8 @@ public class KryptonForm : VisualForm,
         _buttonManager = new ButtonSpecManagerDraw(this, Redirector, ButtonSpecs, buttonSpecsFixed,
             [_drawHeading],
             [StateCommon.Header],
+            [PaletteMetricInt.HeaderButtonEdgeInsetForm],
+            [PaletteMetricInt.HeaderButtonEdgeInsetFormRight],
             [PaletteMetricInt.HeaderButtonEdgeInsetForm],
             [PaletteMetricPadding.HeaderButtonPaddingForm],
             CreateToolStripRenderer,
@@ -2277,6 +2279,7 @@ public class KryptonForm : VisualForm,
             case HeaderStyle.Form:
                 _buttonManager.SetDockerMetrics(drawDocker, palette,
                     PaletteMetricInt.HeaderButtonEdgeInsetForm,
+                    PaletteMetricInt.HeaderButtonEdgeInsetFormRight,
                     PaletteMetricPadding.HeaderButtonPaddingForm);
                 break;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -1241,6 +1241,12 @@ public enum PaletteMetricInt
     HeaderButtonEdgeInsetForm,
 
     /// <summary>
+    /// Specifies how far to inset the right edge of form header buttons (e.g. close button).
+    /// Use 0 to align the close button with the form edge for easier corner clicking.
+    /// </summary>
+    HeaderButtonEdgeInsetFormRight,
+
+    /// <summary>
     /// Specifies how far to inset a button on a calendar header.
     /// </summary>
     HeaderButtonEdgeInsetCalendar,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Material/Bases/PaletteMaterialBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Material/Bases/PaletteMaterialBase.cs
@@ -303,6 +303,8 @@ public abstract class PaletteMaterialBase : PaletteMicrosoft365Base
                 return 3;
             case PaletteMetricInt.HeaderButtonEdgeInsetForm:
                 return 0;
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 2; // keep buttons close to edges for Material
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -3080,6 +3080,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
@@ -3016,6 +3016,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
@@ -3088,6 +3088,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
@@ -2961,6 +2961,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
@@ -2994,6 +2994,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
@@ -2979,6 +2979,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
@@ -2995,6 +2995,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -3597,6 +3597,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -4103,6 +4103,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -3395,6 +3395,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -3880,6 +3880,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -3860,6 +3860,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -3903,6 +3903,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -3409,6 +3409,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
@@ -3094,6 +3094,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -3675,6 +3675,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -3297,6 +3297,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -3284,6 +3284,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -3326,6 +3326,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -3302,6 +3302,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -3002,6 +3002,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
@@ -2943,6 +2943,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
@@ -2995,6 +2995,8 @@ public class PaletteOffice2003Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -2701,6 +2701,8 @@ public class PaletteProfessionalSystem : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -3002,6 +3002,8 @@ public class PaletteSparkleBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
@@ -2849,6 +2849,8 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -2171,6 +2171,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -2962,6 +2962,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -2963,6 +2963,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -2961,6 +2961,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -2961,6 +2961,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                     return 0;
                 }
                 return Math.Max(2, owningForm!.RealWindowBorders.Right);
+            case PaletteMetricInt.HeaderButtonEdgeInsetFormRight:
+                return 0;
             case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                 return 1;
             case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -136,6 +136,7 @@ public class PaletteHeaderButtonRedirect : PaletteTripleMetricRedirect
             PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary
                 or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive
                 or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm
+                or PaletteMetricInt.HeaderButtonEdgeInsetFormRight
                 or PaletteMetricInt.HeaderButtonEdgeInsetInputControl
                 or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2
                 or PaletteMetricInt.HeaderButtonEdgeInsetCustom3 when ButtonEdgeInset != -1 => ButtonEdgeInset,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -152,6 +152,7 @@ public class PaletteHeaderRedirect : PaletteTripleMetricRedirect
             PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary
                 or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive
                 or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm
+                or PaletteMetricInt.HeaderButtonEdgeInsetFormRight
                 or PaletteMetricInt.HeaderButtonEdgeInsetInputControl
                 or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2
                 or PaletteMetricInt.HeaderButtonEdgeInsetCustom3 when ButtonEdgeInset != -1 => ButtonEdgeInset,


### PR DESCRIPTION
# Fix space between form close button and right edge of the form (#3012)

## Summary

Resolves the ~8 pixel gap between the form close button and the right edge of the form, which made it difficult to close forms by moving the cursor to the top-right corner of the screen (especially when maximized).

## Problem

- There was space (about 8 pixels) to the right of the form close button
- Moving the cursor to the top-right corner did not highlight the close button
- The close button was not clickable when placing the cursor near the top-right edge
- Most noticeable when the form is maximized

## Solution

Introduced a separate metric for the right-side spacer so the close button can extend to the form edge:

1. **New palette metric `HeaderButtonEdgeInsetFormRight`** – Returns 0 to eliminate the right-edge gap while keeping the left spacer (`HeaderButtonEdgeInsetForm`) unchanged for spacing between the title and the first button.

2. **ButtonSpecManager layout changes** – Added support for optional right-side metrics:
   - `ButtonSpecManagerBase` accepts `viewMetricIntOutsideRight` for the right spacer
   - `ButtonSpecManagerDraw` has a new overload passing both left and right metrics
   - Right spacer uses `HeaderButtonEdgeInsetFormRight`, left spacer uses `HeaderButtonEdgeInsetForm`

3. **KryptonForm integration** – Uses the new overload with `HeaderButtonEdgeInsetFormRight` for the form caption buttons and passes the right metric in `SetDockerMetrics` for the Form header style.

4. **Palette support** – Implemented `HeaderButtonEdgeInsetFormRight` in all built-in palettes (Office 2007/2010/2013, Visual Studio, Microsoft 365, Sparkle, Professional, Material) and in `PaletteHeaderRedirect`, `PaletteHeaderButtonRedirect`, and `KryptonCustomPaletteBase`.

## Changes

| Area | File(s) |
|------|---------|
| Palette definitions | `PaletteDefinitions.cs` |
| Button spec managers | `ButtonSpecManagerBase.cs`, `ButtonSpecManagerDraw.cs` | | Form | `KryptonForm.cs` |
| Palette controls | `PaletteHeaderRedirect.cs`, `PaletteHeaderButtonRedirect.cs`, `KryptonCustomPaletteBase.cs` | | Built-in palettes | All Office 2007/2010/2013, VS, MS365, Sparkle, Professional, Material palette files |

## Testing

- Maximize a `KryptonForm` and move the cursor to the top-right corner – the close button should highlight and be clickable
- Verify the close button aligns with the form's right edge (no visible gap)
- Confirm left-side spacing (between title and Min button) is unchanged
- Test with different themes (Office 2013, Office 2010, Microsoft 365, etc.)

## Closes

#3012