### PR TITLE
* KryptonLabel with autosize is not working

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3025](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3025), KryptonLabel with AutoSize not working in the Designer – when drawing a KryptonLabel by click-drag on the form, the control now resizes to fit its text (when `AutoSize = true`), matching standard WinForms Label behavior. `KryptonLabel` overrides `SetBoundsCore` to enforce preferred size.
 * Implemented [#1326](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1326), Button Text Tracking - Alternate text color for tracking (hover) state on buttons. Added comprehensive example in TestForm (`ButtonTextTrackingExample`). Wired up `SchemeExtraColors` enum: new `SetSchemeExtraColor`/`GetSchemeExtraColor`/`UpdateSchemeExtraColors` API in `PaletteBase`; `SchemeExtraColorChanged` event; `ButtonTextTracking` resolvable from both `SchemeBaseColors` and `SchemeExtraColors`.
 * Resolved [#3012](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3012), Space between form close button and right edge of the form – introduced `PaletteMetricInt.HeaderButtonEdgeInsetFormRight` (returns 0) so the close button aligns with the form edge; top-right corner is now clickable for easy closing
 * Resolved [#972](https://github.com/Krypton-Suite/Standard-Toolkit/issues/972), Office 2013 & Microsoft 365 control box items are not 'flat' – control box buttons (minimize, maximize, close) now use solid flat fills instead of gradients to match the official Office 2013 appearance

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -527,6 +527,34 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
     /// Gets the default size of the control.
     /// </summary>
     protected override Size DefaultSize => new Size(90, 25);
+
+    /// <summary>
+    /// Sets the bounds of the control. When AutoSize is true, the size is forced to the preferred size
+    /// so that the label fits its content (e.g. when drawn by click-drag in the designer).
+    /// </summary>
+    /// <param name="x">The new Left property value of the control.</param>
+    /// <param name="y">The new Top property value of the control.</param>
+    /// <param name="width">The new Width property value of the control.</param>
+    /// <param name="height">The new Height property value of the control.</param>
+    /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
+    protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
+    {
+        if (AutoSize && (specified & BoundsSpecified.Size) != 0)
+        {
+            Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            
+            // Only apply preferred size when valid (e.g. when Renderer was ready); otherwise
+            // we might get a huge size and blow up the form in the designer.
+            if (preferredSize.Width > 0 && preferredSize.Height > 0
+                && preferredSize.Width < 10000 && preferredSize.Height < 10000)
+            {
+                width = preferredSize.Width;
+                height = preferredSize.Height;
+            }
+        }
+
+        base.SetBoundsCore(x, y, width, height, specified);
+    }
 
     /// <summary>
     /// Work out if this control needs to paint transparent areas.

--- a/Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.Designer.cs
@@ -1,0 +1,242 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class Bug3025KryptonLabelAutoSizeDemo
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
+            this.lblInstruction = new Krypton.Toolkit.KryptonWrapLabel();
+            this.lblSectionAutoSize = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelShort = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelLong = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelNumber = new Krypton.Toolkit.KryptonLabel();
+            this.lblSectionNoAutoSize = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelFixedSize = new Krypton.Toolkit.KryptonLabel();
+            this.lblSectionStyles = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelNormalPanel = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelBoldPanel = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelTitlePanel = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelCaptionPanel = new Krypton.Toolkit.KryptonLabel();
+            this.lblSectionWithImage = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonLabelWithImage = new Krypton.Toolkit.KryptonLabel();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
+            this.kryptonPanelMain.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
+            this.SuspendLayout();
+            //
+            // kryptonPanelMain
+            //
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelWithImage);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionWithImage);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelCaptionPanel);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelTitlePanel);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelBoldPanel);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelNormalPanel);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionStyles);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelFixedSize);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionNoAutoSize);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelNumber);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelLong);
+            this.kryptonPanelMain.Controls.Add(this.kryptonLabelShort);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionAutoSize);
+            this.kryptonPanelMain.Controls.Add(this.lblInstruction);
+            this.kryptonPanelMain.Controls.Add(this.kryptonThemeComboBox1);
+            this.kryptonPanelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanelMain.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanelMain.Name = "kryptonPanelMain";
+            this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
+            this.kryptonPanelMain.Size = new System.Drawing.Size(584, 461);
+            this.kryptonPanelMain.TabIndex = 0;
+            //
+            // kryptonThemeComboBox1
+            //
+            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Global;
+            this.kryptonThemeComboBox1.DropDownWidth = 200;
+            this.kryptonThemeComboBox1.IntegralHeight = false;
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(12, 12);
+            this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(200, 22);
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kryptonThemeComboBox1.TabIndex = 0;
+            //
+            // lblInstruction
+            //
+            this.lblInstruction.AutoSize = true;
+            this.lblInstruction.Location = new System.Drawing.Point(15, 44);
+            this.lblInstruction.Name = "lblInstruction";
+            this.lblInstruction.Size = new System.Drawing.Size(520, 38);
+            this.lblInstruction.Text = "Issue #3025: KryptonLabel with AutoSize = true now resizes to fit its text when " +
+    "placed in the Designer (click-drag). All labels below have AutoSize = true unless " +
+    "marked otherwise. Change theme to verify sizing in different palettes.";
+            //
+            // lblSectionAutoSize
+            //
+            this.lblSectionAutoSize.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionAutoSize.Location = new System.Drawing.Point(15, 95);
+            this.lblSectionAutoSize.Name = "lblSectionAutoSize";
+            this.lblSectionAutoSize.Size = new System.Drawing.Size(180, 27);
+            this.lblSectionAutoSize.TabIndex = 2;
+            this.lblSectionAutoSize.Values.Text = "AutoSize = true (default)";
+            //
+            // kryptonLabelShort
+            //
+            this.kryptonLabelShort.Location = new System.Drawing.Point(15, 128);
+            this.kryptonLabelShort.Name = "kryptonLabelShort";
+            this.kryptonLabelShort.Size = new System.Drawing.Size(45, 20);
+            this.kryptonLabelShort.TabIndex = 3;
+            this.kryptonLabelShort.Values.Text = "Short";
+            //
+            // kryptonLabelLong
+            //
+            this.kryptonLabelLong.Location = new System.Drawing.Point(15, 154);
+            this.kryptonLabelLong.Name = "kryptonLabelLong";
+            this.kryptonLabelLong.Size = new System.Drawing.Size(280, 20);
+            this.kryptonLabelLong.TabIndex = 4;
+            this.kryptonLabelLong.Values.Text = "This is a longer label that auto-sizes to fit this text.";
+            //
+            // kryptonLabelNumber
+            //
+            this.kryptonLabelNumber.Location = new System.Drawing.Point(15, 180);
+            this.kryptonLabelNumber.Name = "kryptonLabelNumber";
+            this.kryptonLabelNumber.Size = new System.Drawing.Size(27, 20);
+            this.kryptonLabelNumber.TabIndex = 5;
+            this.kryptonLabelNumber.Values.Text = "42";
+            //
+            // lblSectionNoAutoSize
+            //
+            this.lblSectionNoAutoSize.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionNoAutoSize.Location = new System.Drawing.Point(15, 213);
+            this.lblSectionNoAutoSize.Name = "lblSectionNoAutoSize";
+            this.lblSectionNoAutoSize.Size = new System.Drawing.Size(195, 27);
+            this.lblSectionNoAutoSize.TabIndex = 6;
+            this.lblSectionNoAutoSize.Values.Text = "AutoSize = false (fixed size)";
+            //
+            // kryptonLabelFixedSize
+            //
+            this.kryptonLabelFixedSize.AutoSize = false;
+            this.kryptonLabelFixedSize.Location = new System.Drawing.Point(15, 246);
+            this.kryptonLabelFixedSize.Name = "kryptonLabelFixedSize";
+            this.kryptonLabelFixedSize.Size = new System.Drawing.Size(200, 25);
+            this.kryptonLabelFixedSize.TabIndex = 7;
+            this.kryptonLabelFixedSize.Values.Text = "Fixed 200×25";
+            //
+            // lblSectionStyles
+            //
+            this.lblSectionStyles.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionStyles.Location = new System.Drawing.Point(15, 284);
+            this.lblSectionStyles.Name = "lblSectionStyles";
+            this.lblSectionStyles.Size = new System.Drawing.Size(95, 27);
+            this.lblSectionStyles.TabIndex = 8;
+            this.lblSectionStyles.Values.Text = "Label styles";
+            //
+            // kryptonLabelNormalPanel
+            //
+            this.kryptonLabelNormalPanel.LabelStyle = Krypton.Toolkit.LabelStyle.NormalPanel;
+            this.kryptonLabelNormalPanel.Location = new System.Drawing.Point(15, 317);
+            this.kryptonLabelNormalPanel.Name = "kryptonLabelNormalPanel";
+            this.kryptonLabelNormalPanel.Size = new System.Drawing.Size(82, 20);
+            this.kryptonLabelNormalPanel.TabIndex = 9;
+            this.kryptonLabelNormalPanel.Values.Text = "NormalPanel";
+            //
+            // kryptonLabelBoldPanel
+            //
+            this.kryptonLabelBoldPanel.LabelStyle = Krypton.Toolkit.LabelStyle.BoldPanel;
+            this.kryptonLabelBoldPanel.Location = new System.Drawing.Point(15, 343);
+            this.kryptonLabelBoldPanel.Name = "kryptonLabelBoldPanel";
+            this.kryptonLabelBoldPanel.Size = new System.Drawing.Size(70, 20);
+            this.kryptonLabelBoldPanel.TabIndex = 10;
+            this.kryptonLabelBoldPanel.Values.Text = "BoldPanel";
+            //
+            // kryptonLabelTitlePanel
+            //
+            this.kryptonLabelTitlePanel.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.kryptonLabelTitlePanel.Location = new System.Drawing.Point(15, 369);
+            this.kryptonLabelTitlePanel.Name = "kryptonLabelTitlePanel";
+            this.kryptonLabelTitlePanel.Size = new System.Drawing.Size(72, 20);
+            this.kryptonLabelTitlePanel.TabIndex = 11;
+            this.kryptonLabelTitlePanel.Values.Text = "TitlePanel";
+            //
+            // kryptonLabelCaptionPanel
+            //
+            this.kryptonLabelCaptionPanel.LabelStyle = Krypton.Toolkit.LabelStyle.GroupBoxCaption;
+            this.kryptonLabelCaptionPanel.Location = new System.Drawing.Point(15, 395);
+            this.kryptonLabelCaptionPanel.Name = "kryptonLabelCaptionPanel";
+            this.kryptonLabelCaptionPanel.Size = new System.Drawing.Size(85, 20);
+            this.kryptonLabelCaptionPanel.TabIndex = 12;
+            this.kryptonLabelCaptionPanel.Values.Text = "CaptionPanel";
+            //
+            // lblSectionWithImage
+            //
+            this.lblSectionWithImage.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionWithImage.Location = new System.Drawing.Point(320, 95);
+            this.lblSectionWithImage.Name = "lblSectionWithImage";
+            this.lblSectionWithImage.Size = new System.Drawing.Size(115, 27);
+            this.lblSectionWithImage.TabIndex = 13;
+            this.lblSectionWithImage.Values.Text = "Text + image";
+            //
+            // kryptonLabelWithImage
+            //
+            this.kryptonLabelWithImage.Location = new System.Drawing.Point(320, 128);
+            this.kryptonLabelWithImage.Name = "kryptonLabelWithImage";
+            this.kryptonLabelWithImage.Size = new System.Drawing.Size(120, 20);
+            this.kryptonLabelWithImage.TabIndex = 14;
+            this.kryptonLabelWithImage.Values.Text = "Label with image";
+            //
+            // Bug3025KryptonLabelAutoSizeDemo
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 461);
+            this.Controls.Add(this.kryptonPanelMain);
+            this.Name = "Bug3025KryptonLabelAutoSizeDemo";
+            this.Text = "Issue #3025: KryptonLabel AutoSize Demo";
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).EndInit();
+            this.kryptonPanelMain.ResumeLayout(false);
+            this.kryptonPanelMain.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanelMain;
+        private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
+        private Krypton.Toolkit.KryptonWrapLabel lblInstruction;
+        private Krypton.Toolkit.KryptonLabel lblSectionAutoSize;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelShort;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelLong;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelNumber;
+        private Krypton.Toolkit.KryptonLabel lblSectionNoAutoSize;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelFixedSize;
+        private Krypton.Toolkit.KryptonLabel lblSectionStyles;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelNormalPanel;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelBoldPanel;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelTitlePanel;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelCaptionPanel;
+        private Krypton.Toolkit.KryptonLabel lblSectionWithImage;
+        private Krypton.Toolkit.KryptonLabel kryptonLabelWithImage;
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.cs
@@ -1,0 +1,38 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Comprehensive demo for Issue #3025: KryptonLabel with AutoSize not working in the designer.
+/// When drawing a KryptonLabel by click-drag in the WinForms Designer, the label now resizes
+/// to fit its text (when AutoSize = true), matching standard Label behavior.
+/// This form demonstrates: AutoSize on/off, various LabelStyles, short/long text, and text + image.
+/// </summary>
+public partial class Bug3025KryptonLabelAutoSizeDemo : KryptonForm
+{
+    public Bug3025KryptonLabelAutoSizeDemo()
+    {
+        InitializeComponent();
+        Load += Bug3025KryptonLabelAutoSizeDemo_Load;
+    }
+
+    private void Bug3025KryptonLabelAutoSizeDemo_Load(object? sender, EventArgs e)
+    {
+        // Set a small image on the "Text + image" label so AutoSize includes image in preferred size
+        const int size = 16;
+        using var bmp = new Bitmap(size, size);
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.Clear(Color.Transparent);
+            g.DrawIcon(SystemIcons.Information, new Rectangle(0, 0, size, size));
+        }
+        kryptonLabelWithImage.Values.Image = (Image)bmp.Clone();
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -64,6 +64,7 @@ public partial class StartScreen : KryptonForm
         CreateButton("Buttons Test", "All the buttons you want to test.", typeof(ButtonsTest));
         CreateButton("Bug 2914 Test", "Tests the fix for 2914.", typeof(Bug2914Test));
         CreateButton("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.", typeof(Bug2984SeparatorTest));
+        CreateButton("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.", typeof(Bug3025KryptonLabelAutoSizeDemo));
         CreateButton("Bug 2935 MDI multi-monitor", "Demo for issue #2935: maximized MDI child form border drawn on the correct monitor. Move the MDI parent to a second monitor, open and maximize a child; the border should stay on the same monitor.", typeof(Bug2935MdiMultiMonitorDemo));
         CreateButton("BugReportingTool", "Easily report bugs with this tool.", typeof(BugReportingDialogTest));
         CreateButton("Code Editor", "Native code editor with syntax highlighting, line numbering, code folding, and auto-completion.", typeof(CodeEditorTest));


### PR DESCRIPTION
# Pull Request: Fix KryptonLabel AutoSize in Designer (Issue #3025)

## Summary

Fixes **KryptonLabel** so that when `AutoSize = true`, the control resizes to fit its text when placed in the WinForms Designer by click-drag, matching the behavior of the standard WinForms `Label`. Adds a comprehensive demo form in TestForm and updates the Changelog.

**Resolves:** [#3025 – KryptonLabel with autosize is not working](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3025)

---

## Problem

When adding a **KryptonLabel** to a form in the Designer by clicking and dragging:

- The control kept the size of the drawn rectangle instead of shrinking to fit its text.
- With `AutoSize = true`, the label behaved as if AutoSize were off (no immediate resize to content).
- The standard WinForms `Label` does resize to fit text after placement; KryptonLabel did not.

Users had to manually adjust the `Size` property or rely on `GetPreferredSize()` at runtime to get the correct size.

---

## Solution

**`KryptonLabel`** now overrides **`SetBoundsCore`**. When `AutoSize` is true and the size is being set (e.g. by the Designer or layout):

1. The control calls `GetPreferredSize(new Size(int.MaxValue, int.MaxValue))` to get the size that fits the current content (text, image, style).
2. It uses that preferred size for `width` and `height` instead of the requested size, so the label always sizes to its content when AutoSize is on.
3. A safeguard only applies the preferred size when it is valid (positive and below 10,000 in each dimension) to avoid blowing up the form if the renderer is not ready (e.g. very early in design time).

So whenever bounds are set—including when the Designer applies the dragged rectangle—an AutoSize label is forced to the preferred size.

---

## Changes

### Code

| File | Change |
|------|--------|
| `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs` | Override `SetBoundsCore`: when `AutoSize` is true and `BoundsSpecified.Size` is set, replace width/height with `GetPreferredSize(...)`, with a validity check before applying. |

### Demo

| File | Change |
|------|--------|
| `Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.cs` | **New.** Form class and `Load` handler that sets an image on the “Text + image” label. | | `Source/Krypton Components/TestForm/Bug3025KryptonLabelAutoSizeDemo.Designer.cs` | **New.** Demo UI: theme combo, instruction text, AutoSize labels (short/long/number), fixed-size label, multiple LabelStyles, and a label with image. | | `Source/Krypton Components/TestForm/StartScreen.cs` | Register **“Bug 3025 KryptonLabel AutoSize Demo”** in `AddButtons()`. |

### Documentation

| File | Change |
|------|--------|
| `Documents/Changelog/Changelog.md` | New entry under V110 Nightly: Resolved #3025 (KryptonLabel AutoSize in Designer) and mention of `Bug3025KryptonLabelAutoSizeDemo`. |

---

## How to verify

### Designer

1. Open a form in the WinForms Designer.
2. Add a **KryptonLabel** by click-drag (click to start, drag, release).
3. **Expected:** The label shrinks to fit its default text (e.g. “kryptonLabel1”) when you release the mouse, instead of keeping the dragged rectangle size.

### Runtime / Demo

1. Run the TestForm application.
2. From the start screen, open **“Bug 3025 KryptonLabel AutoSize Demo”**.
3. Confirm:
   - Instruction text and theme combo at the top.
   - AutoSize labels (short, long, number) sized to their text.
   - One fixed-size label (200×25) for comparison.
   - Several label styles (NormalPanel, BoldPanel, TitlePanel, CaptionPanel).
   - “Text + image” label shows an icon and text and is sized to fit both.
4. Change the theme and confirm labels still size correctly