### PR TITLE
* #3025 bugfix

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -98,16 +98,19 @@ public abstract class VisualSimpleBase : VisualControlBase
             retSize.Height += Padding.Vertical;
 #endif
 
-            // For AutoSize with GrowAndShrink, ensure we never return a size smaller than what
-            // the base class would return, to prevent incorrect shrinking behavior.
-            if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
+            // For AutoSize with GrowAndShrink, use base class size only as fallback when the view
+            // failed to calculate a valid preferred size (e.g. renderer not ready in designer).
+            // Do NOT use it as a floor when we have valid content-based size, or labels with
+            // short text (e.g. "K") would incorrectly stay at DefaultSize 90x25 instead of shrinking.
+            if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink
+                && (retSize.Width <= 0 || retSize.Height <= 0))
             {
-                // Get what the base class would return (this includes padding handling in .NET)
                 Size baseSize = base.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
-
-                // Ensure our calculated size is at least as large as the base class size
-                retSize.Width = Math.Max(retSize.Width, baseSize.Width);
-                retSize.Height = Math.Max(retSize.Height, baseSize.Height);
+                if (baseSize.Width > 0 && baseSize.Height > 0)
+                {
+                    retSize.Width = Math.Max(retSize.Width, baseSize.Width);
+                    retSize.Height = Math.Max(retSize.Height, baseSize.Height);
+                }
             }
 
             // Apply the maximum sizing


### PR DESCRIPTION
# PR #3041: Fix KryptonLabel AutoSize for short text (Issue #3025)

## Summary

Fixes a regression where KryptonLabel with AutoSize and short text (e.g. "K") incorrectly remains at 90×25 pixels instead of shrinking to fit its content.

## Related

- **Issue:** [#3025 – KryptonLabel with autosize is not working](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3025)
- **PR:** #3041

## Problem

When using KryptonLabel with `AutoSize = true` and `AutoSizeMode = GrowAndShrink`:

1. **Original issue (#3025):** Drawn labels in the designer did not resize to fit text and kept the dragged size.
2. **Regression:** After fixing that, labels with short text (e.g. "K") stayed at 90×25 instead of shrinking to the correct size.

The size 90×25 comes from `KryptonLabel.DefaultSize`.

## Root Cause

In `VisualSimpleBase.GetPreferredSize`, the GrowAndShrink path always used `base.GetPreferredSize()` as a minimum:

```csharp
if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
{
    Size baseSize = base.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
    retSize.Width = Math.Max(retSize.Width, baseSize.Width);
    retSize.Height = Math.Max(retSize.Height, baseSize.Height);
}
```

The base call returns the control’s DefaultSize (90×25 for KryptonLabel), so valid content-based sizes for short text were replaced with 90×25.

## Solution

The base size is used only when the view returns an invalid preferred size (width or height ≤ 0), for example when the renderer is not ready in the designer:

- **Valid size from view:** Use it as-is (e.g. "K" → correct small size).
- **Invalid size (0×0):** Fall back to `base.GetPreferredSize()` to avoid collapse and designer issues.

## Changes

| File | Change |
|------|--------|
| `Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs` | Guard the GrowAndShrink floor so it applies only when `retSize.Width <= 0` or `retSize.Height <= 0`. |

## Testing

- [ ] Create KryptonLabel, set text to `"K"`, verify size shrinks to fit text.
- [ ] Create KryptonLabel, set text to `"Short"` and `"This is a longer label"`, verify AutoSize in both cases.
- [ ] Draw KryptonLabel by click-drag in the designer, verify it resizes to fit text after placement.
- [ ] Run `Bug3025KryptonLabelAutoSizeDemo` and confirm all label sizes are correct.