### PR TITLE
* The pattern is redundant fix

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Tooling/ExceptionHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Tooling/ExceptionHandler.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -48,7 +48,7 @@ internal class ExceptionHandler
         bool showStackTrace = false, bool? useExceptionDialog = true,
         bool? showExceptionDialogCopyButton = false, bool? showExceptionDialogSearchBox = false)
     {
-        if (useExceptionDialog is not null or true)
+        if (useExceptionDialog is null or true)
         {
             KryptonExceptionDialog.Show(exception, showExceptionDialogCopyButton, showExceptionDialogSearchBox);
         }


### PR DESCRIPTION
# Fix Redundant Pattern Warning (CS9336)

## Summary
Fixed a compiler warning CS9336 about a redundant pattern in `ExceptionHandler.cs` at line 51.

## Changes
- **File**: `Source/Krypton Components/Krypton.Toolkit/Tooling/ExceptionHandler.cs`
- **Line**: 51
- **Change**: Updated pattern from `is not null or true` to `is null or true`

## Problem
The original pattern `is not null or true` was redundant because:
- `is not null` already covers both `true` and `false` cases
- The `or true` clause makes the condition always evaluate to `true`, making the pattern matching redundant

## Solution
Changed the pattern to `is null or true`, which correctly evaluates to:
- `true` when `useExceptionDialog` is `null` (default behavior - show dialog)
- `true` when `useExceptionDialog` is `true` (explicitly show dialog)
- `false` when `useExceptionDialog` is `false` (explicitly hide dialog)