### PR TITLE
* WinForms borderless form briefly displays system title bar on start…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2922](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2922), WinForms borderless form briefly displays system title bar on startup
 * Implemented [#1031](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1031), A way to 'dynamically' update the palette theme array with the theme name (i.e. if a custom palette is used)
 * Implemented [#2836](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2836), Time to bring over `KryptonMessageBoxExtended`
     - To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this feature is part of the `Krypton.Utilities` assembly.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -198,6 +198,9 @@ public class KryptonForm : VisualForm,
     // Compensate for Windows 11 outer accent border by shrinking the window region slightly
     private Rectangle _lastGripClientRect = Rectangle.Empty;
     private Timer? _clickTimer;
+    // Issue #2922: Workaround for borderless form briefly showing system title bar on startup
+    private bool _borderlessFormFirstShowPending;
+    private double _borderlessTargetOpacity = 1.0;
     private KryptonSystemMenu? _kryptonSystemMenu;
     // SystemMenu context menu components
     private KryptonContextMenu _systemMenuContextMenu;
@@ -1604,6 +1607,42 @@ public class KryptonForm : VisualForm,
         }
 
         base.OnControlRemoved(e);
+    }
+
+    /// <inheritdoc />
+    protected override void SetVisibleCore(bool value)
+    {
+        // When showing a borderless form for the first time we want to start with an opacity of 0 and then fade in to the target opacity.
+        // This is because some themes (e.g. Windows 11) have a fade in animation for borderless windows,
+        // but if we start with the target opacity then the animation is not smooth as it animates from fully
+        // transparent to the target opacity instead of from 0 to the target opacity.
+        if (value && FormBorderStyle == FormBorderStyle.None && !DesignMode && !_borderlessFormFirstShowPending)
+        {
+            // Set a flag to indicate we are in the middle of the first show of a borderless form, so we don't interfere with subsequent calls to SetVisibleCore
+            _borderlessFormFirstShowPending = true;
+
+            // Cache the target opacity to restore after the first show
+            _borderlessTargetOpacity = Opacity;
+
+            // Start with an opacity of 0 to allow the fade in animation to work smoothly
+            Opacity = 0;
+
+            // Let the form become visible with the new opacity value
+            base.SetVisibleCore(true);
+
+            // Use BeginInvoke to ensure the opacity change happens after the form is shown, which allows the fade in animation to work correctly
+            BeginInvoke(() =>
+            {
+                // Clear the flag to indicate the first show is complete
+                Opacity = _borderlessTargetOpacity;
+            });
+
+            // We have handled the first show, so exit to avoid calling base.SetVisibleCore again
+            return;
+        }
+
+        // For subsequent calls to SetVisibleCore we just call the base method with the provided value
+        base.SetVisibleCore(value);
     }
 
     /// <summary>

--- a/Source/Krypton Components/TestForm/BorderlessFormDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/BorderlessFormDemo.Designer.cs
@@ -1,0 +1,116 @@
+﻿namespace TestForm
+{
+    partial class BorderlessFormDemo
+    {
+            /// <summary>
+            /// Required designer variable.
+            /// </summary>
+            private System.ComponentModel.IContainer components = null;
+
+            /// <summary>
+            /// Clean up any resources being used.
+            /// </summary>
+            /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing && (components != null))
+                {
+                    components.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+
+            #region Windows Form Designer generated code
+
+            /// <summary>
+            /// Required method for Designer support - do not modify
+            /// the contents of this method with the code editor.
+            /// </summary>
+            private void InitializeComponent()
+            {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BorderlessFormDemo));
+            this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.klblDescription = new Krypton.Toolkit.KryptonLabel();
+            this.kbtnOpenAnother = new Krypton.Toolkit.KryptonButton();
+            this.kbtnClose = new Krypton.Toolkit.KryptonButton();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+            this.kryptonPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // kryptonPanel1
+            // 
+            this.kryptonPanel1.Controls.Add(this.klblDescription);
+            this.kryptonPanel1.Controls.Add(this.kbtnOpenAnother);
+            this.kryptonPanel1.Controls.Add(this.kbtnClose);
+            this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Name = "kryptonPanel1";
+            this.kryptonPanel1.Padding = new System.Windows.Forms.Padding(20);
+            this.kryptonPanel1.Size = new System.Drawing.Size(884, 200);
+            this.kryptonPanel1.TabIndex = 0;
+            // 
+            // klblDescription
+            // 
+            this.klblDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.klblDescription.Location = new System.Drawing.Point(23, 23);
+            this.klblDescription.Name = "klblDescription";
+            this.klblDescription.Size = new System.Drawing.Size(809, 80);
+            this.klblDescription.StateCommon.ShortText.MultiLine = Krypton.Toolkit.InheritBool.True;
+            this.klblDescription.StateCommon.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.klblDescription.TabIndex = 0;
+            this.klblDescription.Values.Text = resources.GetString("klblDescription.Values.Text");
+            // 
+            // kbtnOpenAnother
+            // 
+            this.kbtnOpenAnother.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.kbtnOpenAnother.Location = new System.Drawing.Point(667, 155);
+            this.kbtnOpenAnother.Name = "kbtnOpenAnother";
+            this.kbtnOpenAnother.Size = new System.Drawing.Size(100, 25);
+            this.kbtnOpenAnother.TabIndex = 1;
+            this.kbtnOpenAnother.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnOpenAnother.Values.Text = "Open Another";
+            this.kbtnOpenAnother.Click += new System.EventHandler(this.kbtnOpenAnother_Click);
+            // 
+            // kbtnClose
+            // 
+            this.kbtnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.kbtnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.kbtnClose.Location = new System.Drawing.Point(773, 155);
+            this.kbtnClose.Name = "kbtnClose";
+            this.kbtnClose.Size = new System.Drawing.Size(90, 25);
+            this.kbtnClose.TabIndex = 2;
+            this.kbtnClose.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnClose.Values.Text = "Close";
+            this.kbtnClose.Click += new System.EventHandler(this.kbtnClose_Click);
+            // 
+            // BorderlessFormDemo
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.kbtnClose;
+            this.ClientSize = new System.Drawing.Size(884, 200);
+            this.CloseBox = false;
+            this.ControlBox = false;
+            this.Controls.Add(this.kryptonPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "BorderlessFormDemo";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Borderless Form Demo (Issue #2922)";
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+            this.kryptonPanel1.ResumeLayout(false);
+            this.kryptonPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+            }
+
+            #endregion
+
+            private Krypton.Toolkit.KryptonPanel kryptonPanel1;
+            private Krypton.Toolkit.KryptonLabel klblDescription;
+            private Krypton.Toolkit.KryptonButton kbtnOpenAnother;
+            private Krypton.Toolkit.KryptonButton kbtnClose;
+        }
+}

--- a/Source/Krypton Components/TestForm/BorderlessFormDemo.cs
+++ b/Source/Krypton Components/TestForm/BorderlessFormDemo.cs
@@ -1,0 +1,37 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Demo for Issue #2922: Borderless KryptonForm startup without system title bar flicker.
+/// </summary>
+public partial class BorderlessFormDemo : KryptonForm
+{
+    public BorderlessFormDemo()
+    {
+        InitializeComponent();
+    }
+
+    private void kbtnOpenAnother_Click(object? sender, EventArgs e)
+    {
+        var another = new BorderlessFormDemo
+        {
+            Text = $"Borderless Form Demo #{DateTime.Now:HHmmss}",
+            StartPosition = FormStartPosition.Manual,
+            Location = new Point(Location.X + 40, Location.Y + 40),
+        };
+        another.Show();
+    }
+
+    private void kbtnClose_Click(object? sender, EventArgs e)
+    {
+        Close();
+    }
+}

--- a/Source/Krypton Components/TestForm/BorderlessFormDemo.resx
+++ b/Source/Krypton Components/TestForm/BorderlessFormDemo.resx
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="klblDescription.Values.Text" xml:space="preserve">
+    <value>Demo for Issue #2922: Borderless form startup fix.
+
+The form should appear directly in its borderless state with no brief flash of the Windows system title bar. Use "Open Another" to test the fix again.</value>
+  </data>
+</root>

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -63,6 +63,7 @@ public partial class StartScreen : KryptonForm
         CreateButton("Button Text Tracking", "Demonstrates alternate text color for tracking (hover) state on KryptonButton, KryptonCheckButton, KryptonColorButton and other controls (Issue #1326). Improves readability in dark themes.", typeof(ButtonTextTrackingExample));
         CreateButton("Buttons Test", "All the buttons you want to test.", typeof(ButtonsTest));
         CreateButton("KryptonColorButton Custom Colours", "Comprehensive demo of KryptonColorButton custom colours (Issue #776): CustomColors, MaxCustomColors, and visibility. Only 10 colours, or custom + theme + standard, or cap display count.", typeof(KryptonColorButtonDemo));
+        CreateButton("Borderless Form Demo", "Demo for Issue #2922: Borderless KryptonForm without system title bar flicker on startup. Form should appear directly in borderless state.", typeof(BorderlessFormDemo));
         CreateButton("Bug 2914 Test", "Tests the fix for 2914.", typeof(Bug2914Test));
         CreateButton("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.", typeof(Bug2984SeparatorTest));
         CreateButton("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.", typeof(Bug3025KryptonLabelAutoSizeDemo));


### PR DESCRIPTION
…up (V110)

# Fix: Borderless form briefly displays system title bar on startup (Issue #2922)

## Summary

Fixes a visual glitch where borderless WinForms forms (`FormBorderStyle.None`) briefly show the Windows system title bar for a few milliseconds when opening, before switching to the intended custom borderless appearance. The form now appears directly in its final borderless state with no flicker.

## Related Issues

- **Closes** [#2922](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2922) – [Bug]: WinForms borderless form briefly displays system title bar on startup

## Root Cause

When a borderless form is first shown, the native window goes through an initial layout and paint cycle during which the system chrome can briefly render before the custom borderless configuration takes effect. This is a known WinForms/DWM timing behavior on Windows 10+.

## Solution

Override `SetVisibleCore` in `KryptonForm` to apply an opacity workaround when showing a borderless form for the first time at runtime:

1. When `FormBorderStyle` is `None` and the form is about to be shown, temporarily set `Opacity = 0`
2. Call `base.SetVisibleCore(true)` so the form renders (any flicker is invisible)
3. Use `BeginInvoke` to restore the original opacity on the next message loop iteration, after the form has fully initialized and painted in its correct borderless state

The workaround only runs for the initial show, does not affect design mode, and preserves any user-configured opacity value.

## Files Changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs`

## Testing

1. Create a `KryptonForm` with `FormBorderStyle = FormBorderStyle.None`.
2. Run the application and open the form.
3. **Verify:** The form appears directly in its borderless state with no brief flash of the system title bar.
4. **Verify:** Subsequent show/hide cycles behave normally (no workaround applied after first show).
5. **Verify:** Forms with non-None border styles are unaffected.