### PR TITLE
* WinForms borderless form briefly displays system title bar on start…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#2922](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2922), WinForms borderless form briefly displays system title bar on startup
 * Implemented [#776](https://github.com/Krypton-Suite/Standard-Toolkit/issues/776), Ability to set a number of custom colours for `KryptonColorButton`
 * Implemented [#2968](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2968), Move **all** RTL specific dialogs to use the feature fully
 * Implemented [#3043](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3043), Canary LTS release workflow

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -197,6 +197,9 @@ public class KryptonForm : VisualForm,
     // Compensate for Windows 11 outer accent border by shrinking the window region slightly
     private Rectangle _lastGripClientRect = Rectangle.Empty;
     private Timer? _clickTimer;
+    // Issue #2922: Workaround for borderless form briefly showing system title bar on startup
+    private bool _borderlessFormFirstShowPending;
+    private double _borderlessTargetOpacity = 1.0;
     private KryptonSystemMenu? _kryptonSystemMenu;
     // SystemMenu context menu components
     private KryptonContextMenu _systemMenuContextMenu;
@@ -1538,7 +1541,6 @@ public class KryptonForm : VisualForm,
     /// Raises the ControlRemoved event.
     /// </summary>
     /// <param name="e">An EventArgs containing event data.</param>
-    //protected override void OnControlRemoved(ControlEventArgs e)
     protected override void OnControlRemoved(ControlEventArgs e)
     {
         // Is the cached reference being removed?
@@ -1552,6 +1554,42 @@ public class KryptonForm : VisualForm,
         }
 
         base.OnControlRemoved(e);
+    }
+
+    /// <inheritdoc />
+    protected override void SetVisibleCore(bool value)
+    {
+        // When showing a borderless form for the first time we want to start with an opacity of 0 and then fade in to the target opacity.
+        // This is because some themes (e.g. Windows 11) have a fade in animation for borderless windows,
+        // but if we start with the target opacity then the animation is not smooth as it animates from fully
+        // transparent to the target opacity instead of from 0 to the target opacity.
+        if (value && FormBorderStyle == FormBorderStyle.None && !DesignMode && !_borderlessFormFirstShowPending)
+        {
+            // Set a flag to indicate we are in the middle of the first show of a borderless form, so we don't interfere with subsequent calls to SetVisibleCore
+            _borderlessFormFirstShowPending = true;
+
+            // Cache the target opacity to restore after the first show
+            _borderlessTargetOpacity = Opacity;
+
+            // Start with an opacity of 0 to allow the fade in animation to work smoothly
+            Opacity = 0;
+
+            // Let the form become visible with the new opacity value
+            base.SetVisibleCore(true);
+
+            // Use BeginInvoke to ensure the opacity change happens after the form is shown, which allows the fade in animation to work correctly
+            BeginInvoke(() =>
+            {
+                // Clear the flag to indicate the first show is complete
+                Opacity = _borderlessTargetOpacity;
+            });
+
+            // We have handled the first show, so exit to avoid calling base.SetVisibleCore again
+            return;
+        }
+
+        // For subsequent calls to SetVisibleCore we just call the base method with the provided value
+        base.SetVisibleCore(value);
     }
 
     /// <summary>


### PR DESCRIPTION
…up (V105 LTS)

# Fix: Borderless form briefly displays system title bar on startup (Issue #2922)

## Summary

Fixes a visual glitch where borderless WinForms forms (`FormBorderStyle.None`) briefly show the Windows system title bar for a few milliseconds when opening, before switching to the intended custom borderless appearance. The form now appears directly in its final borderless state with no flicker.

## Related Issues

- **Closes** [#2922](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2922) – [Bug]: WinForms borderless form briefly displays system title bar on startup

## Root Cause

When a borderless form is first shown, the native window goes through an initial layout and paint cycle during which the system chrome can briefly render before the custom borderless configuration takes effect. This is a known WinForms/DWM timing behavior on Windows 10+.

## Solution

Override `SetVisibleCore` in `KryptonForm` to apply an opacity workaround when showing a borderless form for the first time at runtime:

1. When `FormBorderStyle` is `None` and the form is about to be shown, temporarily set `Opacity = 0`
2. Call `base.SetVisibleCore(true)` so the form renders (any flicker is invisible)
3. Use `BeginInvoke` to restore the original opacity on the next message loop iteration, after the form has fully initialized and painted in its correct borderless state

The workaround only runs for the initial show, does not affect design mode, and preserves any user-configured opacity value.

## Files Changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs`

## Testing

1. Create a `KryptonForm` with `FormBorderStyle = FormBorderStyle.None`.
2. Run the application and open the form.
3. **Verify:** The form appears directly in its borderless state with no brief flash of the system title bar.
4. **Verify:** Subsequent show/hide cycles behave normally (no workaround applied after first show).
5. **Verify:** Forms with non-None border styles are unaffected.