### PR TITLE
#3090 Fix ModernBuild: support VS2022/Current script profiles (alpha)

### DIFF
--- a/Scripts/ModernBuild/General/AppState.cs
+++ b/Scripts/ModernBuild/General/AppState.cs
@@ -45,6 +45,12 @@ public sealed class AppState
     /// </summary>
     public string ProjectFile { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the selected scripts profile (Auto, VS2022, Current).
+    /// Controls which Scripts folder variant is preferred when resolving .proj files.
+    /// </summary>
+    public ScriptProfile ScriptProfile { get; set; } = ScriptProfile.Auto;
+
     #endregion
 
     #region Logging Configuration

--- a/Scripts/ModernBuild/General/Definitions.cs
+++ b/Scripts/ModernBuild/General/Definitions.cs
@@ -150,6 +150,28 @@ public enum TasksPage
 }
 
 /// <summary>
+/// Defines which scripts folder variant the Modern Build tool should target.
+/// This allows explicit distinction between VS2022 and Current (VS2026) script sets.
+/// </summary>
+public enum ScriptProfile
+{
+    /// <summary>
+    /// Automatically choose the best scripts folder based on the detected MSBuild path.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Force use of the Scripts/VS2022 project files.
+    /// </summary>
+    VS2022,
+
+    /// <summary>
+    /// Force use of the Scripts/Current project files (intended for VS2026+).
+    /// </summary>
+    Current
+}
+
+/// <summary>
 /// Defines the different NuGet-specific actions available in the NuGet page.
 /// Each action represents a specific NuGet operation or combination of operations.
 /// </summary>


### PR DESCRIPTION
Fixes #3090 

Update `ModernBuild` to match the current repository build layout and prevent invalid build/action combinations.

The repo now has toolset-specific script folders (`Scripts/VS2022` and `Scripts/Current`). ModernBuild now supports that structure directly by adding a Scripts profile (`Auto`, `VS2022`, `Current`), resolving project files using the selected/effective profile, and showing the active profile in the UI. In Auto mode, the effective profile is inferred from the detected MSBuild path.

It also fixes action validity and execution behavior: `Canary`/`Stable` no longer allow invalid `Rebuild` selection in Ops, rebuild-like workflows on channels without a `Rebuild` target use `Build`, and `Build` now actually runs MSBuild `Build` (instead of `Rebuild`). The left sidebar width was increased to avoid truncating the F9 row, and `Scripts/ModernBuild/README.md` was fully revised to document the new behavior, controls, and resolution rules.

Validation: built `Scripts/ModernBuild/ModernBuild.csproj` successfully for `net9.0-windows` and `net10.0-windows`; verified that only Nightly project files define a `Rebuild` target and updated UI/action logic accordingly.