### PR TITLE
* Colors in theme exporting XMLs is missing (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3101), Colors in theme exporting XMLs is missing
 * Implemented [#2597](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2597), Use the `KryptonContextMenu` in `KryptonHScrollBar` & `KryptonVScrollBar`
 * Resolved [#3103](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3103), Name of the theme is not being serialized in XML files
 * Implemented [#3073](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3073), Bring over the file hashing/verification utility

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -3541,7 +3541,8 @@ public class KryptonCustomPaletteBase : PaletteBase
                             var defaultAttribs = prop.GetCustomAttributes(typeof(DefaultValueAttribute), false);
 
                             // Does this property have a default value attribute?
-                            if (defaultAttribs.Length == 1)
+                            // Use the first one found (KryptonDefaultColor is a DefaultValueAttribute subclass)
+                            if (defaultAttribs.Length >= 1)
                             {
                                 // Cast to correct type
                                 var defaultAttrib = defaultAttribs[0] as DefaultValueAttribute;
@@ -3704,8 +3705,8 @@ public class KryptonCustomPaletteBase : PaletteBase
                             {
                                 var defaultAttribs = prop.GetCustomAttributes(typeof(DefaultValueAttribute), false);
 
-                                // Does this property have a default value attribute?
-                                if (defaultAttribs.Length == 1)
+                                // Does this property have at least one default value attribute?
+                                if (defaultAttribs.Length >= 1)
                                 {
                                     // Cast to correct type
                                     var defaultAttrib = (DefaultValueAttribute)defaultAttribs[0];

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBack.cs
@@ -105,8 +105,10 @@ public class PaletteRibbonBack : Storage,
     /// <summary>
     /// Gets and sets the first background color for the ribbon item.
     /// </summary>
+    [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"First background color for the ribbon item.")]
+    [DefaultValue(typeof(Color), "Empty")]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color BackColor1
     {
@@ -247,6 +249,7 @@ public class PaletteRibbonBack : Storage,
     /// <summary>
     /// Gets and sets the fifth background color for the ribbon item.
     /// </summary>
+    [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Fifth background color for the ribbon item.")]
     [DefaultValue(typeof(Color), "Empty")]

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonFileAppTab.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonFileAppTab.cs
@@ -83,6 +83,7 @@ public class PaletteRibbonFileAppTab : Storage, IPaletteRibbonFileAppTab
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon app button dark color.")]
+    [DefaultValue(typeof(Color),  "31, 72, 161")]
     [RefreshProperties(RefreshProperties.All)]
     public Color RibbonFileAppTabBottomColor
     {
@@ -113,6 +114,7 @@ public class PaletteRibbonFileAppTab : Storage, IPaletteRibbonFileAppTab
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon app button light color.")]
+    [DefaultValue(typeof(Color), "84, 158, 243")]
     [RefreshProperties(RefreshProperties.All)]
     public Color RibbonFileAppTabTopColor
     {
@@ -145,6 +147,7 @@ public class PaletteRibbonFileAppTab : Storage, IPaletteRibbonFileAppTab
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon app button text color.")]
+    [DefaultValue(typeof(Color), "White")]
     [RefreshProperties(RefreshProperties.All)]
     public Color RibbonFileAppTabTextColor
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneral.cs
@@ -244,6 +244,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Color used for ribbon context text.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color ContextTextColor
     {
@@ -279,6 +280,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Dark disabled color for ribbon glyphs.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color DisabledDark
     {
@@ -313,6 +315,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Light disabled color for ribbon glyphs.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color DisabledLight
     {
@@ -347,6 +350,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon group dialog launcher button dark color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color GroupDialogDark
     {
@@ -382,6 +386,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon group dialog launcher button light color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color GroupDialogLight
     {
@@ -417,6 +422,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon drop arrow dark color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color DropArrowDark
     {
@@ -451,6 +457,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon drop arrow light color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color DropArrowLight
     {
@@ -486,6 +493,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon group separator dark color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color GroupSeparatorDark
     {
@@ -521,6 +529,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon group separator light color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color GroupSeparatorLight
     {
@@ -556,6 +565,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon minimize bar dark color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color MinimizeBarDarkColor
     {
@@ -591,6 +601,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon minimize bar light color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color MinimizeBarLightColor
     {
@@ -627,6 +638,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab row background solid color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabRowBackgroundSolidColor
     {
@@ -663,6 +675,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab row background gradient dark rafting color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabRowBackgroundGradientRaftingDarkColor
     {
@@ -699,6 +712,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab row background gradient light rafting color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabRowBackgroundGradientRaftingLightColor
     {
@@ -735,6 +749,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab row background gradient first color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabRowBackgroundGradientFirstColor
     {
@@ -838,6 +853,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab separator color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabSeparatorColor
     {
@@ -873,6 +889,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Ribbon tab context separator color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TabSeparatorContextColor
     {
@@ -978,6 +995,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Quick access toolbar extra button dark color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color QATButtonDarkColor
     {
@@ -1013,6 +1031,7 @@ public class PaletteRibbonGeneral : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Quick access toolbar extra button light color.")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color QATButtonLightColor
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonText.cs
@@ -89,7 +89,7 @@ public class PaletteRibbonText : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Color for the text.")]
-    [DefaultValue(typeof(Color), "")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color TextColor
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteFont.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteFont.cs
@@ -43,7 +43,7 @@ public class KryptonPaletteFont : Storage
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => (CommonLongTextFont == new Font("Segoe UI", 9f)) && (CommonShortTextFont == new Font("Segoe UI", 9f));
+    public override bool IsDefault =>  FontsAreDefault(CommonLongTextFont) && FontsAreDefault(CommonShortTextFont);
 
     #endregion
 
@@ -87,6 +87,20 @@ public class KryptonPaletteFont : Storage
     /// Resets the CommonShortTextFont property to its default value.
     /// </summary>
     public void ResetCommonShortTextFont() => CommonShortTextFont = new Font("Segoe UI", 9f);
+
+    #endregion
+
+    #region Implementation
+
+    private bool FontsAreDefault(Font? font)
+    {
+        if (font is null)
+        {
+            return true;
+        }
+
+        return font.Name == @"Segoe UI" && Math.Abs(font.Size - 9f) < 0.001f && font is { Style: FontStyle.Regular, Unit: GraphicsUnit.Point };
+    }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateCommonBaseValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateCommonBaseValues.cs
@@ -72,7 +72,6 @@ public class ProgressBarTriStateCommonBaseValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"First background color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color BackColor1
     {
@@ -82,7 +81,6 @@ public class ProgressBarTriStateCommonBaseValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"Second background color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color BackColor2
     {
@@ -154,7 +152,6 @@ public class ProgressBarTriStateCommonBaseValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"First text color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color TextColor1
     {
@@ -164,7 +161,6 @@ public class ProgressBarTriStateCommonBaseValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"Second text color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color TextColor2
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateRegionBackValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateRegionBackValues.cs
@@ -68,7 +68,6 @@ public class ProgressBarTriStateRegionBackValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"First background color.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color Color1
     {
@@ -87,7 +86,6 @@ public class ProgressBarTriStateRegionBackValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"Second background color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color Color2
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateRegionContentValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ProgressBar/TriState/ProgressBarTriStateRegionContentValues.cs
@@ -56,7 +56,6 @@ public class ProgressBarTriStateRegionContentValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"First text/content color. Empty uses default or opposite when UseOppositeTextColors is enabled.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color Color1
     {
@@ -75,7 +74,6 @@ public class ProgressBarTriStateRegionContentValues : Storage
 
     [Category(@"Visuals")]
     [Description(@"Second text/content color. Empty uses default.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
     [KryptonDefaultColor]
     public Color Color2
     {


### PR DESCRIPTION
# Fix: Colors missing from exported KryptonPalette XML (#3101)

Closes #3101

## Summary

When exporting a `KryptonCustomPaletteBase` (custom palette) to XML, configured color values were either silently dropped or written as `Value=""` (empty), making the exported file unusable. This was caused by a combination of bugs in the serialization logic and missing/incorrect `DefaultValueAttribute` decorations across several palette classes.

## Problem

Exporting a `KryptonPalette` via the designer or `Export()` API produced XML entries such as:

```xml
<Color1 Type="Color" Value="" />
<TextColor Type="Color" Value="" />
```

…or the properties were omitted entirely, even when explicit colors had been set.

## Root Causes

The `ExportObjectToElement` method in `KryptonCustomPaletteBase` uses reflection to walk the palette object graph. For leaf properties decorated with `[KryptonPersist(false)]`, it checks `DefaultValueAttribute` to determine whether a value equals its default (and can therefore be skipped when `ignoreDefaults=true`). Several bugs prevented this from working correctly:

1. **Overly strict attribute count check** – The condition `if (defaultAttribs.Length == 1)` silently skipped the default-value comparison whenever a property had zero *or* more than one `DefaultValueAttribute`-derived attributes (e.g., both `[KryptonDefaultColor]` and a redundant `[DefaultValue]`). Changed to `>= 1`.

2. **`[DefaultValue(typeof(Color), "")]` stores `null`** – `PaletteRibbonText.TextColor` used an empty string as the type-converter input. `ColorConverter` cannot parse `""`, so the attribute stored `null` instead of `Color.Empty`. The comparison `null.Equals(Color.Empty)` is skipped, meaning `Color.Empty` was always written as `Value=""`.

3. **Missing `[KryptonPersist(false)]` on `PaletteRibbonBack`** – `BackColor1` and `BackColor5` had no `[KryptonPersist]` attribute at all, so they were silently skipped by the serializer and never exported.

4. **Missing `[KryptonDefaultColor]` on `PaletteRibbonGeneral`** – All 18 color properties (`ContextTextColor`, `DisabledDark`, `DisabledLight`, `GroupDialogDark`, `GroupDialogLight`, `DropArrowDark`, `DropArrowLight`, `GroupSeparatorDark`, `GroupSeparatorLight`, `MinimizeBarDarkColor`, `MinimizeBarLightColor`, `TabRowBackgroundSolidColor`, `TabRowBackgroundGradientRaftingDarkColor`, `TabRowBackgroundGradientRaftingLightColor`, `TabSeparatorColor`, `TabSeparatorContextColor`, `QATButtonDarkColor`, `QATButtonLightColor`) were missing a `DefaultValueAttribute`, causing `Color.Empty` to always be written as `Value=""`.

5. **Missing `[DefaultValue]` on `PaletteRibbonFileAppTab`** – The three app-button color properties (`RibbonFileAppTabBottomColor`, `RibbonFileAppTabTopColor`, `RibbonFileAppTabTextColor`) lacked `DefaultValueAttribute`, so their non-empty defaults could never be detected and they were always exported even when unchanged.

6. **`KryptonPaletteFont.IsDefault` reference comparison bug** – `IsDefault` compared `Font` objects with `==` (reference equality), meaning it always returned `false`. The result was that the font palette node would always be exported, even when fonts were at their defaults. Fixed with a proper value-based `FontsAreDefault` helper.

## Additional Fixes (same PR)

- **`PaletteName` set to full file path on export** – When exporting via the Save dialog, `PaletteName` was incorrectly set to the full file path (e.g., `C:\Users\...\MyTheme.ktheme`) instead of just the file name. Fixed by using `Path.GetFileNameWithoutExtension(...)` so the embedded name in the XML is clean (e.g., `MyTheme`).

- **`ProgressBarTriState` redundant `[DefaultValue]` removed** – Color properties in `ProgressBarTriStateRegionContentValues`, `ProgressBarTriStateRegionBackValues`, and `ProgressBarTriStateCommonBaseValues` had both `[KryptonDefaultColor]` and a redundant `[DefaultValue(typeof(Color), "Empty")]`. The redundant attribute was removed.

## Changes

### `KryptonCustomPaletteBase.cs`
- `ExportObjectToElement`: changed `defaultAttribs.Length == 1` → `>= 1` so that `KryptonDefaultColor` (a `DefaultValueAttribute` subclass) is correctly recognized even when it is the only attribute present.
- `ResetObjectToDefault`: same `== 1` → `>= 1` fix for consistency.
- `PaletteName` on export/import: now uses `Path.GetFileNameWithoutExtension` rather than the raw file path.

### `PaletteRibbonText.cs`
- `TextColor`: replaced `[DefaultValue(typeof(Color), "")]` with `[KryptonDefaultColor]`. The empty string failed to parse via `ColorConverter`, resulting in a `null` stored default.

### `PaletteRibbonBack.cs`
- `BackColor1`: added missing `[KryptonPersist(false)]` and `[DefaultValue(typeof(Color), "Empty")]`.
- `BackColor5`: added missing `[KryptonPersist(false)]`.

### `PaletteRibbonGeneral.cs`
- Added `[KryptonDefaultColor]` to all 18 color properties that default to `Color.Empty`.
- Added `[DefaultValue(typeof(Color), "Transparent")]` to `TabRowBackgroundGradientFirstColor` (default is `Color.Transparent`).

### `PaletteRibbonFileAppTab.cs`
- Added `[DefaultValue(typeof(Color), "31, 72, 161")]` to `RibbonFileAppTabBottomColor`.
- Added `[DefaultValue(typeof(Color), "84, 158, 243")]` to `RibbonFileAppTabTopColor`.
- Added `[DefaultValue(typeof(Color), "White")]` to `RibbonFileAppTabTextColor`.

### `KryptonPaletteFont.cs`
- `IsDefault`: replaced broken `new Font(...) ==` reference comparison with a `FontsAreDefault` helper that compares font name, size, style, and unit by value.

### `ProgressBarTriState*Values.cs`
- Removed redundant `[DefaultValue(typeof(Color), nameof(Color.Empty))]` attributes from color properties that already carry `[KryptonDefaultColor]`.

## Testing

1. Create a new `KryptonCustomPaletteBase` in the designer or at runtime.
2. Set one or more color properties (e.g., `Palette.ButtonStyles.ButtonCommon.StateCommon.Back.Color1 = Color.Red`).
3. Export the palette to XML via **right-click → Export…** or the `Export()` API.
4. Verify the exported XML contains the set color (`Value="Red"`) and does **not** contain `Value=""` entries for unset properties.
5. Re-import the XML and confirm the colors are restored correctly.
6. Repeat with Ribbon-specific color properties (`RibbonGeneral`, `RibbonAppMenuDocsTitle`, ribbon back colors, etc.).

## Linked Issues

- Fixes #3101