### PR TITLE
* Docking: Loading configuration while form is hidden remover splitte…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3124), Docking: Loading configuration while form is hidden remover splitter
 * Implemented [#3112](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3112), Titlebar menu for `KryptonForm`
 * Implemented [#3117](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3117), Disabling focus when clicking on a `KryptonButton`
 * Resolved [#3123](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3123), `KryptonComboBox` DropDownWidth doesn't resize with the control

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -66,6 +66,7 @@ public abstract class KryptonSpace : KryptonWorkspace
     private readonly EventHandler _visibleUpdate;
     private bool _awaitingFocusUpdate;
     private bool _awaitingVisibleUpdate;
+    private bool _pendingVisibleUpdateOnHandle;
     private bool _setFocus;
     private string _closeTooltip;
     private string _pinTooltip;
@@ -243,14 +244,25 @@ public abstract class KryptonSpace : KryptonWorkspace
             // Cache focus update until invoke occurs
             _setFocus = focus;
 
-            // No point requesting the update more than once
-            if (!_awaitingVisibleUpdate && IsHandleCreated)
+            // If the control is already visible then we can update the visible state of the cells, otherwise we need to defer until the control becomes visible
+            if (IsHandleCreated)
             {
-                // Async invoke ensures the delegate is called in sync with the message queue, this means that all the
-                // layout changes for the space control will be finished and so then we can update the visible state of
-                // the cells to reflect the tab visible changes.
-                BeginInvoke(_visibleUpdate);
-                _awaitingVisibleUpdate = true;
+                // No point requesting the update more than once
+                if (!_awaitingVisibleUpdate)
+                {
+                    // Async invoke ensures the delegate is called in sync with the message queue, this means that all the
+                    // layout changes for the space control will be finished and so then we can update the visible state of
+                    // the cells to reflect the tab visible changes.
+                    BeginInvoke(_visibleUpdate);
+                    _awaitingVisibleUpdate = true;
+                }
+            }
+            else
+            {
+                // The control has no window handle yet (e.g. form is hidden during config load).
+                // Defer the visible update until the handle is created so that cell visibility
+                // and layout are correctly applied once the form becomes visible.
+                _pendingVisibleUpdateOnHandle = true;
             }
         }
     }
@@ -352,6 +364,23 @@ public abstract class KryptonSpace : KryptonWorkspace
     /// Gets a value indicating if docking specific visible changes should be applied.
     /// </summary>
     protected virtual bool ApplyDockingVisibility => true;
+
+    /// <summary>
+    /// Overridden to apply any pending visible update that was deferred because the handle
+    /// did not exist when <see cref="UpdateVisible(bool)"/> was called (e.g. the form was
+    /// hidden while a docking configuration was being loaded).
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+
+        if (_pendingVisibleUpdateOnHandle)
+        {
+            _pendingVisibleUpdateOnHandle = false;
+            UpdateVisible(_setFocus);
+        }
+    }
 
     /// <summary>
     /// Raises the CellGainsFocus event.


### PR DESCRIPTION
…r (V110)

## Fix #3124 — Docking: Loading configuration while form is hidden removes splitter resize ability

### Summary

Loading a docking configuration (via `KryptonDockingManager.LoadConfigFromFile` / `LoadConfigFromStream`) while the host form is hidden causes some dock space separators to become unresizable after the form is shown. Floating the affected dock space and re-docking it restores resizing, which confirmed the issue was a stale initialisation state rather than a structural defect in the saved configuration.

### Root Cause

`KryptonSpace.UpdateVisible(bool focus)` is the method responsible for setting the correct `Visible` state on each `KryptonWorkspaceCell` inside a dockspace after pages are loaded, and for triggering `PerformLayout()` to reflect those changes. It works by posting an async `BeginInvoke` call so the update runs in sync with the WinForms message queue.

`BeginInvoke` requires a valid window handle (`HWND`). The guard condition for this was:

```csharp
if (!_awaitingVisibleUpdate && IsHandleCreated)
{
    BeginInvoke(_visibleUpdate);
    _awaitingVisibleUpdate = true;
}
```

When the form is hidden (`this.Hide()`), the dockspace controls have no HWND yet — `IsHandleCreated` is `false`. The entire `UpdateVisible` call was silently skipped. The cells therefore remained in an incorrect visibility state (invisible by default) after config load.

This broke separator resizing because `FindMovementRect` — which computes how far a separator can be dragged — calls `DockingHelper.InnerRectangle`, which only counts `child.Visible == true` controls. With cells invisible, the inner rectangle was computed as empty, producing a zero-dimension movement rectangle for the separator, making the dock space appear completely unresizable.

When you floated and re-docked, a fresh dockspace was constructed after `Show()` so `IsHandleCreated` was already `true`, which is why that workaround fixed it.

### Fix

**File:** `Krypton Components\Krypton.Docking\Control Docking\KryptonSpace.cs`

Two small changes:

1. **`UpdateVisible(bool focus)`** — when `IsHandleCreated` is `false`, instead of silently doing nothing, set a new `_pendingVisibleUpdateOnHandle` flag so the deferred request is remembered.

2. **`OnHandleCreated(EventArgs e)` (new override)** — when the HWND is eventually created (i.e. when the form becomes visible), check `_pendingVisibleUpdateOnHandle` and call `UpdateVisible` at that point. This queues the `BeginInvoke` correctly and the cells get their proper visibility and layout applied before the user can interact with the separators.

### Behaviour

- **No change to existing behaviour** when the form is already visible during config load — the `IsHandleCreated` path is taken exactly as before.
- **Fix applies** only when `IsHandleCreated` is `false` at load time; the pending flag defers the update until `OnHandleCreated` fires, which is the earliest safe point to call `BeginInvoke`.

### Manual Repro Steps

1. Create a form with a `KryptonDockingManager` and two or more docked panels.
2. Save the docking configuration to a file.
3. On next launch, call `this.Hide()`, then `kryptonDockingManager1.LoadConfigFromFile(path)`, then `this.Show()`.
4. **Before fix:** some dock spaces cannot be resized by dragging their splitter.
5. **After fix:** all dock spaces resize correctly.