### PR TITLE
* Taskbar Progress Bar support

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#2890](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2890), Taskbar Progress Bar support
 * Resolved [#3124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3124), Docking: Loading configuration while form is hidden remover splitter
 * Implemented [#3112](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3112), Titlebar menu for `KryptonForm`
 * Implemented [#3117](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3117), Disabling focus when clicking on a `KryptonButton`

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -4528,3 +4528,26 @@ public enum ScrollbarManagerMode
 }
 
 #endregion
+
+#region Enum KryptonTaskbarProgressState
+
+/// <summary>Specifies the state of the taskbar progress indicator when <see cref="KryptonProgressBar.UseTaskbarProgress"/> is enabled.</summary>
+public enum KryptonTaskbarProgressState
+{
+    /// <summary>No progress indicator is shown. Equivalent to <c>TBPF_NOPROGRESS</c>.</summary>
+    NoProgress = 0,
+
+    /// <summary>A pulsing green indicator is shown without a specific value. Equivalent to <c>TBPF_INDETERMINATE</c>.</summary>
+    Indeterminate = 1,
+
+    /// <summary>A green progress indicator shows the current completion amount. Equivalent to <c>TBPF_NORMAL</c>.</summary>
+    Normal = 2,
+
+    /// <summary>A red progress indicator shows that an error has occurred. Equivalent to <c>TBPF_ERROR</c>.</summary>
+    Error = 4,
+
+    /// <summary>A yellow progress indicator shows that the operation has been paused. Equivalent to <c>TBPF_PAUSED</c>.</summary>
+    Paused = 8
+}
+
+#endregion

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -98,6 +98,7 @@ public partial class StartScreen : KryptonForm
         CreateButton("Splash Screen", string.Empty, typeof(SplashScreenExample));
         CreateButton("Taskbar Overlay Icon Test", "Comprehensive demonstration of taskbar overlay icons on KryptonForm with configurable icons, descriptions, and interactive examples.", typeof(TaskbarOverlayIconTest));
         CreateButton("Taskbar Thumbnail Buttons", "Demo of taskbar thumbnail toolbar buttons (Play, Pause, Next, Stop) in the taskbar preview. Hover the taskbar button to see them.", typeof(TaskbarThumbnailButtonsDemo));
+        CreateButton("Taskbar Progress Bar Demo", "Comprehensive demo of KryptonProgressBar taskbar synchronisation (Issue #2890). Covers enable/disable toggle, simulated download, manual slider, all ProgressBarStyles, all KryptonTaskbarProgressState overrides (Normal/Error/Paused/Indeterminate/NoProgress), and Min/Max range.", typeof(TaskbarProgressBarDemo));
         CreateButton("Theme Controls", string.Empty, typeof(ThemeControlExamples));
         CreateButton("Tooltip Extended/Infinite Timeout", "Comprehensive demo of extended and infinite tooltip timeout (Issue #3075). Krypton tooltips support AutoPopDelay > 5000ms and 0 (infinite) on all Windows versions.", typeof(TooltipTimeoutTest));
         CreateButton("TextBox Validating Test", "Tests fix for Validating event duplication bug #2801", typeof(KryptonTextBoxValidatingTest));

--- a/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.Designer.cs
@@ -1,0 +1,333 @@
+﻿namespace TestForm
+{
+    partial class TaskbarProgressBarDemo
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonGroupBox1 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonProgressBar1 = new Krypton.Toolkit.KryptonProgressBar();
+            this.kryptonTrackBar1 = new Krypton.Toolkit.KryptonTrackBar();
+            this.klblValue = new Krypton.Toolkit.KryptonLabel();
+            this.klblStatus = new Krypton.Toolkit.KryptonLabel();
+            this.kryptonGroupBox2 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kchkEnableTaskbar = new Krypton.Toolkit.KryptonCheckBox();
+            this.kryptonGroupBox3 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kbtnStartSimulation = new Krypton.Toolkit.KryptonButton();
+            this.kbtnStopSimulation = new Krypton.Toolkit.KryptonButton();
+            this.kryptonGroupBox4 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.kryptonGroupBox5 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonLabel3 = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbState = new Krypton.Toolkit.KryptonComboBox();
+            this.kbtnSetError = new Krypton.Toolkit.KryptonButton();
+            this.kbtnSetPaused = new Krypton.Toolkit.KryptonButton();
+            this.kbtnSetNormal = new Krypton.Toolkit.KryptonButton();
+            this.kbtnClearProgress = new Krypton.Toolkit.KryptonButton();
+            this.kryptonGroupBox6 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonLabel4 = new Krypton.Toolkit.KryptonLabel();
+            this.knudMinimum = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonLabel5 = new Krypton.Toolkit.KryptonLabel();
+            this.knudMaximum = new Krypton.Toolkit.KryptonNumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+            this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).BeginInit();
+            this.kryptonGroupBox1.Panel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2)).BeginInit();
+            this.kryptonGroupBox2.Panel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox3)).BeginInit();
+            this.kryptonGroupBox3.Panel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox4)).BeginInit();
+            this.kryptonGroupBox4.Panel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbStyle)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox5)).BeginInit();
+            this.kryptonGroupBox5.Panel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbState)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox6)).BeginInit();
+            this.kryptonGroupBox6.Panel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // kryptonPanel1
+            // 
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox6);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox5);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox4);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox3);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox2);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox1);
+            this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Name = "kryptonPanel1";
+            this.kryptonPanel1.Size = new System.Drawing.Size(680, 620);
+            this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonGroupBox1 — Progress bar, track bar, value and status labels
+            // 
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(12, 12);
+            this.kryptonGroupBox1.Name = "kryptonGroupBox1";
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(656, 140);
+            this.kryptonGroupBox1.TabIndex = 0;
+            this.kryptonGroupBox1.Values.Heading = "Progress Bar";
+            // Progress bar
+            this.kryptonProgressBar1.Location = new System.Drawing.Point(10, 10);
+            this.kryptonProgressBar1.Name = "kryptonProgressBar1";
+            this.kryptonProgressBar1.Size = new System.Drawing.Size(626, 26);
+            this.kryptonProgressBar1.TabIndex = 0;
+            // Track bar
+            this.kryptonTrackBar1.Location = new System.Drawing.Point(10, 44);
+            this.kryptonTrackBar1.Name = "kryptonTrackBar1";
+            this.kryptonTrackBar1.Size = new System.Drawing.Size(626, 38);
+            this.kryptonTrackBar1.TabIndex = 1;
+            this.kryptonTrackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            // Value label
+            this.klblValue.Location = new System.Drawing.Point(10, 88);
+            this.klblValue.Name = "klblValue";
+            this.klblValue.Size = new System.Drawing.Size(200, 20);
+            this.klblValue.TabIndex = 2;
+            this.klblValue.Values.Text = "Value: 0 / 100";
+            // Status label
+            this.klblStatus.Location = new System.Drawing.Point(220, 88);
+            this.klblStatus.Name = "klblStatus";
+            this.klblStatus.Size = new System.Drawing.Size(416, 20);
+            this.klblStatus.TabIndex = 3;
+            this.klblStatus.Values.Text = "Taskbar: OFF";
+            this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonProgressBar1);
+            this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonTrackBar1);
+            this.kryptonGroupBox1.Panel.Controls.Add(this.klblValue);
+            this.kryptonGroupBox1.Panel.Controls.Add(this.klblStatus);
+            // 
+            // kryptonGroupBox2 — Enable/Disable toggle
+            // 
+            this.kryptonGroupBox2.Location = new System.Drawing.Point(12, 162);
+            this.kryptonGroupBox2.Name = "kryptonGroupBox2";
+            this.kryptonGroupBox2.Size = new System.Drawing.Size(320, 68);
+            this.kryptonGroupBox2.TabIndex = 1;
+            this.kryptonGroupBox2.Values.Heading = "Scenario 1 — Enable / Disable";
+            this.kchkEnableTaskbar.Location = new System.Drawing.Point(10, 10);
+            this.kchkEnableTaskbar.Name = "kchkEnableTaskbar";
+            this.kchkEnableTaskbar.Size = new System.Drawing.Size(280, 20);
+            this.kchkEnableTaskbar.TabIndex = 0;
+            this.kchkEnableTaskbar.Values.Text = "UseTaskbarProgress (synchronise with taskbar)";
+            this.kchkEnableTaskbar.CheckedChanged += new System.EventHandler(this.kchkEnableTaskbar_CheckedChanged);
+            this.kryptonGroupBox2.Panel.Controls.Add(this.kchkEnableTaskbar);
+            // 
+            // kryptonGroupBox3 — Simulated download
+            // 
+            this.kryptonGroupBox3.Location = new System.Drawing.Point(348, 162);
+            this.kryptonGroupBox3.Name = "kryptonGroupBox3";
+            this.kryptonGroupBox3.Size = new System.Drawing.Size(320, 68);
+            this.kryptonGroupBox3.TabIndex = 2;
+            this.kryptonGroupBox3.Values.Heading = "Scenario 2 — Simulated Download";
+            this.kbtnStartSimulation.Location = new System.Drawing.Point(10, 10);
+            this.kbtnStartSimulation.Name = "kbtnStartSimulation";
+            this.kbtnStartSimulation.Size = new System.Drawing.Size(140, 30);
+            this.kbtnStartSimulation.TabIndex = 0;
+            this.kbtnStartSimulation.Values.Text = "Start";
+            this.kbtnStartSimulation.Click += new System.EventHandler(this.kbtnStartSimulation_Click);
+            this.kbtnStopSimulation.Location = new System.Drawing.Point(160, 10);
+            this.kbtnStopSimulation.Name = "kbtnStopSimulation";
+            this.kbtnStopSimulation.Size = new System.Drawing.Size(140, 30);
+            this.kbtnStopSimulation.TabIndex = 1;
+            this.kbtnStopSimulation.Values.Text = "Stop";
+            this.kbtnStopSimulation.Click += new System.EventHandler(this.kbtnStopSimulation_Click);
+            this.kryptonGroupBox3.Panel.Controls.Add(this.kbtnStartSimulation);
+            this.kryptonGroupBox3.Panel.Controls.Add(this.kbtnStopSimulation);
+            // 
+            // kryptonGroupBox4 — ProgressBarStyle
+            // 
+            this.kryptonGroupBox4.Location = new System.Drawing.Point(12, 240);
+            this.kryptonGroupBox4.Name = "kryptonGroupBox4";
+            this.kryptonGroupBox4.Size = new System.Drawing.Size(320, 68);
+            this.kryptonGroupBox4.TabIndex = 3;
+            this.kryptonGroupBox4.Values.Heading = "Scenario 4 — ProgressBarStyle";
+            this.kryptonLabel2.Location = new System.Drawing.Point(10, 14);
+            this.kryptonLabel2.Name = "kryptonLabel2";
+            this.kryptonLabel2.Size = new System.Drawing.Size(42, 20);
+            this.kryptonLabel2.TabIndex = 0;
+            this.kryptonLabel2.Values.Text = "Style:";
+            this.kcmbStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbStyle.Location = new System.Drawing.Point(58, 10);
+            this.kcmbStyle.Name = "kcmbStyle";
+            this.kcmbStyle.Size = new System.Drawing.Size(242, 22);
+            this.kcmbStyle.TabIndex = 1;
+            this.kcmbStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbStyle_SelectedIndexChanged);
+            this.kryptonGroupBox4.Panel.Controls.Add(this.kryptonLabel2);
+            this.kryptonGroupBox4.Panel.Controls.Add(this.kcmbStyle);
+            // 
+            // kryptonGroupBox5 — TaskbarProgressState
+            // 
+            this.kryptonGroupBox5.Location = new System.Drawing.Point(348, 240);
+            this.kryptonGroupBox5.Name = "kryptonGroupBox5";
+            this.kryptonGroupBox5.Size = new System.Drawing.Size(320, 170);
+            this.kryptonGroupBox5.TabIndex = 4;
+            this.kryptonGroupBox5.Values.Heading = "Scenario 5 — TaskbarProgressState";
+            this.kryptonLabel3.Location = new System.Drawing.Point(10, 14);
+            this.kryptonLabel3.Name = "kryptonLabel3";
+            this.kryptonLabel3.Size = new System.Drawing.Size(42, 20);
+            this.kryptonLabel3.TabIndex = 0;
+            this.kryptonLabel3.Values.Text = "State:";
+            this.kcmbState.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbState.Location = new System.Drawing.Point(58, 10);
+            this.kcmbState.Name = "kcmbState";
+            this.kcmbState.Size = new System.Drawing.Size(242, 22);
+            this.kcmbState.TabIndex = 1;
+            this.kcmbState.SelectedIndexChanged += new System.EventHandler(this.kcmbState_SelectedIndexChanged);
+            this.kbtnSetNormal.Location = new System.Drawing.Point(10, 42);
+            this.kbtnSetNormal.Name = "kbtnSetNormal";
+            this.kbtnSetNormal.Size = new System.Drawing.Size(138, 30);
+            this.kbtnSetNormal.TabIndex = 2;
+            this.kbtnSetNormal.Values.Text = "Normal (green)";
+            this.kbtnSetNormal.Click += new System.EventHandler(this.kbtnSetNormal_Click);
+            this.kbtnSetPaused.Location = new System.Drawing.Point(162, 42);
+            this.kbtnSetPaused.Name = "kbtnSetPaused";
+            this.kbtnSetPaused.Size = new System.Drawing.Size(138, 30);
+            this.kbtnSetPaused.TabIndex = 3;
+            this.kbtnSetPaused.Values.Text = "Paused (yellow)";
+            this.kbtnSetPaused.Click += new System.EventHandler(this.kbtnSetPaused_Click);
+            this.kbtnSetError.Location = new System.Drawing.Point(10, 82);
+            this.kbtnSetError.Name = "kbtnSetError";
+            this.kbtnSetError.Size = new System.Drawing.Size(138, 30);
+            this.kbtnSetError.TabIndex = 4;
+            this.kbtnSetError.Values.Text = "Error (red)";
+            this.kbtnSetError.Click += new System.EventHandler(this.kbtnSetError_Click);
+            this.kbtnClearProgress.Location = new System.Drawing.Point(162, 82);
+            this.kbtnClearProgress.Name = "kbtnClearProgress";
+            this.kbtnClearProgress.Size = new System.Drawing.Size(138, 30);
+            this.kbtnClearProgress.TabIndex = 5;
+            this.kbtnClearProgress.Values.Text = "Clear (disable)";
+            this.kbtnClearProgress.Click += new System.EventHandler(this.kbtnClearProgress_Click);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kryptonLabel3);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kcmbState);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kbtnSetNormal);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kbtnSetPaused);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kbtnSetError);
+            this.kryptonGroupBox5.Panel.Controls.Add(this.kbtnClearProgress);
+            // 
+            // kryptonGroupBox6 — Min/Max range
+            // 
+            this.kryptonGroupBox6.Location = new System.Drawing.Point(12, 420);
+            this.kryptonGroupBox6.Name = "kryptonGroupBox6";
+            this.kryptonGroupBox6.Size = new System.Drawing.Size(320, 68);
+            this.kryptonGroupBox6.TabIndex = 5;
+            this.kryptonGroupBox6.Values.Heading = "Scenario 6 — Minimum / Maximum Range";
+            this.kryptonLabel4.Location = new System.Drawing.Point(10, 14);
+            this.kryptonLabel4.Name = "kryptonLabel4";
+            this.kryptonLabel4.Size = new System.Drawing.Size(28, 20);
+            this.kryptonLabel4.TabIndex = 0;
+            this.kryptonLabel4.Values.Text = "Min:";
+            this.knudMinimum.Location = new System.Drawing.Point(44, 10);
+            this.knudMinimum.Minimum = 0;
+            this.knudMinimum.Maximum = 9999;
+            this.knudMinimum.Name = "knudMinimum";
+            this.knudMinimum.Size = new System.Drawing.Size(80, 22);
+            this.knudMinimum.TabIndex = 1;
+            this.knudMinimum.Value = 0;
+            this.knudMinimum.ValueChanged += new System.EventHandler(this.knudMinimum_ValueChanged);
+            this.kryptonLabel5.Location = new System.Drawing.Point(138, 14);
+            this.kryptonLabel5.Name = "kryptonLabel5";
+            this.kryptonLabel5.Size = new System.Drawing.Size(32, 20);
+            this.kryptonLabel5.TabIndex = 2;
+            this.kryptonLabel5.Values.Text = "Max:";
+            this.knudMaximum.Location = new System.Drawing.Point(176, 10);
+            this.knudMaximum.Minimum = 1;
+            this.knudMaximum.Maximum = 9999;
+            this.knudMaximum.Name = "knudMaximum";
+            this.knudMaximum.Size = new System.Drawing.Size(80, 22);
+            this.knudMaximum.TabIndex = 3;
+            this.knudMaximum.Value = 100;
+            this.knudMaximum.ValueChanged += new System.EventHandler(this.knudMaximum_ValueChanged);
+            this.kryptonGroupBox6.Panel.Controls.Add(this.kryptonLabel4);
+            this.kryptonGroupBox6.Panel.Controls.Add(this.knudMinimum);
+            this.kryptonGroupBox6.Panel.Controls.Add(this.kryptonLabel5);
+            this.kryptonGroupBox6.Panel.Controls.Add(this.knudMaximum);
+            // 
+            // TaskbarProgressBarDemo
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(680, 620);
+            this.Controls.Add(this.kryptonPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.Name = "TaskbarProgressBarDemo";
+            this.Text = "Taskbar Progress Bar Demo (Issue #2890)";
+            this.Load += new System.EventHandler(this.TaskbarProgressBarDemo_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).EndInit();
+            this.kryptonGroupBox1.Panel.ResumeLayout(false);
+            this.kryptonGroupBox1.Panel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2)).EndInit();
+            this.kryptonGroupBox2.Panel.ResumeLayout(false);
+            this.kryptonGroupBox2.Panel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox3)).EndInit();
+            this.kryptonGroupBox3.Panel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox4)).EndInit();
+            this.kryptonGroupBox4.Panel.ResumeLayout(false);
+            this.kryptonGroupBox4.Panel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbStyle)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox5)).EndInit();
+            this.kryptonGroupBox5.Panel.ResumeLayout(false);
+            this.kryptonGroupBox5.Panel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbState)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox6)).EndInit();
+            this.kryptonGroupBox6.Panel.ResumeLayout(false);
+            this.kryptonGroupBox6.Panel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+            this.kryptonPanel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanel1;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox1;
+        private Krypton.Toolkit.KryptonProgressBar kryptonProgressBar1;
+        private Krypton.Toolkit.KryptonTrackBar kryptonTrackBar1;
+        private Krypton.Toolkit.KryptonLabel klblValue;
+        private Krypton.Toolkit.KryptonLabel klblStatus;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox2;
+        private Krypton.Toolkit.KryptonCheckBox kchkEnableTaskbar;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox3;
+        private Krypton.Toolkit.KryptonButton kbtnStartSimulation;
+        private Krypton.Toolkit.KryptonButton kbtnStopSimulation;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox4;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel2;
+        private Krypton.Toolkit.KryptonComboBox kcmbStyle;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox5;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel3;
+        private Krypton.Toolkit.KryptonComboBox kcmbState;
+        private Krypton.Toolkit.KryptonButton kbtnSetNormal;
+        private Krypton.Toolkit.KryptonButton kbtnSetPaused;
+        private Krypton.Toolkit.KryptonButton kbtnSetError;
+        private Krypton.Toolkit.KryptonButton kbtnClearProgress;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox6;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel4;
+        private Krypton.Toolkit.KryptonNumericUpDown knudMinimum;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel5;
+        private Krypton.Toolkit.KryptonNumericUpDown knudMaximum;
+    }
+}

--- a/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.cs
+++ b/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.cs
@@ -1,0 +1,274 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Comprehensive demonstration of the KryptonProgressBar taskbar progress integration
+/// via <see cref="KryptonProgressBar.UseTaskbarProgress"/> and
+/// <see cref="KryptonProgressBar.TaskbarProgressState"/> (issue #2890).
+///
+/// Scenarios covered:
+///  1. Basic enable/disable toggle
+///  2. Simulated download with a Timer (Normal state, live value updates)
+///  3. Manual value slider
+///  4. All ProgressBarStyles (Continuous, Blocks, Marquee)
+///  5. All KryptonTaskbarProgressState overrides (Normal, Error, Paused, Indeterminate, NoProgress)
+///  6. Minimum/Maximum range customisation
+/// </summary>
+public partial class TaskbarProgressBarDemo : KryptonForm
+{
+    private readonly System.Windows.Forms.Timer _simulationTimer;
+    private bool _simulationRunning;
+
+    public TaskbarProgressBarDemo()
+    {
+        InitializeComponent();
+
+        _simulationTimer = new System.Windows.Forms.Timer { Interval = 80 };
+        _simulationTimer.Tick += OnSimulationTick;
+    }
+
+    private void TaskbarProgressBarDemo_Load(object? sender, EventArgs e)
+    {
+        Icon = SystemIcons.Application;
+
+        PopulateStyleCombo();
+        PopulateStateCombo();
+
+        kryptonTrackBar1.Minimum = 0;
+        kryptonTrackBar1.Maximum = 100;
+        kryptonTrackBar1.Value = 0;
+        kryptonTrackBar1.SmallChange = 1;
+        kryptonTrackBar1.LargeChange = 10;
+        kryptonTrackBar1.TickFrequency = 10;
+        kryptonTrackBar1.ValueChanged += OnTrackBarValueChanged;
+
+        kryptonProgressBar1.Minimum = 0;
+        kryptonProgressBar1.Maximum = 100;
+        kryptonProgressBar1.Value = 0;
+        kryptonProgressBar1.UseTaskbarProgress = kchkEnableTaskbar.Checked;
+
+        UpdateValueLabel(0);
+        UpdateStatusLabel();
+        UpdateButtonStates();
+    }
+
+    protected override void OnFormClosed(FormClosedEventArgs e)
+    {
+        _simulationTimer.Stop();
+        _simulationTimer.Dispose();
+        base.OnFormClosed(e);
+    }
+
+    // ── Scenario 1: Enable/Disable toggle ────────────────────────────────────
+
+    private void kchkEnableTaskbar_CheckedChanged(object? sender, EventArgs e)
+    {
+        kryptonProgressBar1.UseTaskbarProgress = kchkEnableTaskbar.Checked;
+        UpdateStatusLabel();
+    }
+
+    // ── Scenario 2: Simulated download ───────────────────────────────────────
+
+    private void kbtnStartSimulation_Click(object? sender, EventArgs e)
+    {
+        if (_simulationRunning)
+        {
+            return;
+        }
+
+        kryptonProgressBar1.Value = 0;
+        kryptonTrackBar1.Value = 0;
+        kryptonProgressBar1.Style = ProgressBarStyle.Continuous;
+        kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Normal;
+        kcmbStyle.SelectedIndex = 0;
+        kcmbState.SelectedIndex = 2;
+
+        _simulationRunning = true;
+        _simulationTimer.Start();
+        UpdateButtonStates();
+        UpdateStatusLabel();
+    }
+
+    private void kbtnStopSimulation_Click(object? sender, EventArgs e)
+    {
+        StopSimulation();
+    }
+
+    private void OnSimulationTick(object? sender, EventArgs e)
+    {
+        int next = kryptonProgressBar1.Value + 1;
+
+        if (next >= kryptonProgressBar1.Maximum)
+        {
+            next = kryptonProgressBar1.Maximum;
+            StopSimulation();
+        }
+
+        kryptonProgressBar1.Value = next;
+        kryptonTrackBar1.Value = next;
+        UpdateValueLabel(next);
+    }
+
+    private void StopSimulation()
+    {
+        _simulationTimer.Stop();
+        _simulationRunning = false;
+        UpdateButtonStates();
+        UpdateStatusLabel();
+    }
+
+    // ── Scenario 3: Manual slider ─────────────────────────────────────────────
+
+    private void OnTrackBarValueChanged(object? sender, EventArgs e)
+    {
+        if (_simulationRunning)
+        {
+            return;
+        }
+
+        kryptonProgressBar1.Value = kryptonTrackBar1.Value;
+        UpdateValueLabel(kryptonTrackBar1.Value);
+    }
+
+    // ── Scenario 4: ProgressBarStyle ─────────────────────────────────────────
+
+    private void PopulateStyleCombo()
+    {
+        kcmbStyle.Items.Clear();
+        kcmbStyle.Items.Add(ProgressBarStyle.Continuous);
+        kcmbStyle.Items.Add(ProgressBarStyle.Blocks);
+        kcmbStyle.Items.Add(ProgressBarStyle.Marquee);
+        kcmbStyle.SelectedIndex = 0;
+    }
+
+    private void kcmbStyle_SelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (kcmbStyle.SelectedItem is ProgressBarStyle style)
+        {
+            kryptonProgressBar1.Style = style;
+        }
+    }
+
+    // ── Scenario 5: KryptonTaskbarProgressState overrides ────────────────────
+
+    private void PopulateStateCombo()
+    {
+        kcmbState.Items.Clear();
+        kcmbState.Items.Add(KryptonTaskbarProgressState.NoProgress);
+        kcmbState.Items.Add(KryptonTaskbarProgressState.Indeterminate);
+        kcmbState.Items.Add(KryptonTaskbarProgressState.Normal);
+        kcmbState.Items.Add(KryptonTaskbarProgressState.Error);
+        kcmbState.Items.Add(KryptonTaskbarProgressState.Paused);
+        kcmbState.SelectedIndex = 2;
+    }
+
+    private void kcmbState_SelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (kcmbState.SelectedItem is KryptonTaskbarProgressState state)
+        {
+            kryptonProgressBar1.TaskbarProgressState = state;
+            UpdateStatusLabel();
+        }
+    }
+
+    private void kbtnSetError_Click(object? sender, EventArgs e)
+    {
+        kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Error;
+        kcmbState.SelectedItem = KryptonTaskbarProgressState.Error;
+        UpdateStatusLabel();
+    }
+
+    private void kbtnSetPaused_Click(object? sender, EventArgs e)
+    {
+        kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Paused;
+        kcmbState.SelectedItem = KryptonTaskbarProgressState.Paused;
+        UpdateStatusLabel();
+    }
+
+    private void kbtnSetNormal_Click(object? sender, EventArgs e)
+    {
+        kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Normal;
+        kcmbState.SelectedItem = KryptonTaskbarProgressState.Normal;
+        UpdateStatusLabel();
+    }
+
+    private void kbtnClearProgress_Click(object? sender, EventArgs e)
+    {
+        kryptonProgressBar1.UseTaskbarProgress = false;
+        kchkEnableTaskbar.Checked = false;
+        UpdateStatusLabel();
+    }
+
+    // ── Scenario 6: Min/Max range ─────────────────────────────────────────────
+
+    private void knudMinimum_ValueChanged(object? sender, EventArgs e)
+    {
+        int min = (int)knudMinimum.Value;
+        if (min >= kryptonProgressBar1.Maximum)
+        {
+            return;
+        }
+
+        kryptonProgressBar1.Minimum = min;
+        kryptonTrackBar1.Minimum = min;
+
+        if (kryptonProgressBar1.Value < min)
+        {
+            kryptonProgressBar1.Value = min;
+            kryptonTrackBar1.Value = min;
+        }
+
+        UpdateValueLabel(kryptonProgressBar1.Value);
+    }
+
+    private void knudMaximum_ValueChanged(object? sender, EventArgs e)
+    {
+        int max = (int)knudMaximum.Value;
+        if (max <= kryptonProgressBar1.Minimum)
+        {
+            return;
+        }
+
+        kryptonProgressBar1.Maximum = max;
+        kryptonTrackBar1.Maximum = max;
+
+        if (kryptonProgressBar1.Value > max)
+        {
+            kryptonProgressBar1.Value = max;
+            kryptonTrackBar1.Value = max;
+        }
+
+        UpdateValueLabel(kryptonProgressBar1.Value);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void UpdateValueLabel(int value)
+    {
+        klblValue.Text = $"Value: {value} / {kryptonProgressBar1.Maximum}";
+    }
+
+    private void UpdateStatusLabel()
+    {
+        string taskbarPart = kryptonProgressBar1.UseTaskbarProgress
+            ? $"Taskbar: ON  |  State: {kryptonProgressBar1.TaskbarProgressState}"
+            : "Taskbar: OFF";
+        string simPart = _simulationRunning ? "  |  Simulation: Running" : string.Empty;
+        klblStatus.Text = $"{taskbarPart}{simPart}";
+    }
+
+    private void UpdateButtonStates()
+    {
+        kbtnStartSimulation.Enabled = !_simulationRunning;
+        kbtnStopSimulation.Enabled = _simulationRunning;
+        kryptonTrackBar1.Enabled = !_simulationRunning;
+    }
+}

--- a/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.resx
+++ b/Source/Krypton Components/TestForm/TaskbarProgressBarDemo.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
# PR: Taskbar Progress Bar support for `KryptonProgressBar` (fixes #2890)

## Summary

Implements [Feature Request #2890](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2890) — the Windows taskbar button progress indicator can now be synchronised with a `KryptonProgressBar` control by setting a single opt-in property.

All five taskbar states (`Normal`, `Paused`, `Error`, `Indeterminate`, `NoProgress`) are supported. The implementation reuses the existing `PI.ITaskbarList3` / `PI.TaskbarList` / `PI.TBPFLAG` COM declarations already present in `PlatformInvoke.cs` and is consistent with the existing `UpdateTaskbarOverlayIcon` pattern in `VisualForm`.

---

## Files Changed

| File | Change |
|---|---|
| `Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs` | New fields, properties, and private helpers|`TestForm/TaskbarProgressBarDemo.cs` | **New file** — comprehensive demo form | | `TestForm/TaskbarProgressBarDemo.Designer.cs` | **New file** — designer file for the demo form | | `TestForm/StartScreen.cs` | +1 line — registers the demo in the Start Screen | | `Documents/taskbar-progress-bar.md` | **New file** — developer documentation |

---

## New Public API

### `KryptonProgressBar.UseTaskbarProgress` (`bool`, default `false`)

Opt-in toggle. When `true`, every change to `Value`, `Minimum`, `Maximum`, `Style`, or `TaskbarProgressState` is immediately reflected on the parent form's taskbar button via `ITaskbarList3`. Setting it back to `false` clears the indicator (`TBPF_NOPROGRESS`). The indicator is also cleared automatically when the control is disposed.

```csharp
kryptonProgressBar1.UseTaskbarProgress = true;
kryptonProgressBar1.Value = 60;           // taskbar shows 60 %
kryptonProgressBar1.UseTaskbarProgress = false; // taskbar indicator removed
```

### `KryptonProgressBar.TaskbarProgressState` (`KryptonTaskbarProgressState`, default `Normal`)

Overrides the automatic state when `UseTaskbarProgress` is `true`. Allows signalling `Error` (red) or `Paused` (yellow) independently of the on-screen bar appearance.

```csharp
kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Error;  // red
kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Paused; // yellow
kryptonProgressBar1.TaskbarProgressState = KryptonTaskbarProgressState.Normal; // green, restored
```

### `KryptonTaskbarProgressState` (new `enum` in `Krypton.Toolkit`)

```csharp
public enum KryptonTaskbarProgressState
{
    NoProgress    = 0,  // TBPF_NOPROGRESS    — hides the indicator
    Indeterminate = 1,  // TBPF_INDETERMINATE — pulsing green, no value
    Normal        = 2,  // TBPF_NORMAL        — green determinate bar
    Error         = 4,  // TBPF_ERROR         — red determinate bar
    Paused        = 8   // TBPF_PAUSED        — yellow determinate bar
}
```

Values are numerically equal to the underlying Win32 `TBPFLAG` flags.

---

## Automatic Style Mapping

When `TaskbarProgressState` is `Normal` (the default), the taskbar state is derived automatically from `Style`:

| `ProgressBarStyle` | `TBPFLAG` | Value sent? |
|---|---|---|
| `Continuous` | `TBPF_NORMAL` | Yes |
| `Blocks` | `TBPF_NORMAL` | Yes |
| `Marquee` | `TBPF_INDETERMINATE` | **No** — per MSDN, `SetProgressValue` would clear `TBPF_INDETERMINATE` |

`TaskbarProgressState = Error` or `Paused` takes priority over `Style` in all cases.

---

## MSDN Compliance Notes

The implementation follows the [`ITaskbarList3::SetProgressState`](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressstate) and [`ITaskbarList3::SetProgressValue`](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressvalue) specifications precisely:

1. **`SetProgressValue` must not be called in Indeterminate mode.** Per MSDN, calling it clears `TBPF_INDETERMINATE` and silently switches to a determinate display. The `Marquee` path passes `sendValue: false`.
2. **Both calls share one COM instance.** A single `ITaskbarList3` object is created, `HrInit()` is called once, then `SetProgressState` and (when needed) `SetProgressValue` are called in sequence — no redundant COM instantiation.
3. **`TBPF_NOPROGRESS` on dismiss.** Per MSDN, the indicator must be dismissed with `SetProgressState(TBPF_NOPROGRESS)` when the operation completes or is cancelled. This is called when `UseTaskbarProgress` is set `false` and when the control is disposed.
4. **Value range offset.** `SetProgressValue` receives `(value - minimum, maximum - minimum)` so that a bar configured with a non-zero `Minimum` reports the correct percentage.

---

## Hooks Added to `KryptonProgressBar`

| Trigger | Effect |
|---|---|
| `Value` setter | `SyncTaskbarProgress()` |
| `Increment(int)` | `SyncTaskbarProgress()` |
| `PerformStep()` | Via `Increment` → `SyncTaskbarProgress()` | | `Style` setter (Marquee) | `SyncTaskbarProgress()` → `TBPF_INDETERMINATE` | | `Style` setter (non-Marquee) | `SyncTaskbarProgress()` → `TBPF_NORMAL` + value | | `TaskbarProgressState` setter | `SyncTaskbarProgress()` | | `UseTaskbarProgress` → `true` | `SyncTaskbarProgress()` | | `UseTaskbarProgress` → `false` | `ClearTaskbarProgress()` | | `OnParentChanged` | `SyncTaskbarProgress()` |
| `OnHandleCreated` | `SyncTaskbarProgress()` |
| `Dispose(true)` | `ClearTaskbarProgress()` |

---

## Design-time Safety

`ApplyTaskbarProgress` checks `CommonHelper.DesignMode()` and returns immediately, so no COM calls are ever made inside the Visual Studio Designer.

---

## Breaking Changes

None. `UseTaskbarProgress` defaults to `false`; all existing `KryptonProgressBar` usages are unaffected. The new enum is an additive public type.

---

## Platform Requirements

- **Minimum:** Windows 7 / Windows Server 2008 R2 (`ITaskbarList3` in `Explorerframe.dll`)
- **TFMs:** `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net11.0-windows`
- Silently no-ops on Windows Vista and earlier (COM instantiation fails, caught and logged)

---

## Testing

### Manual steps — TestForm

1. Build and run `TestForm`.
2. Open **"Taskbar Progress Bar Demo"** from the Start Screen.
3. Tick **"UseTaskbarProgress (synchronise with taskbar)"** — the taskbar button should immediately show a green bar at 0 %.
4. Drag the slider — the taskbar bar should update in real-time.
5. Click **"Start"** (simulated download) — the bar should animate from 0 → 100 % on the taskbar, then disappear automatically when the simulation completes and `UseTaskbarProgress` is toggled off.
6. Set `Style` to **Marquee** — the taskbar button should switch to a pulsing indeterminate animation.
7. Click **"Error (red)"** — the taskbar bar should turn red at the current position.
8. Click **"Paused (yellow)"** — the taskbar bar should turn yellow.
9. Click **"Normal (green)"** — the taskbar bar should return to green.
10. Click **"Clear (disable)"** — the taskbar indicator should disappear.
11. Change **Min** to 50 and **Max** to 150, then set value to 100 — confirm the taskbar shows 50 %.
12. Minimise the form and confirm the taskbar thumbnail preview still reflects the correct progress state.

### Existing tests

No existing automated tests cover `KryptonProgressBar`; this is consistent with the project's manual-verification approach. The `ProgressBarTest` and `ProgressBarTriStateTest` forms are unaffected.