### PR TITLE
* TextBox item for KryptonContextMenu-Items (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Implemented [#3113](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3113), TextBox item for KryptonContextMenu-Items
 * Resolved [#3124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3124), Docking: Loading configuration while form is hidden remover splitter
 * Resolved [#3123](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3123), `KryptonComboBox` DropDownWidth doesn't resize with the control
 * Implemented [#3117](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3117), Disabling focus when clicking on a `KryptonButton`

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
@@ -30,7 +30,9 @@ public class KryptonContextMenuCollection : TypedRestrictCollection<KryptonConte
         typeof(KryptonContextMenuRadioButton),
         typeof(KryptonContextMenuColorColumns),
         typeof(KryptonContextMenuMonthCalendar),
-        typeof(KryptonContextMenuImageSelect)
+        typeof(KryptonContextMenuImageSelect),
+        typeof(KryptonContextMenuTextBox),
+        typeof(KryptonContextMenuComboBox)
     ];
     #endregion
 
@@ -215,7 +217,9 @@ public class KryptonContextMenuItemCollection : TypedRestrictCollection<KryptonC
         typeof(KryptonContextMenuRadioButton),
         typeof(KryptonContextMenuColorColumns),
         typeof(KryptonContextMenuMonthCalendar),
-        typeof(KryptonContextMenuImageSelect)
+        typeof(KryptonContextMenuImageSelect),
+        typeof(KryptonContextMenuTextBox),
+        typeof(KryptonContextMenuComboBox)
     ];
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuComboBox.cs
@@ -5,27 +5,280 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
+/// <summary>
+/// Provide a context menu combo box item.
+/// </summary>
 [ToolboxItem(false)]
 [ToolboxBitmap(typeof(KryptonContextMenuComboBox), "ToolboxBitmaps.KryptonComboBox.bmp")]
 [DesignerCategory(@"code")]
 [DesignTimeVisible(false)]
-[DefaultProperty("Text")]
-[DefaultEvent("SelectedIndexChanged")]
+[DefaultProperty(nameof(Text))]
+[DefaultEvent(nameof(SelectedIndexChanged))]
 public class KryptonContextMenuComboBox : KryptonContextMenuItemBase
 {
-    public override int ItemChildCount { get; }
+    #region Instance Fields
 
-    public override KryptonContextMenuItemBase? this[int index] => throw new NotImplementedException();
+    private string _text;
+    private int _minimumWidth;
+    private bool _enabled;
+    private int _selectedIndex;
+    private readonly ObjectCollection _items;
 
-    public override bool ProcessShortcut(Keys keyData) => throw new NotImplementedException();
+    #endregion
 
-    public override ViewBase GenerateView(IContextMenuProvider provider, object parent, ViewLayoutStack columns, bool standardStyle,
-        bool imageColumn) => throw new NotImplementedException();
+    #region Events
+    
+    /// <summary>
+    /// Occurs when the SelectedIndex property changes.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Occurs when the SelectedIndex property changes.")]
+    public event EventHandler? SelectedIndexChanged;
+
+    /// <summary>
+    /// Occurs when the value of the Text property changes.
+    /// </summary>
+    [Category(@"Property Changed")]
+    [Description(@"Occurs when the value of the Text property changes.")]
+    public event EventHandler? TextChanged;
+
+    #endregion
+
+    #region Identity
+    
+    /// <summary>
+    /// Initialize a new instance of the KryptonContextMenuComboBox class.
+    /// </summary>
+    public KryptonContextMenuComboBox()
+        : this(string.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the KryptonContextMenuComboBox class.
+    /// </summary>
+    /// <param name="initialText">Initial text value.</param>
+    public KryptonContextMenuComboBox(string initialText)
+    {
+        _text = initialText;
+        _minimumWidth = 120;
+        _enabled = true;
+        _selectedIndex = -1;
+        _items = new ObjectCollection(this);
+    }
+
+    /// <summary>
+    /// Returns a description of the instance.
+    /// </summary>
+    /// <returns>String representation.</returns>
+    public override string ToString() => Text;
+
+    #endregion
+
+    #region Public
+    
+    /// <summary>
+    /// Returns the number of child menu items.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override int ItemChildCount => 0;
+
+    /// <summary>
+    /// Returns the indexed child menu item.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override KryptonContextMenuItemBase? this[int index] => null;
+
+    /// <summary>
+    /// Test for the provided shortcut and perform relevant action if a match is found.
+    /// </summary>
+    /// <param name="keyData">Key data to check against shortcut definitions.</param>
+    /// <returns>True if shortcut was handled, otherwise false.</returns>
+    public override bool ProcessShortcut(Keys keyData) => false;
+
+    /// <summary>
+    /// Returns a view appropriate for this item based on the object it is inside.
+    /// </summary>
+    /// <param name="provider">Provider of context menu information.</param>
+    /// <param name="parent">Owning object reference.</param>
+    /// <param name="columns">Containing columns.</param>
+    /// <param name="standardStyle">Draw items with standard or alternate style.</param>
+    /// <param name="imageColumn">Draw an image background for the item images.</param>
+    /// <returns>ViewBase that is the root of the view hierarchy being added.</returns>
+    public override ViewBase GenerateView(IContextMenuProvider provider,
+        object parent,
+        ViewLayoutStack columns,
+        bool standardStyle,
+        bool imageColumn)
+    {
+        SetProvider(provider);
+        return new ViewDrawMenuComboBox(provider, this);
+    }
+
+    /// <summary>
+    /// Gets and sets the text displayed in the combo box edit area.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Appearance")]
+    [Description(@"Text displayed in the combo box edit area.")]
+    [DefaultValue("")]
+    [Localizable(true)]
+    public string Text
+    {
+        get => _text;
+
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
+                TextChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the collection of items in the combo box.
+    /// </summary>
+    [Category(@"Data")]
+    [Description(@"The items in the combo box.")]
+    [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    [MergableProperty(false)]
+    public ObjectCollection Items => _items;
+
+    /// <summary>
+    /// Gets and sets the index specifying the currently selected item.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectedIndex
+    {
+        get => _selectedIndex;
+
+        set
+        {
+            if (_selectedIndex != value)
+            {
+                _selectedIndex = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(SelectedIndex)));
+                SelectedIndexChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the currently selected item.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public object? SelectedItem => (_selectedIndex >= 0 && _selectedIndex < _items.Count) ? _items[_selectedIndex] : null;
+
+    /// <summary>
+    /// Gets and sets the minimum display width of the combo box.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Layout")]
+    [Description(@"Minimum display width of the combo box in pixels.")]
+    [DefaultValue(120)]
+    public int MinimumWidth
+    {
+        get => _minimumWidth;
+
+        set
+        {
+            if (_minimumWidth != value)
+            {
+                _minimumWidth = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(MinimumWidth)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets a value indicating whether the combo box is enabled.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether the combo box is enabled.")]
+    [DefaultValue(true)]
+    public bool Enabled
+    {
+        get => _enabled;
+
+        set
+        {
+            if (_enabled != value)
+            {
+                _enabled = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Enabled)));
+            }
+        }
+    }
+
+    #endregion
+
+    #region Internal
+    
+    internal void OnSelectedIndexChangedInternal() => SelectedIndexChanged?.Invoke(this, EventArgs.Empty);
+
+    #endregion
+
+    /// <summary>
+    /// Simple string collection for combo box items.
+    /// </summary>
+    public class ObjectCollection : List<object>
+    {
+        private readonly KryptonContextMenuComboBox _owner;
+
+        internal ObjectCollection(KryptonContextMenuComboBox owner)
+        {
+            _owner = owner;
+        }
+
+        /// <summary>
+        /// Adds an item and notifies the owner of the change.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        public new void Add(object item)
+        {
+            base.Add(item);
+            _owner.OnPropertyChanged(new PropertyChangedEventArgs(nameof(Items)));
+        }
+
+        /// <summary>
+        /// Removes an item and notifies the owner of the change.
+        /// </summary>
+        /// <param name="item">Item to remove.</param>
+        /// <returns>True if the item was found and removed.</returns>
+        public new bool Remove(object item)
+        {
+            var result = base.Remove(item);
+            if (result)
+            {
+                _owner.OnPropertyChanged(new PropertyChangedEventArgs(nameof(Items)));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Clears all items and notifies the owner of the change.
+        /// </summary>
+        public new void Clear()
+        {
+            base.Clear();
+            _owner.OnPropertyChanged(new PropertyChangedEventArgs(nameof(Items)));
+        }
+    }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuTextBox.cs
@@ -1,0 +1,179 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provide a context menu text box item.
+/// </summary>
+[ToolboxItem(false)]
+[ToolboxBitmap(typeof(KryptonContextMenuTextBox), "ToolboxBitmaps.KryptonTextBox.bmp")]
+[DesignerCategory(@"code")]
+[DesignTimeVisible(false)]
+[DefaultProperty(nameof(Text))]
+[DefaultEvent(nameof(TextChanged))]
+public class KryptonContextMenuTextBox : KryptonContextMenuItemBase
+{
+    #region Instance Fields
+    
+    private string _text;
+    private int _minimumWidth;
+    private bool _enabled;
+
+    #endregion
+
+    #region Events
+    
+    /// <summary>
+    /// Occurs when the value of the Text property changes.
+    /// </summary>
+    [Category(@"Property Changed")]
+    [Description(@"Occurs when the value of the Text property changes.")]
+    public event EventHandler? TextChanged;
+
+    #endregion
+
+    #region Identity
+    
+    /// <summary>
+    /// Initialize a new instance of the KryptonContextMenuTextBox class.
+    /// </summary>
+    public KryptonContextMenuTextBox()
+        : this(string.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the KryptonContextMenuTextBox class.
+    /// </summary>
+    /// <param name="initialText">Initial text value.</param>
+    public KryptonContextMenuTextBox(string initialText)
+    {
+        _text = initialText;
+        _minimumWidth = 120;
+        _enabled = true;
+    }
+
+    /// <summary>
+    /// Returns a description of the instance.
+    /// </summary>
+    /// <returns>String representation.</returns>
+    public override string ToString() => Text;
+
+    #endregion
+
+    #region Public
+
+    /// <summary>
+    /// Returns the number of child menu items.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override int ItemChildCount => 0;
+
+    /// <summary>
+    /// Returns the indexed child menu item.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override KryptonContextMenuItemBase? this[int index] => null;
+
+    /// <summary>
+    /// Test for the provided shortcut and perform relevant action if a match is found.
+    /// </summary>
+    /// <param name="keyData">Key data to check against shortcut definitions.</param>
+    /// <returns>True if shortcut was handled, otherwise false.</returns>
+    public override bool ProcessShortcut(Keys keyData) => false;
+
+    /// <summary>
+    /// Returns a view appropriate for this item based on the object it is inside.
+    /// </summary>
+    /// <param name="provider">Provider of context menu information.</param>
+    /// <param name="parent">Owning object reference.</param>
+    /// <param name="columns">Containing columns.</param>
+    /// <param name="standardStyle">Draw items with standard or alternate style.</param>
+    /// <param name="imageColumn">Draw an image background for the item images.</param>
+    /// <returns>ViewBase that is the root of the view hierarchy being added.</returns>
+    public override ViewBase GenerateView(IContextMenuProvider provider,
+        object parent,
+        ViewLayoutStack columns,
+        bool standardStyle,
+        bool imageColumn)
+    {
+        SetProvider(provider);
+        return new ViewDrawMenuTextBox(provider, this);
+    }
+
+    /// <summary>
+    /// Gets and sets the text box value.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Appearance")]
+    [Description(@"Text box value.")]
+    [DefaultValue("")]
+    [Localizable(true)]
+    public string Text
+    {
+        get => _text;
+
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
+                TextChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the minimum display width of the text box.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Layout")]
+    [Description(@"Minimum display width of the text box in pixels.")]
+    [DefaultValue(120)]
+    public int MinimumWidth
+    {
+        get => _minimumWidth;
+
+        set
+        {
+            if (_minimumWidth != value)
+            {
+                _minimumWidth = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(MinimumWidth)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets a value indicating whether the text box is enabled.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether the text box is enabled.")]
+    [DefaultValue(true)]
+    public bool Enabled
+    {
+        get => _enabled;
+
+        set
+        {
+            if (_enabled != value)
+            {
+                _enabled = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Enabled)));
+            }
+        }
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuCollectionEditor.cs
@@ -50,7 +50,9 @@ public partial class KryptonContextMenuCollectionEditor : CollectionEditor
         typeof(KryptonContextMenuRadioButton),
         typeof(KryptonContextMenuColorColumns),
         typeof(KryptonContextMenuMonthCalendar),
-        typeof(KryptonContextMenuImageSelect)
+        typeof(KryptonContextMenuImageSelect),
+        typeof(KryptonContextMenuTextBox),
+        typeof(KryptonContextMenuComboBox)
     ];
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuItemCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuItemCollectionEditor.cs
@@ -41,6 +41,8 @@ public class KryptonContextMenuItemCollectionEditor : CollectionEditor
         typeof(KryptonContextMenuRadioButton),
         typeof(KryptonContextMenuColorColumns),
         typeof(KryptonContextMenuMonthCalendar),
-        typeof(KryptonContextMenuImageSelect)
+        typeof(KryptonContextMenuImageSelect),
+        typeof(KryptonContextMenuTextBox),
+        typeof(KryptonContextMenuComboBox)
     ];
 }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuComboBox.cs
@@ -1,0 +1,212 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class ViewDrawMenuComboBox : ViewComposite
+{
+    #region Instance Fields
+
+    private readonly IContextMenuProvider _provider;
+    private readonly KryptonComboBox _comboBox;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the ViewDrawMenuComboBox class.
+    /// </summary>
+    /// <param name="provider">Reference to provider.</param>
+    /// <param name="comboBoxItem">Reference to owning combo box entry.</param>
+    public ViewDrawMenuComboBox(IContextMenuProvider provider,
+        KryptonContextMenuComboBox comboBoxItem)
+    {
+        _provider = provider;
+        KryptonContextMenuComboBox = comboBoxItem;
+
+        _comboBox = new KryptonComboBox
+        {
+            Text = comboBoxItem.Text,
+            Enabled = provider.ProviderEnabled && comboBoxItem.Enabled,
+            MinimumSize = new Size(comboBoxItem.MinimumWidth, 0)
+        };
+
+        foreach (var item in comboBoxItem.Items)
+        {
+            _comboBox.Items.Add(item);
+        }
+
+        if (comboBoxItem.SelectedIndex >= 0 && comboBoxItem.SelectedIndex < _comboBox.Items.Count)
+        {
+            _comboBox.SelectedIndex = comboBoxItem.SelectedIndex;
+        }
+
+        _comboBox.SelectedIndexChanged += OnComboBoxSelectedIndexChanged;
+        _comboBox.TextChanged += OnComboBoxTextChanged;
+        comboBoxItem.PropertyChanged += OnPropertyChanged;
+    }
+
+    /// <summary>
+    /// Obtains the String representation of this instance.
+    /// </summary>
+    /// <returns>User readable name of the instance.</returns>
+    public override string ToString() => $"ViewDrawMenuComboBox:{Id}";
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _comboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
+            _comboBox.TextChanged -= OnComboBoxTextChanged;
+            KryptonContextMenuComboBox.PropertyChanged -= OnPropertyChanged;
+
+            _comboBox.Parent?.Controls.Remove(_comboBox);
+
+            _comboBox.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region KryptonContextMenuComboBox
+
+    /// <summary>
+    /// Gets access to the owning combo box data model.
+    /// </summary>
+    public KryptonContextMenuComboBox KryptonContextMenuComboBox { get; }
+
+    #endregion
+
+    #region ComboBox
+
+    /// <summary>
+    /// Gets access to the hosted KryptonComboBox instance.
+    /// </summary>
+    public KryptonComboBox ComboBox => _comboBox;
+
+    #endregion
+
+    #region ItemEnabled
+
+    /// <summary>
+    /// Gets the enabled state of the item.
+    /// </summary>
+    public bool ItemEnabled { get; private set; }
+
+    #endregion
+
+    #region Layout
+
+    /// <summary>
+    /// Discover the preferred size of the element.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    public override Size GetPreferredSize([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        ItemEnabled = _provider.ProviderEnabled && KryptonContextMenuComboBox.Enabled;
+        _comboBox.Enabled = ItemEnabled;
+
+        var comboPreferred = _comboBox.GetPreferredSize(Size.Empty);
+        var preferredWidth = Math.Max(KryptonContextMenuComboBox.MinimumWidth, comboPreferred.Width) + 6;
+        var preferredHeight = comboPreferred.Height + 4;
+
+        return new Size(preferredWidth, preferredHeight);
+    }
+
+    /// <summary>
+    /// Perform a layout of the elements.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public override void Layout([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        ClientRectangle = context.DisplayRectangle;
+
+        if (context.Control != null && _comboBox.Parent != context.Control)
+        {
+            context.Control.Controls.Add(_comboBox);
+        }
+
+        _comboBox.SetBounds(
+            ClientRectangle.X + 3,
+            ClientRectangle.Y + 2,
+            ClientRectangle.Width - 6,
+            ClientRectangle.Height - 4);
+
+        _comboBox.Visible = Visible;
+
+        base.Layout(context);
+    }
+
+    #endregion
+
+    #region Private
+
+    private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        KryptonContextMenuComboBox.SelectedIndex = _comboBox.SelectedIndex;
+    }
+
+    private void OnComboBoxTextChanged(object? sender, EventArgs e)
+    {
+        KryptonContextMenuComboBox.Text = _comboBox.Text;
+    }
+
+    private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(KryptonContextMenuComboBox.Text):
+                if (_comboBox.Text != KryptonContextMenuComboBox.Text)
+                {
+                    _comboBox.Text = KryptonContextMenuComboBox.Text;
+                }
+                break;
+            case nameof(KryptonContextMenuComboBox.Enabled):
+                _comboBox.Enabled = _provider.ProviderEnabled && KryptonContextMenuComboBox.Enabled;
+                break;
+            case nameof(KryptonContextMenuComboBox.MinimumWidth):
+                _comboBox.MinimumSize = new Size(KryptonContextMenuComboBox.MinimumWidth, 0);
+                _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(true));
+                break;
+            case nameof(KryptonContextMenuComboBox.SelectedIndex):
+                if (_comboBox.SelectedIndex != KryptonContextMenuComboBox.SelectedIndex)
+                {
+                    _comboBox.SelectedIndex = KryptonContextMenuComboBox.SelectedIndex;
+                }
+                break;
+            case nameof(KryptonContextMenuComboBox.Items):
+                _comboBox.Items.Clear();
+                foreach (var item in KryptonContextMenuComboBox.Items)
+                {
+                    _comboBox.Items.Add(item);
+                }
+                _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(true));
+                break;
+        }
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuTextBox.cs
@@ -1,0 +1,181 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class ViewDrawMenuTextBox : ViewComposite
+{
+    #region Instance Fields
+
+    private readonly IContextMenuProvider _provider;
+    private readonly KryptonTextBox _textBox;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the ViewDrawMenuTextBox class.
+    /// </summary>
+    /// <param name="provider">Reference to provider.</param>
+    /// <param name="textBoxItem">Reference to owning text box entry.</param>
+    public ViewDrawMenuTextBox(IContextMenuProvider provider,
+        KryptonContextMenuTextBox textBoxItem)
+    {
+        _provider = provider;
+        KryptonContextMenuTextBox = textBoxItem;
+
+        _textBox = new KryptonTextBox
+        {
+            Text = textBoxItem.Text,
+            Enabled = provider.ProviderEnabled && textBoxItem.Enabled,
+            MinimumSize = new Size(textBoxItem.MinimumWidth, 0)
+        };
+
+        _textBox.TextChanged += OnTextBoxTextChanged;
+        textBoxItem.PropertyChanged += OnPropertyChanged;
+    }
+
+    /// <summary>
+    /// Obtains the String representation of this instance.
+    /// </summary>
+    /// <returns>User readable name of the instance.</returns>
+    public override string ToString() => $"ViewDrawMenuTextBox:{Id}";
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _textBox.TextChanged -= OnTextBoxTextChanged;
+            KryptonContextMenuTextBox.PropertyChanged -= OnPropertyChanged;
+
+            _textBox.Parent?.Controls.Remove(_textBox);
+
+            _textBox.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region KryptonContextMenuTextBox
+
+    /// <summary>
+    /// Gets access to the owning text box data model.
+    /// </summary>
+    public KryptonContextMenuTextBox KryptonContextMenuTextBox { get; }
+
+    #endregion
+
+    #region TextBox
+
+    /// <summary>
+    /// Gets access to the hosted KryptonTextBox instance.
+    /// </summary>
+    public KryptonTextBox TextBox => _textBox;
+
+    #endregion
+
+    #region ItemEnabled
+
+    /// <summary>
+    /// Gets the enabled state of the item.
+    /// </summary>
+    public bool ItemEnabled { get; private set; }
+
+    #endregion
+
+    #region Layout
+
+    /// <summary>
+    /// Discover the preferred size of the element.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    public override Size GetPreferredSize([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        ItemEnabled = _provider.ProviderEnabled && KryptonContextMenuTextBox.Enabled;
+        _textBox.Enabled = ItemEnabled;
+
+        // Height from the text box preferred size; width from MinimumWidth setting plus padding
+        var textBoxPreferred = _textBox.GetPreferredSize(Size.Empty);
+        var preferredWidth = Math.Max(KryptonContextMenuTextBox.MinimumWidth, textBoxPreferred.Width) + 6;
+        var preferredHeight = textBoxPreferred.Height + 4;
+
+        return new Size(preferredWidth, preferredHeight);
+    }
+
+    /// <summary>
+    /// Perform a layout of the elements.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public override void Layout([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        ClientRectangle = context.DisplayRectangle;
+
+        // Ensure the text box lives inside the menu popup control
+        if (context.Control != null && _textBox.Parent != context.Control)
+        {
+            context.Control.Controls.Add(_textBox);
+        }
+
+        // Position and show the text box within the allocated client area
+        _textBox.SetBounds(
+            ClientRectangle.X + 3,
+            ClientRectangle.Y + 2,
+            ClientRectangle.Width - 6,
+            ClientRectangle.Height - 4);
+
+        _textBox.Visible = Visible;
+
+        base.Layout(context);
+    }
+
+    #endregion
+
+    #region Private
+
+    private void OnTextBoxTextChanged(object? sender, EventArgs e) => KryptonContextMenuTextBox.Text = _textBox.Text;
+
+    private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(KryptonContextMenuTextBox.Text):
+                if (_textBox.Text != KryptonContextMenuTextBox.Text)
+                {
+                    _textBox.Text = KryptonContextMenuTextBox.Text;
+                }
+                break;
+            case nameof(KryptonContextMenuTextBox.Enabled):
+                _textBox.Enabled = _provider.ProviderEnabled && KryptonContextMenuTextBox.Enabled;
+                break;
+            case nameof(KryptonContextMenuTextBox.MinimumWidth):
+                _textBox.MinimumSize = new Size(KryptonContextMenuTextBox.MinimumWidth, 0);
+                _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(true));
+                break;
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
# PR: TextBox and ComboBox items for `KryptonContextMenu` (fixes #3113)

## Summary

Implements [Feature Request #3113](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3113) — `KryptonContextMenu` can now host an inline `KryptonTextBox` or `KryptonComboBox` directly inside its item list, following the same pattern used by other embedded-control items (`KryptonContextMenuMonthCalendar`, `KryptonContextMenuCheckBox`, etc.).

The existing `KryptonContextMenuComboBox` stub (which previously threw `NotImplementedException` on every member) is fully implemented. A companion `KryptonContextMenuTextBox` class is added as a new item type. Both types appear in the designer's collection editor "Add…" drop-down and are available in both the top-level `KryptonContextMenuCollection` and the nested `KryptonContextMenuItemCollection`.

---

## Files Changed

| File | Change |
|---|---|
| `Krypton.Toolkit/ContextMenu/KryptonContextMenuTextBox.cs` | **New file** — data model for the TextBox context menu item | | `Krypton.Toolkit/View Draw/ViewDrawMenuTextBox.cs` | **New file** — view that hosts a live `KryptonTextBox` in the popup | | `Krypton.Toolkit/ContextMenu/KryptonContextMenuComboBox.cs` | Replaced `NotImplementedException` stub with full implementation | | `Krypton.Toolkit/View Draw/ViewDrawMenuComboBox.cs` | **New file** — view that hosts a live `KryptonComboBox` in the popup | | `Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs` | Registered both new types in `KryptonContextMenuCollection._types` and `KryptonContextMenuItemCollection._types` | | `Krypton.Toolkit/Designers/Editors/KryptonContextMenuCollectionEditor.cs` | Added both types to `CreateNewItemTypes()` | | `Krypton.Toolkit/Designers/Editors/KryptonContextMenuItemCollectionEditor.cs` | Added both types to `CreateNewItemTypes()` |

---

## New Public API

### `KryptonContextMenuTextBox`

```csharp
[ToolboxItem(false), DesignTimeVisible(false)]
[DefaultProperty(nameof(Text)), DefaultEvent(nameof(TextChanged))]
public class KryptonContextMenuTextBox : KryptonContextMenuItemBase
{
    // Initial value for the text box
    public string Text { get; set; }           // default ""

    // Minimum rendered width of the text box in pixels
    public int MinimumWidth { get; set; }       // default 120

    // Whether the control accepts input
    public bool Enabled { get; set; }           // default true

    // Raised whenever Text changes (from either the UI or code)
    public event EventHandler? TextChanged;
}
```

### `KryptonContextMenuComboBox` (was a stub)

```csharp
[ToolboxItem(false), DesignTimeVisible(false)]
[DefaultProperty(nameof(Text)), DefaultEvent(nameof(SelectedIndexChanged))]
public class KryptonContextMenuComboBox : KryptonContextMenuItemBase
{
    public string Text { get; set; }            // default ""
    public int MinimumWidth { get; set; }       // default 120
    public bool Enabled { get; set; }           // default true

    // Live collection — changes propagate to the hosted KryptonComboBox automatically
    public ObjectCollection Items { get; }

    public int SelectedIndex { get; set; }      // default -1
    public object? SelectedItem { get; }        // read-only derived from SelectedIndex

    public event EventHandler? SelectedIndexChanged;
    public event EventHandler? TextChanged;
}
```

---

## Architecture — How the Controls Are Embedded

Both items follow the **embedded-control pattern** used by `ViewDrawMenuMonthCalendar`:

1. The data-model class (`KryptonContextMenuTextBox` / `KryptonContextMenuComboBox`) holds all serialisable state and notifies listeners via `INotifyPropertyChanged` (inherited from `KryptonContextMenuItemBase`).
2. `GenerateView()` constructs the corresponding `ViewDrawMenu*` class and calls `SetProvider(provider)` as required by the base contract.
3. The `ViewDrawMenu*` class creates a `KryptonTextBox` / `KryptonComboBox` and, during `Layout()`, parents it to `context.Control` (the live `VisualContextMenu` popup window) and positions it within the allocated client rectangle.
4. Two-way binding is maintained: UI changes write back to the model; model `PropertyChanged` events update the hosted control.
5. `Dispose()` unhooks all event handlers and removes the hosted control from its parent before disposing it.

---

## Usage Example

```csharp
var contextMenu = new KryptonContextMenu();
var items = new KryptonContextMenuItems();

// TextBox item
var tbItem = new KryptonContextMenuTextBox { Text = "Search…", MinimumWidth = 160 };
tbItem.TextChanged += (s, e) => Console.WriteLine($"Text: {tbItem.Text}");

// ComboBox item
var cbItem = new KryptonContextMenuComboBox { MinimumWidth = 160 };
cbItem.Items.Add("Option A");
cbItem.Items.Add("Option B");
cbItem.Items.Add("Option C");
cbItem.SelectedIndexChanged += (s, e) => Console.WriteLine($"Selected: {cbItem.SelectedItem}");

items.Items.AddRange(new KryptonContextMenuItemBase[]
{
    new KryptonContextMenuHeading("Filter"),
    tbItem,
    new KryptonContextMenuSeparator(),
    new KryptonContextMenuHeading("Category"),
    cbItem
});

contextMenu.Items.Add(items);
contextMenu.Show(button, button.PointToScreen(Point.Empty));
```

---

## Designer Support

Both types are registered in all three collection type lists:

- `KryptonContextMenuCollection._types` — top-level items collection on `KryptonContextMenu`
- `KryptonContextMenuItemCollection._types` — nested items collection inside a `KryptonContextMenuItems` group
- `KryptonContextMenuCollectionEditor.CreateNewItemTypes()` — drives the "Add…" button in the VS collection editor
- `KryptonContextMenuItemCollectionEditor.CreateNewItemTypes()` — same for the nested editor

---

## Breaking Changes

None. The `KryptonContextMenuComboBox` stub previously threw `NotImplementedException`; any code that was actually instantiating it at runtime would already have been broken. The new implementation is backwards-compatible with any code that merely declared or held a reference to the type.

---

## Platform Requirements

- **TFMs:** `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net11.0-windows`
- No new P/Invoke or COM dependencies.

---

## Testing

### Manual steps

1. Build and run `TestForm`.
2. Add a `KryptonContextMenu` to any test form.
3. Open the collection editor (click the `Items` property ellipsis in the Properties window).
4. Click **Add** — confirm `KryptonContextMenuTextBox` and `KryptonContextMenuComboBox` appear in the type list.
5. Add one of each. Set `Text`, `MinimumWidth`, and (for the combo box) populate `Items`.
6. Right-click the form at runtime to open the menu — both controls should render inline in the popup.
7. Type in the text box — confirm `TextChanged` fires and `Text` is updated on the model.
8. Select an item in the combo box — confirm `SelectedIndexChanged` fires and `SelectedItem` reflects the selection.
9. Set `Enabled = false` on each item — confirm the hosted controls are visually disabled and reject input.
10. Resize the popup by changing `MinimumWidth` at runtime — confirm the controls reflow correctly.

### Existing tests

No existing automated tests cover context menu items; this is consistent with the project's manual-verification approach. All other `KryptonContextMenu` item types are unaffected.