### PR TITLE
* Form Icon Misplaced in Contextual Tabs (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#3163](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3163), Form Icon Misplaced in Contextual Tabs
 * Implemented [#3113](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3113), TextBox item for KryptonContextMenu-Items
 * Resolved [#3124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3124), Docking: Loading configuration while form is hidden remover splitter
 * Resolved [#3123](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3123), `KryptonComboBox` DropDownWidth doesn't resize with the control

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
@@ -172,6 +172,27 @@ internal class ViewDrawRibbonAppButton : ViewLeaf
 
         // If there is an application button image to be drawn
         Image? localImage = _ribbon.RibbonFileAppButton.AppButtonImage;
+
+        // If there is no image, but the form has an icon, then use that as the image
+        Image? formIconBitmap;
+
+        // Fixes #64 / #3163: In Office 2007 (orb) mode, use the form icon when AppButtonImage is not set
+        if (localImage == null && _ribbon.RibbonShape == PaletteRibbonShape.Office2007)
+        {
+            // Only use the form icon if it is actually being shown on the form. If the form is configured to not show an icon, then we should not use it as the image for the application button.
+            var form = _ribbon.FindForm();
+
+            // If the form is configured to show an icon and a control box, and the form has an icon assigned, then use that as the image for the application button
+            if (form is { ShowIcon: true, ControlBox: true, Icon: not null })
+            {
+                // Convert the form icon to a bitmap and use that as the image for the application button
+                formIconBitmap = form.Icon.ToBitmap();
+
+                // If the form icon is larger than 32x32, then we need to scale it down to fit within the application button
+                localImage = formIconBitmap;
+            }
+        }
+
         if (localImage != null)
         {
             // We always draw the image a 24x24 image (if dpi = 1!)

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs
@@ -144,14 +144,13 @@ internal class ViewLayoutRibbonContextTitles : ViewLayoutDocker
         // Do we need to position a filler element?
         if (filler != null)
         {
-            // How much space available on the left side
+            // How much space available on the left side (between caption start and leftmost context tab)
             var leftSpace = xLeftMost - ClientRectangle.Left;
-            var rightSpace = ClientRectangle.Right - xRightMost;
 
-            // Use the side with the most space
-            context.DisplayRectangle = leftSpace >= rightSpace
-                ? new Rectangle(ClientLocation.X, ClientLocation.Y, leftSpace, ClientHeight)
-                : new Rectangle(xRightMost, ClientLocation.Y, rightSpace, ClientHeight);
+            // Fixes #64 / #3163: Form icon must always be to the left of the QAT dropdown and
+            // contextual tabs (Excel/Word behavior). Previously it was placed on whichever side
+            // had more space, causing the icon to appear after contextual tabs.
+            context.DisplayRectangle = new Rectangle(ClientLocation.X, ClientLocation.Y, leftSpace, ClientHeight);
 
             filler.Layout(context);
         }


### PR DESCRIPTION
# PR: Form icon misplaced in contextual tabs

Closes #3163
Fixes https://github.com/Krypton-Suite-Legacy-Archive/Krypton-NET-5.470/issues/64

## Summary

Ensures the form icon (and title) always appears to the **left** of the Quick Access Toolbar (QAT) dropdown and contextual tabs when the ribbon is integrated into the KryptonForm caption. Previously, the icon could be positioned after the contextual tabs.

## Motivation

In Ribbon forms with contextual tabs, the form icon was placed on whichever side of the context titles had the most space. When contextual tabs occupied the left portion of the caption, the icon was drawn on the right—after the tabs—which is incorrect. Microsoft Office (Excel, Word) always shows the form icon to the left of the QAT dropdown, regardless of contextual tab layout.

## Changes

### ViewLayoutRibbonContextTitles

- **Before:** The filler element (form icon and title) was placed on the side with more space (`leftSpace >= rightSpace`).
- **After:** The filler is always placed on the **left**—between the caption start and the leftmost context tab—so the icon appears to the left of the QAT and contextual tabs.

### ViewDrawRibbonAppButton

- **Office 2007 orb fallback:** When `AppButtonImage` is not set and `RibbonShape` is `Office2007`, the orb now displays the form icon (when `ShowIcon` and `ControlBox` are true). If `AppButtonImage` is explicitly set, it continues to take precedence.

## Testing

1. **Positioning (Office 2010+):** Create a KryptonForm with a KryptonRibbon using Office 2010 (or newer) ribbon shape, integrated into form chrome. Add contextual tabs. Ensure the form has an icon and `ShowIcon` is true. Verify the form icon appears to the **left** of the QAT dropdown and contextual tabs (not after them). Resize and confirm the icon stays in place.
2. **Orb fallback (Office 2007):** Use Office 2007 ribbon shape. Do **not** set `AppButtonImage` on the ribbon. Ensure the form has an icon and `ShowIcon` is true. Verify the form icon appears **inside the orb**. Set `AppButtonImage` explicitly and confirm it overrides the form icon.

## Files modified

| File | Change |
|------|--------|
| `Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs` | Always position filler (form icon + title) on the left instead of the side with most space | | `Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs` | Use form icon in orb when `AppButtonImage` is not set (Office 2007 shape only) |

<img width="719" height="167" alt="Screenshot 2026-03-10 104831" src="https://github.com/user-attachments/assets/4645c1d2-349a-4b71-af3a-f3c7094cf9e0" />

Warnings are unrelated, to be fixed in a future PR (Pattern matching).