### PR TITLE
* Form Icon Misplaced in Contextual Tabs (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3163](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3163), Form Icon Misplaced in Contextual Tabs
 * Implemented [#1358](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1358), Can the Ribbon QAT buttons follow the same styles as `ButtonSpecs`
 * Implemented [#3156](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3156), OAuth2 with PKCE support
   * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this feature is part of the `Krypton.Utilities` assembly.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
@@ -172,6 +172,27 @@ internal class ViewDrawRibbonAppButton : ViewLeaf
 
         // If there is an application button image to be drawn
         Image? localImage = _ribbon.RibbonFileAppButton.AppButtonImage;
+
+        // If there is no image, and we are in Office 2007 mode, then attempt to use the form icon instead
+        Image? formIconBitmap;
+
+        // Fixes #64 / #3163: In Office 2007 (orb) mode, use the form icon when AppButtonImage is not set
+        if (localImage == null && _ribbon.RibbonShape == PaletteRibbonShape.Office2007)
+        {
+            // Only use the form icon if the form is configured to show it, otherwise we end up with a blank image which looks odd
+            var form = _ribbon.FindForm();
+
+            // We only use the form icon if the form is configured to show it, otherwise we end up with a blank image which looks odd
+            if (form is { ShowIcon: true, ControlBox: true, Icon: not null })
+            {
+                // Convert the form icon to a bitmap and use that as the image to draw
+                formIconBitmap = form.Icon.ToBitmap();
+
+                // If the form icon is larger than 32x32, then we need to scale it down to fit within the app button
+                localImage = formIconBitmap;
+            }
+        }
+
         if (localImage != null)
         {
             // We always draw the image a 24x24 image (if dpi = 1!)

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs
@@ -144,14 +144,13 @@ internal class ViewLayoutRibbonContextTitles : ViewLayoutDocker
         // Do we need to position a filler element?
         if (filler != null)
         {
-            // How much space available on the left side
+            // How much space available on the left side (between caption start and leftmost context tab)
             var leftSpace = xLeftMost - ClientRectangle.Left;
-            var rightSpace = ClientRectangle.Right - xRightMost;
 
-            // Use the side with the most space
-            context.DisplayRectangle = leftSpace >= rightSpace
-                ? new Rectangle(ClientLocation.X, ClientLocation.Y, leftSpace, ClientHeight)
-                : new Rectangle(xRightMost, ClientLocation.Y, rightSpace, ClientHeight);
+            // Fixes #64 / #3163: Form icon must always be to the left of the QAT dropdown and
+            // contextual tabs (Excel/Word behavior). Previously it was placed on whichever side
+            // had more space, causing the icon to appear after contextual tabs.
+            context.DisplayRectangle = new Rectangle(ClientLocation.X, ClientLocation.Y, leftSpace, ClientHeight);
 
             filler.Layout(context);
         }


### PR DESCRIPTION
# PR: Form icon misplaced in contextual tabs

Closes #3163
Fixes https://github.com/Krypton-Suite-Legacy-Archive/Krypton-NET-5.470/issues/64

## Summary

Ensures the form icon (and title) always appears to the **left** of the Quick Access Toolbar (QAT) dropdown and contextual tabs when the ribbon is integrated into the KryptonForm caption. Previously, the icon could be positioned after the contextual tabs.

## Motivation

In Ribbon forms with contextual tabs, the form icon was placed on whichever side of the context titles had the most space. When contextual tabs occupied the left portion of the caption, the icon was drawn on the right—after the tabs—which is incorrect. Microsoft Office (Excel, Word) always shows the form icon to the left of the QAT dropdown, regardless of contextual tab layout.

## Changes

### ViewLayoutRibbonContextTitles

- **Before:** The filler element (form icon and title) was placed on the side with more space (`leftSpace >= rightSpace`).
- **After:** The filler is always placed on the **left**—between the caption start and the leftmost context tab—so the icon appears to the left of the QAT and contextual tabs.

### ViewDrawRibbonAppButton

- **Office 2007 orb fallback:** When `AppButtonImage` is not set and `RibbonShape` is `Office2007`, the orb now displays the form icon (when `ShowIcon` and `ControlBox` are true). If `AppButtonImage` is explicitly set, it continues to take precedence.

## Testing

1. **Positioning (Office 2010+):** Create a KryptonForm with a KryptonRibbon using Office 2010 (or newer) ribbon shape, integrated into form chrome. Add contextual tabs. Ensure the form has an icon and `ShowIcon` is true. Verify the form icon appears to the **left** of the QAT dropdown and contextual tabs (not after them). Resize and confirm the icon stays in place.
2. **Orb fallback (Office 2007):** Use Office 2007 ribbon shape. Do **not** set `AppButtonImage` on the ribbon. Ensure the form has an icon and `ShowIcon` is true. Verify the form icon appears **inside the orb**. Set `AppButtonImage` explicitly and confirm it overrides the form icon.

## Files modified

| File | Change |
|------|--------|
| `Krypton.Ribbon/View Layout/ViewLayoutRibbonContextTitles.cs` | Always position filler (form icon + title) on the left instead of the side with most space | | `Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs` | Use form icon in orb when `AppButtonImage` is not set (Office 2007 shape only) |

<img width="668" height="300" alt="image" src="https://github.com/user-attachments/assets/f04c4a7e-d627-4cb2-94f4-c2d65dae9860" />
