### PR TITLE
* Fix `nullable` warning in `VisualOAuth2LoginForm.Designer`

### DIFF
--- a/Source/Krypton Components/Krypton.Utilities/Components/Krypton OAuth2/Controls Visuals/VisualOAuth2LoginForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/Krypton OAuth2/Controls Visuals/VisualOAuth2LoginForm.Designer.cs
@@ -7,7 +7,7 @@ internal sealed partial class VisualOAuth2LoginForm
     /// <summary>
     /// Required designer variable.
     /// </summary>
-    private System.ComponentModel.IContainer? components;
+    private System.ComponentModel.IContainer components;
 
     /// <summary>
     /// Clean up any resources being used.


### PR DESCRIPTION
* Fix `nullable` warning in `VisualOAuth2LoginForm.Designer`

<img width="687" height="263" alt="image" src="https://github.com/user-attachments/assets/7c3d1225-cbff-4ea2-bcab-fc00aa15f528" />
