### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@
 
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/10](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/10)

In general, the fix is to explicitly set `permissions` for the workflow or at least for the flagged job so that the `GITHUB_TOKEN` has only the scopes it needs. Since the `release-alpha` job only needs to read the repository contents (for `actions/checkout`) and does not perform any authenticated write operations against the GitHub API, we can safely restrict its token to `contents: read`. This matches CodeQL’s suggested minimal starting point.

The best fix with minimal functional change is:

- Add a `permissions:` block at the workflow root, directly under `name: Release`, so it applies to all jobs that don’t override it.
- Set it to `contents: read`, which is sufficient for `actions/checkout` and other standard read operations.
- Do not add broader scopes (like `contents: write` or `packages: write`) since they are not required by any code shown for the `release-alpha` job, and we were not shown other jobs to justify them.

Concretely:

- Edit `.github/workflows/release.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 5 (`name: Release`) and line 6 (`on:`).

No additional imports, methods, or other definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
