### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,9 @@
 
 name: Nightly Release
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run nightly build automatically at midnight UTC every day


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/4](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` for the workflow or for the `nightly` job so that the `GITHUB_TOKEN` follows the principle of least privilege. Since the workflow only needs to read repository contents (for checkout and build) and does not perform any GitHub write operations, we can safely restrict permissions to `contents: read` at the top level. This will apply to all jobs (there is only `nightly`) and satisfies the CodeQL recommendation.

The single best fix without changing functionality is:

- Add a root-level `permissions:` block after the `name:` declaration (around line 8–9).
- Set `contents: read` as a minimal permission; other scopes are not needed based on the provided steps.

Concretely, in `.github/workflows/nightly.yml`, insert:

```yaml
permissions:
  contents: read
```

between `name: Nightly Release` and the `on:` block. No imports or additional definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
