### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,6 +16,9 @@ on:
       - Canary
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   canary:
     runs-on: windows-2025-vs2026


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/3](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/3)

In general, fix this by adding an explicit `permissions` block that grants only the minimal GitHub API permissions needed. Since this workflow builds, publishes to NuGet, and calls external services but does not modify GitHub resources (no pushing commits, creating releases, or managing issues/PRs), it can safely use `contents: read` only.

The best fix here is to add a workflow‑level `permissions` block (applies to all jobs) near the top of `.github/workflows/canary.yml`, just after the `name:` (or before `jobs:`). This keeps the configuration simple: a single block that limits `GITHUB_TOKEN` to read‑only repository contents. No additional methods, imports, or changes to steps are required, because none of the existing steps rely on elevated token permissions.

Concretely:
- Edit `.github/workflows/canary.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between the `on:` section and the `jobs:` section (e.g., after line 17 or line 18).  
This will satisfy CodeQL’s requirement and enforce least privilege without changing current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
