### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
     paths-ignore: ['.git*', '.vscode']
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-2025-vs2026


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/2](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that scopes `GITHUB_TOKEN` to the minimal rights needed. For a pure build workflow that only checks out code, restores packages, and builds artifacts, `contents: read` is usually sufficient; if it needs to read packages from GitHub Packages, `packages: read` can be added as well. This block can be declared at the workflow root (applies to all jobs) or per job.

The best minimal change here is to add a single workflow-level `permissions` block right after the `on:` section and before `jobs:`. This will apply to both `build` and `release` jobs without changing any steps. Based on the visible steps (checkout, cache, restore, build, pack, version detection), they only need to read repository contents, so `contents: read` is adequate. No imports or additional code are needed; only YAML configuration changes within `.github/workflows/build.yml`.

Concretely, in `.github/workflows/build.yml`, between the existing `workflow_dispatch:` line (20) and the `jobs:` key (21), insert:

```yaml
permissions:
  contents: read
```

This explicitly limits the default `GITHUB_TOKEN` permissions for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
