### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -7,6 +7,9 @@
 
 name: Canary LTS Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/1](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block that grants only the minimal scopes needed. This workflow’s steps use `actions/checkout`, which needs `contents: read`, and they do not need to write to the repo or interact with issues/PRs. Therefore, setting `permissions: contents: read` at the workflow root (top-level, alongside `name` and `on`) is sufficient and will apply to all jobs unless overridden.

Concretely:
- Edit `.github/workflows/canary-lts-release.yml`.
- Insert a `permissions:` section after the `name: Canary LTS Release` line (line 8) and before the `on:` block (line 10).
- Set `contents: read` inside this block.
- No additional imports, actions, or code changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
