### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ['**']


### PR DESCRIPTION
Potential fix for [https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/5](https://github.com/Krypton-Suite/Standard-Toolkit/security/code-scanning/5)

To fix the problem, define explicit minimal `GITHUB_TOKEN` permissions in the workflow. The safest general approach is to add a top-level `permissions` block (applies to all jobs) with `contents: read`, and then only grant broader permissions at the job level if a particular job truly needs them. In this case, both `build` and `release` jobs only read the repository and talk to external endpoints, so `contents: read` is sufficient.

The best fix without changing existing functionality is:

- Add a top-level `permissions:` block right after `name: Build` (before `on:`) setting `contents: read`.
- This will apply to both `build` and `release` jobs since they do not define their own `permissions` blocks.
- No additional imports, methods, or definitions are needed because this is purely a YAML configuration change within `.github/workflows/build.yml`.

Concretely:
- In `.github/workflows/build.yml`, between line 4 (`name: Build`) and line 6 (`on:`), insert:

```yaml
permissions:
  contents: read
```

This explicitly restricts the `GITHUB_TOKEN` to read-only access to repository contents for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
