### PR TITLE
`KryptonDockingManager.LoadConfigFromArray` throws exception (V105)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -46,6 +46,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), `KryptonDockingManager.LoadConfigFromArray` throws exception
 * Resolved [#3164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3164), Toolkit: Font property values are being serialized depending of the current culture in exported XML theme file
 * Resolved [#3013](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3013), Maximized form's size exceeds the screen's working area
 * Implemented [#3173](https://github.com/Krypton-Suite/Standad-Toolkit/issues/3173), Use pattern matching

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -788,22 +788,33 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
 
         set
         {
-            // Should only ever set the value once
+            if (value == null)
+            {
+                // Allow clearing when the space has been disposed (e.g. empty dockspace after config load)
+                if (_space != null)
+                {
+                    _space.Disposed -= OnSpaceDisposed;
+                    _space.WorkspaceCellAdding -= OnSpaceCellAdding;
+                    _space.PageDrop -= RaiseSpacePageDrop;
+                    _space = null;
+                }
+
+                return;
+            }
+
+            // Should only ever set the value once (except when clearing with null)
             if (_space != null)
             {
                 throw new ArgumentException(@"Cannot set the 'Space' property more than once.", nameof(SpaceControl));
             }
 
             // Cache for future use
-            _space = value ?? throw new ArgumentNullException(nameof(value));
+            _space = value;
 
             // Hook into space events we need to monitor
-            if (SpaceControl != null)
-            {
-                SpaceControl.Disposed += OnSpaceDisposed;
-                SpaceControl.WorkspaceCellAdding += OnSpaceCellAdding;
-                SpaceControl.PageDrop += RaiseSpacePageDrop;
-            }
+            value.Disposed += OnSpaceDisposed;
+            value.WorkspaceCellAdding += OnSpaceCellAdding;
+            value.PageDrop += RaiseSpacePageDrop;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -812,9 +812,9 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
             _space = value;
 
             // Hook into space events we need to monitor
-            value.Disposed += OnSpaceDisposed;
-            value.WorkspaceCellAdding += OnSpaceCellAdding;
-            value.PageDrop += RaiseSpacePageDrop;
+            _space!.Disposed += OnSpaceDisposed;
+            _space.WorkspaceCellAdding += OnSpaceCellAdding;
+            _space.PageDrop += RaiseSpacePageDrop;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupColorButton.cs
@@ -375,7 +375,7 @@ internal class ViewDrawRibbonGroupColorButton : ViewComposite,
         contentLayout.Add(_viewLargeCenter, ViewDockStyle.Bottom);
 
         // Add a 1 pixel separator at bottom of button before the text
-        contentLayout.Add(new ViewLayoutRibbonSeparator(1, ViewDockStyle.Bottom);
+        contentLayout.Add(new ViewLayoutRibbonSeparator(1, false), ViewDockStyle.Bottom);
 
         // Add the content into the background and border
         _viewLarge.Add(contentLayout);


### PR DESCRIPTION
# Fix KryptonDockingManager.LoadConfigFromArray throws exception (#3227)

## Summary

Resolves an `ArgumentException` thrown when loading a docking configuration via `LoadConfigFromArray` in certain scenarios where a dockspace ends up with no pages after load.

## Problem

When calling `KryptonDockingManager.LoadConfigFromArray()`, the following exception could occur:

```
System.ArgumentException: 'Cannot set the 'Space' property more than once.'
Parameter name: SpaceControl'
  at Krypton.Docking.KryptonDockingSpace.set_SpaceControl(KryptonSpace value)
  at Krypton.Docking.KryptonDockingDockspace.LoadElementFromXml(XmlReader xmlReader, KryptonPageCollection pages)
  ...
```

This happened when:
- Loading a saved docking configuration where some pages referenced in the config were not present in the `pages` collection passed to the loader
- The workspace structure (cells, groups) was restored, but no pages could be matched
- Result: a dockspace with `PageCount == 0`
- The code disposed the empty dockspace and attempted `SpaceControl = null!` to clear the reference
- The `SpaceControl` setter in `KryptonDockingSpace` only allowed a single assignment and threw on any subsequent call (including when clearing with null)

## Solution

Modified the `SpaceControl` setter in `KryptonDockingSpace` to allow clearing the reference when passed `null`:

- **When `value == null`**: Unhook from the current control's events, set `_space = null`, and return (no throw)
- **When `value` is non-null**: Existing behavior unchanged — assignment allowed only once; subsequent non-null assignments still throw

This supports the "clear after dispose" case used when an empty dockspace is removed during config load.

## Changes

| File | Description |
|------|-------------|
| `Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs` | Updated `SpaceControl` setter to handle `null` for clearing the reference |

## Testing

1. Build the solution (e.g. via `run.cmd` or `Scripts/VS2022/build-stable.cmd`)
2. Load a saved docking config using `LoadConfigFromArray(Convert.FromBase64String(configText))` where:
   - The config was saved with a prior session, or
   - Some referenced pages are not in the current `pages` collection
3. Verify the config loads successfully without throwing
4. Run TestForm and validate docking save/load scenarios

## Related

- Fixes [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227)
- Area: Docking

<img width="674" height="256" alt="image" src="https://github.com/user-attachments/assets/798b0c46-6924-4ae1-a8ce-17a5bdd29add" />
