### PR TITLE
2801-V110-KryptonTextBox-Validating-event-fires-twice

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
@@ -1315,10 +1315,8 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
 
     private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
     private void OnTextBoxMouseEnter(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -2570,10 +2570,8 @@ public class KryptonCheckedListBox : VisualControlBase,
 
     private void OnListBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnListBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3293,10 +3293,8 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnComboBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnComboBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnComboBoxFormat(object? sender, ListControlConvertEventArgs e) => OnFormat(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -2049,10 +2049,8 @@ public class KryptonDomainUpDown : VisualControlBase,
 
     private void OnDomainUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnDomainUpDownValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnDomainUpDownValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1904,10 +1904,8 @@ public class KryptonListBox : VisualControlBase,
 
     private void OnListBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnListBoxMouseChange(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1856,10 +1856,8 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
     private void OnMaskedTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnMaskedTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnMaskedTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -2159,10 +2159,8 @@ public class KryptonNumericUpDown : VisualControlBase,
 
     private void OnNumericUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnNumericUpDownValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnNumericUpDownValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2391,10 +2391,8 @@ public class KryptonRichTextBox : VisualControlBase,
 
     private void OnRichTextBoxLinkClicked(object? sender, LinkClickedEventArgs e) => OnLinkClicked(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnRichTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnRichTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1927,10 +1927,8 @@ public class KryptonTextBox : VisualControlBase,
 
     private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2477,10 +2477,8 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTreeViewValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTreeViewValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnTreeViewNodeMouseHover(object? sender, TreeNodeMouseHoverEventArgs e) => OnNodeMouseHover(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -794,7 +794,6 @@ public abstract class VisualControlBase : Control,
     /// <returns>PaletteRedirect derived class.</returns>
     protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Forward a Validating event from a child control. This method should be called by derived classes
     /// when forwarding validation events from internal controls to prevent duplicate validation events
@@ -817,7 +816,6 @@ public abstract class VisualControlBase : Control,
         }
     }
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Forward a Validated event from a child control. This method should be called by derived classes
     /// when forwarding validation events from internal controls to prevent duplicate validation events
@@ -864,7 +862,6 @@ public abstract class VisualControlBase : Control,
 
     #region Protected Overrides
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Raises the Validated event when the control is finished validating.
     /// </summary>
@@ -892,7 +889,6 @@ public abstract class VisualControlBase : Control,
         base.OnValidated(e);
     }
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Raises the Validating event, allowing validation logic to be performed before the control loses focus.
     /// </summary>


### PR DESCRIPTION
- Issue: #2801
- Remove TODO comments
- No changelog required

<img width="279" height="144" alt="image" src="https://github.com/user-attachments/assets/57d39b41-37f5-42b1-92c9-7348c9ab4f2d" />
