### PR TITLE
2801-V105-KryptonTextBox-Validating-event-fires-twice

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
@@ -1315,10 +1315,8 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
 
     private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
     private void OnTextBoxMouseEnter(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -2502,10 +2502,8 @@ public class KryptonCheckedListBox : VisualControlBase,
 
     private void OnListBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnListBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3251,10 +3251,8 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnComboBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnComboBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnComboBoxFormat(object? sender, ListControlConvertEventArgs e) => OnFormat(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -2007,10 +2007,8 @@ public class KryptonDomainUpDown : VisualControlBase,
 
     private void OnDomainUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnDomainUpDownValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnDomainUpDownValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1856,10 +1856,8 @@ public class KryptonListBox : VisualControlBase,
 
     private void OnListBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnListBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnListBoxMouseChange(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1856,10 +1856,8 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
     private void OnMaskedTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnMaskedTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnMaskedTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -2116,10 +2116,8 @@ public class KryptonNumericUpDown : VisualControlBase,
 
     private void OnNumericUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnNumericUpDownValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnNumericUpDownValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2327,10 +2327,8 @@ public class KryptonRichTextBox : VisualControlBase,
 
     private void OnRichTextBoxLinkClicked(object? sender, LinkClickedEventArgs e) => OnLinkClicked(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnRichTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnRichTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1885,10 +1885,8 @@ public class KryptonTextBox : VisualControlBase,
 
     private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2410,10 +2410,8 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTreeViewValidated(object? sender, EventArgs e) => ForwardValidated(e);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private void OnTreeViewValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
 
     private void OnTreeViewNodeMouseHover(object? sender, TreeNodeMouseHoverEventArgs e) => OnNodeMouseHover(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -41,7 +41,6 @@ public abstract class VisualControlBase : Control,
     protected VisualPopupToolTip? _visualBasePopupToolTip;
     private readonly ToolTipManager _toolTipManager;
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     private bool _isForwardingValidationFromChild;
 
     private int _minimumControlHeight;
@@ -798,7 +797,6 @@ public abstract class VisualControlBase : Control,
     /// <returns>PaletteRedirect derived class.</returns>
     protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Forward a Validating event from a child control. This method should be called by derived classes
     /// when forwarding validation events from internal controls to prevent duplicate validation events
@@ -821,7 +819,6 @@ public abstract class VisualControlBase : Control,
         }
     }
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Forward a Validated event from a child control. This method should be called by derived classes
     /// when forwarding validation events from internal controls to prevent duplicate validation events
@@ -866,7 +863,6 @@ public abstract class VisualControlBase : Control,
 
     #region Protected Overrides
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     /// <summary>
     /// Raises the Validating event, allowing validation logic to be performed before the control loses focus.
     /// </summary>
@@ -895,7 +891,6 @@ public abstract class VisualControlBase : Control,
         base.OnValidating(e);
     }
 
-    // TODO: Workaround for issue where ContainerControl style causes duplicate validation events. See issue https://github.com/Krypton-Suite/Standard-Toolkit/issues/2801 for details.
     protected override void OnValidated(EventArgs e)
     {
         // Root cause fix: When ContainerControl style is set, Windows Forms validation mechanism treats


### PR DESCRIPTION
- Issue: #2801
- Remove TODO comments
- No changelog required

<img width="288" height="170" alt="image" src="https://github.com/user-attachments/assets/faa50141-e3f0-42d9-a03f-42bfe158ff03" />
