### PR TITLE
* Fix `run.cmd`

### DIFF
--- a/Scripts/Build/update-nuget.cmd
+++ b/Scripts/Build/update-nuget.cmd
@@ -1,21 +1,5 @@
 @echo off
-
-cls
-
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
-echo 3. Go back to main menu
-echo 4. End
-
-set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
-
-@echo Invalid input, please try again.
-
-pause
+setlocal EnableExtensions
 
 goto setmenu
 
@@ -23,16 +7,16 @@ goto setmenu
 
 cls
 
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
+echo 1. Update NuGet.exe (nuget update -Self)
+echo 2. Clear NuGet HTTP cache (nuget locals http-cache -clear)
 echo 3. Go back to main menu
 echo 4. End
-
+echo:
 set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
+if "%answer%"=="1" (goto updatenuget)
+if "%answer%"=="2" (goto clearnugethttpcache)
+if "%answer%"=="3" (goto backtorun)
+if "%answer%"=="4" (goto end)
 
 @echo Invalid input, please try again.
 
@@ -41,23 +25,41 @@ pause
 goto setmenu
 
 :backtorun
-cd ..
-
-run.cmd
+:: Exit code 2: caller (run.cmd) branches to main menu. Do not start a nested run.cmd
+:: here; that stops the parent batch and the menu is never reached reliably.
+endlocal
+exit /b 2
 
 :updatenuget
 cls
 
-nuget update
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo Install the NuGet CLI or add it to your PATH, then try again.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget update -Self
 
 pause
 
 goto setmenu
 
-:updatenugetself
+:clearnugethttpcache
 cls
 
-nuget update -Self
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget locals http-cache -clear
 
 pause
 
@@ -68,4 +70,5 @@ goto setmenu
 
 pause
 
-exit
+endlocal
+exit /b 0

--- a/Scripts/Current/update-nuget.cmd
+++ b/Scripts/Current/update-nuget.cmd
@@ -1,21 +1,5 @@
 @echo off
-
-cls
-
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
-echo 3. Go back to main menu
-echo 4. End
-
-set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
-
-@echo Invalid input, please try again.
-
-pause
+setlocal EnableExtensions
 
 goto setmenu
 
@@ -23,16 +7,16 @@ goto setmenu
 
 cls
 
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
+echo 1. Update NuGet.exe (nuget update -Self)
+echo 2. Clear NuGet HTTP cache (nuget locals http-cache -clear)
 echo 3. Go back to main menu
 echo 4. End
-
+echo:
 set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
+if "%answer%"=="1" (goto updatenuget)
+if "%answer%"=="2" (goto clearnugethttpcache)
+if "%answer%"=="3" (goto backtorun)
+if "%answer%"=="4" (goto end)
 
 @echo Invalid input, please try again.
 
@@ -41,23 +25,41 @@ pause
 goto setmenu
 
 :backtorun
-cd ..
-
-run.cmd
+:: Exit code 2: caller (run.cmd) branches to main menu. Do not start a nested run.cmd
+:: here; that stops the parent batch and the menu is never reached reliably.
+endlocal
+exit /b 2
 
 :updatenuget
 cls
 
-nuget update
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo Install the NuGet CLI or add it to your PATH, then try again.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget update -Self
 
 pause
 
 goto setmenu
 
-:updatenugetself
+:clearnugethttpcache
 cls
 
-nuget update -Self
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget locals http-cache -clear
 
 pause
 
@@ -68,4 +70,5 @@ goto setmenu
 
 pause
 
-exit
+endlocal
+exit /b 0

--- a/Scripts/VS2022/update-nuget.cmd
+++ b/Scripts/VS2022/update-nuget.cmd
@@ -1,21 +1,5 @@
 @echo off
-
-cls
-
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
-echo 3. Go back to main menu
-echo 4. End
-
-set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
-
-@echo Invalid input, please try again.
-
-pause
+setlocal EnableExtensions
 
 goto setmenu
 
@@ -23,16 +7,16 @@ goto setmenu
 
 cls
 
-echo 1. Update NuGet client
-echo 2. Update NuGet client (use 'Self' switch)
+echo 1. Update NuGet.exe (nuget update -Self)
+echo 2. Clear NuGet HTTP cache (nuget locals http-cache -clear)
 echo 3. Go back to main menu
 echo 4. End
-
+echo:
 set /p answer="Enter number (1 - 4): "
-if %answer%==1 (goto updatenuget)
-if %answer%==2 (goto updatenugetself)
-if %answer%==3 (goto backtorun)
-if %answer%==4 (goto end)
+if "%answer%"=="1" (goto updatenuget)
+if "%answer%"=="2" (goto clearnugethttpcache)
+if "%answer%"=="3" (goto backtorun)
+if "%answer%"=="4" (goto end)
 
 @echo Invalid input, please try again.
 
@@ -41,23 +25,41 @@ pause
 goto setmenu
 
 :backtorun
-cd ..
-
-run.cmd
+:: Exit code 2: caller (run.cmd) branches to main menu. Do not start a nested run.cmd
+:: here; that stops the parent batch and the menu is never reached reliably.
+endlocal
+exit /b 2
 
 :updatenuget
 cls
 
-nuget update
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo Install the NuGet CLI or add it to your PATH, then try again.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget update -Self
 
 pause
 
 goto setmenu
 
-:updatenugetself
+:clearnugethttpcache
 cls
 
-nuget update -Self
+where nuget >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: nuget.exe was not found on PATH.
+    echo.
+    pause
+    goto setmenu
+)
+
+nuget locals http-cache -clear
 
 pause
 
@@ -68,4 +70,5 @@ goto setmenu
 
 pause
 
-exit
+endlocal
+exit /b 0

--- a/run.cmd
+++ b/run.cmd
@@ -1,4 +1,4 @@
-﻿:: Last updated: Saturday 6th December, 2025 @ 10:00
+:: Last updated: Sunday 29th March, 2026 @ 11:00
 
 @echo off
 
@@ -16,7 +16,7 @@ goto selectvsversion
 :selectvsversion
 cls
 
-@echo Welcome to the Krypton Toolkit Build system, version: 3.0a.
+@echo Welcome to the Krypton Toolkit Build system, version: 3.1.
 @echo Please select the Visual Studio toolset to target.
 echo:
 @echo ==============================================================================================
@@ -65,6 +65,41 @@ echo.
 exit /b 0
 
 :: ===================================================================================================
+:: Workspace clean helpers (use "call :label"; returns via exit /b)
+
+:cleanbinandobj
+echo Deleting the 'Bin' folder
+rd /s /q "Bin"
+echo Deleted the 'Bin' folder
+echo Deleting the 'Krypton.Docking\obj' folder
+rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
+echo Deleted the 'Krypton.Docking\obj' folder
+echo Deleting the 'Krypton.Navigator\obj' folder
+rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
+echo Deleted the 'Krypton.Navigator\obj' folder
+echo Deleting the 'Krypton.Ribbon\obj' folder
+rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
+echo Deleted the 'Krypton.Ribbon\obj' folder
+echo Deleting the 'Krypton.Toolkit\obj' folder
+rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
+echo Deleted the 'Krypton.Toolkit\obj' folder
+echo Deleting the 'Krypton.Workspace\obj' folder
+rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
+echo Deleted the 'Krypton.Workspace\obj' folder
+exit /b 0
+
+:cleanlogs
+echo Deleting the 'Logs' folder
+del /f "Logs"
+exit /b 0
+
+:cleanrootbuildlog
+echo Deleting the 'build.log' file
+del /f build.log
+echo Deleted the 'build.log' file
+exit /b 0
+
+:: ===================================================================================================
 
 :mainmenu
 
@@ -94,7 +129,7 @@ if "%answer%"=="4" (goto buildandpacktoolkit)
 if "%answer%"=="5" (goto debugproject)
 if "%answer%"=="6" (goto nugettools)
 if "%answer%"=="7" (goto createarchives)
-if "%answer%"=="8" (goto webview2menu)
+if "%answer%"=="8" (goto webview2tools)
 if "%answer%"=="9" (goto selectvsversion)
 if "%answer%"=="10" (goto exitbuildsystem)
 
@@ -141,7 +176,7 @@ set /p answer="Enter number (1 - 5): "
 if %answer%==1 (goto packnightly)
 if %answer%==2 (goto packcanary)
 if %answer%==3 (goto packstable)
-if %answer%==4 (goto packlts)
+if %answer%==4 (goto packltsmenu)
 if %answer%==5 (goto mainmenu)
 
 @echo Invalid input, please try again.
@@ -219,26 +254,8 @@ pause
 :cleanproject
 cls
 
-echo Deleting the 'Bin' folder
-rd /s /q "Bin"
-echo Deleted the 'Bin' folder
-echo Deleting the 'Krypton.Docking\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
-echo Deleted the 'Krypton.Docking\obj' folder
-echo Deleting the 'Krypton.Navigator\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
-echo Deleted the 'Krypton.Navigator\obj' folder
-echo Deleting the 'Krypton.Ribbon\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
-echo Deleted the 'Krypton.Ribbon\obj' folder
-echo Deleting the 'Krypton.Toolkit\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
-echo Deleted the 'Krypton.Toolkit\obj' folder
-echo Deleting the 'Krypton.Workspace\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
-echo Deleted the 'Krypton.Workspace\obj' folder
-echo Deleting the 'Logs' folder
-del /f "Logs"
+call :cleanbinandobj
+call :cleanlogs
 
 pause
 
@@ -246,31 +263,10 @@ goto mainmenu
 
 :clearproject
 
-echo Deleting the 'Bin' folder
-rd /s /q "Bin"
-echo Deleted the 'Bin' folder
-echo Deleting the 'Krypton.Docking\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
-echo Deleted the 'Krypton.Docking\obj' folder
-echo Deleting the 'Krypton.Navigator\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
-echo Deleted the 'Krypton.Navigator\obj' folder
-echo Deleting the 'Krypton.Ribbon\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
-echo Deleted the 'Krypton.Ribbon\obj' folder
-echo Deleting the 'Krypton.Toolkit\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
-echo Deleted the 'Krypton.Toolkit\obj' folder
-echo Deleting the 'Krypton.Workspace\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
-echo Deleted the 'Krypton.Workspace\obj' folder
-echo Deleting the 'Logs' folder
-del /f "Logs"
+call :cleanbinandobj
+call :cleanlogs
 
 :: ===================================================================================================
-
-:cleanproject
-goto cleanproject
 
 :buildproject
 goto buildmenu
@@ -280,9 +276,6 @@ goto packmenu
 
 :debugproject
 goto debugmenu
-
-:nugettools
-goto createarchives
 
 :createarchives
 cls
@@ -320,21 +313,13 @@ goto createarchives
 
 :: ===================================================================================================
 
-:webview2menu
-
-cls
-
-cd Scripts/WebVew2/
-
-WebView2Setup.cmd
-
-:; ===================================================================================================
-
 :updatenuget
 cls
 
 
 call "%VS_SCRIPTS_DIR%\update-nuget.cmd"
+set "UPDATE_NUGET_EC=%errorlevel%"
+if "%UPDATE_NUGET_EC%"=="2" goto mainmenu
 
 
 pause
@@ -614,32 +599,15 @@ goto packltsmenu
 :debug
 cls
 
-echo Deleting the 'Bin' folder
-rd /s /q "Bin"
-echo Deleted the 'Bin' folder
-echo Deleting the 'Krypton.Docking\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
-echo Deleted the 'Krypton.Docking\obj' folder
-echo Deleting the 'Krypton.Navigator\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
-echo Deleted the 'Krypton.Navigator\obj' folder
-echo Deleting the 'Krypton.Ribbon\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
-echo Deleted the 'Krypton.Ribbon\obj' folder
-echo Deleting the 'Krypton.Toolkit\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
-echo Deleted the 'Krypton.Toolkit\obj' folder
-echo Deleting the 'Krypton.Workspace\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
-echo Deleted the 'Krypton.Workspace\obj' folder
-echo Deleting the 'build.log' file
-del /f build.log
-echo Deleted the 'build.log' file
+call :cleanbinandobj
+call :cleanrootbuildlog
 
 cls
 
 
 call "%VS_SCRIPTS_DIR%\build-nightly.cmd"
+
+goto debugmenu
 
 :: ===================================================================================================
 
@@ -648,6 +616,8 @@ cls
 
 
 call "%VS_SCRIPTS_DIR%\update-nuget.cmd"
+set "UPDATE_NUGET_EC=%errorlevel%"
+if "%UPDATE_NUGET_EC%"=="2" goto mainmenu
 
 :buildandcreatenugetpackages
 cls
@@ -672,6 +642,8 @@ if %answer%==6 (goto mainmenu)
 
 pause
 
+goto buildandcreatenugetpackages
+
 :: ===================================================================================================
 
 :buildnightlypackages
@@ -679,27 +651,8 @@ cls
 
 echo Step 1: Clean
 
-echo Deleting the 'Bin' folder
-rd /s /q "Bin"
-echo Deleted the 'Bin' folder
-echo Deleting the 'Krypton.Docking\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
-echo Deleted the 'Krypton.Docking\obj' folder
-echo Deleting the 'Krypton.Navigator\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
-echo Deleted the 'Krypton.Navigator\obj' folder
-echo Deleting the 'Krypton.Ribbon\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
-echo Deleted the 'Krypton.Ribbon\obj' folder
-echo Deleting the 'Krypton.Toolkit\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
-echo Deleted the 'Krypton.Toolkit\obj' folder
-echo Deleting the 'Krypton.Workspace\obj' folder
-rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
-echo Deleted the 'Krypton.Workspace\obj' folder
-echo Deleting the 'build.log' file
-del /f build.log
-echo Deleted the 'build.log' file
+call :cleanbinandobj
+call :cleanrootbuildlog
 
 cls
 
@@ -718,6 +671,88 @@ call "%VS_SCRIPTS_DIR%\build-nightly-custom.cmd" Pack
 
 pause
 
+goto buildandcreatenugetpackages
+
+:: ===================================================================================================
+
+:buildcanarypackages
+cls
+
+echo Step 1: Clean
+
+call :cleanbinandobj
+call :cleanrootbuildlog
+
+cls
+
+echo Step 2: Build and pack
+
+call "%VS_SCRIPTS_DIR%\build-canary.cmd" Pack
+
+pause
+
+goto buildandcreatenugetpackages
+
+:: ===================================================================================================
+
+:buildstablepackages
+cls
+
+echo Step 1: Clean
+
+call :cleanbinandobj
+call :cleanrootbuildlog
+
+cls
+
+echo Step 2: Build and pack
+
+call "%VS_SCRIPTS_DIR%\build-stable.cmd" Pack
+
+pause
+
+goto buildandcreatenugetpackages
+
+:: ===================================================================================================
+
+:buildstablelitepackages
+cls
+
+echo Step 1: Clean
+
+call :cleanbinandobj
+call :cleanrootbuildlog
+
+cls
+
+echo Step 2: Build and pack ^(lite^)
+
+call "%VS_SCRIPTS_DIR%\build-stable.cmd" PackLite
+
+pause
+
+goto buildandcreatenugetpackages
+
+:: ===================================================================================================
+
+:buildltspackages
+cls
+
+echo Step 1: Clean
+
+call :cleanbinandobj
+call :cleanrootbuildlog
+
+cls
+
+echo Step 2: Build and pack
+
+call "%VS_SCRIPTS_DIR%\build-lts.cmd" Pack
+
+pause
+
+goto buildandcreatenugetpackages
+
 :: ===================================================================================================
 
 :rebuildproject
@@ -725,6 +760,8 @@ cls
 
 
 call "%VS_SCRIPTS_DIR%\rebuild-build-nightly.cmd"
+
+goto buildmenu
 
 :: ===================================================================================================
 
@@ -805,11 +842,11 @@ echo Setting up WebView2 SDK for KryptonWebView2 control...
 echo This will install the latest stable WebView2 SDK version.
 echo.
 
-cd Scripts
+pushd "%~dp0Scripts\WebVew2"
 
-Setup-WebView2SDK.cmd
+call Setup-WebView2SDK.cmd
 
-cd ..
+popd
 
 pause
 
@@ -824,11 +861,11 @@ echo Updating WebView2 SDK to latest version...
 echo This will check for updates and install the newest stable version.
 echo.
 
-cd Scripts
+pushd "%~dp0Scripts\WebVew2"
 
-Update-WebView2SDK.cmd
+call Update-WebView2SDK.cmd
 
-cd ..
+popd
 
 pause
 
@@ -842,11 +879,11 @@ cls
 echo Checking WebView2 SDK version...
 echo.
 
-cd Scripts
+pushd "%~dp0Scripts\WebVew2"
 
-Check-WebView2Version.cmd
+call Check-WebView2Version.cmd
 
-cd ..
+popd
 
 pause
 


### PR DESCRIPTION
# PR: Fix `run.cmd`, NuGet update scripts, and workspace clean helpers

## Summary

Repairs the interactive build menu (`run.cmd`), consolidates duplicated clean-up logic, and fixes all three `update-nuget.cmd` variants (`Scripts\VS2022`, `Scripts\Current`, `Scripts\Build`) so NuGet maintenance and “return to main menu” behave correctly when launched from `run.cmd`.

## Problems addressed

### `run.cmd`

- **Duplicate `:nugettools` label** — The first definition redirected to the archives menu, so main menu item **6 (NuGet Tools)** never reached the real NuGet flow.
- **Invalid `:packlts` target** — Pack menu option 4 referenced a missing label (`:packlts`); corrected to `:packltsmenu`.
- **Redundant / misleading `:cleanproject` block** — Removed the duplicate label that only jumped to itself.
- **Fall-through bugs** — Several labels ran into the next section without `goto`:
  - Debug path continued into NuGet tools after the nightly build.
  - NuGet “build packages” submenu invalid input fell through into nightly package steps.
  - Nightly package flow fell through into rebuild / other targets.
  - Rebuild path could continue into “build and pack nightly” after the child script returned.
- **WebView2** — Main menu item **8** pointed at a short `:webview2menu` that then fell through into `:updatenuget`. Menu now uses **`:webview2tools`**, and WebView2 scripts are invoked from **`Scripts\WebVew2`** via `pushd "%~dp0Scripts\WebVew2"` and `call` (folder name matches the repo as-is).
- **Missing labels** — NuGet package submenu options 2–5 jumped to non-existent labels; added **`:buildcanarypackages`**, **`:buildstablepackages`**, **`:buildstablelitepackages`**, **`:buildltspackages`** (clean + appropriate `build-*.cmd` `Pack` / `PackLite`).
- **Workspace clean-up** — Introduced **`:cleanbinandobj`**, **`:cleanlogs`**, and **`:cleanrootbuildlog`** and replaced repeated `rd`/`del` blocks.

### `update-nuget.cmd` (all three script folders)

- **“Go back to main menu”** — Starting nested `run.cmd` without `call` broke return to the outer `run.cmd`. The script now returns with **`exit /b 2`**; **`run.cmd`** checks **`UPDATE_NUGET_EC`** and **`goto mainmenu`** when the code is `2`.
- **Wrong NuGet command for “update client”** — `nuget update` updates solution packages, not `nuget.exe`. Client update uses **`nuget update -Self`**; second menu action is **`nuget locals http-cache -clear`**.
- **Wrong working directory for `run.cmd`** — Removed reliance on `cd ..` to find the repo root for nested `run.cmd` (superseded by return-code handling).
- **Unsafe `if %answer%==…`** — Replaced with quoted comparisons for empty input.
- **`exit` vs `exit /b`** — **`:end`** uses **`endlocal`** and **`exit /b 0`** when the script is **`call`**ed from `run.cmd` so the parent session is not torn down.
- **Duplicate menu** — Single **`:setmenu`** entry via initial **`goto setmenu`**.
- **`where nuget`** — Clear error if `nuget.exe` is not on `PATH`.

## Files touched

| Path | Change |
|------|--------|
| `run.cmd` | Menu fixes, flow/`goto` corrections, WebView2 paths, package targets, clean helpers, NuGet exit-code handling | | `Scripts\VS2022\update-nuget.cmd` | Rewritten menu, commands, return codes, `call`-safe exit | | `Scripts\Current\update-nuget.cmd` | Same as VS2022 variant | | `Scripts\Build\update-nuget.cmd` | Same as VS2022 variant | | `Documents\PR-run-cmd-and-build-scripts.md` | This PR description (optional to keep or delete after merge) |

## How to verify

1. Run **`run.cmd`**, pick a VS script set, and exercise:
   - **6** — NuGet Tools → option **3** — should return to **main menu** (not archives or a stuck submenu).
   - **7** → **10** (Update NuGet tools) → option **3** — should return to **main menu**.
   - **3** (Create NuGet packages) → **4** (LTS) — should open the LTS pack submenu (no “label not found”).
   - **8** — WebView2 — should show the WebView2 submenu and run scripts from `Scripts\WebVew2`.
2. From **NuGet Tools**, run **1** or **2** only if `nuget.exe` is on `PATH`; confirm sensible errors if it is missing.

## Notes

- **`Scripts\WebVew2`** is the existing folder spelling in the repo; paths intentionally match it.
- **`Documents\PR-run-cmd-and-build-scripts.md`** is for copy-paste into the GitHub/Git PR description; remove it from the branch if you prefer not to commit PR text.

## Suggested commit / PR title

`Fix run.cmd flow, NuGet update scripts, and workspace clean helpers`