### PR TITLE
* AIO Package fix

### DIFF
--- a/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
+++ b/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
@@ -63,6 +63,8 @@
 		  We only want to include the referenced DLLs (Krypton.Docking, Krypton.Navigator, etc.), not this wrapper project's output.
 		-->
 		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<!-- Prevent project references from being emitted as NuGet dependencies; this package carries binaries directly. -->
+		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 	</PropertyGroup>
 	<!-- WebView2: path to bundled DLLs in Krypton.Utilities (same as used by Utilities build). Run Scripts\WebVew2\Populate-BundledWebView2.cmd to populate. -->
 	<PropertyGroup>


### PR DESCRIPTION
## Summary
- Fix aggregate package metadata for `Krypton.Standard.Toolkit` so NuGet does not emit project-reference dependencies.
- Add `SuppressDependenciesWhenPacking=true` in the aggregator project to prevent invalid dependency IDs (notably `Krypton.Navigator.Utilities`) from being written to package dependency groups.
- Preserve current package behavior of shipping toolkit binaries directly inside the package.

## Problem
Installing `Krypton.Standard.Toolkit` can fail with:

`Unable to find package Krypton.Navigator.Utilities`

`Krypton.Navigator.Utilities` is an internal assembly/project in this repository, not a published standalone NuGet package. If emitted as a dependency, restore fails on consumer machines.

## Root Cause
The aggregate package project references multiple internal projects to build and collect outputs. During packing, project references can be translated into NuGet dependency metadata unless explicitly suppressed.

## Fix
- File updated: `Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj`
- Added:
  - `<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>`

This keeps the package self-contained and prevents invalid dependency declarations.

## Impact
- Prevents restore/install failures caused by non-existent dependency package IDs.
- No runtime behavior change for toolkit assemblies.
- Affects package metadata generation only.