### PR TITLE
* `KryptonToast` no longer works properly

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3018), `KryptonToast` no longer works properly
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), `KryptonDockingManager.LoadConfigFromArray` throws exception
 * Resolved [#3225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3225), Ribbon large button image-to-text separator not DPI-scaled
 * Resolved [#3256](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3256), Tree View Event is Crashing

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -71,6 +71,8 @@ internal partial class VisualToastBasicForm : KryptonForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         krtbNotificationContentText.Text = _basicToastNotificationData.NotificationContent ?? string.Empty;
 
         klblHeader.Text = _basicToastNotificationData.NotificationTitle;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -90,6 +90,8 @@ internal partial class VisualToastBasicWithProgressBarForm : KryptonForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         krtbNotificationContentText.Text = _basicToastNotificationData.NotificationContent ?? string.Empty;
 
         klblHeader.Text = _basicToastNotificationData.NotificationTitle;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -67,6 +67,8 @@ internal partial class VisualToastBasicRtlAwareForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         krtbNotificationContentText.Text = _basicToastNotificationData.NotificationContent ?? string.Empty;
 
         klblHeader.Text = _basicToastNotificationData.NotificationTitle;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -67,6 +67,8 @@ internal partial class VisualToastBasicWithProgressBarRtlAwareForm : VisualToast
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         krtbNotificationContentText.Text = _basicToastNotificationData.NotificationContent ?? string.Empty;
 
         klblHeader.Text = _basicToastNotificationData.NotificationTitle;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastComboBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastComboBoxUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -55,6 +55,8 @@ internal partial class VisualToastComboBoxUserInputForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastDateTimeUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastDateTimeUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -54,6 +54,8 @@ internal partial class VisualToastDateTimeUserInputForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastDomainUpDownUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastDomainUpDownUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -55,6 +55,8 @@ internal partial class VisualToastDomainUpDownUserInputForm : VisualToastBaseFor
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastMaskedTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastMaskedTextBoxUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -55,6 +55,8 @@ internal partial class VisualToastMaskedTextBoxUserInputForm : VisualToastBaseFo
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastNUDUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastNUDUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -55,6 +55,8 @@ internal partial class VisualToastNUDUserInputForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/Normal/VisualToastTextBoxUserInputForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -78,6 +78,8 @@ internal partial class VisualToastTextBoxUserInputForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _notificationTitleText;
 
         krtbNotificationContentText.Text = _notificationContentText;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastComboBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastComboBoxUserInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastComboBoxUserInputWithProgressBarForm : VisualT
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastDateTimeUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastDateTimeUserInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastDateTimeUserInputWithProgressBarForm : VisualT
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastDomianUpDownInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastDomianUpDownInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastDomianUpDownInputWithProgressBarForm : VisualT
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastMaskedTextBoxInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastMaskedTextBoxInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastMaskedTextBoxInputWithProgressBarForm : Visual
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastNUDUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastNUDUserInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastNUDUserInputWithProgressBarForm : VisualToastB
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastTextBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/LTR/ProgressBar/VisualToastTextBoxUserInputWithProgressBarForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastTextBoxUserInputWithProgressBarForm : VisualTo
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastComboBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastComboBoxUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -55,6 +55,8 @@ internal partial class VisualToastComboBoxUserInputRtlAwareForm : VisualToastBas
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastDateTimeUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastDateTimeUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -59,6 +59,8 @@ internal partial class VisualToastDateTimeUserInputRtlAwareForm : VisualToastBas
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastDomainUpDownUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastDomainUpDownUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastDomainUpDownUserInputRtlAwareForm : VisualToas
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastMaskedTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastMaskedTextBoxUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastMaskedTextBoxUserInputRtlAwareForm : VisualToa
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastNUDUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastNUDUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastNUDUserInputRtlAwareForm : VisualToastBaseForm
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle;
 
         krtbNotificationContentText.Text = _data.NotificationContent;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/Normal/VisualToastTextBoxUserInputRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -76,6 +76,8 @@ internal partial class VisualToastTextBoxUserInputRtlAwareForm : VisualToastBase
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _notificationTitleText;
 
         krtbNotificationContentText.Text = _notificationContentText;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastComboBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastComboBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastComboBoxUserInputWithProgressBarRtlAwareForm :
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastDateTimeUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastDateTimeUserInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastDateTimeUserInputWithProgressBarRtlAwareForm :
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastDomainUpDownInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastDomainUpDownInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastDomainUpDownInputWithProgressBarRtlAwareForm :
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastMaskedTextBoxInputWithProgressBarRtlAwareForm 
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastNUDUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastNUDUserInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastNUDUserInputWithProgressBarRtlAwareForm : Visu
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastTextBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/User Input/RTL/ProgressBar/VisualToastTextBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -57,6 +57,8 @@ internal partial class VisualToastTextBoxUserInputWithProgressBarRtlAwareForm : 
 
     private void UpdateText()
     {
+        GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText);
+
         klblHeader.Text = _data.NotificationTitle ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
 
         krtbNotificationContentText.Text = _data.NotificationContent ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/GlobalStaticValues.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/GlobalStaticValues.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -163,9 +163,17 @@ public class GlobalStaticValues
         // per ticket #1692
         get => KryptonManager.CurrentGlobalPalette.GetContentLongTextColor1(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
     }
+
     #endregion
 
     #region Methods
+
+    /// <summary>
+    /// Applies <see cref="KryptonMessageBoxRichTextBoxTextColor"/> to a read-only panel-client <see cref="Krypton.Toolkit.KryptonRichTextBox"/> (toast body text; #3018).
+    /// </summary>
+    internal static void ApplyToastRichTextContentColor(Krypton.Toolkit.KryptonRichTextBox richTextBox) =>
+        richTextBox.StateCommon.Content.Color1 = KryptonMessageBoxRichTextBoxTextColor;
+
     /// <summary>
     /// Helper method that returns a generic message when a variable is null.
     /// </summary>


### PR DESCRIPTION
# Fix KryptonToast notification body text visibility (#3018)

## Summary

Fixes a regression where toast notification **body text** could appear missing (especially on darker themes) after `KryptonToast` lived in `Krypton.Utilities`. The title and layout were fine; the read-only **`KryptonRichTextBox`** used for the message did not apply a label-appropriate foreground colour.

## Issue

- [Bug: KryptonToast no longer works properly — #3018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3018)

## Root cause

Toast forms use **`KryptonRichTextBox`** with **`InputControlStyle.PanelClient`** and **`ReadOnly = true`** to show static content while matching form chrome. That combination can take the **input-control** colour path while the control is drawn like **text on a panel**, so foreground and background colours may coincide (invisible text).

The same situation was already addressed for **`KryptonMessageBox`** in [#1692](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1692) by setting:

`StateCommon.Content.Color1` from `GlobalStaticValues.KryptonMessageBoxRichTextBoxTextColor` (palette: `LabelNormalPanel` long text, normal state).

Toast visuals never applied that adjustment after the move to `Krypton.Utilities`.

## Solution

1. **`Krypton.Utilities` — `GlobalStaticValues`**

   - Added internal helper **`ApplyToastRichTextContentColor(KryptonRichTextBox)`**, which assigns `StateCommon.Content.Color1` using the same source as the message box (`KryptonMessageBoxRichTextBoxTextColor`).

2. **All toast visual forms** that host **`krtbNotificationContentText`**

   - At the start of **`UpdateText()`**, call **`GlobalStaticValues.ApplyToastRichTextContentColor(krtbNotificationContentText)`** before assigning the notification text.

   This covers basic toasts (LTR/RTL, with and without progress bar) and user-input toasts (all LTR/RTL and progress-bar variants). Only the read-only rich text used for the **notification content** is affected.

## Out of scope (by design)

Editable toast controls (`KryptonTextBox`, `KryptonComboBox`, `KryptonNumericUpDown`, etc.) use normal input styling, **not** `PanelClient` for the rich-text workaround. They should continue to use the theme’s input colours; the message-box label colour is not appropriate for those controls.

## How to verify

1. Run **`ToastNotificationQuickTestForm`** or **`UserInputToastNotificationTest`** (or any code path that calls `KryptonToast.ShowBasicNotification` / `ShowNotification`).
2. Switch to a **dark** palette (for example Office 2010 Black or another high-contrast dark theme).
3. Confirm **notification title** and **body** text are both readable.

## Checklist

- [x] Behaviour aligned with `VisualMessageBoxForm` / `VisualMessageBoxRtlAwareForm` rich text handling ([#1692](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1692)).

<img width="670" height="254" alt="image" src="https://github.com/user-attachments/assets/5a2cb92f-a395-4b81-8bcd-9d1b528b215b" />
