### PR TITLE
* Tree View Event is Crashing (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -46,6 +46,7 @@
 
 ## 2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026
 
+* Resolved [#3256](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3256), Tree View Event is Crashing
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), `KryptonDockingManager.LoadConfigFromArray` throws exception
 * Resolved [#3225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3225), Ribbon large button image-to-text separator not DPI-scaled
 * Resolved [#3164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3164), Toolkit: Font property values are being serialized depending of the current culture in exported XML theme file

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -4286,9 +4286,13 @@ public class KryptonCustomPaletteBase : PaletteBase
             case PaletteButtonSpecStyle.Undo:
                 return ButtonSpecs.Previous;
             default:
-                // Should never happen!
-                Debug.Assert(false);
-                throw DebugTools.NotImplemented(style.ToString());
+                // Unknown or out-of-range values (e.g. newer enum, bad serialization) — avoid crashing the UI.
+                Debug.Assert(false, $"Unhandled {nameof(PaletteButtonSpecStyle)}: {(int)style}");
+                if (Debugger.IsAttached)
+                {
+                    throw DebugTools.NotImplemented(style.ToString());
+                }
+                return ButtonSpecs.Generic;
         }
     }
 


### PR DESCRIPTION
# Fix crash when using custom palette with title-bar / toolbar button specs (#3256)

## Summary

Resolves a crash reported when interacting with controls (for example a `KryptonTreeView`) while using **`PaletteMode.Custom`** with **`KryptonCustomPaletteBase`**. The failure surfaced as the integrated “Not Implemented” dialog pointing at `GetPaletteButtonSpec` in `KryptonCustomPaletteBase.cs`.

## Root cause

`KryptonFormTitleBar` creates standard toolbar **`ButtonSpecAny`** entries with types such as **`New`**, **`Open`**, **`Save`**, and so on. Those types map to **`PaletteButtonSpecStyle`** values that must be resolved through the active palette.

If any **`PaletteButtonSpecStyle`** still fell through the **`switch`** in **`KryptonCustomPaletteBase.GetPaletteButtonSpec`**, the **`default`** branch called **`DebugTools.NotImplemented`**, which blocks the UI and throws. A repaint triggered by ordinary input (e.g. clicking the tree view) is enough to hit that path.

Related context: handling for the full set of toolbar-related **`PaletteButtonSpecStyle`** values in this method was expanded for **#3072**; this change completes the behaviour for **#3256** by making the **`default`** path safe when an unexpected or out-of-range value appears (forward compatibility, bad serialization, etc.).

## Changes

- **`KryptonCustomPaletteBase.GetPaletteButtonSpec`**: **`default`** now **`Debug.Assert`s** (debug builds) with the numeric style value, then **returns `ButtonSpecs.Generic`** instead of **`DebugTools.NotImplemented`**, so the application does not hard-crash.
- **`Documents/Changelog/Changelog.md`**: entry for **#3256**.

## Testing

- Run **Test Form** → **Tree View** example (or **Tree View Test**) with **`KryptoManager.GlobalPaletteMode = PaletteMode.Custom`** and a **`KryptonCustomPaletteBase`** instance as **`GlobalCustomPalette`**.
- Click the **`KryptonTreeView`** and interact with nodes; confirm no **“Not Implemented – GetPaletteButtonSpec”** dialog and no related exception.

## References

- Closes / fixes [Tree View Event is Crashing (#3256)](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3256)
- Related: [Some samples do not work (#3072)](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3072)