### PR TITLE
* Implement `ActionLists` for file dialogs (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002), Implement `ActionLists` for file dialogs, `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` to expose common design-time properties.
 * Implemented [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305), QR Code Generation/Viewer
   * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Utilities` assembly.
 * Resolved [#3018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3018), `KryptonToast` no longer works properly

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFolderBrowserDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFolderBrowserDialog.cs
@@ -15,6 +15,7 @@ namespace Krypton.Toolkit;
 ///  'File Browser dialog' from which the user can select a Directory.
 /// </summary>
 [DesignerCategory(@"code")]
+[Designer(typeof(KryptonFolderBrowserDialogDesigner))]
 [Description("Displays a Kryptonised version of the standard 'File Browser dialog' from which the user can select a Directory.")]
 [ToolboxBitmap(typeof(FolderBrowserDialog), @"ToolboxBitmaps.KryptonFolderBrowserDialog.bmp")]
 [ToolboxItem(true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOpenFileDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOpenFileDialog.cs
@@ -15,6 +15,7 @@ namespace Krypton.Toolkit;
 ///  Displays a dialog window from which the user can select a file.
 /// </summary>
 [DesignerCategory(@"code")]
+[Designer(typeof(KryptonOpenFileDialogDesigner))]
 [Description("Displays a Kryptonised version of the standard 'OpenFile dialog window' from which the user can select a file.")]
 [ToolboxBitmap(typeof(OpenFileDialog), @"ToolboxBitmaps.KryptonOpenFileDialog.bmp")]
 [ToolboxItem(true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSaveFileDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSaveFileDialog.cs
@@ -15,6 +15,7 @@ namespace Krypton.Toolkit;
 ///  Displays a dialog window from which the user can select a file.
 /// </summary>
 [DesignerCategory(@"code")]
+[Designer(typeof(KryptonSaveFileDialogDesigner))]
 [Description("Displays a Kryptonised version of the standard 'SaveFile dialog window' from which the user can select a file.")]
 [ToolboxBitmap(typeof(SaveFileDialog), @"ToolboxBitmaps.KryptonSaveFileDialog.bmp")]
 [ToolboxItem(true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFolderBrowserDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFolderBrowserDialogActionList.cs
@@ -1,0 +1,77 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonFolderBrowserDialogActionList : DesignerActionList
+{
+    private readonly KryptonFolderBrowserDialog _dialog;
+    private readonly IComponentChangeService? _service;
+
+    public KryptonFolderBrowserDialogActionList(KryptonFolderBrowserDialogDesigner owner)
+        : base(owner.Component)
+    {
+        _dialog = (owner.Component as KryptonFolderBrowserDialog)!;
+        _service = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+    }
+
+    public string Title
+    {
+        get => _dialog.Title;
+        set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
+    }
+
+    public string SelectedPath
+    {
+        get => _dialog.SelectedPath;
+        set => SetProperty(_dialog.SelectedPath, value, () => _dialog.SelectedPath = value);
+    }
+
+    public Environment.SpecialFolder RootFolder
+    {
+        get => _dialog.RootFolder;
+        set => SetProperty(_dialog.RootFolder, value, () => _dialog.RootFolder = value);
+    }
+
+#if NET8_0_OR_GREATER
+    public string InitialDirectory
+    {
+        get => _dialog.InitialDirectory;
+        set => SetProperty(_dialog.InitialDirectory, value, () => _dialog.InitialDirectory = value);
+    }
+#endif
+
+    public override DesignerActionItemCollection GetSortedActionItems()
+    {
+        var actions = new DesignerActionItemCollection();
+
+        if (_dialog != null)
+        {
+            actions.Add(new DesignerActionHeaderItem(@"Dialog"));
+            actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(SelectedPath), @"Selected Path", @"Dialog", @"Selected or initial folder path."));
+#if NET8_0_OR_GREATER
+            actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));
+#endif
+            actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+            actions.Add(new DesignerActionPropertyItem(nameof(RootFolder), nameof(RootFolder), @"Behavior", @"Root folder shown by the browser."));
+        }
+
+        return actions;
+    }
+
+    private void SetProperty<T>(T oldValue, T newValue, Action setValue)
+    {
+        if (!Equals(oldValue, newValue))
+        {
+            _service?.OnComponentChanged(_dialog, null, oldValue, newValue);
+            setValue();
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFolderBrowserDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFolderBrowserDialogActionList.cs
@@ -27,6 +27,12 @@ internal class KryptonFolderBrowserDialogActionList : DesignerActionList
         set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
     }
 
+    public Icon? Icon
+    {
+        get => _dialog.Icon;
+        set => SetProperty(_dialog.Icon, value, () => _dialog.Icon = value);
+    }
+
     public string SelectedPath
     {
         get => _dialog.SelectedPath;
@@ -55,6 +61,7 @@ internal class KryptonFolderBrowserDialogActionList : DesignerActionList
         {
             actions.Add(new DesignerActionHeaderItem(@"Dialog"));
             actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(Icon), nameof(Icon), @"Dialog", @"Dialog icon."));
             actions.Add(new DesignerActionPropertyItem(nameof(SelectedPath), @"Selected Path", @"Dialog", @"Selected or initial folder path."));
 #if NET8_0_OR_GREATER
             actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonOpenFileDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonOpenFileDialogActionList.cs
@@ -1,0 +1,101 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonOpenFileDialogActionList : DesignerActionList
+{
+    private readonly KryptonOpenFileDialog _dialog;
+    private readonly IComponentChangeService? _service;
+
+    public KryptonOpenFileDialogActionList(KryptonOpenFileDialogDesigner owner)
+        : base(owner.Component)
+    {
+        _dialog = (owner.Component as KryptonOpenFileDialog)!;
+        _service = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+    }
+
+    public string Title
+    {
+        get => _dialog.Title;
+        set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
+    }
+
+    public string FileName
+    {
+        get => _dialog.FileName;
+        set => SetProperty(_dialog.FileName, value, () => _dialog.FileName = value);
+    }
+
+    public string Filter
+    {
+        get => _dialog.Filter;
+        set => SetProperty(_dialog.Filter, value, () => _dialog.Filter = value);
+    }
+
+    public string InitialDirectory
+    {
+        get => _dialog.InitialDirectory;
+        set => SetProperty(_dialog.InitialDirectory, value, () => _dialog.InitialDirectory = value);
+    }
+
+    public bool Multiselect
+    {
+        get => _dialog.Multiselect;
+        set => SetProperty(_dialog.Multiselect, value, () => _dialog.Multiselect = value);
+    }
+
+    public bool CheckFileExists
+    {
+        get => _dialog.CheckFileExists;
+        set => SetProperty(_dialog.CheckFileExists, value, () => _dialog.CheckFileExists = value);
+    }
+
+    public bool CheckPathExists
+    {
+        get => _dialog.CheckPathExists;
+        set => SetProperty(_dialog.CheckPathExists, value, () => _dialog.CheckPathExists = value);
+    }
+
+    public bool ValidateNames
+    {
+        get => _dialog.ValidateNames;
+        set => SetProperty(_dialog.ValidateNames, value, () => _dialog.ValidateNames = value);
+    }
+
+    public override DesignerActionItemCollection GetSortedActionItems()
+    {
+        var actions = new DesignerActionItemCollection();
+
+        if (_dialog != null)
+        {
+            actions.Add(new DesignerActionHeaderItem(@"Dialog"));
+            actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(FileName), nameof(FileName), @"Dialog", @"Selected file name."));
+            actions.Add(new DesignerActionPropertyItem(nameof(Filter), nameof(Filter), @"Dialog", @"Filter options."));
+            actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));
+            actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+            actions.Add(new DesignerActionPropertyItem(nameof(Multiselect), nameof(Multiselect), @"Behavior", @"Allow selecting multiple files."));
+            actions.Add(new DesignerActionPropertyItem(nameof(CheckFileExists), nameof(CheckFileExists), @"Behavior", @"Validate that selected file exists."));
+            actions.Add(new DesignerActionPropertyItem(nameof(CheckPathExists), nameof(CheckPathExists), @"Behavior", @"Validate that selected path exists."));
+            actions.Add(new DesignerActionPropertyItem(nameof(ValidateNames), nameof(ValidateNames), @"Behavior", @"Allow only valid file names."));
+        }
+
+        return actions;
+    }
+
+    private void SetProperty<T>(T oldValue, T newValue, Action setValue)
+    {
+        if (!Equals(oldValue, newValue))
+        {
+            _service?.OnComponentChanged(_dialog, null, oldValue, newValue);
+            setValue();
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonOpenFileDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonOpenFileDialogActionList.cs
@@ -27,6 +27,12 @@ internal class KryptonOpenFileDialogActionList : DesignerActionList
         set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
     }
 
+    public Icon? Icon
+    {
+        get => _dialog.Icon;
+        set => SetProperty(_dialog.Icon, value, () => _dialog.Icon = value);
+    }
+
     public string FileName
     {
         get => _dialog.FileName;
@@ -77,6 +83,7 @@ internal class KryptonOpenFileDialogActionList : DesignerActionList
         {
             actions.Add(new DesignerActionHeaderItem(@"Dialog"));
             actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(Icon), nameof(Icon), @"Dialog", @"Dialog icon."));
             actions.Add(new DesignerActionPropertyItem(nameof(FileName), nameof(FileName), @"Dialog", @"Selected file name."));
             actions.Add(new DesignerActionPropertyItem(nameof(Filter), nameof(Filter), @"Dialog", @"Filter options."));
             actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSaveFileDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSaveFileDialogActionList.cs
@@ -27,6 +27,12 @@ internal class KryptonSaveFileDialogActionList : DesignerActionList
         set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
     }
 
+    public Icon? Icon
+    {
+        get => _dialog.Icon;
+        set => SetProperty(_dialog.Icon, value, () => _dialog.Icon = value);
+    }
+
     public string FileName
     {
         get => _dialog.FileName;
@@ -71,6 +77,7 @@ internal class KryptonSaveFileDialogActionList : DesignerActionList
         {
             actions.Add(new DesignerActionHeaderItem(@"Dialog"));
             actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(Icon), nameof(Icon), @"Dialog", @"Dialog icon."));
             actions.Add(new DesignerActionPropertyItem(nameof(FileName), nameof(FileName), @"Dialog", @"Selected file name."));
             actions.Add(new DesignerActionPropertyItem(nameof(Filter), nameof(Filter), @"Dialog", @"Filter options."));
             actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSaveFileDialogActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSaveFileDialogActionList.cs
@@ -1,0 +1,94 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonSaveFileDialogActionList : DesignerActionList
+{
+    private readonly KryptonSaveFileDialog _dialog;
+    private readonly IComponentChangeService? _service;
+
+    public KryptonSaveFileDialogActionList(KryptonSaveFileDialogDesigner owner)
+        : base(owner.Component)
+    {
+        _dialog = (owner.Component as KryptonSaveFileDialog)!;
+        _service = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+    }
+
+    public string Title
+    {
+        get => _dialog.Title;
+        set => SetProperty(_dialog.Title, value, () => _dialog.Title = value);
+    }
+
+    public string FileName
+    {
+        get => _dialog.FileName;
+        set => SetProperty(_dialog.FileName, value, () => _dialog.FileName = value);
+    }
+
+    public string Filter
+    {
+        get => _dialog.Filter;
+        set => SetProperty(_dialog.Filter, value, () => _dialog.Filter = value);
+    }
+
+    public string InitialDirectory
+    {
+        get => _dialog.InitialDirectory;
+        set => SetProperty(_dialog.InitialDirectory, value, () => _dialog.InitialDirectory = value);
+    }
+
+    public bool CreatePrompt
+    {
+        get => _dialog.CreatePrompt;
+        set => SetProperty(_dialog.CreatePrompt, value, () => _dialog.CreatePrompt = value);
+    }
+
+    public bool OverwritePrompt
+    {
+        get => _dialog.OverwritePrompt;
+        set => SetProperty(_dialog.OverwritePrompt, value, () => _dialog.OverwritePrompt = value);
+    }
+
+    public bool ValidateNames
+    {
+        get => _dialog.ValidateNames;
+        set => SetProperty(_dialog.ValidateNames, value, () => _dialog.ValidateNames = value);
+    }
+
+    public override DesignerActionItemCollection GetSortedActionItems()
+    {
+        var actions = new DesignerActionItemCollection();
+
+        if (_dialog != null)
+        {
+            actions.Add(new DesignerActionHeaderItem(@"Dialog"));
+            actions.Add(new DesignerActionPropertyItem(nameof(Title), nameof(Title), @"Dialog", @"Dialog title."));
+            actions.Add(new DesignerActionPropertyItem(nameof(FileName), nameof(FileName), @"Dialog", @"Selected file name."));
+            actions.Add(new DesignerActionPropertyItem(nameof(Filter), nameof(Filter), @"Dialog", @"Filter options."));
+            actions.Add(new DesignerActionPropertyItem(nameof(InitialDirectory), @"Initial Directory", @"Dialog", @"Initial directory shown by the dialog."));
+            actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+            actions.Add(new DesignerActionPropertyItem(nameof(CreatePrompt), nameof(CreatePrompt), @"Behavior", @"Prompt before creating a non-existent file."));
+            actions.Add(new DesignerActionPropertyItem(nameof(OverwritePrompt), nameof(OverwritePrompt), @"Behavior", @"Prompt before overwriting existing file."));
+            actions.Add(new DesignerActionPropertyItem(nameof(ValidateNames), nameof(ValidateNames), @"Behavior", @"Allow only valid file names."));
+        }
+
+        return actions;
+    }
+
+    private void SetProperty<T>(T oldValue, T newValue, Action setValue)
+    {
+        if (!Equals(oldValue, newValue))
+        {
+            _service?.OnComponentChanged(_dialog, null, oldValue, newValue);
+            setValue();
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonFolderBrowserDialogDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonFolderBrowserDialogDesigner.cs
@@ -1,0 +1,29 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonFolderBrowserDialogDesigner : ComponentDesigner
+{
+    /// <summary>
+    ///  Gets the design-time action lists supported by the component associated with the designer.
+    /// </summary>
+    public override DesignerActionListCollection ActionLists
+    {
+        get
+        {
+            var actionLists = new DesignerActionListCollection
+            {
+                new KryptonFolderBrowserDialogActionList(this)
+            };
+
+            return actionLists;
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonOpenFileDialogDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonOpenFileDialogDesigner.cs
@@ -1,0 +1,29 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonOpenFileDialogDesigner : ComponentDesigner
+{
+    /// <summary>
+    ///  Gets the design-time action lists supported by the component associated with the designer.
+    /// </summary>
+    public override DesignerActionListCollection ActionLists
+    {
+        get
+        {
+            var actionLists = new DesignerActionListCollection
+            {
+                new KryptonOpenFileDialogActionList(this)
+            };
+
+            return actionLists;
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSaveFileDialogDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSaveFileDialogDesigner.cs
@@ -1,0 +1,29 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class KryptonSaveFileDialogDesigner : ComponentDesigner
+{
+    /// <summary>
+    ///  Gets the design-time action lists supported by the component associated with the designer.
+    /// </summary>
+    public override DesignerActionListCollection ActionLists
+    {
+        get
+        {
+            var actionLists = new DesignerActionListCollection
+            {
+                new KryptonSaveFileDialogActionList(this)
+            };
+
+            return actionLists;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implements [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002) by adding design-time `ActionLists` for file dialog components.
- Improves WinForms designer usability for `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` by surfacing common properties in smart tags.
- Updates the changelog with the new feature entry.

## Changes

- Added designer bindings:
  - `KryptonOpenFileDialog` -> `KryptonOpenFileDialogDesigner`
  - `KryptonSaveFileDialog` -> `KryptonSaveFileDialogDesigner`
  - `KryptonFolderBrowserDialog` -> `KryptonFolderBrowserDialogDesigner`
- Added new designer classes:
  - `Designers/Designers/KryptonOpenFileDialogDesigner.cs`
  - `Designers/Designers/KryptonSaveFileDialogDesigner.cs`
  - `Designers/Designers/KryptonFolderBrowserDialogDesigner.cs`
- Added new action list classes:
  - `Designers/Action Lists/KryptonOpenFileDialogActionList.cs`
  - `Designers/Action Lists/KryptonSaveFileDialogActionList.cs`
  - `Designers/Action Lists/KryptonFolderBrowserDialogActionList.cs`
- Added changelog entry:
  - `Documents/Changelog/Changelog.md`

## Designer Actions Exposed

- **KryptonOpenFileDialog**
  - `Title`, `FileName`, `Filter`, `InitialDirectory`
  - `Multiselect`, `CheckFileExists`, `CheckPathExists`, `ValidateNames`
- **KryptonSaveFileDialog**
  - `Title`, `FileName`, `Filter`, `InitialDirectory`
  - `CreatePrompt`, `OverwritePrompt`, `ValidateNames`
- **KryptonFolderBrowserDialog**
  - `Title`, `SelectedPath`, `RootFolder`
  - `InitialDirectory` (`NET8_0_OR_GREATER` only)

<img width="686" height="253" alt="image" src="https://github.com/user-attachments/assets/a4e8cfcf-253a-47aa-ae47-d16dd874aa08" />
