### PR TITLE
2914-V110-White bar is shown in a KryptonForm Sizable without buttons and text

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2914](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2914), White bar is shown in a KryptonForm Sizable without buttons and text
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), `KryptonDockingManager.LoadConfigFromArray` throws exception
 * Resolved [#3225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3225), Ribbon large button image-to-text separator not DPI-scaled
 * Resolved [#3256](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3256), Tree View Event is Crashing

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -2046,7 +2046,7 @@ public class KryptonForm : VisualForm,
     protected override void WindowChromeStart()
     {
         // Make sure the views for the buttons are created
-        if (_recreateButtons && this.ControlBox && !string.IsNullOrWhiteSpace(this.Text))
+        if (_recreateButtons && this.ControlBox)
         {
             _buttonManager.RecreateButtons();
             _recreateButtons = false;
@@ -3326,36 +3326,37 @@ public class KryptonForm : VisualForm,
 
 
 	/// <summary>
-	/// Determines whether the KryptonForm has usable caption content
-	/// for non-client painting (Text / TextExtra and chrome-aware).
+	/// Determines whether the form has usable caption content
+	/// for non-client area painting.
 	/// </summary>
 	protected override bool HasCaptionContent()
 	{
-		// No border => no non-client caption at all
+		// No border means no non-client caption at all.
 		if (FormBorderStyle == FormBorderStyle.None)
+			return false;
+
+		/*
+		 * Special-case workaround:
+		 *
+		 * For Sizable forms without a control box and without any caption text,
+		 * the framework may still attempt non-client painting, which can result
+		 * in visual artifacts (e.g. a white bar when the form is deactivated).
+		 *
+		 * This check is intentionally limited to FormBorderStyle.Sizable.
+		 * Tool window styles are excluded because they may legitimately have
+		 * no visible title text and still require non-client painting.
+		 */
+		if (FormBorderStyle == FormBorderStyle.Sizable &&
+			!ControlBox &&
+			string.IsNullOrWhiteSpace(Text) &&
+			string.IsNullOrWhiteSpace(TextExtra))
 		{
 			return false;
 		}
 
-		// No visible caption content
-		bool hasCaptionText =
-			!string.IsNullOrWhiteSpace(Text) ||
-			!string.IsNullOrWhiteSpace(TextExtra);
-
-		if (!hasCaptionText)
-		{
-			return false;
-		}
-
-		// Edge-case:
-		// When ControlBox is false and caption content is minimal,
-		// avoid treating the caption as usable to prevent
-		// non-client artifacts (e.g. white bar on deactivate).
-		if (!ControlBox && string.IsNullOrWhiteSpace(TextExtra))
-		{
-			return false;
-		}
-
+		// All remaining bordered styles are considered to have usable
+		// caption content from a non-client painting perspective,
+		// regardless of whether a visible title text is present.
 		return FormBorderStyle switch
 		{
 			FormBorderStyle.FixedSingle => true,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -3326,27 +3326,36 @@ public class KryptonForm : VisualForm,
 
 
 	/// <summary>
-	/// Determines whether the KryptonForm has a native non-client frame
-	/// with a visible and paintable caption (Text or TextExtra).
+	/// Determines whether the KryptonForm has usable caption content
+	/// for non-client painting (Text / TextExtra and chrome-aware).
 	/// </summary>
 	protected override bool HasCaptionContent()
 	{
-		// No border means no non-client area at all
+		// No border => no non-client caption at all
 		if (FormBorderStyle == FormBorderStyle.None)
 		{
 			return false;
 		}
 
-		// Krypton caption content can come from Text or TextExtra
-		if (string.IsNullOrWhiteSpace(Text) &&
-			string.IsNullOrWhiteSpace(TextExtra))
+		// No visible caption content
+		bool hasCaptionText =
+			!string.IsNullOrWhiteSpace(Text) ||
+			!string.IsNullOrWhiteSpace(TextExtra);
+
+		if (!hasCaptionText)
 		{
-			// Treat empty caption as non-usable to avoid NC repaint issues
-			// (e.g. white line when window is deactivated)
 			return false;
 		}
 
-		// Explicit enumeration for clarity and future-proofing
+		// Edge-case:
+		// When ControlBox is false and caption content is minimal,
+		// avoid treating the caption as usable to prevent
+		// non-client artifacts (e.g. white bar on deactivate).
+		if (!ControlBox && string.IsNullOrWhiteSpace(TextExtra))
+		{
+			return false;
+		}
+
 		return FormBorderStyle switch
 		{
 			FormBorderStyle.FixedSingle => true,
@@ -3355,11 +3364,7 @@ public class KryptonForm : VisualForm,
 			FormBorderStyle.Sizable => true,
 			FormBorderStyle.FixedToolWindow => true,
 			FormBorderStyle.SizableToolWindow => true,
-
-			FormBorderStyle.None => false,
-
-			// Defensive default for future enum values
-			_ => true
+			_ => false
 		};
 	}
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -2046,7 +2046,7 @@ public class KryptonForm : VisualForm,
     protected override void WindowChromeStart()
     {
         // Make sure the views for the buttons are created
-        if (_recreateButtons)
+        if (_recreateButtons && this.ControlBox && !string.IsNullOrWhiteSpace(this.Text))
         {
             _buttonManager.RecreateButtons();
             _recreateButtons = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -3322,5 +3322,44 @@ public class KryptonForm : VisualForm,
 
         return _isInAdministratorMode;
     }
-    #endregion
+	#endregion
+
+
+	/// <summary>
+	/// Determines whether the KryptonForm has a native non-client frame
+	/// with a visible and paintable caption (Text or TextExtra).
+	/// </summary>
+	protected override bool HasCaptionContent()
+	{
+		// No border means no non-client area at all
+		if (FormBorderStyle == FormBorderStyle.None)
+		{
+			return false;
+		}
+
+		// Krypton caption content can come from Text or TextExtra
+		if (string.IsNullOrWhiteSpace(Text) &&
+			string.IsNullOrWhiteSpace(TextExtra))
+		{
+			// Treat empty caption as non-usable to avoid NC repaint issues
+			// (e.g. white line when window is deactivated)
+			return false;
+		}
+
+		// Explicit enumeration for clarity and future-proofing
+		return FormBorderStyle switch
+		{
+			FormBorderStyle.FixedSingle => true,
+			FormBorderStyle.Fixed3D => true,
+			FormBorderStyle.FixedDialog => true,
+			FormBorderStyle.Sizable => true,
+			FormBorderStyle.FixedToolWindow => true,
+			FormBorderStyle.SizableToolWindow => true,
+
+			FormBorderStyle.None => false,
+
+			// Defensive default for future enum values
+			_ => true
+		};
+	}
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -3331,9 +3331,11 @@ public class KryptonForm : VisualForm,
 	/// </summary>
 	protected override bool HasCaptionContent()
 	{
-		// No border means no non-client caption at all.
-		if (FormBorderStyle == FormBorderStyle.None)
-			return false;
+        // No border means no non-client caption at all.
+        if (FormBorderStyle == FormBorderStyle.None)
+        {
+            return false;
+        }
 
 		/*
 		 * Special-case workaround:

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -777,8 +777,14 @@ public abstract class VisualForm : Form,
             {
                 hRgn = invalidRegion.GetHrgn(g);
 
+                if (!HasCaptionContent())
+                    this.SuspendPaint();
+
                 PI.RedrawWindow(Handle, IntPtr.Zero, hRgn.Value,
                     PI.RDW_FRAME | PI.RDW_UPDATENOW | PI.RDW_INVALIDATE);
+
+				if (!HasCaptionContent())
+					this.ResumePaint();
             }
             catch (InvalidOperationException ioEx)
             {
@@ -795,10 +801,25 @@ public abstract class VisualForm : Form,
         }
     }
 
-    /// <summary>
-    /// Gets rectangle that is the real window rectangle based on Win32 API call.
-    /// </summary>
-    protected Rectangle RealWindowRectangle
+	/// <summary>
+	/// Determines whether the form has a native non-client frame with a usable caption.
+	/// 
+	/// This method must be overridden by derived classes that provide
+	/// a concrete implementation of form chrome handling.
+	/// </summary>
+	/// <exception cref="NotSupportedException">
+	/// Thrown when the method is not overridden in a derived class.
+	/// </exception>
+	protected virtual bool HasCaptionContent()
+	{
+		throw new NotSupportedException(
+			$"{GetType().Name} must override HasCaptionContent() to provide a valid implementation.");
+	}
+
+	/// <summary>
+	/// Gets rectangle that is the real window rectangle based on Win32 API call.
+	/// </summary>
+	protected Rectangle RealWindowRectangle
     {
         get
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -777,14 +777,18 @@ public abstract class VisualForm : Form,
             {
                 hRgn = invalidRegion.GetHrgn(g);
 
-                if (!HasCaptionContent())
+                if (!this.HasCaptionContent())
+                {
                     this.SuspendPaint();
+                }
 
                 PI.RedrawWindow(Handle, IntPtr.Zero, hRgn.Value,
                     PI.RDW_FRAME | PI.RDW_UPDATENOW | PI.RDW_INVALIDATE);
 
-				if (!HasCaptionContent())
-					this.ResumePaint();
+                if (!this.HasCaptionContent())
+                {
+                    this.ResumePaint();
+                }
             }
             catch (InvalidOperationException ioEx)
             {

--- a/Source/Krypton Components/TestForm/Bug2914Test.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug2914Test.Designer.cs
@@ -28,22 +28,88 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.SuspendLayout();
-            // 
-            // Bug2914Test
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.CloseBox = false;
-            this.ControlBox = false;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "Bug2914Test";
-            this.ResumeLayout(false);
+			this.components = new System.ComponentModel.Container();
+			this.kryptonButton1 = new Krypton.Toolkit.KryptonButton();
+			this.kryptonButton2 = new Krypton.Toolkit.KryptonButton();
+			this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+			this.kryptonButton3 = new Krypton.Toolkit.KryptonButton();
+			this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
+			((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+			this.kryptonPanel1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// kryptonButton1
+			// 
+			this.kryptonButton1.Location = new System.Drawing.Point(43, 39);
+			this.kryptonButton1.Name = "kryptonButton1";
+			this.kryptonButton1.Size = new System.Drawing.Size(353, 77);
+			this.kryptonButton1.TabIndex = 1;
+			this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+			this.kryptonButton1.Values.Text = "Open same Form without ControlBox in a Modal";
+			this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
+			// 
+			// kryptonButton2
+			// 
+			this.kryptonButton2.Location = new System.Drawing.Point(561, 367);
+			this.kryptonButton2.Name = "kryptonButton2";
+			this.kryptonButton2.Size = new System.Drawing.Size(243, 52);
+			this.kryptonButton2.TabIndex = 1;
+			this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+			this.kryptonButton2.Values.Text = "Close Form";
+			this.kryptonButton2.Click += new System.EventHandler(this.kryptonButton2_Click);
+			// 
+			// kryptonPanel1
+			// 
+			this.kryptonPanel1.Controls.Add(this.kryptonButton3);
+			this.kryptonPanel1.Controls.Add(this.kryptonButton1);
+			this.kryptonPanel1.Controls.Add(this.kryptonButton2);
+			this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+			this.kryptonPanel1.Name = "kryptonPanel1";
+			this.kryptonPanel1.Size = new System.Drawing.Size(934, 450);
+			this.kryptonPanel1.TabIndex = 3;
+			// 
+			// kryptonButton3
+			// 
+			this.kryptonButton3.Location = new System.Drawing.Point(463, 39);
+			this.kryptonButton3.Name = "kryptonButton3";
+			this.kryptonButton3.Size = new System.Drawing.Size(353, 77);
+			this.kryptonButton3.TabIndex = 1;
+			this.kryptonButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+			this.kryptonButton3.Values.Text = "Open same Form in a Modal";
+			this.kryptonButton3.Click += new System.EventHandler(this.kryptonButton3_Click);
+			// 
+			// kryptonManager1
+			// 
+			this.kryptonManager1.ShowAdministratorSuffix = false;
+			this.kryptonManager1.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+			this.kryptonManager1.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
+			this.kryptonManager1.ToolkitStrings.PrintPreviewDialogStrings.PaginationPartOneText = "of";
+			this.kryptonManager1.ToolkitStrings.PrintPreviewDialogStrings.PaginationPartTwoText = null;
+			this.kryptonManager1.ToolkitStrings.PrintPreviewDialogStrings.ZoomInButtonText = "Zoom &Out";
+			this.kryptonManager1.ToolkitStrings.PrintPreviewDialogStrings.ZoomOutButtonText = null;
+			// 
+			// Bug2914Test
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(934, 450);
+			this.Controls.Add(this.kryptonPanel1);
+			this.Name = "Bug2914Test";
+			this.Text = "Bug 2914 Test";
+			this.Load += new System.EventHandler(this.Bug2914Test_Load);
+			((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+			this.kryptonPanel1.ResumeLayout(false);
+			this.ResumeLayout(false);
 
         }
 
-        #endregion
-    }
+		#endregion
+
+		private KryptonButton kryptonButton1;
+		private KryptonButton kryptonButton2;
+		private KryptonPanel kryptonPanel1;
+		private KryptonManager kryptonManager1;
+		private KryptonButton kryptonButton3;
+	}
 }

--- a/Source/Krypton Components/TestForm/Bug2914Test.cs
+++ b/Source/Krypton Components/TestForm/Bug2914Test.cs
@@ -31,7 +31,7 @@ public partial class Bug2914Test : KryptonForm
 		Bug2914Test frm = new Bug2914Test();
 
 		// Center the form on the screen when it is shown
-		frm.StartPosition = FormStartPosition.CenterScreen;
+		frm.StartPosition = FormStartPosition.Manual;
 
 		// Explicitly set the location (redundant when using CenterScreen,
 		// but kept for consistency or testing purposes)

--- a/Source/Krypton Components/TestForm/Bug2914Test.cs
+++ b/Source/Krypton Components/TestForm/Bug2914Test.cs
@@ -16,4 +16,68 @@ public partial class Bug2914Test : KryptonForm
     {
         InitializeComponent();
     }
+
+	private void Bug2914Test_Load(object sender, EventArgs e)
+	{
+
+	}
+
+	// Event handler for kryptonButton1 click
+	// Opens the Bug2914Test form as a modal dialog with no title bar text
+	// and without the system control buttons (minimize, maximize, close).
+	private void kryptonButton1_Click(object sender, EventArgs e)
+	{
+		// Create a new instance of the Bug2914Test form
+		Bug2914Test frm = new Bug2914Test();
+
+		// Center the form on the screen when it is shown
+		frm.StartPosition = FormStartPosition.CenterScreen;
+
+		// Explicitly set the location (redundant when using CenterScreen,
+		// but kept for consistency or testing purposes)
+		frm.Location = new Point(0, 0);
+
+		// Remove the window title text
+		frm.Text = string.Empty;
+
+		// Allow the form to be resized
+		frm.FormBorderStyle = FormBorderStyle.Sizable;
+
+		// Disable the control box (Close, Minimize, Maximize buttons)
+		frm.ControlBox = false;
+
+		// Show the form as a modal dialog
+		frm.ShowDialog();
+	}
+
+	// Event handler for kryptonButton2 click
+	// Closes the current form.
+	private void kryptonButton2_Click(object sender, EventArgs e)
+	{
+		// Close the current window
+		this.Close();
+	}
+
+	// Event handler for kryptonButton3 click
+	// Opens the Bug2914Test form as a modal dialog with a visible title.
+	private void kryptonButton3_Click(object sender, EventArgs e)
+	{
+		// Create a new instance of the Bug2914Test form
+		Bug2914Test frm = new Bug2914Test();
+
+		// Center the form on the screen
+		frm.StartPosition = FormStartPosition.CenterScreen;
+
+		// Set the initial position of the form
+		frm.Location = new Point(0, 0);
+
+		// Set the window title text
+		frm.Text = "HOLA";
+
+		// Allow the form to be resized
+		frm.FormBorderStyle = FormBorderStyle.Sizable;
+
+		// Show the form as a modal dialog
+		frm.ShowDialog();
+	}
 }

--- a/Source/Krypton Components/TestForm/Bug2914Test.cs
+++ b/Source/Krypton Components/TestForm/Bug2914Test.cs
@@ -30,12 +30,12 @@ public partial class Bug2914Test : KryptonForm
 		// Create a new instance of the Bug2914Test form
 		Bug2914Test frm = new Bug2914Test();
 
-		// Center the form on the screen when it is shown
+		// Use manual start position so the form location is fully controlled by code
 		frm.StartPosition = FormStartPosition.Manual;
 
-		// Explicitly set the location (redundant when using CenterScreen,
-		// but kept for consistency or testing purposes)
-		frm.Location = new Point(0, 0);
+		// Set an explicit initial location for the form
+		// (useful for deterministic positioning or layout testing)
+		frm.Location = new Point(100, 100);
 
 		// Remove the window title text
 		frm.Text = string.Empty;
@@ -72,7 +72,7 @@ public partial class Bug2914Test : KryptonForm
 		frm.Location = new Point(0, 0);
 
 		// Set the window title text
-		frm.Text = "HOLA";
+		frm.Text = "Normal window";
 
 		// Allow the form to be resized
 		frm.FormBorderStyle = FormBorderStyle.Sizable;

--- a/Source/Krypton Components/TestForm/Bug2914Test.resx
+++ b/Source/Krypton Components/TestForm/Bug2914Test.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="kryptonManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Fixed an issue in KryptonForm where a white title bar area was still rendered
when ControlBox was set to false and the form Text was empty.

The form now correctly hides the non-client title area when no caption
or control buttons are present, ensuring consistent visual behavior.

#2914 