### PR TITLE
* Use the new artifacts feature to simplify build paths

### DIFF
--- a/.github/workflows/alpha-backup-sync.yml
+++ b/.github/workflows/alpha-backup-sync.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Ensure alpha-backup exists
         if: steps.kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         id: ensure_backup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -92,7 +92,7 @@ jobs:
       - name: Create PR from alpha to alpha-backup
         if: steps.kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         id: create_pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: Enable auto-merge on PR
         if: steps.kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_NODE_ID: ${{ fromJson(steps.create_pr.outputs.result).pr_node_id }}
         with:

--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR author
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-label-issue-areas.yml
+++ b/.github/workflows/auto-label-issue-areas.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract and apply area labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-label-pr-backup.yml
+++ b/.github/workflows/auto-label-pr-backup.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR modifies alpha-backup-sync.yml
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
       - name: Build
-        run: msbuild "Scripts/Build/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
   release:
     runs-on: windows-2025-vs2026
@@ -231,10 +231,10 @@ jobs:
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
       - name: Build Release
-        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Get Version
         id: get_version

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -163,7 +163,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $buildArgs = 'Scripts/Build/canary.proj /t:Build /p:Configuration=Canary /p:Platform="Any CPU"'
+          $buildArgs = 'Scripts/Build/canary.proj /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true'
 
           if (${{ steps.prepare_cert.outputs.cert_available }} -eq 'true') {
             $buildArgs += ' /p:EnableAuthenticodeSigning=true'
@@ -182,7 +182,7 @@ jobs:
 
       - name: Pack Canary
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -191,15 +191,15 @@ jobs:
 
       - name: Restore
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Restore /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Build Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
@@ -213,7 +213,11 @@ jobs:
             exit 0
           }
 
-          $packages = Get-ChildItem "Bin/Packages/Canary/*.nupkg" -ErrorAction SilentlyContinue
+          $packageCandidates = @(
+            "artifacts/packages/Canary/*.nupkg",
+            "Bin/Packages/Canary/*.nupkg"
+          )
+          $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
 
           if ($packages) {
@@ -249,7 +253,14 @@ jobs:
           $version = $null
 
           try {
-            $dllPath = Get-ChildItem "Bin/Canary/net48/Krypton.Toolkit.dll" -ErrorAction Stop
+            $dllCandidates = @(
+              "artifacts/bin/Canary/net48/Krypton.Toolkit.dll",
+              "Bin/Canary/net48/Krypton.Toolkit.dll"
+            )
+            $dllPath = Get-ChildItem -Path $dllCandidates -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $dllPath) {
+              throw "Krypton.Toolkit.dll not found in artifacts or Bin output paths."
+            }
             $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllPath.FullName).Version
             $version = $assemblyVersion.ToString()
             Write-Host "Got version from assembly: $version"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build solution
         shell: pwsh
-        run: msbuild "Scripts/Build/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -233,15 +233,15 @@ jobs:
 
       - name: Restore
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Restore /p:Configuration=Nightly /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Build Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
@@ -255,7 +255,11 @@ jobs:
             exit 0
           }
 
-          $packages = Get-ChildItem "Bin/Packages/Nightly/*.nupkg" -ErrorAction SilentlyContinue
+          $packageCandidates = @(
+            "artifacts/packages/Nightly/*.nupkg",
+            "Bin/Packages/Nightly/*.nupkg"
+          )
+          $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
 
           if ($packages) {
@@ -293,7 +297,14 @@ jobs:
 
           # Try to get version from the built assembly (most reliable)
           try {
-            $dllPath = Get-ChildItem "Bin/Nightly/net48/Krypton.Toolkit.dll" -ErrorAction Stop
+            $dllCandidates = @(
+              "artifacts/bin/Nightly/net48/Krypton.Toolkit.dll",
+              "Bin/Nightly/net48/Krypton.Toolkit.dll"
+            )
+            $dllPath = Get-ChildItem -Path $dllCandidates -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $dllPath) {
+              throw "Krypton.Toolkit.dll not found in artifacts or Bin output paths."
+            }
             $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllPath.FullName).Version
             $version = $assemblyVersion.ToString()
             Write-Host "Got version from assembly: $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,12 @@ jobs:
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -170,7 +170,11 @@ jobs:
             exit 0
           }
           
-          $packages = Get-ChildItem "Bin/Packages/Release/*.nupkg" -ErrorAction SilentlyContinue
+          $packageCandidates = @(
+            "artifacts/packages/Release/*.nupkg",
+            "Bin/Packages/Release/*.nupkg"
+          )
+          $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
           
           if ($packages) {
@@ -209,7 +213,14 @@ jobs:
           
           # Try to get version from the built assembly (most reliable)
           try {
-            $dllPath = Get-ChildItem "Bin/Release/net48/Krypton.Toolkit.dll" -ErrorAction Stop
+            $dllCandidates = @(
+              "artifacts/bin/Release/net48/Krypton.Toolkit.dll",
+              "Bin/Release/net48/Krypton.Toolkit.dll"
+            )
+            $dllPath = Get-ChildItem -Path $dllCandidates -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $dllPath) {
+              throw "Krypton.Toolkit.dll not found in artifacts or Bin output paths."
+            }
             $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllPath.FullName).Version
             $version = $assemblyVersion.ToString()
             Write-Host "Got version from assembly: $version"
@@ -414,12 +425,12 @@ jobs:
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -434,7 +445,11 @@ jobs:
             exit 0
           }
           
-          $packages = Get-ChildItem "Bin/Packages/Release/*.nupkg" -ErrorAction SilentlyContinue
+          $packageCandidates = @(
+            "artifacts/packages/Release/*.nupkg",
+            "Bin/Packages/Release/*.nupkg"
+          )
+          $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
           
           if ($packages) {
@@ -473,7 +488,14 @@ jobs:
           
           # Try to get version from the built assembly (most reliable)
           try {
-            $dllPath = Get-ChildItem "Bin/Release/net48/Krypton.Toolkit.dll" -ErrorAction Stop
+            $dllCandidates = @(
+              "artifacts/bin/Release/net48/Krypton.Toolkit.dll",
+              "Bin/Release/net48/Krypton.Toolkit.dll"
+            )
+            $dllPath = Get-ChildItem -Path $dllCandidates -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $dllPath) {
+              throw "Krypton.Toolkit.dll not found in artifacts or Bin output paths."
+            }
             $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllPath.FullName).Version
             $version = $assemblyVersion.ToString()
             Write-Host "Got version from assembly: $version"
@@ -690,12 +712,12 @@ jobs:
       - name: Build Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -710,7 +732,11 @@ jobs:
             exit 0
           }
           
-          $packages = Get-ChildItem "Bin/Packages/Canary/*.nupkg" -ErrorAction SilentlyContinue
+          $packageCandidates = @(
+            "artifacts/packages/Canary/*.nupkg",
+            "Bin/Packages/Canary/*.nupkg"
+          )
+          $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
           
           if ($packages) {
@@ -749,7 +775,14 @@ jobs:
           
           # Try to get version from the built assembly (most reliable)
           try {
-            $dllPath = Get-ChildItem "Bin/Canary/net48/Krypton.Toolkit.dll" -ErrorAction Stop
+            $dllCandidates = @(
+              "artifacts/bin/Canary/net48/Krypton.Toolkit.dll",
+              "Bin/Canary/net48/Krypton.Toolkit.dll"
+            )
+            $dllPath = Get-ChildItem -Path $dllCandidates -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $dllPath) {
+              throw "Krypton.Toolkit.dll not found in artifacts or Bin output paths."
+            }
             $assemblyVersion = [System.Reflection.AssemblyName]::GetAssemblyName($dllPath.FullName).Version
             $version = $assemblyVersion.ToString()
             Write-Host "Got version from assembly: $version"
@@ -958,12 +991,12 @@ jobs:
       - name: Build Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU"
+        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       # Note: NuGet publishing for alpha/nightly builds is handled by nightly.yml workflow
       # which runs on a schedule and checks for changes in the last 24 hours

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `Source/Krypton Components`: Core libraries (`Krypton.Toolkit`, `Krypton.Ribbon`, `Krypton.Navigator`, `Krypton.Workspace`, `Krypton.Docking`) and the solution `Krypton Toolkit Suite 2022 - VS2022.sln`
 - `Source/Krypton Components/TestForm`: WinForms sample app used to validate changes
 - `Source/TestHarnesses`: Small repro/test harnesses (e.g., `ThemeSwapRepro`)
-- `Scripts/`: Build and packaging scripts; `run.cmd` (root) launches an interactive menu; scripts live under `Scripts/VS2022/`, `Scripts/Current/`, `Scripts/Build/` (e.g., `build-stable.cmd`, `build-canary.cmd`, `build-nightly.cmd`, `build.proj`)
+- `Scripts/`: Build and packaging scripts; `run.cmd` (root) launches an interactive menu; scripts live under `Scripts/VS2022/`, `Scripts/Current/`, `Scripts/Build/` (e.g., `build-stable.cmd`, `build-canary.cmd`, `build-nightly.cmd`, `build.proj`); optional Terminal.Gui build/pack UI in `Scripts/ModernBuild/` ([ModernBuild README](Scripts/ModernBuild/README.md))
 - `Bin/`: Build outputs by configuration (e.g., `Bin/Debug`)
 - `Documents/`, `Assets/`, `Logs/`: Docs, images, and build logs
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,17 @@
 <Project>
+	<PropertyGroup>
+		<UseArtifactsOutput Condition="'$(UseArtifactsOutput)' == ''">false</UseArtifactsOutput>
+		<KryptonLegacyBinRoot>$(MSBuildThisFileDirectory)Bin\</KryptonLegacyBinRoot>
+		<KryptonLegacyPackageRoot>$(KryptonLegacyBinRoot)Packages\</KryptonLegacyPackageRoot>
+		<KryptonArtifactsRoot>$(MSBuildThisFileDirectory)artifacts\</KryptonArtifactsRoot>
+
+		<KryptonBuildOutputRoot Condition="'$(UseArtifactsOutput)' == 'true'">$(KryptonArtifactsRoot)bin\</KryptonBuildOutputRoot>
+		<KryptonBuildOutputRoot Condition="'$(UseArtifactsOutput)' != 'true'">$(KryptonLegacyBinRoot)</KryptonBuildOutputRoot>
+
+		<KryptonPackageOutputRoot Condition="'$(UseArtifactsOutput)' == 'true'">$(KryptonArtifactsRoot)packages\</KryptonPackageOutputRoot>
+		<KryptonPackageOutputRoot Condition="'$(UseArtifactsOutput)' != 'true'">$(KryptonLegacyPackageRoot)</KryptonPackageOutputRoot>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<PropertyGroup>

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#998](https://github.com/Krypton-Suite/Standard-Toolkit/issues/998), Use the new artifacts feature to simplify build paths. Added opt-in artifacts output support for build/package paths via shared MSBuild properties (`UseArtifactsOutput=true`) and updated `ModernBuild` package discovery to work with both legacy `Bin/*` and `artifacts/packages/*` layouts.
+  * Updated GitHub Actions workflows to build with artifacts output enabled and to resolve package/DLL paths from `artifacts/*` with legacy `Bin/*` fallback.
 * Implemented [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002), Implement `ActionLists` for file dialogs, `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` to expose common design-time properties.
 * Implemented [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305), QR Code Generation/Viewer
   * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Utilities` assembly.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@
   * [Krypton Workspace](#krypton-workspace)
   * [Krypton Docking](#krypton-docking)
 
-=======
-
 ## NuGet Information
 
 View [package version details and supported frameworks](https://krypton-suite.github.io/Standard-Toolkit-Online-Help/Source/Help/Output/articles/Support/Krypton%20Toolkit%20Suite%20Standard%20Modules.html).
@@ -239,6 +237,12 @@ The `KryptonInputBox` now uses the new `KryptonInputBoxData` API, to handle data
 
 As of V90.00 support for longer path names **will** need to be enabled if you want to build the toolkit yourself. For more details on how to do this, please follow the instructions in the [long path names configuration guide](https://krypton-suite.github.io/Standard-Toolkit-Online-Help/Source/Help/Output/articles/Contributing/AllowingforLongerPathandFileNames.html).
 
+Quick options from the repository root:
+
+- **Solution build:** `dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug` (see [AGENTS.md](AGENTS.md) for TestForm and preset script notes).
+- **Interactive scripts:** `run.cmd` or the channel scripts under `Scripts/VS2022/` (and related folders).
+- **ModernBuild (optional):** keyboard-driven build, pack, and NuGet workflows — see [Scripts/ModernBuild/README.md](Scripts/ModernBuild/README.md).
+
 =======
 
 ## Known Issues & Workarounds
@@ -266,8 +270,8 @@ Ahmed-Abdelhameed have been fixing and adding more capabilities to this toolkit.
 * There is also an Extensions project, which takes these base controls and add more useful complete controls (Currently outside the scope of this help). To find out more about the Extended Toolkit, please visit the [Extended Toolkit repository](https://github.com/Krypton-Suite/Extended-Toolkit)
 * All .Net Versions from 4.8.2 are catered for (interim releases, i.e. releases in-between Long Term Support (LTS) versions of .NET will **only** be supported for the duration of that particular version, usually 24 months.)
 * New versions of NuGet packages can be obtained via the [Krypton Suite NuGet profile page](https://www.nuget.org/profiles/Krypton_Suite), or via your package manager by searching `Krypton.`.
-* New, major versions are released annually, with patches if needed released throughout that period. Version 100 is expected to release in November 2025.
-* For tips on how to build the toolkit for yourself, please read the following [article](https://krypton-suite.github.io/Standard-Toolkit-Online-Help/Source/Help/Output/articles/Contributing/HowtoBuild.html).
+* New, major versions are released annually, with patches if needed released throughout that period (for example, V100 shipped November 2025). See the [changelog](Documents/Changelog/Changelog.md) for current work.
+* For tips on how to build the toolkit for yourself, please read the following [article](https://krypton-suite.github.io/Standard-Toolkit-Online-Help/Source/Help/Output/articles/Contributing/HowtoBuild.html). Repository-specific commands and tooling are summarized in [AGENTS.md](AGENTS.md) and [Scripts/ModernBuild/README.md](Scripts/ModernBuild/README.md).
 
 ## Contributing to this project
 

--- a/Scripts/Build/build.proj
+++ b/Scripts/Build/build.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
-		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
+		<ReleaseSourcePath>$(KryptonBuildOutputRoot)Release\</ReleaseSourcePath>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
+		<ReleaseBuildPath>$(ReleaseSourcePath)Zips\</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -72,7 +74,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -82,17 +84,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Release\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(ReleaseSourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -101,12 +103,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar.gz&quot; &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot;"
@@ -116,7 +118,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Release&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(ReleaseSourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/Build/canary.proj
+++ b/Scripts/Build/canary.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
-		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
+		<CanarySourcePath>$(KryptonBuildOutputRoot)Canary\</CanarySourcePath>
+		<CanaryPackagesPath>$(KryptonPackageOutputRoot)Canary\</CanaryPackagesPath>
+		<CanaryBuildPath>$(CanarySourcePath)Zips\</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -57,7 +59,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -69,17 +71,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Canary\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(CanarySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -88,12 +90,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar.gz&quot; &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot;"
@@ -103,7 +105,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Canary&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(CanarySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/Build/installer.proj
+++ b/Scripts/Build/installer.proj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Installer</Configuration>
+		<InstallerSourcePath>$(KryptonBuildOutputRoot)Installer\</InstallerSourcePath>
+		<InstallerPackagesPath>$(KryptonPackageOutputRoot)Installer\</InstallerPackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +31,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -54,7 +56,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -64,11 +66,11 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Installer\**\*.*" Exclude="..\Bin\Installer\*vshost.exe*" />
+			<DebugApplicationFiles Include="$(InstallerSourcePath)**\*.*" Exclude="$(InstallerSourcePath)*vshost.exe*" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 		<Zip Files="@(DebugApplicationFiles)"
-		     WorkingDirectory="..\Bin\Installer"
+		     WorkingDirectory="$(InstallerSourcePath)"
 		     ZipFileName="$(NightlyBuildPath)\$(StringDate)_$(NightlyZipName).zip"
 		     ZipLevel="9" />
 	</Target>

--- a/Scripts/Build/longtermstable.proj
+++ b/Scripts/Build/longtermstable.proj
@@ -4,6 +4,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +30,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -70,7 +71,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
-		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
+		<NightlySourcePath>$(KryptonBuildOutputRoot)Nightly\</NightlySourcePath>
+		<NightlyPackagesPath>$(KryptonPackageOutputRoot)Nightly\</NightlyPackagesPath>
+		<NightlyBuildPath>$(NightlySourcePath)Zips\</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
 
@@ -33,7 +35,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -58,7 +60,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -68,17 +70,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Nightly\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(NightlySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -87,12 +89,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar.gz&quot; &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot;"
@@ -102,7 +104,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Nightly&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(NightlySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
-		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
+		<ReleaseSourcePath>$(KryptonBuildOutputRoot)Release\</ReleaseSourcePath>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
+		<ReleaseBuildPath>$(ReleaseSourcePath)Zips\</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -72,7 +74,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -82,17 +84,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Release\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(ReleaseSourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -101,12 +103,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar.gz&quot; &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot;"
@@ -116,7 +118,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Release&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(ReleaseSourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
-		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
+		<CanarySourcePath>$(KryptonBuildOutputRoot)Canary\</CanarySourcePath>
+		<CanaryPackagesPath>$(KryptonPackageOutputRoot)Canary\</CanaryPackagesPath>
+		<CanaryBuildPath>$(CanarySourcePath)Zips\</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -57,7 +59,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -69,17 +71,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Canary\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(CanarySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -88,12 +90,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar.gz&quot; &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot;"
@@ -103,7 +105,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Canary&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(CanarySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/Current/installer.proj
+++ b/Scripts/Current/installer.proj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Installer</Configuration>
+		<InstallerSourcePath>$(KryptonBuildOutputRoot)Installer\</InstallerSourcePath>
+		<InstallerPackagesPath>$(KryptonPackageOutputRoot)Installer\</InstallerPackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +31,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -54,7 +56,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -64,11 +66,11 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Installer\**\*.*" Exclude="..\Bin\Installer\*vshost.exe*" />
+			<DebugApplicationFiles Include="$(InstallerSourcePath)**\*.*" Exclude="$(InstallerSourcePath)*vshost.exe*" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 		<Zip Files="@(DebugApplicationFiles)"
-		     WorkingDirectory="..\Bin\Installer"
+		     WorkingDirectory="$(InstallerSourcePath)"
 		     ZipFileName="$(NightlyBuildPath)\$(StringDate)_$(NightlyZipName).zip"
 		     ZipLevel="9" />
 	</Target>

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -4,6 +4,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +30,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -70,7 +71,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
-		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
+		<NightlySourcePath>$(KryptonBuildOutputRoot)Nightly\</NightlySourcePath>
+		<NightlyPackagesPath>$(KryptonPackageOutputRoot)Nightly\</NightlyPackagesPath>
+		<NightlyBuildPath>$(NightlySourcePath)Zips\</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
 
@@ -33,7 +35,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -58,7 +60,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -68,17 +70,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Nightly\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(NightlySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -87,12 +89,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar.gz&quot; &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot;"
@@ -102,7 +104,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Nightly&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(NightlySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/ModernBuild/General/BuildLogic.cs
+++ b/Scripts/ModernBuild/General/BuildLogic.cs
@@ -1068,10 +1068,11 @@ internal static class BuildLogic
     {
         try
         {
-            string bin = Path.Combine(state.RootPath, "Bin", "Release");
-            if (!Directory.Exists(bin))
+            string? packageFolder = GetCandidatePackageFolders(state)
+                .FirstOrDefault(Directory.Exists);
+            if (string.IsNullOrWhiteSpace(packageFolder))
             {
-                state.OnOutput?.Invoke($"ZIP: folder not found: {bin}");
+                state.OnOutput?.Invoke("ZIP: no package folder found in expected output locations.");
                 return;
             }
             string date = DateTime.Now.ToString("yyyyMMdd");
@@ -1082,7 +1083,7 @@ internal static class BuildLogic
                 try { File.Delete(zipPath); } catch { }
             }
             state.OnOutput?.Invoke($"Creating ZIP: {zipPath}");
-            System.IO.Compression.ZipFile.CreateFromDirectory(bin, zipPath, System.IO.Compression.CompressionLevel.Optimal, includeBaseDirectory: false);
+            System.IO.Compression.ZipFile.CreateFromDirectory(packageFolder, zipPath, System.IO.Compression.CompressionLevel.Optimal, includeBaseDirectory: false);
             state.NuGetLastZipPath = zipPath;
         }
         catch (Exception ex)
@@ -1365,7 +1366,7 @@ internal static class BuildLogic
 
     /// <summary>
     /// Gets the list of candidate directories that may contain NuGet packages.
-    /// Currently returns only the Bin/Release directory regardless of channel.
+    /// Supports both legacy Bin/* and newer artifacts/packages/* layouts.
     /// </summary>
     /// <param name="state">The application state containing build configuration.</param>
     /// <returns>A list of directory paths to search for NuGet packages.</returns>
@@ -1393,9 +1394,21 @@ internal static class BuildLogic
         list.Add(Path.Combine(bin, "Debug"));
         return list.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         */
-        // Packages are always produced into Bin/Release regardless of channel
-        string binRelease = Path.Combine(state.RootPath, "Bin", "Release");
-        return new[] { binRelease };
+        string configuration = GetEffectiveConfiguration(state);
+        string artifactsConfig = Path.Combine(state.RootPath, "artifacts", "packages", configuration);
+        string artifactsRelease = Path.Combine(state.RootPath, "artifacts", "packages", "Release");
+        string legacyPackageConfig = Path.Combine(state.RootPath, "Bin", "Packages", configuration);
+        string legacyBinConfig = Path.Combine(state.RootPath, "Bin", configuration);
+        string legacyBinRelease = Path.Combine(state.RootPath, "Bin", "Release");
+
+        return new[]
+        {
+            artifactsConfig,
+            artifactsRelease,
+            legacyPackageConfig,
+            legacyBinConfig,
+            legacyBinRelease
+        }.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>

--- a/Scripts/ModernBuild/README.md
+++ b/Scripts/ModernBuild/README.md
@@ -1,6 +1,6 @@
-## ModernBuild - User Guide
+# ModernBuild - User Guide
 
-### What is ModernBuild?
+## What is ModernBuild?
 
 ModernBuild is a Windows terminal UI (TUI) tool for building, packing, and publishing Krypton Suite artifacts from the repository root using MSBuild and NuGet.
 
@@ -34,27 +34,31 @@ Legacy fallback locations are still probed:
 - `Scripts/`
 - `Scripts/Project-Files/`
 
-Logs are written to `Logs/`. NuGet package discovery currently uses `Bin/Release/`.
+Logs are written to `Logs/`. NuGet package discovery supports both legacy `Bin/*` outputs and `artifacts/packages/*` outputs.
 
 ### Build and run
 
-Build:
+The project multi-targets `net8.0-windows`, `net9.0-windows`, and `net10.0-windows`. Pass `-f <tfm>` to build or run a specific framework (otherwise the SDK may build all targets).
+
+Build (example, Release on .NET 9):
 
 ```powershell
-dotnet build Scripts/ModernBuild/ModernBuild.csproj -c Release
+dotnet build Scripts/ModernBuild/ModernBuild.csproj -c Release -f net9.0-windows
 ```
 
 Run:
 
 ```powershell
-dotnet run --project Scripts/ModernBuild/ModernBuild.csproj
+dotnet run --project Scripts/ModernBuild/ModernBuild.csproj -f net9.0-windows
 ```
 
-Or run a built executable, for example:
+Or run a built executable after building, for example:
 
 ```powershell
-Scripts/ModernBuild/bin/Debug/net9.0-windows/ModernBuild.exe
+Scripts\ModernBuild\bin\Release\net9.0-windows\ModernBuild.exe
 ```
+
+Use `Debug` instead of `Release` when you built a Debug configuration, and substitute `net8.0-windows` or `net10.0-windows` if you targeted that TFM.
 
 ### UI layout
 
@@ -174,7 +178,7 @@ Legacy fallback (both modes):
 - `nuget.exe` not found
   - Put `nuget.exe` on PATH
 - No packages found for push
-  - Ensure expected packages exist under `Bin/Release/`
+  - Ensure expected packages exist under `Bin/Packages/<Configuration>`, `Bin/<Configuration>`, or `artifacts/packages/<Configuration>`
 
 ### Notes
 

--- a/Scripts/VS2022/build.proj
+++ b/Scripts/VS2022/build.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
-		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
+		<ReleaseSourcePath>$(KryptonBuildOutputRoot)Release\</ReleaseSourcePath>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
+		<ReleaseBuildPath>$(ReleaseSourcePath)Zips\</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -72,7 +74,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -82,17 +84,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Release\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(ReleaseSourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -101,12 +103,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Release\**\*.*" Exclude="..\Bin\Release\*vshost.exe*;..\Bin\Release\**\*.json;..\Bin\Release\**\*.pdb" />
+			<DebugApplicationFiles Include="$(ReleaseSourcePath)**\*.*" Exclude="$(ReleaseSourcePath)*vshost.exe*;$(ReleaseSourcePath)**\*.json;$(ReleaseSourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(ReleaseBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;..\Bin\Release\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot; &quot;$(ReleaseSourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(ReleaseBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar.gz&quot; &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate).tar&quot;"
@@ -116,7 +118,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Release&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(ReleaseBuildPath)\$(ReleaseZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(ReleaseSourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/VS2022/canary.proj
+++ b/Scripts/VS2022/canary.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
-		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
+		<CanarySourcePath>$(KryptonBuildOutputRoot)Canary\</CanarySourcePath>
+		<CanaryPackagesPath>$(KryptonPackageOutputRoot)Canary\</CanaryPackagesPath>
+		<CanaryBuildPath>$(CanarySourcePath)Zips\</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
 
@@ -31,7 +33,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -57,7 +59,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(CanaryPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -69,17 +71,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Canary\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(CanarySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -88,12 +90,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
+			<DebugApplicationFiles Include="$(CanarySourcePath)**\*.*" Exclude="$(CanarySourcePath)*vshost.exe*;$(CanarySourcePath)**\*.json;$(CanarySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;$(CanarySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(CanaryBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar.gz&quot; &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot;"
@@ -103,7 +105,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Canary&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(CanarySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Scripts/VS2022/installer.proj
+++ b/Scripts/VS2022/installer.proj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Installer</Configuration>
+		<InstallerSourcePath>$(KryptonBuildOutputRoot)Installer\</InstallerSourcePath>
+		<InstallerPackagesPath>$(KryptonPackageOutputRoot)Installer\</InstallerPackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +31,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -54,7 +56,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Installer\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(InstallerPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -64,11 +66,11 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Installer\**\*.*" Exclude="..\Bin\Installer\*vshost.exe*" />
+			<DebugApplicationFiles Include="$(InstallerSourcePath)**\*.*" Exclude="$(InstallerSourcePath)*vshost.exe*" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 		<Zip Files="@(DebugApplicationFiles)"
-		     WorkingDirectory="..\Bin\Installer"
+		     WorkingDirectory="$(InstallerSourcePath)"
 		     ZipFileName="$(NightlyBuildPath)\$(StringDate)_$(NightlyZipName).zip"
 		     ZipLevel="9" />
 	</Target>

--- a/Scripts/VS2022/longtermstable.proj
+++ b/Scripts/VS2022/longtermstable.proj
@@ -4,6 +4,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<ReleasePackagesPath>$(KryptonPackageOutputRoot)Release\</ReleasePackagesPath>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -29,7 +30,7 @@
 	
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -70,7 +71,7 @@
 	
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(ReleasePackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -4,7 +4,9 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
-		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
+		<NightlySourcePath>$(KryptonBuildOutputRoot)Nightly\</NightlySourcePath>
+		<NightlyPackagesPath>$(KryptonPackageOutputRoot)Nightly\</NightlyPackagesPath>
+		<NightlyBuildPath>$(NightlySourcePath)Zips\</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
 
@@ -33,7 +35,7 @@
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -58,7 +60,7 @@
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="$(NightlyPackagesPath)*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
@@ -68,17 +70,17 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Nightly\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '$(NightlySourcePath)*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
@@ -87,12 +89,12 @@
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="$(NightlySourcePath)**\*.*" Exclude="$(NightlySourcePath)*vshost.exe*;$(NightlySourcePath)**\*.json;$(NightlySourcePath)**\*.pdb" />
 		</ItemGroup>
 		<MakeDir Directories="$(NightlyBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;$(NightlySourcePath)*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
 		      WorkingDirectory="$(NightlyBuildPath)" />
 		<Exec Command="7z.exe a -tgzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar.gz&quot; &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot;"
@@ -102,7 +104,7 @@
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Nightly&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;$(NightlySourcePath)&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -153,4 +153,16 @@
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>
+
+	<!-- CS7069: ExpandableObjectConverter metadata must resolve System.ComponentModel.TypeConverter at compile time.
+	     .NET 9+ SDK package pruning can treat a direct System.ComponentModel.TypeConverter reference as prunable and
+	     apply IncludeAssets=none, which removes it from the compile graph. Disable pruning for non-net4 TFMs here and
+	     keep an explicit package reference for those TFMs so WinForms/WPF libraries retain a stable compile ref. -->
+	<PropertyGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
+		<RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
+		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+	</ItemGroup>
 </Project>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -46,7 +46,7 @@
 
 	<!-- Configure NuGet package output to separate directory for easier management -->
 	<PropertyGroup>
-		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\Bin\Packages\$(Configuration)\</PackageOutputPath>
+		<PackageOutputPath>$(KryptonPackageOutputRoot)$(Configuration)\</PackageOutputPath>
 	</PropertyGroup>
 
 	<Choose>

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -3,6 +3,10 @@
 		<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../../'))" />
 		-->
 
+	<PropertyGroup Condition="'$(UseArtifactsOutput)' == 'true'">
+		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\</OutputPath>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<PropertyGroup>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/README.md
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/README.md
@@ -24,7 +24,7 @@ For the main, initial migration those 2 arrays were chosen to be converted and r
 | `SchemeBaseColorsExtensions` | Converts a `KryptonColorSchemeBase` into the legacy `Color[]` layouts via `ToArray()` and `ToTrackBarArray()` (6 entries). |
 
 Nothing in the low-level rendering pipeline had to change – all internal code still
-works with simple arrays – but **every public API writen or reviewed becomes
+works with simple arrays – but **every public API written or reviewed becomes
 readable and type-safe**.
 
 ## Current migration workflow (SchemeGenerator v2)

--- a/Source/Krypton Components/Krypton.Utilities/Lib/WebView2/README.md
+++ b/Source/Krypton Components/Krypton.Utilities/Lib/WebView2/README.md
@@ -10,7 +10,7 @@ This folder contains the Microsoft WebView2 managed assemblies used by the Krypt
 
 ## How to populate
 
-From the repository root, run:
+From the repository root, run (the scripts folder is spelled **`WebVew2`** in the repository):
 
 ```
 Scripts\WebVew2\Populate-BundledWebView2.cmd

--- a/Source/Krypton Components/TestForm/PaletteViewer/README.md
+++ b/Source/Krypton Components/TestForm/PaletteViewer/README.md
@@ -68,12 +68,18 @@ Because every step runs dynamically, PaletteViewer automatically adapts to new T
 
 ## Building & running
 
-The project targets **.NET Framework 4.7.2** and has no dependencies beyond the Krypton Toolkit packages. In Visual Studio 2022:
+PaletteViewer is part of the **TestForm** sample (`Source/Krypton Components/TestForm`). The suite solution multi-targets **.NET Framework 4.7.2** and newer **`-windows`** TFMs; PaletteViewer follows the TestForm project targets.
 
-1. Open `Krypton Toolkit Suite 2022 - VS2022.sln`.
+**Visual Studio 2022**
+
+1. Open `Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln`.
 2. Set **TestForm** as the startup project.
 3. Build and run.
-4. In the running application select *PaletteViewer* from the test harness menu.
+4. In the running application, open *PaletteViewer* from the test harness menu.
+
+**Command line (from repository root)**
+
+See [AGENTS.md](../../../../AGENTS.md) for the usual `dotnet run --project "...TestForm.csproj"` invocation, then use the in-app menu to launch PaletteViewer.
 
 ---
 

--- a/Source/TestHarnesses/ThemeSwapRepro/README.md
+++ b/Source/TestHarnesses/ThemeSwapRepro/README.md
@@ -1,6 +1,11 @@
-# Run with:
+# ThemeSwapRepro
 
-  dotnet run --project "Source/TestHarnesses/ThemeSwapRepro/ThemeSwapRepro.csproj" -c Debug
+Run from the **repository root**:
 
-It opens 3 forms with a `KryptonThemeComboBox` each and repeatedly toggles themes across forms to reproduce WM_COMMAND faults.
-Logs written to %TEMP%\ThemeSwapRepro.log
+```
+dotnet run --project "Source/TestHarnesses/ThemeSwapRepro/ThemeSwapRepro.csproj" -c Debug
+```
+
+It opens three forms with a `KryptonThemeComboBox` each and repeatedly toggles themes across forms to reproduce WM_COMMAND faults.
+
+Logs are written to `%TEMP%\ThemeSwapRepro.log`.


### PR DESCRIPTION
# Use artifacts-style build outputs (#998)

## Summary

This change adds optional MSBuild output layout aligned with the .NET SDK “artifacts” style: binaries under `artifacts/bin/<Configuration>/` and NuGet packages under `artifacts/packages/<Configuration>/`, while keeping **legacy `Bin/` behavior as the default** for local and script builds. Orchestrated builds (script `.proj` files and GitHub Actions) can opt in with `/p:UseArtifactsOutput=true` and use shared properties so Clean, Pack, Push, archives, and version discovery stay consistent.

Closes / implements [GitHub #998](https://github.com/Krypton-Suite/Standard-Toolkit/issues/998).

## What changed

### MSBuild / repo

- **Root `Directory.Build.props`**: `UseArtifactsOutput` (default `false`), `KryptonLegacyBinRoot`, `KryptonLegacyPackageRoot`, `KryptonArtifactsRoot`, `KryptonBuildOutputRoot`, `KryptonPackageOutputRoot`.
- **`Source/Krypton Components/Directory.Build.props`**: `PackageOutputPath` uses `$(KryptonPackageOutputRoot)$(Configuration)\`.
- **`Source/Krypton Components/Directory.Build.targets`**: When `UseArtifactsOutput=true`, sets `OutputPath` to `$(KryptonBuildOutputRoot)$(Configuration)\` so component outputs match the script layout.

### Scripts

- **`Scripts/VS2022/*.proj`**, **`Scripts/Current/*.proj`**, **`Scripts/Build/*.proj`**: Paths for clean, push, and archive targets use `$(KryptonBuildOutputRoot)` / `$(KryptonPackageOutputRoot)` instead of hardcoded `..\Bin\...`.

### ModernBuild

- **`Scripts/ModernBuild/General/BuildLogic.cs`**: Package folder and related discovery checks `artifacts/packages/...` and `artifacts/bin/...` in addition to legacy `Bin/...`.
- **`Scripts/ModernBuild/README.md`**: Documents dual-layout behavior (and related lint fixes as applicable).

### CI

- Workflows pass **`/p:UseArtifactsOutput=true`** on relevant `msbuild` steps (e.g. `build.yml`, `release.yml`, `nightly.yml`, `canary.yml`, `codeql.yml`, `canary-lts-release.yml` where applicable).
- Push and version steps resolve **`.nupkg` and `Krypton.Toolkit.dll` from `artifacts/...` first**, with **`Bin/...` fallback** for backward compatibility.

### Documentation

- **`Documents/Changelog/Changelog.md`**: Entry for #998 (under the current nightly section).
- **`Documents/Build System/`**: Updated overview, `DirectoryBuildConfiguration`, `MSBuildProjectFiles`, `ModernBuildTool`, `BuildScripts`, `NuGetPackaging`, `VersionManagement`, `Troubleshooting`, `KillSwitches`, and **`Current/BuildWorkflow.md`** / **`Current/ReleaseWorkflow.md`** for artifacts paths, `UseArtifactsOutput`, and alignment with current workflow jobs.

## Backward compatibility

- Default remains **`UseArtifactsOutput=false`**: outputs stay under **`Bin/`** and **`Bin/Packages/`** unless the property is set.
- CI and dual-path resolution allow older expectations (`Bin/...`) to keep working where fallback is implemented.

## How to verify

- **Local (legacy)**  
  - Run existing script or `msbuild` on `Scripts/Build/build.proj` without `UseArtifactsOutput`.  
  - Confirm assemblies and packages under `Bin/<Configuration>/` and `Bin/Packages/<Configuration>/`.

- **Local or CI (artifacts)**  
  - Build with `/p:UseArtifactsOutput=true`.  
  - Confirm `artifacts/bin/<Configuration>/` and `artifacts/packages/<Configuration>/`.

- **ModernBuild**  
  - Pack/push/ZIP flows find packages when outputs live under either layout.

- **Optional**  
  - Open **`Source/Krypton Components/TestForm`** or your usual harness after a full build to smoke-test UI.

## Notes / follow-ups

- If any project hits resource or SDK warnings when forcing `UseArtifactsOutput` on a narrow subset of TFMs, treat that as a separate tooling/project follow-up; the property is primarily validated through the main orchestrated `.proj` and CI paths documented above.
- **`canary-lts-release.yml`**: If that workflow still references paths spelled `Artefacts/`, reconcile with `artifacts/` + `Bin/` in a follow-up PR if those steps are still active.

## Checklist

- [x] Changelog updated (`Documents/Changelog/Changelog.md`)
- [x] Build System docs updated (`Documents/Build System/`)
- [ ] PR targets the correct base branch (e.g. `alpha` / `canary` / `master` per team process)
- [ ] CI green on this branch