### PR TITLE
* `KryptonContextMenuComboBox` & `KryptonContextMenuProgressBar` need…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#1673](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1673), `KryptonContextMenuComboBox` & `KryptonContextMenuProgressBar` need to be implemented. `KryptonContextMenuProgressBar` for context menus (and enabled **Add ComboBox** in the context menu collection editor).
 * Implemented [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002), Implement `ActionLists` for file dialogs, `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` to expose common design-time properties.
 * Implemented [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305), QR Code Generation/Viewer
   * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Utilities` assembly.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
@@ -32,7 +32,8 @@ public class KryptonContextMenuCollection : TypedRestrictCollection<KryptonConte
         typeof(KryptonContextMenuMonthCalendar),
         typeof(KryptonContextMenuImageSelect),
         typeof(KryptonContextMenuTextBox),
-        typeof(KryptonContextMenuComboBox)
+        typeof(KryptonContextMenuComboBox),
+        typeof(KryptonContextMenuProgressBar)
     ];
     #endregion
 
@@ -219,7 +220,8 @@ public class KryptonContextMenuItemCollection : TypedRestrictCollection<KryptonC
         typeof(KryptonContextMenuMonthCalendar),
         typeof(KryptonContextMenuImageSelect),
         typeof(KryptonContextMenuTextBox),
-        typeof(KryptonContextMenuComboBox)
+        typeof(KryptonContextMenuComboBox),
+        typeof(KryptonContextMenuProgressBar)
     ];
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuProgressBar.cs
@@ -1,33 +1,282 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2023 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
  */
 #endregion
 
-
 namespace Krypton.Toolkit;
 
-/*[ToolboxItem(false)]
-[ToolboxBitmap(typeof(KryptonButton), "ToolboxBitmaps.KryptonButton.bmp")]
+/// <summary>
+/// Provide a context menu progress bar item.
+/// </summary>
+[ToolboxItem(false)]
+[ToolboxBitmap(typeof(KryptonProgressBar))]
 [DesignerCategory(@"code")]
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Value))]
-[DefaultEvent(nameof(ProgressChanged))]
 public class KryptonContextMenuProgressBar : KryptonContextMenuItemBase
 {
-    public override int ItemChildCount { get; }
+    #region Instance Fields
+    private int _minimumWidth;
+    private readonly KryptonProgressBar _progressBar;
 
-    public override KryptonContextMenuItemBase? this[int index] => throw new NotImplementedException();
+    #endregion
 
-    public override bool ProcessShortcut(Keys keyData)
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the KryptonContextMenuProgressBar class.
+    /// </summary>
+    public KryptonContextMenuProgressBar()
     {
-        throw new NotImplementedException();
+        _minimumWidth = 120;
+
+        _progressBar = new KryptonProgressBar
+        {
+            Size = new Size(100, 22)
+        };
     }
 
-    public override ViewBase GenerateView(IContextMenuProvider provider, object parent, ViewLayoutStack columns, bool standardStyle,
+    /// <summary>
+    /// Returns a description of the instance.
+    /// </summary>
+    /// <returns>String representation.</returns>
+    public override string ToString() => $@"{Value} / {Maximum}";
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _progressBar.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// Returns the number of child menu items.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override int ItemChildCount => 0;
+
+    /// <summary>
+    /// Returns the indexed child menu item.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override KryptonContextMenuItemBase? this[int index] => null;
+
+    /// <summary>
+    /// Test for the provided shortcut and perform relevant action if a match is found.
+    /// </summary>
+    /// <param name="keyData">Key data to check against shortcut definitions.</param>
+    /// <returns>True if shortcut was handled, otherwise false.</returns>
+    public override bool ProcessShortcut(Keys keyData) => false;
+
+    /// <summary>
+    /// Returns a view appropriate for this item based on the object it is inside.
+    /// </summary>
+    /// <param name="provider">Provider of context menu information.</param>
+    /// <param name="parent">Owning object reference.</param>
+    /// <param name="columns">Containing columns.</param>
+    /// <param name="standardStyle">Draw items with standard or alternate style.</param>
+    /// <param name="imageColumn">Draw an image background for the item images.</param>
+    /// <returns>ViewBase that is the root of the view hierarchy being added.</returns>
+    public override ViewBase GenerateView(IContextMenuProvider provider,
+        object parent,
+        ViewLayoutStack columns,
+        bool standardStyle,
         bool imageColumn)
     {
-        throw new NotImplementedException();
+        SetProvider(provider);
+        return new ViewDrawMenuProgressBar(provider, this);
     }
-}*/
+
+    /// <summary>
+    /// Gets or sets the lower bound of the range.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Lower bound of the range.")]
+    [DefaultValue(0)]
+    public int Minimum
+    {
+        get => _progressBar.Minimum;
+
+        set
+        {
+            if (_progressBar.Minimum != value)
+            {
+                _progressBar.Minimum = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Minimum)));
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the upper bound of the range.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Upper bound of the range.")]
+    [DefaultValue(100)]
+    public int Maximum
+    {
+        get => _progressBar.Maximum;
+
+        set
+        {
+            if (_progressBar.Maximum != value)
+            {
+                _progressBar.Maximum = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Maximum)));
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the current position.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Current position within the range.")]
+    [DefaultValue(0)]
+    public int Value
+    {
+        get => _progressBar.Value;
+
+        set
+        {
+            if (_progressBar.Value != value)
+            {
+                _progressBar.Value = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the amount by which a call to <see cref="KryptonProgressBar.PerformStep"/> increments the position.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Step increment used by PerformStep.")]
+    [DefaultValue(10)]
+    public int Step
+    {
+        get => _progressBar.Step;
+
+        set
+        {
+            if (_progressBar.Step != value)
+            {
+                _progressBar.Step = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Step)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the progress bar style.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Progress bar display style.")]
+    [DefaultValue(ProgressBarStyle.Continuous)]
+    public ProgressBarStyle Style
+    {
+        get => _progressBar.Style;
+
+        set
+        {
+            if (_progressBar.Style != value)
+            {
+                _progressBar.Style = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Style)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the marquee animation speed in milliseconds.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Time period in milliseconds for marquee animation.")]
+    [DefaultValue(100)]
+    public int MarqueeAnimationSpeed
+    {
+        get => _progressBar.MarqueeAnimationSpeed;
+
+        set
+        {
+            if (_progressBar.MarqueeAnimationSpeed != value)
+            {
+                _progressBar.MarqueeAnimationSpeed = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(MarqueeAnimationSpeed)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the minimum display width of the progress bar.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Layout")]
+    [Description(@"Minimum display width of the progress bar in pixels.")]
+    [DefaultValue(120)]
+    public int MinimumWidth
+    {
+        get => _minimumWidth;
+
+        set
+        {
+            if (_minimumWidth != value)
+            {
+                _minimumWidth = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(MinimumWidth)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets a value indicating whether the progress bar is enabled.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether the progress bar is enabled.")]
+    [DefaultValue(true)]
+    public bool Enabled
+    {
+        get => _progressBar.Enabled;
+
+        set
+        {
+            if (_progressBar.Enabled != value)
+            {
+                _progressBar.Enabled = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(Enabled)));
+            }
+        }
+    }
+
+    #endregion
+
+    #region Internal
+    /// <summary>
+    /// Gets the underlying KryptonProgressBar; used by the view to host the control directly.
+    /// </summary>
+    internal KryptonProgressBar ProgressBar => _progressBar;
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuCollectionEditor.cs
@@ -52,7 +52,8 @@ public partial class KryptonContextMenuCollectionEditor : CollectionEditor
         typeof(KryptonContextMenuMonthCalendar),
         typeof(KryptonContextMenuImageSelect),
         typeof(KryptonContextMenuTextBox),
-        typeof(KryptonContextMenuComboBox)
+        typeof(KryptonContextMenuComboBox),
+        typeof(KryptonContextMenuProgressBar)
     ];
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuItemCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonContextMenuItemCollectionEditor.cs
@@ -43,6 +43,7 @@ public class KryptonContextMenuItemCollectionEditor : CollectionEditor
         typeof(KryptonContextMenuMonthCalendar),
         typeof(KryptonContextMenuImageSelect),
         typeof(KryptonContextMenuTextBox),
-        typeof(KryptonContextMenuComboBox)
+        typeof(KryptonContextMenuComboBox),
+        typeof(KryptonContextMenuProgressBar)
     ];
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
@@ -97,10 +97,15 @@ public partial class KryptonContextMenuCollectionEditor
                         return 12;
                     case KryptonContextMenuMonthCalendar _:
                         return 13;
+                    case KryptonContextMenuComboBox _:
+                        return 14;
+                    case KryptonContextMenuTextBox _:
+                        return 15;
+                    case KryptonContextMenuProgressBar _:
+                        return 16;
                 }
 
-                Debug.Assert(false);
-                return -1;
+                return 2;
             }
 
             private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e) =>
@@ -209,6 +214,7 @@ public partial class KryptonContextMenuCollectionEditor
         private Button _buttonAddColorColumns;
         private Button _buttonAddImageSelect;
         private Button _buttonAddComboBox;
+        private Button _buttonAddProgressBar;
         private PropertyGrid _propertyGrid1;
         private IContainer components;
         private TableLayoutPanel _tableLayoutPanel1;
@@ -256,6 +262,7 @@ public partial class KryptonContextMenuCollectionEditor
             _buttonAddColorColumns = new Button();
             _buttonAddImageSelect = new Button();
             _buttonAddComboBox = new Button();
+            _buttonAddProgressBar = new Button();
             _tableLayoutPanel1 = new TableLayoutPanel();
             _panel1 = new Panel();
             _tableLayoutPanel1.SuspendLayout();
@@ -317,7 +324,9 @@ public partial class KryptonContextMenuCollectionEditor
                 BlueArrowResources.arrow_down_blue,
                 GenericKryptonImageResources.KryptonContextMenuImageSelect,
                 GenericKryptonImageResources.KryptonMonthCalendar,
-                GenericKryptonImageResources.KryptonComboBox
+                GenericKryptonImageResources.KryptonComboBox,
+                GenericKryptonImageResources.KryptonTextBox,
+                GenericKryptonImageResources.KryptonNumericUpDown
             ]);
 
             // TODO: Do these need updating?
@@ -336,6 +345,8 @@ public partial class KryptonContextMenuCollectionEditor
             _imageList.Images.SetKeyName(12, "KryptonContextMenuImageSelect.bmp");
             _imageList.Images.SetKeyName(13, "KryptonContextMenuMonthCalendar.bmp");
             _imageList.Images.SetKeyName(14, "KryptonComboBox.bmp");
+            _imageList.Images.SetKeyName(15, "KryptonTextBox.bmp");
+            _imageList.Images.SetKeyName(16, "KryptonNumericUpDown.bmp");
             // 
             // label1
             // 
@@ -588,9 +599,22 @@ public partial class KryptonContextMenuCollectionEditor
             _buttonAddComboBox.Text = @"Add ComboBox";
             _buttonAddComboBox.TextImageRelation = TextImageRelation.ImageBeforeText;
             _buttonAddComboBox.UseVisualStyleBackColor = true;
-            // Note Remove this when fully implemented
-            _buttonAddComboBox.Enabled = false;
             _buttonAddComboBox.Click += buttonAddComboBox_Click;
+            // 
+            // buttonAddProgressBar
+            // 
+            _buttonAddProgressBar.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            _buttonAddProgressBar.ImageAlign = ContentAlignment.MiddleLeft;
+            _buttonAddProgressBar.ImageIndex = 16;
+            _buttonAddProgressBar.ImageList = _imageList;
+            _buttonAddProgressBar.Location = new Point(21, 603);
+            _buttonAddProgressBar.Name = nameof(_buttonAddProgressBar);
+            _buttonAddProgressBar.Size = new Size(184, 32);
+            _buttonAddProgressBar.TabIndex = 18;
+            _buttonAddProgressBar.Text = @"Add ProgressBar";
+            _buttonAddProgressBar.TextImageRelation = TextImageRelation.ImageBeforeText;
+            _buttonAddProgressBar.UseVisualStyleBackColor = true;
+            _buttonAddProgressBar.Click += buttonAddProgressBar_Click;
             // 
             // tableLayoutPanel1
             // 
@@ -619,6 +643,7 @@ public partial class KryptonContextMenuCollectionEditor
             // panel1
             // 
             _panel1.Controls.Add(_buttonMoveUp);
+            _panel1.Controls.Add(_buttonAddProgressBar);
             _panel1.Controls.Add(_buttonAddComboBox);
             _panel1.Controls.Add(_buttonAddMonthCalendar);
             _panel1.Controls.Add(_buttonAddImageSelect);
@@ -848,6 +873,8 @@ public partial class KryptonContextMenuCollectionEditor
         private void buttonAddImageSelect_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuImageSelect)));
 
         private void buttonAddComboBox_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuComboBox)));
+
+        private void buttonAddProgressBar_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuProgressBar)));
 
         private void buttonDelete_Click(object? sender, EventArgs e)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuProgressBar.cs
@@ -1,0 +1,146 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal class ViewDrawMenuProgressBar : ViewComposite
+{
+    #region Instance Fields
+    private readonly IContextMenuProvider _provider;
+    private readonly KryptonProgressBar _progressBar;
+
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the ViewDrawMenuProgressBar class.
+    /// </summary>
+    /// <param name="provider">Reference to provider.</param>
+    /// <param name="progressBarItem">Reference to owning progress bar entry.</param>
+    public ViewDrawMenuProgressBar(IContextMenuProvider provider,
+        KryptonContextMenuProgressBar progressBarItem)
+    {
+        _provider = provider;
+        KryptonContextMenuProgressBar = progressBarItem;
+
+        _progressBar = progressBarItem.ProgressBar;
+        _progressBar.Enabled = provider.ProviderEnabled && progressBarItem.Enabled;
+        _progressBar.MinimumSize = new Size(progressBarItem.MinimumWidth, 0);
+
+        progressBarItem.PropertyChanged += OnPropertyChanged;
+    }
+
+    /// <summary>
+    /// Obtains the String representation of this instance.
+    /// </summary>
+    /// <returns>User readable name of the instance.</returns>
+    public override string ToString() => $"ViewDrawMenuProgressBar:{Id}";
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            KryptonContextMenuProgressBar.PropertyChanged -= OnPropertyChanged;
+
+            _progressBar.Parent?.Controls.Remove(_progressBar);
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region KryptonContextMenuProgressBar
+    /// <summary>
+    /// Gets access to the owning progress bar data model.
+    /// </summary>
+    public KryptonContextMenuProgressBar KryptonContextMenuProgressBar { get; }
+
+    #endregion
+
+    #region ItemEnabled
+    /// <summary>
+    /// Gets the enabled state of the item.
+    /// </summary>
+    public bool ItemEnabled { get; private set; }
+
+    #endregion
+
+    #region Layout
+    /// <summary>
+    /// Discover the preferred size of the element.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    public override Size GetPreferredSize([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        ItemEnabled = _provider.ProviderEnabled && KryptonContextMenuProgressBar.Enabled;
+        _progressBar.Enabled = ItemEnabled;
+
+        var preferred = _progressBar.GetPreferredSize(Size.Empty);
+        var preferredWidth = Math.Max(KryptonContextMenuProgressBar.MinimumWidth, preferred.Width) + 6;
+        var preferredHeight = preferred.Height + 4;
+
+        return new Size(preferredWidth, preferredHeight);
+    }
+
+    /// <summary>
+    /// Perform a layout of the elements.
+    /// </summary>
+    /// <param name="context">Layout context.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public override void Layout([DisallowNull] ViewLayoutContext context)
+    {
+        Debug.Assert(context != null);
+
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        ClientRectangle = context.DisplayRectangle;
+
+        if (context.Control != null && _progressBar.Parent != context.Control)
+        {
+            context.Control.Controls.Add(_progressBar);
+        }
+
+        _progressBar.SetBounds(
+            ClientRectangle.X + 3,
+            ClientRectangle.Y + 2,
+            ClientRectangle.Width - 6,
+            ClientRectangle.Height - 4);
+
+        _progressBar.Visible = Visible;
+
+        base.Layout(context);
+    }
+    #endregion
+
+    #region Private
+    private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(KryptonContextMenuProgressBar.Enabled):
+                _progressBar.Enabled = _provider.ProviderEnabled && KryptonContextMenuProgressBar.Enabled;
+                break;
+            case nameof(KryptonContextMenuProgressBar.MinimumWidth):
+                _progressBar.MinimumSize = new Size(KryptonContextMenuProgressBar.MinimumWidth, 0);
+                _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(true));
+                break;
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
@@ -65,6 +65,7 @@ namespace TestForm
             this.kryptonButton3 = new Krypton.Toolkit.KryptonButton();
             this.kryptonButton1 = new Krypton.Toolkit.KryptonButton();
             this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonContextMenuComboBox1 = new Krypton.Toolkit.KryptonContextMenuComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcbColorScheme)).BeginInit();
@@ -102,7 +103,6 @@ namespace TestForm
             this.KryptonCalcInput1.AllowDecimals = true;
             this.KryptonCalcInput1.ButtonSpecs.Add(this.buttonSpecAny2);
             this.KryptonCalcInput1.DecimalPlaces = 2;
-            this.KryptonCalcInput1.DropDownWidth = 0;
             this.KryptonCalcInput1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.KryptonCalcInput1.Location = new System.Drawing.Point(120, 270);
             this.KryptonCalcInput1.Name = "KryptonCalcInput1";
@@ -235,7 +235,8 @@ namespace TestForm
             // kryptonContextMenu1
             // 
             this.kryptonContextMenu1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
-            this.kryptonContextMenuItems1});
+            this.kryptonContextMenuItems1,
+            this.kryptonContextMenuComboBox1});
             // 
             // kryptonContextMenuItems1
             // 
@@ -354,6 +355,10 @@ namespace TestForm
             this.buttonSpecAny1.Text = "Test Text";
             this.buttonSpecAny1.UniqueName = "bad5983b9e7f4d82b15e55a1a19807bb";
             // 
+            // kryptonContextMenuComboBox1
+            // 
+            this.kryptonContextMenuComboBox1.Text = "kryptonContextMenuComboBox1";
+            // 
             // ButtonsTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -408,5 +413,6 @@ namespace TestForm
         private Krypton.Toolkit.KryptonLabel kryptonLabel2;
         private KryptonCalcInput KryptonCalcInput1;
         private ButtonSpecAny buttonSpecAny2;
+        private KryptonContextMenuComboBox kryptonContextMenuComboBox1;
     }
 }

--- a/Source/Krypton Components/TestForm/ButtonsTest.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.cs
@@ -16,6 +16,13 @@ public partial class ButtonsTest : KryptonForm
         InitializeComponent();
         kcbColorScheme.SelectedItem = "OfficeThemes";
         kcbSortMode.Enabled = false;
+
+        // #1673 sample: progress bar in the shared UAC drop-down context menu
+        kryptonContextMenuItems1.Items.Insert(0, new KryptonContextMenuProgressBar
+        {
+            MinimumWidth = 200,
+            Value = 42
+        });
     }
 
     private void kcbtnDropDown_SelectedColorChanged(object sender, ColorEventArgs e)

--- a/Source/Krypton Components/TestForm/ButtonsTest.resx
+++ b/Source/Krypton Components/TestForm/ButtonsTest.resx
@@ -121,116 +121,108 @@
   <data name="buttonSpecAny2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DQAACw0B7QfALAAAAAd0SU1FB9gEDw0NJWkouy0AAAK4SURBVDhPdVNbSFRRFN3jYxwHxbcovt9+KOiH
-        KAgiZlg6VpqO3pEczBgbRdR8IBGk0EOs7z6DCOrDyNBSC7FmHEctfGQPK4iIKKuv7CMwwdW6M02g5IbD
-        3Nlnr7XXWfsc8cRBkeoDIpuHRBr4V+PO7o4qkVqDyK9jIvV/U+4oE6lTdLqd6b4+NAcEoFrEzPQuErIq
-        LVrtzp2SErT4+aFOpNG1oXau1+t3ZgcGsDI0BEd/P6x6PdjiHwk/lHaCJsrLMV5aipHCQpz29UUt80LZ
-        Px62tWFlcBALPT1wdnTAbrGgS6eDQqwK7tZqMV1WhgfFxRjNy8NITg5upaaqBNuqfGMj5dusVji47E1N
-        cJrNmDMa0csuPQQ72NVG6Y/y8zGWnY3RlBT0enurDZpUhXKcXSwsfKIocJpMmK+pwbOqKhdwrqgI87m5
-        mImLw0RwMO75++OcCE6KWAj1chGowTMr7ezoqKjAUmUlVnneJUp9GhXlWguRkbCT4IKXF6x7wZ5Qne70
-        8YGzoADLSUl4EROD9fh4rCckYCk8HMMEt+4HVuMECc5Q3nRgIF5R8ofkZHxOT8entDSskeCKRoPu/4zY
-        FarbHSyYJHg1NhbvCf6WkYGfNG0zKwsb/H5Nkqus6dtLQjeVVm7c5fznIiKwRoKPdPpNdDQ2EhOxRRO/
-        Z2a6SJdDQnCJtV0eEl5L4ymRnZu8KJNBQZhll+ckWCXRRZ55mMVf6MNXKnhHX1boi411g8zTjAY5IrJ1
-        jTO9zTGO8xo/DguDLTQUA27DzPTEoMp+SzUvSbTIicxw/z7VsvG2HBUxNdO46xzhKJNjJOl3j8pzTg3P
-        bLjMJotUZ+eaok9nSUqcSbVA1IfRwsQNqujkL6/XXqc1PLPhPImn2EAFU537MXmihmy8279p6H7PWUPJ
-        h7m2uNydReQPiLFB/uRDeL0AAAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gEDw0NJWkouy0AAALVSURBVDhPdVNdSJNhFH7eb+3b/NjQ1mc4Nldq
+        OS8cuAtRCEKmYS0rLX/2TXIsx2xGmGYiEaTQH9V1l0EEdVFk9GM/SKXpzMKf7D+IiCirq+wisGBPfbNF
+        ST1wbt7D85xznvMe4BfWAJvLgdm1QCMAkXr/EzVAXRXwtRoI/JWoBBo0szkx0NXFZouFm4HQQpFGQGuR
+        5cR5n48tJhMbgKZkQq8cUJTE3Z4eTh45wuHubsYUhYE/REKAttNkYr/fz8sVFTy3ahW3G42sAzSUA59v
+        7NjByd5e3uvsZLytjUPRKNvNZmpASCfvlmUOVFbyalkZ+4qLea6oiGdWrNAFvuvt1zeZzYnBWIzDsRiH
+        wmHGQyGO1Ndzj9HITlnmcEUFB30+3iwp4SWPh315edxjMOgFwskxtgBaVJZ5R9MYDwY5WlvLBzU1SeLI
+        6tUc9Xp5Kzub/RkZvJiWxn0AtwFRANJvkwL6nEYjh9ev5/iGDZzy+zleVMT7WVnJuLd0KYcyMnhAkhhb
+        SE5Bd3rXokWMl5ZyIieHjxwOPnO5+GzZMo6rKo9KElv/R9axFdA6AA5YrXySnc3Xubl8l5/PtytXclpV
+        eUwI7v7HipPQ3W4TgtesVk45nXyVm8uPbje/eDycLSzkjNvNp6rK40Kwa6GIBmitQvCConAkM5PTTiff
+        5OXxud3OmeXLOef18lNBQVJ0YvFiHhKC7SmRaqA+AiROm0y8lp7Ou6rKh04npzIzeVCSeFQIvne5+MHt
+        5sucHE46HBxMT2evEIzqtm0E5k4YDDwry7xssfD2kiUctNnYM29YqAOo0tt+YbfzscvFsaws3rLZeEVR
+        GNE/0iYg2AzwpNHIPkXhJYuF3fOrSs0puoCqwwYDx1SVQ6rK61Yr9wrBZiCY9EA/jBYheEqWuUsIhhea
+        BIh2oGq/JPG6xZIkt6aOKYVaIFgHfNP+f84iAqyLAHORVOWf+AGIsUH+OoOTngAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="kryptonColorButton1.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
-        AAAAAElFTkSuQmCC
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
+        AAAASUVORK5CYII=
 </value>
   </data>
   <data name="kcbtnDropDown.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
-        AAAAAElFTkSuQmCC
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
+        AAAASUVORK5CYII=
 </value>
   </data>
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="kryptonButton5.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="kryptonButton6.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="kryptonButton7.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="kryptonButton8.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
-</value>
-  </data>
   <metadata name="kryptonCommand1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>245, 17</value>
   </metadata>
   <metadata name="kryptonCommand2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>449, 17</value>
   </metadata>
+  <data name="kryptonButton5.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJWSURBVDhPtZLdS1NxHId/v52NQFZzFWimbq7ozTT/g/bH
+        RFRE1o0E3dRFktXIRDBt8ygma9XYpDKhYpnvmjt25pT24mnu5RhSKwq80L6fOEdSJ9FVPfBcne/nuTj8
+        GPsfHPfMnazzyKE6t5z/MiHg86ghpIaYfftdASdEqbi6TXLWts+INW4ZR3pTdMinYi3OaSXCKT9qxPIb
+        QVRfCk4lwIoLxjUd7/O1bhnVnigd7YrjoDcHh1clh1cFxRgoxrEWZVgJc+SHjFh+JWBpQMhvBtokOLw5
+        fVDVm9O19WR1aZ7pYp6DoowoykCzDOpzIzYC1S1TsD9YH1R2Z6iyO4OKrgwqxLR+jFkGinBQhBEiDCRz
+        yvVtCRxzja0PujIo70xjvyeNMrfmIiAzQOagGU40w0CSLmX9ps3A4abhfHmHgrL7i7r7OlIoaU+h5N5H
+        QOKgMCeEGTRpmtPqOEfaZ9r8B2qfIfDjrQHQ6trxNAOmOegdw95WBXtaFrBb8+4CrM0LKG0Mw9HQH9gI
+        pB8Lzk9BI/2c4ERTDDTFiSYZYZLB2pyE9U4SFleCLK4kLLcTsDcM0IH6p86NgEbWJ4hf+wWicQYa44Qx
+        Bk2LK4Fdt+LYeTNO5qY4Sq8MoepCUCwYaygiK17sEaRvzwTQCCeMcNAw10fmGzEUNcao5PIgqs77JVt9
+        oPAh/UaLpDqNoSWvkVZfc9Agp6LrH2C+FkHZpRewn3sSstWLfx5vRWkXrqY7TfgeNMDaMEyVZ/2wnXl4
+        cfvdX1HadtiTrSbFftoXsp16VLf9+z/jF9G1kGWCriLIAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kryptonButton6.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJWSURBVDhPtZLdS1NxHId/v52NQFZzFWimbq7ozTT/g/bH
+        RFRE1o0E3dRFktXIRDBt8ygma9XYpDKhYpnvmjt25pT24mnu5RhSKwq80L6fOEdSJ9FVPfBcne/nuTj8
+        GPsfHPfMnazzyKE6t5z/MiHg86ghpIaYfftdASdEqbi6TXLWts+INW4ZR3pTdMinYi3OaSXCKT9qxPIb
+        QVRfCk4lwIoLxjUd7/O1bhnVnigd7YrjoDcHh1clh1cFxRgoxrEWZVgJc+SHjFh+JWBpQMhvBtokOLw5
+        fVDVm9O19WR1aZ7pYp6DoowoykCzDOpzIzYC1S1TsD9YH1R2Z6iyO4OKrgwqxLR+jFkGinBQhBEiDCRz
+        yvVtCRxzja0PujIo70xjvyeNMrfmIiAzQOagGU40w0CSLmX9ps3A4abhfHmHgrL7i7r7OlIoaU+h5N5H
+        QOKgMCeEGTRpmtPqOEfaZ9r8B2qfIfDjrQHQ6trxNAOmOegdw95WBXtaFrBb8+4CrM0LKG0Mw9HQH9gI
+        pB8Lzk9BI/2c4ERTDDTFiSYZYZLB2pyE9U4SFleCLK4kLLcTsDcM0IH6p86NgEbWJ4hf+wWicQYa44Qx
+        Bk2LK4Fdt+LYeTNO5qY4Sq8MoepCUCwYaygiK17sEaRvzwTQCCeMcNAw10fmGzEUNcao5PIgqs77JVt9
+        oPAh/UaLpDqNoSWvkVZfc9Agp6LrH2C+FkHZpRewn3sSstWLfx5vRWkXrqY7TfgeNMDaMEyVZ/2wnXl4
+        cfvdX1HadtiTrSbFftoXsp16VLf9+z/jF9G1kGWCriLIAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kryptonButton7.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJWSURBVDhPtZLdS1NxHId/v52NQFZzFWimbq7ozTT/g/bH
+        RFRE1o0E3dRFktXIRDBt8ygma9XYpDKhYpnvmjt25pT24mnu5RhSKwq80L6fOEdSJ9FVPfBcne/nuTj8
+        GPsfHPfMnazzyKE6t5z/MiHg86ghpIaYfftdASdEqbi6TXLWts+INW4ZR3pTdMinYi3OaSXCKT9qxPIb
+        QVRfCk4lwIoLxjUd7/O1bhnVnigd7YrjoDcHh1clh1cFxRgoxrEWZVgJc+SHjFh+JWBpQMhvBtokOLw5
+        fVDVm9O19WR1aZ7pYp6DoowoykCzDOpzIzYC1S1TsD9YH1R2Z6iyO4OKrgwqxLR+jFkGinBQhBEiDCRz
+        yvVtCRxzja0PujIo70xjvyeNMrfmIiAzQOagGU40w0CSLmX9ps3A4abhfHmHgrL7i7r7OlIoaU+h5N5H
+        QOKgMCeEGTRpmtPqOEfaZ9r8B2qfIfDjrQHQ6trxNAOmOegdw95WBXtaFrBb8+4CrM0LKG0Mw9HQH9gI
+        pB8Lzk9BI/2c4ERTDDTFiSYZYZLB2pyE9U4SFleCLK4kLLcTsDcM0IH6p86NgEbWJ4hf+wWicQYa44Qx
+        Bk2LK4Fdt+LYeTNO5qY4Sq8MoepCUCwYaygiK17sEaRvzwTQCCeMcNAw10fmGzEUNcao5PIgqs77JVt9
+        oPAh/UaLpDqNoSWvkVZfc9Agp6LrH2C+FkHZpRewn3sSstWLfx5vRWkXrqY7TfgeNMDaMEyVZ/2wnXl4
+        cfvdX1HadtiTrSbFftoXsp16VLf9+z/jF9G1kGWCriLIAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kryptonButton8.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJWSURBVDhPtZLdS1NxHId/v52NQFZzFWimbq7ozTT/g/bH
+        RFRE1o0E3dRFktXIRDBt8ygma9XYpDKhYpnvmjt25pT24mnu5RhSKwq80L6fOEdSJ9FVPfBcne/nuTj8
+        GPsfHPfMnazzyKE6t5z/MiHg86ghpIaYfftdASdEqbi6TXLWts+INW4ZR3pTdMinYi3OaSXCKT9qxPIb
+        QVRfCk4lwIoLxjUd7/O1bhnVnigd7YrjoDcHh1clh1cFxRgoxrEWZVgJc+SHjFh+JWBpQMhvBtokOLw5
+        fVDVm9O19WR1aZ7pYp6DoowoykCzDOpzIzYC1S1TsD9YH1R2Z6iyO4OKrgwqxLR+jFkGinBQhBEiDCRz
+        yvVtCRxzja0PujIo70xjvyeNMrfmIiAzQOagGU40w0CSLmX9ps3A4abhfHmHgrL7i7r7OlIoaU+h5N5H
+        QOKgMCeEGTRpmtPqOEfaZ9r8B2qfIfDjrQHQ6trxNAOmOegdw95WBXtaFrBb8+4CrM0LKG0Mw9HQH9gI
+        pB8Lzk9BI/2c4ERTDDTFiSYZYZLB2pyE9U4SFleCLK4kLLcTsDcM0IH6p86NgEbWJ4hf+wWicQYa44Qx
+        Bk2LK4Fdt+LYeTNO5qY4Sq8MoepCUCwYaygiK17sEaRvzwTQCCeMcNAw10fmGzEUNcao5PIgqs77JVt9
+        oPAh/UaLpDqNoSWvkVZfc9Agp6LrH2C+FkHZpRewn3sSstWLfx5vRWkXrqY7TfgeNMDaMEyVZ/2wnXl4
+        cfvdX1HadtiTrSbFftoXsp16VLf9+z/jF9G1kGWCriLIAAAAAElFTkSuQmCC
+</value>
+  </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAUAMDAAAAEAIACoJQAAVgAAACAgAAABACAAqBAAAP4lAAAgIAAAAQAIAKgIAACmNgAAEBAAAAEA


### PR DESCRIPTION
… to be implemented

## Summary

- Implements [#1673](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1673) by completing `KryptonContextMenuProgressBar` and wiring it into context menu rendering, design-time editors, and collection type restrictions.
- Enables the existing ComboBox option in the context menu collection editor and adds explicit icon mapping for text box/combo box/progress bar entries in the tree.
- Adds a small TestForm usage example and updates the changelog entry for the V110 nightly section.

## What Changed

- Added `ViewDrawMenuProgressBar` to host `KryptonProgressBar` inside context menus.
- Replaced the commented stub in `KryptonContextMenuProgressBar` with a full implementation:
  - `GenerateView`, `Dispose`, and standard context-menu item overrides.
  - Exposed properties: `Minimum`, `Maximum`, `Value`, `Step`, `Style`, `MarqueeAnimationSpeed`, `MinimumWidth`, `Enabled`.
- Added `KryptonContextMenuProgressBar` to allowed item-type lists:
  - `KryptonContextMenuCollection`
  - `KryptonContextMenuItemCollection`
  - `KryptonContextMenuCollectionEditor`
  - `KryptonContextMenuItemCollectionEditor`
- Updated `KryptonContextMenuCollectionForm`:
  - Added **Add ProgressBar** button.
  - Enabled **Add ComboBox** button.
  - Added icon list entries and tree-node icon mapping for `KryptonContextMenuTextBox`, `KryptonContextMenuComboBox`, and `KryptonContextMenuProgressBar`.
  - Switched unknown item icon fallback to a safe default.
- Added a TestForm sample insertion of `KryptonContextMenuProgressBar` in `ButtonsTest`.
- Added changelog entry for #1673 in `Documents/Changelog/Changelog.md`.

## Manual Test Plan

- [ ] Open a form using the context menu collection editor and verify **Add ComboBox** is enabled.
- [ ] In the same editor, verify **Add ProgressBar** appears and creates a `KryptonContextMenuProgressBar` item.
- [ ] Confirm text box/combo box/progress bar entries show appropriate icons in the hierarchy tree.
- [ ] Run TestForm and open the button context menu in `ButtonsTest`; verify the progress bar item is visible and laid out correctly.
- [ ] Confirm normal/disabled context menu behavior still works for existing items.

## Notes

- Full solution build currently reports existing environment/resource issues (`MSB3822`/`MSB3823`) on legacy target frameworks; these are not introduced by this change set.

<img width="669" height="261" alt="image" src="https://github.com/user-attachments/assets/54027c94-d3f6-4966-a105-2379bda56bf0" />
