### PR TITLE
* Adding NotificationIcon Size in ToastNotification

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#2125](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2125), Adding NotificationIcon Size in ToastNotification. Added `NotificationIconWidth` and `NotificationIconHeight` to toast data models and wired basic toast views to render and layout icons using custom dimensions.
 * Implemented [#998](https://github.com/Krypton-Suite/Standard-Toolkit/issues/998), Use the new artifacts feature to simplify build paths. Added opt-in artifacts output support for build/package paths via shared MSBuild properties (`UseArtifactsOutput=true`) and updated `ModernBuild` package discovery to work with both legacy `Bin/*` and `artifacts/packages/*` layouts.
   * Updated GitHub Actions workflows to build with artifacts output enabled and to resolve package/DLL paths from `artifacts/*` with legacy `Bin/*` fallback.
 * Implemented [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002), Implement `ActionLists` for file dialogs, `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` to expose common design-time properties.

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -154,15 +154,15 @@
 		</Otherwise>
 	</Choose>
 
-	<!-- CS7069: ExpandableObjectConverter metadata must resolve System.ComponentModel.TypeConverter at compile time.
-	     .NET 9+ SDK package pruning can treat a direct System.ComponentModel.TypeConverter reference as prunable and
-	     apply IncludeAssets=none, which removes it from the compile graph. Disable pruning for non-net4 TFMs here and
-	     keep an explicit package reference for those TFMs so WinForms/WPF libraries retain a stable compile ref. -->
+	<!-- CS7069 metadata resolution: keep explicit compile-time component-model refs for non-net4 TFMs.
+	     .NET 9+ SDK package pruning can mark these as prunable and drop them from compile assets, which then breaks
+	     inherited WinForms metadata (for example ExpandableObjectConverter and Component on Ribbon/ButtonSpec types). -->
 	<PropertyGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
 		<RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
+		<PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 	</ItemGroup>
 </Project>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -154,14 +154,15 @@
 		</Otherwise>
 	</Choose>
 
-	<!-- CS7069 metadata resolution: keep explicit compile-time component-model refs for non-net4 TFMs.
+	<!-- CS7069 metadata resolution: keep explicit compile-time component-model refs for net8/net9 only.
+	     Newer TFMs (net10+) should use inbox framework assemblies to avoid assembly-version conflicts.
 	     .NET 9+ SDK package pruning can mark these as prunable and drop them from compile assets, which then breaks
 	     inherited WinForms metadata (for example ExpandableObjectConverter and Component on Ribbon/ButtonSpec types). -->
-	<PropertyGroup Condition="'$(TargetFramework)' == '' or $(TargetFramework.StartsWith('net4')) != 'true'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows' Or '$(TargetFramework)' == 'net9.0-windows'">
 		<RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == '' or $(TargetFramework.StartsWith('net4')) != 'true'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows' Or '$(TargetFramework)' == 'net9.0-windows'">
 		<PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 	</ItemGroup>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+ <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
 
 	<!-- Target Framework Selection: Determines which .NET versions to build for based on configuration -->
@@ -164,5 +164,14 @@
 	<ItemGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
 		<PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+	</ItemGroup>
+
+	<!-- MSB3822/MSB3823 resource generation fix for net4x TFMs with non-string .resx entries. -->
+	<PropertyGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) == 'true'">
+		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) == 'true'">
+		<PackageReference Include="System.Resources.Extensions" Version="4.7.1" />
 	</ItemGroup>
 </Project>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -157,11 +157,11 @@
 	<!-- CS7069 metadata resolution: keep explicit compile-time component-model refs for non-net4 TFMs.
 	     .NET 9+ SDK package pruning can mark these as prunable and drop them from compile assets, which then breaks
 	     inherited WinForms metadata (for example ExpandableObjectConverter and Component on Ribbon/ButtonSpec types). -->
-	<PropertyGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
+	<PropertyGroup Condition="'$(TargetFramework)' == '' or $(TargetFramework.StartsWith('net4')) != 'true'">
 		<RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' != '' and $(TargetFramework.StartsWith('net4')) != 'true'">
+	<ItemGroup Condition="'$(TargetFramework)' == '' or $(TargetFramework.StartsWith('net4')) != 'true'">
 		<PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 	</ItemGroup>

--- a/Source/Krypton Components/Krypton.Navigator.Utilities/Krypton.Navigator.Utilities.csproj
+++ b/Source/Krypton Components/Krypton.Navigator.Utilities/Krypton.Navigator.Utilities.csproj
@@ -50,6 +50,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
 		<ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
 	</ItemGroup>
 

--- a/Source/Krypton Components/Krypton.Navigator.Utilities/Krypton.Navigator.Utilities.csproj
+++ b/Source/Krypton Components/Krypton.Navigator.Utilities/Krypton.Navigator.Utilities.csproj
@@ -32,6 +32,7 @@
 
 	<ItemGroup>
 		<Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs" Link="General\PlatformInvoke.cs" />
+		<Compile Include="..\Krypton.Toolkit\General\Scroll Bars\WIN32ScrollBars.cs" Link="General\Scroll Bars\WIN32ScrollBars.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicForm.cs
@@ -113,13 +113,17 @@ internal partial class VisualToastBasicForm : KryptonForm
 
     private void UpdateIcon()
     {
+        var iconSize = GraphicsExtensionUtilities.ResolveToastNotificationIconSize(
+            _basicToastNotificationData.NotificationIconWidth,
+            _basicToastNotificationData.NotificationIconHeight);
+
         var bitmap = GraphicsExtensionUtilities.GetToastNotificationBitmap(
             _basicToastNotificationData.NotificationIcon,
             null,
             _basicToastNotificationData.CustomImage,
-            new Size(128, 128));
+            iconSize);
 
-        SetIcon(bitmap);
+        SetIcon(bitmap, iconSize);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>
@@ -128,7 +132,11 @@ internal partial class VisualToastBasicForm : KryptonForm
     private void UpdateDoNotShowAgainOptionCheckState() => kchkDoNotShowAgain.CheckState =
         _basicToastNotificationData.DoNotShowAgainOptionCheckState ?? CheckState.Unchecked;
 
-    private void SetIcon(Bitmap? image) => pbxIcon.Image = image;
+    private void SetIcon(Bitmap? image, Size size)
+    {
+        pbxIcon.Size = size;
+        pbxIcon.Image = image;
+    }
 
     private void UpdateLocation() =>
         //Once loaded, position the form, or position it to the bottom left of the screen with added padding

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/LTR/VisualToastBasicWithProgressBarForm.cs
@@ -132,13 +132,17 @@ internal partial class VisualToastBasicWithProgressBarForm : KryptonForm
 
     private void UpdateIcon()
     {
+        var iconSize = GraphicsExtensionUtilities.ResolveToastNotificationIconSize(
+            _basicToastNotificationData.NotificationIconWidth,
+            _basicToastNotificationData.NotificationIconHeight);
+
         var bitmap = GraphicsExtensionUtilities.GetToastNotificationBitmap(
             _basicToastNotificationData.NotificationIcon,
             null,
             _basicToastNotificationData.CustomImage,
-            new Size(128, 128));
+            iconSize);
 
-        SetIcon(bitmap);
+        SetIcon(bitmap, iconSize);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>
@@ -148,7 +152,11 @@ internal partial class VisualToastBasicWithProgressBarForm : KryptonForm
         kchkDoNotShowAgain.CheckState =
             _basicToastNotificationData.DoNotShowAgainOptionCheckState ?? CheckState.Unchecked;
 
-    private void SetIcon(Bitmap? image) => pbxImage.Image = image;
+    private void SetIcon(Bitmap? image, Size size)
+    {
+        pbxImage.Size = size;
+        pbxImage.Image = image;
+    }
 
     private void UpdateLocation()
     {

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicRtlAwareForm.cs
@@ -108,16 +108,24 @@ internal partial class VisualToastBasicRtlAwareForm : VisualToastBaseForm
 
     private void UpdateIcon()
     {
+        var iconSize = GraphicsExtensionUtilities.ResolveToastNotificationIconSize(
+            _basicToastNotificationData.NotificationIconWidth,
+            _basicToastNotificationData.NotificationIconHeight);
+
         var bitmap = GraphicsExtensionUtilities.GetToastNotificationBitmap(
             _basicToastNotificationData.NotificationIcon,
             null,
             _basicToastNotificationData.CustomImage,
-            new Size(128, 128));
+            iconSize);
 
-        SetIcon(bitmap);
+        SetIcon(bitmap, iconSize);
     }
 
-    private void SetIcon(Bitmap? image) => pbxImage.Image = image;
+    private void SetIcon(Bitmap? image, Size size)
+    {
+        pbxImage.Size = size;
+        pbxImage.Image = image;
+    }
 
     private void UpdateLocation()
     {

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/Controls Visuals/Basic/RTL/VisualToastBasicWithProgressBarRtlAwareForm.cs
@@ -109,13 +109,17 @@ internal partial class VisualToastBasicWithProgressBarRtlAwareForm : VisualToast
 
     private void UpdateIcon()
     {
+        var iconSize = GraphicsExtensionUtilities.ResolveToastNotificationIconSize(
+            _basicToastNotificationData.NotificationIconWidth,
+            _basicToastNotificationData.NotificationIconHeight);
+
         var bitmap = GraphicsExtensionUtilities.GetToastNotificationBitmap(
             _basicToastNotificationData.NotificationIcon,
             null,
             _basicToastNotificationData.CustomImage,
-            new Size(128, 128));
+            iconSize);
 
-        SetIcon(bitmap);
+        SetIcon(bitmap, iconSize);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>
@@ -125,7 +129,11 @@ internal partial class VisualToastBasicWithProgressBarRtlAwareForm : VisualToast
         kchkDoNotShowAgain.CheckState =
             _basicToastNotificationData.DoNotShowAgainOptionCheckState ?? CheckState.Unchecked;
 
-    private void SetIcon(Bitmap? image) => pbxImage.Image = image;
+    private void SetIcon(Bitmap? image, Size size)
+    {
+        pbxImage.Size = size;
+        pbxImage.Image = image;
+    }
 
     private void UpdateLocation()
     {

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonBasicToastData.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonBasicToastData.cs
@@ -117,6 +117,14 @@ public struct KryptonBasicToastData
     /// <value>The notification icon.</value>
     public KryptonToastIcon? NotificationIcon { get; set; }
 
+    /// <summary>Gets or sets the notification icon width.</summary>
+    /// <value>The notification icon width.</value>
+    public int? NotificationIconWidth { get; set; }
+
+    /// <summary>Gets or sets the notification icon height.</summary>
+    /// <value>The notification icon height.</value>
+    public int? NotificationIconHeight { get; set; }
+
     /// <summary>Gets or sets the notification title horizontal alignment.</summary>
     /// <value>The notification title horizontal alignment.</value>
     public PaletteRelativeAlign? NotificationTitleAlignmentH { get; set; }
@@ -166,6 +174,10 @@ public struct KryptonBasicToastData
         NotificationTitleAlignmentH = PaletteRelativeAlign.Center;
 
         NotificationTitleAlignmentV = PaletteRelativeAlign.Center;
+
+        NotificationIconWidth = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
+
+        NotificationIconHeight = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonCommonToastData.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonCommonToastData.cs
@@ -113,6 +113,14 @@ public struct KryptonCommonToastData
     /// <value>The notification icon.</value>
     public KryptonToastIcon? NotificationIcon { get; set; }
 
+    /// <summary>Gets or sets the notification icon width.</summary>
+    /// <value>The notification icon width.</value>
+    public int? NotificationIconWidth { get; set; }
+
+    /// <summary>Gets or sets the notification icon height.</summary>
+    /// <value>The notification icon height.</value>
+    public int? NotificationIconHeight { get; set; }
+
     #endregion
 
     #region Identity
@@ -147,6 +155,10 @@ public struct KryptonCommonToastData
         ToastHost = null;
 
         RightToLeftLayout = Toolkit.RightToLeftLayout.LeftToRight;
+
+        NotificationIconWidth = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
+
+        NotificationIconHeight = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonUserInputToastData.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonToast/General/KryptonUserInputToastData.cs
@@ -129,6 +129,14 @@ public struct KryptonUserInputToastData
     /// <value>The notification icon.</value>
     public KryptonToastIcon? NotificationIcon { get; set; }
 
+    /// <summary>Gets or sets the notification icon width.</summary>
+    /// <value>The notification icon width.</value>
+    public int? NotificationIconWidth { get; set; }
+
+    /// <summary>Gets or sets the notification icon height.</summary>
+    /// <value>The notification icon height.</value>
+    public int? NotificationIconHeight { get; set; }
+
     /// <summary>Gets or sets the type of the notification input area.</summary>
     /// <value>The type of the notification input area.</value>
     public KryptonToastInputAreaType? NotificationInputAreaType { get; set; }
@@ -208,6 +216,10 @@ public struct KryptonUserInputToastData
         ToastHost = null;
 
         SelectedIndex = 0;
+
+        NotificationIconWidth = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
+
+        NotificationIconHeight = GraphicsExtensionUtilities.DEFAULT_TOAST_ICON_SIZE;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Utilities/Utilities/GraphicsExtensionUtilities.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Utilities/GraphicsExtensionUtilities.cs
@@ -10,6 +10,8 @@ namespace Krypton.Utilities;
 
 public static class GraphicsExtensionUtilities
 {
+    public const int DEFAULT_TOAST_ICON_SIZE = 128;
+
     /// <summary>Gets the type of the toast notification icon.</summary>
     /// <param name="notificationIconType">Type of the notification icon.</param>
     /// <param name="customImage">The custom image.</param>
@@ -113,6 +115,28 @@ public static class GraphicsExtensionUtilities
         }
 
         return resolved as Bitmap ?? new Bitmap(resolved);
+    }
+
+    /// <summary>Resolves a toast notification icon size from optional width and height values.</summary>
+    /// <param name="width">Optional width.</param>
+    /// <param name="height">Optional height.</param>
+    /// <returns>A safe size for toast notification icon rendering.</returns>
+    public static Size ResolveToastNotificationIconSize(int? width, int? height)
+    {
+        var resolvedWidth = width ?? DEFAULT_TOAST_ICON_SIZE;
+        var resolvedHeight = height ?? DEFAULT_TOAST_ICON_SIZE;
+
+        if (resolvedWidth <= 0)
+        {
+            resolvedWidth = DEFAULT_TOAST_ICON_SIZE;
+        }
+
+        if (resolvedHeight <= 0)
+        {
+            resolvedHeight = DEFAULT_TOAST_ICON_SIZE;
+        }
+
+        return new Size(resolvedWidth, resolvedHeight);
     }
 
     /// <summary>Resize the image to the specified width and height. Copied from: https://stackoverflow.com/questions/1922040/how-to-resize-an-image-c-sharp</summary>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -111,6 +111,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="Cyotek.Windows.Forms.ColorPicker" Version="2.0.0-beta.7" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
+++ b/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
@@ -25,6 +25,8 @@ public partial class ToastNotificationQuickTestForm : KryptonForm
             NotificationTitle = @"Hello World!",
             NotificationContent = @"This is a simple test...",
             NotificationIcon = KryptonToastIcon.Information,
+            NotificationIconWidth = 16,
+            NotificationIconHeight = 16,
             CountDownSeconds = 60
         };
 


### PR DESCRIPTION
## Summary

- Implemented [#2125](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2125) by adding configurable toast notification icon dimensions via `NotificationIconWidth` and `NotificationIconHeight`.
- Added new icon size properties to `KryptonBasicToastData`, `KryptonUserInputToastData`, and `KryptonCommonToastData` with backward-compatible defaults (`128x128`).
- Centralized icon size resolution in `GraphicsExtensionUtilities` and updated basic toast visual forms (LTR/RTL, with/without progress bar) to render and layout icons using resolved size values.
- Updated docs in `Documents/KryptonToastNotification.md` and `Documents/KryptonToastNotificationManager.md` to describe icon sizing and current toast data types.
- Added a quick usage example in `ToastNotificationQuickTestForm` showing a compact icon (`16x16`).
- Fixed `net472` compile failure in `Krypton.Navigator.Utilities` by linking `WIN32ScrollBars.cs` alongside linked `PlatformInvoke.cs`, resolving missing type errors (`CS0246`) for `WIN32ScrollBars.ScrollInfo`.

## Why

Toast icons were fixed at `128x128`, which made notifications visually heavy in many scenarios. This change allows consumers to set icon dimensions per notification while preserving existing behavior when size is not specified. In addition, `Krypton.Navigator.Utilities` links `PlatformInvoke.cs` from `Krypton.Toolkit`; adding the matching `WIN32ScrollBars` compile item keeps linked source dependencies intact across target frameworks.

## Test Plan

- [ ] Open `TestForm` and trigger the basic toast quick test; verify icon renders at `16x16` using the updated sample data.
- [ ] Trigger basic toast notifications without setting icon size; verify default behavior remains `128x128`.
- [ ] Trigger basic progress bar toast notifications and verify custom icon sizing is respected.
- [ ] Verify RTL basic toast notifications (with and without progress bar) also respect custom icon dimensions.
- [ ] Verify invalid icon sizes (`<= 0`) gracefully fall back to default size.
- [ ] Confirm documentation examples for icon sizing compile conceptually against current API names (`KryptonBasicToastData`, `KryptonUserInputToastData`).
- [ ] Build `Krypton.Navigator.Utilities` for `net472` and verify `PlatformInvoke.cs` no longer reports `CS0246` for `WIN32ScrollBars`.

## Why

Toast icons were fixed at `128x128`, which made notifications visually heavy in many scenarios. This change allows consumers to set icon dimensions per notification while preserving existing behavior when size is not specified.

## Test Plan

- [ ] Open `TestForm` and trigger the basic toast quick test; verify icon renders at `16x16` using the updated sample data.
- [ ] Trigger basic toast notifications without setting icon size; verify default behavior remains `128x128`.
- [ ] Trigger basic progress bar toast notifications and verify custom icon sizing is respected.
- [ ] Verify RTL basic toast notifications (with and without progress bar) also respect custom icon dimensions.
- [ ] Verify invalid icon sizes (`<= 0`) gracefully fall back to default size.
- [ ] Confirm documentation examples for icon sizing compile conceptually against current API names (`KryptonBasicToastData`, `KryptonUserInputToastData`).

<img width="662" height="256" alt="image" src="https://github.com/user-attachments/assets/085a8ac8-f717-4e3d-be95-5570d0303e57" />
