### PR TITLE
* `KryptonThemeComboBox` does not change theme when `SelectedIndex` i… (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 * Implemented [#1673](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1673), `KryptonContextMenuComboBox` & `KryptonContextMenuProgressBar` need to be implemented. `KryptonContextMenuProgressBar` for context menus (and enabled **Add ComboBox** in the context menu collection editor).
 * Resolved [#2914](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2914), White bar is shown in a KryptonForm Sizable without buttons and text
 * Implemented [#2125](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2125), Adding NotificationIcon Size in ToastNotification. Added `NotificationIconWidth` and `NotificationIconHeight` to toast data models and wired basic toast views to render and layout icons using custom dimensions.

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -79,6 +79,20 @@ public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryp
     #region Implementation
 
     /// <summary>
+    /// Resolves the theme label from the combo's selected list item when possible, so programmatic
+    /// index changes still apply the correct palette (Toolkit #3283).
+    /// </summary>
+    private string GetSelectedThemeName()
+    {
+        if (SelectedIndex > -1 && SelectedItem is string s && s.Length > 0)
+        {
+            return s;
+        }
+
+        return Text ?? string.Empty;
+    }
+
+    /// <summary>
     /// This method will run when the KryptonManager.GlobalPaletteChanged event is fired.<br/>
     /// It will synchronize the SelectedIndex with the newly assigned Global Palette.
     /// </summary>
@@ -151,7 +165,7 @@ public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryp
     /// <inheritdoc />
     protected override void OnSelectedIndexChanged(EventArgs e)
     {
-        if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, Text, _manager, _kryptonCustomPalette))
+        if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
         {
             //theme change went wrong, make the active theme the selected theme in the list.
             SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -67,6 +67,22 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
     #region Implementation
 
     /// <summary>
+    /// Theme resolution must use the list item string (same approach as <see cref="KryptonThemeListBox"/>).
+    /// For an owner-draw <see cref="KryptonComboBox"/>, <see cref="Control.Text"/> can lag or stay empty when
+    /// <see cref="ComboBox.SelectedIndex"/> is set programmatically, which would otherwise map to
+    /// <see cref="PaletteMode.Global"/> and revert the selection (see #3283).
+    /// </summary>
+    private string GetSelectedThemeName()
+    {
+        if (SelectedIndex > -1 && SelectedItem is string s && s.Length > 0)
+        {
+            return s;
+        }
+
+        return Text ?? string.Empty;
+    }
+
+    /// <summary>
     /// Routine that will be executed when the control is fully instantiated.
     /// </summary>
     /// <param name="e">EventArgs param. Not used in this implementation.</param>
@@ -148,6 +164,11 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
 
         if (!IsHandleCreated)
         {
+            if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
+            {
+                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            }
+
             base.OnSelectedIndexChanged(e);
             return;
         }
@@ -162,7 +183,7 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
             ThemeChangeCoordinator.Begin(FindForm());
             try
             {
-                if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, Text, _manager, _kryptonCustomPalette))
+                if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
                 {
                     // theme change failed; resync index to current global palette
                     SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);

--- a/Source/Krypton Components/TestForm/Bug3283ThemeComboBoxProgrammaticTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug3283ThemeComboBoxProgrammaticTest.Designer.cs
@@ -1,0 +1,179 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+partial class Bug3283ThemeComboBoxProgrammaticTest
+{
+    private System.ComponentModel.IContainer components = null;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    private void InitializeComponent()
+    {
+        this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
+        this.lblInstruction = new Krypton.Toolkit.KryptonWrapLabel();
+        this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
+        this.kryptonLabelSelection = new Krypton.Toolkit.KryptonLabel();
+        this.kryptonLabelGlobalMode = new Krypton.Toolkit.KryptonLabel();
+        this.kryptonButtonCycle = new Krypton.Toolkit.KryptonButton();
+        this.kryptonButtonJumpLow = new Krypton.Toolkit.KryptonButton();
+        this.kryptonButtonJumpHigh = new Krypton.Toolkit.KryptonButton();
+        this.kryptonButtonPreHandle = new Krypton.Toolkit.KryptonButton();
+        this.kryptonPanelHost = new Krypton.Toolkit.KryptonPanel();
+        this.kryptonLabelPreHandleResult = new Krypton.Toolkit.KryptonLabel();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
+        this.kryptonPanelMain.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelHost)).BeginInit();
+        this.kryptonPanelHost.SuspendLayout();
+        this.SuspendLayout();
+        //
+        // kryptonPanelMain
+        //
+        this.kryptonPanelMain.Controls.Add(this.kryptonLabelPreHandleResult);
+        this.kryptonPanelMain.Controls.Add(this.kryptonPanelHost);
+        this.kryptonPanelMain.Controls.Add(this.kryptonButtonPreHandle);
+        this.kryptonPanelMain.Controls.Add(this.kryptonButtonJumpHigh);
+        this.kryptonPanelMain.Controls.Add(this.kryptonButtonJumpLow);
+        this.kryptonPanelMain.Controls.Add(this.kryptonButtonCycle);
+        this.kryptonPanelMain.Controls.Add(this.kryptonLabelGlobalMode);
+        this.kryptonPanelMain.Controls.Add(this.kryptonLabelSelection);
+        this.kryptonPanelMain.Controls.Add(this.kryptonThemeComboBox1);
+        this.kryptonPanelMain.Controls.Add(this.lblInstruction);
+        this.kryptonPanelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.kryptonPanelMain.Location = new System.Drawing.Point(0, 0);
+        this.kryptonPanelMain.Name = "kryptonPanelMain";
+        this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
+        this.kryptonPanelMain.Size = new System.Drawing.Size(600, 330);
+        this.kryptonPanelMain.TabIndex = 0;
+        //
+        // lblInstruction
+        //
+        this.lblInstruction.AutoSize = false;
+        this.lblInstruction.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+        this.lblInstruction.Location = new System.Drawing.Point(12, 12);
+        this.lblInstruction.Name = "lblInstruction";
+        this.lblInstruction.Size = new System.Drawing.Size(576, 56);
+        this.lblInstruction.Text = "Issue #3283: Use the buttons to change SelectedIndex in code. The global palette (see second line) must follow the combo selection. You can still change the theme from the drop-down as usual.";
+        //
+        // kryptonThemeComboBox1
+        //
+        this.kryptonThemeComboBox1.DropDownWidth = 400;
+        this.kryptonThemeComboBox1.IntegralHeight = false;
+        this.kryptonThemeComboBox1.Location = new System.Drawing.Point(12, 74);
+        this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
+        this.kryptonThemeComboBox1.Size = new System.Drawing.Size(400, 22);
+        this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+        this.kryptonThemeComboBox1.TabIndex = 0;
+        //
+        // kryptonLabelSelection
+        //
+        this.kryptonLabelSelection.Location = new System.Drawing.Point(12, 104);
+        this.kryptonLabelSelection.Name = "kryptonLabelSelection";
+        this.kryptonLabelSelection.Size = new System.Drawing.Size(576, 24);
+        this.kryptonLabelSelection.TabIndex = 1;
+        this.kryptonLabelSelection.Values.Text = "SelectedIndex";
+        //
+        // kryptonLabelGlobalMode
+        //
+        this.kryptonLabelGlobalMode.Location = new System.Drawing.Point(12, 130);
+        this.kryptonLabelGlobalMode.Name = "kryptonLabelGlobalMode";
+        this.kryptonLabelGlobalMode.Size = new System.Drawing.Size(576, 24);
+        this.kryptonLabelGlobalMode.TabIndex = 2;
+        this.kryptonLabelGlobalMode.Values.Text = "Global palette";
+        //
+        // kryptonButtonCycle
+        //
+        this.kryptonButtonCycle.Location = new System.Drawing.Point(12, 164);
+        this.kryptonButtonCycle.Name = "kryptonButtonCycle";
+        this.kryptonButtonCycle.Size = new System.Drawing.Size(200, 32);
+        this.kryptonButtonCycle.TabIndex = 3;
+        this.kryptonButtonCycle.Values.Text = "Cycle SelectedIndex (+1)";
+        //
+        // kryptonButtonJumpLow
+        //
+        this.kryptonButtonJumpLow.Location = new System.Drawing.Point(220, 164);
+        this.kryptonButtonJumpLow.Name = "kryptonButtonJumpLow";
+        this.kryptonButtonJumpLow.Size = new System.Drawing.Size(170, 32);
+        this.kryptonButtonJumpLow.TabIndex = 4;
+        this.kryptonButtonJumpLow.Values.Text = "Jump to ~25% index";
+        //
+        // kryptonButtonJumpHigh
+        //
+        this.kryptonButtonJumpHigh.Location = new System.Drawing.Point(398, 164);
+        this.kryptonButtonJumpHigh.Name = "kryptonButtonJumpHigh";
+        this.kryptonButtonJumpHigh.Size = new System.Drawing.Size(190, 32);
+        this.kryptonButtonJumpHigh.TabIndex = 5;
+        this.kryptonButtonJumpHigh.Values.Text = "Jump to ~75% index";
+        //
+        // kryptonButtonPreHandle
+        //
+        this.kryptonButtonPreHandle.Location = new System.Drawing.Point(12, 204);
+        this.kryptonButtonPreHandle.Name = "kryptonButtonPreHandle";
+        this.kryptonButtonPreHandle.Size = new System.Drawing.Size(420, 32);
+        this.kryptonButtonPreHandle.TabIndex = 6;
+        this.kryptonButtonPreHandle.Values.Text = "Add fresh KryptonThemeComboBox (index set before handle)";
+        //
+        // kryptonPanelHost
+        //
+        this.kryptonPanelHost.Location = new System.Drawing.Point(12, 242);
+        this.kryptonPanelHost.Name = "kryptonPanelHost";
+        this.kryptonPanelHost.Size = new System.Drawing.Size(576, 28);
+        this.kryptonPanelHost.TabIndex = 7;
+        //
+        // kryptonLabelPreHandleResult
+        //
+        this.kryptonLabelPreHandleResult.Location = new System.Drawing.Point(12, 274);
+        this.kryptonLabelPreHandleResult.Name = "kryptonLabelPreHandleResult";
+        this.kryptonLabelPreHandleResult.Size = new System.Drawing.Size(576, 44);
+        this.kryptonLabelPreHandleResult.TabIndex = 8;
+        this.kryptonLabelPreHandleResult.Values.Text = "";
+        //
+        // Bug3283ThemeComboBoxProgrammaticTest
+        //
+        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.ClientSize = new System.Drawing.Size(600, 330);
+        this.Controls.Add(this.kryptonPanelMain);
+        this.Name = "Bug3283ThemeComboBoxProgrammaticTest";
+        this.Text = "Issue #3283: KryptonThemeComboBox programmatic";
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).EndInit();
+        this.kryptonPanelMain.ResumeLayout(false);
+        this.kryptonPanelMain.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
+        ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelHost)).EndInit();
+        this.kryptonPanelHost.ResumeLayout(false);
+        this.ResumeLayout(false);
+    }
+
+    #endregion
+
+    private Krypton.Toolkit.KryptonPanel kryptonPanelMain;
+    private Krypton.Toolkit.KryptonWrapLabel lblInstruction;
+    private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
+    private Krypton.Toolkit.KryptonLabel kryptonLabelSelection;
+    private Krypton.Toolkit.KryptonLabel kryptonLabelGlobalMode;
+    private Krypton.Toolkit.KryptonButton kryptonButtonCycle;
+    private Krypton.Toolkit.KryptonButton kryptonButtonJumpLow;
+    private Krypton.Toolkit.KryptonButton kryptonButtonJumpHigh;
+    private Krypton.Toolkit.KryptonButton kryptonButtonPreHandle;
+    private Krypton.Toolkit.KryptonPanel kryptonPanelHost;
+    private Krypton.Toolkit.KryptonLabel kryptonLabelPreHandleResult;
+}

--- a/Source/Krypton Components/TestForm/Bug3283ThemeComboBoxProgrammaticTest.cs
+++ b/Source/Krypton Components/TestForm/Bug3283ThemeComboBoxProgrammaticTest.cs
@@ -1,0 +1,82 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Manual test for Issue #3283: <see cref="Krypton.Toolkit.KryptonThemeComboBox"/> must apply the global
+/// palette when <see cref="System.Windows.Forms.ComboBox.SelectedIndex"/> is set in code, not only when
+/// the user picks from the drop-down.
+/// </summary>
+public partial class Bug3283ThemeComboBoxProgrammaticTest : KryptonForm
+{
+    public Bug3283ThemeComboBoxProgrammaticTest()
+    {
+        InitializeComponent();
+        kryptonThemeComboBox1.SelectedIndexChanged += (_, _) => RefreshStatusLabels();
+        kryptonButtonCycle.Click += (_, _) => CycleSelectedIndex();
+        kryptonButtonJumpLow.Click += (_, _) => JumpToRelativeIndex(0.25);
+        kryptonButtonJumpHigh.Click += (_, _) => JumpToRelativeIndex(0.75);
+        kryptonButtonPreHandle.Click += (_, _) => AddComboWithProgrammaticIndexBeforeHost();
+        Load += (_, _) => RefreshStatusLabels();
+    }
+
+    private void RefreshStatusLabels()
+    {
+        object? item = kryptonThemeComboBox1.SelectedItem;
+        kryptonLabelSelection.Values.Text = $"SelectedIndex = {kryptonThemeComboBox1.SelectedIndex}, SelectedItem = {item?.ToString() ?? "(null)"}";
+        kryptonLabelGlobalMode.Values.Text = $"KryptonManager.CurrentGlobalPaletteMode = {KryptonManager.CurrentGlobalPaletteMode}";
+    }
+
+    private void CycleSelectedIndex()
+    {
+        int count = kryptonThemeComboBox1.Items.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        int i = kryptonThemeComboBox1.SelectedIndex;
+        i = i < 0 ? 0 : (i + 1) % count;
+        kryptonThemeComboBox1.SelectedIndex = i;
+    }
+
+    private void JumpToRelativeIndex(double fraction)
+    {
+        int count = kryptonThemeComboBox1.Items.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        int idx = (int)(fraction * (count - 1));
+        idx = Math.Max(0, Math.Min(count - 1, idx));
+        kryptonThemeComboBox1.SelectedIndex = idx;
+    }
+
+    private void AddComboWithProgrammaticIndexBeforeHost()
+    {
+        kryptonPanelHost.Controls.Clear();
+
+        var combo = new Krypton.Toolkit.KryptonThemeComboBox();
+        int count = combo.Items.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        int idx = Math.Min(4, count - 1);
+        combo.SelectedIndex = idx;
+        combo.Dock = DockStyle.Fill;
+        kryptonPanelHost.Controls.Add(combo);
+        kryptonLabelPreHandleResult.Values.Text =
+            $"Added a new {nameof(Krypton.Toolkit.KryptonThemeComboBox)} with SelectedIndex = {idx} before its handle existed; the app theme should match that entry.";
+        RefreshStatusLabels();
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -67,6 +67,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<Bug2914Test>("Bug 2914 Test", "Tests the fix for 2914.");
         CreateButton<Bug2984SeparatorTest>("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.");
         CreateButton<Bug3025KryptonLabelAutoSizeDemo>("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.");
+        CreateButton<Bug3283ThemeComboBoxProgrammaticTest>("Bug 3283 ThemeComboBox programmatic", "Issue #3283: KryptonThemeComboBox must apply the global palette when SelectedIndex is set in code. Buttons cycle or jump the index; status lines show selection vs KryptonManager.CurrentGlobalPaletteMode. Optional: add a fresh combo with index set before its handle exists.");
         CreateButton<Bug2935MdiMultiMonitorDemo>("Bug 2935 MDI multi-monitor", "Demo for issue #2935: maximized MDI child form border drawn on the correct monitor. Move the MDI parent to a second monitor, open and maximize a child; the border should stay on the same monitor.");
         CreateButton<Bug3013TestForm>("Bug 3013 Test", "Tests the fix for 3013.");
         CreateButton<BugReportingDialogTest>("BugReportingTool", "Easily report bugs with this tool.");

--- a/run.cmd
+++ b/run.cmd
@@ -1,4 +1,4 @@
-:: Last updated: Sunday 29th March, 2026 @ 11:00
+:: Last updated: Sunday 19th April, 2026 @ 13:00
 
 @echo off
 
@@ -16,7 +16,7 @@ goto selectvsversion
 :selectvsversion
 cls
 
-@echo Welcome to the Krypton Toolkit Build system, version: 3.1.
+@echo Welcome to the Krypton Toolkit Build system, version: 3.1a.
 @echo Please select the Visual Studio toolset to target.
 echo:
 @echo ==============================================================================================
@@ -189,11 +189,13 @@ goto packmenu
 cls
 
 echo 1. Debug
-echo 2. Go back to main mainmenu
+echo 2. Run TestForm project
+echo 3. Go back to main mainmenu
 echo:
-set /p answer="Enter number (1 - 2): "
+set /p answer="Enter number (1 - 3): "
 if %answer%==1 (goto debug)
-if %answer%==2 (goto mainmenu)
+if %answer%==2 (goto runtestform)
+if %answer%==3 (goto mainmenu)
 
 @echo Invalid input, please try again.
 
@@ -892,3 +894,13 @@ goto webview2tools
 :clearlogfiles
 
 :clearbinaries
+
+:: ===================================================================================================
+
+:runtestform
+
+cls
+
+echo Running TestForm project...
+
+dotnet run --project "Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net11.0-windows


### PR DESCRIPTION
…s changed

# Fix: `KryptonThemeComboBox` applies theme when `SelectedIndex` is set programmatically

Fixes [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283)

## Summary

`KryptonThemeComboBox` now applies the global palette when `SelectedIndex` is changed in code, not only when the user selects an entry from the drop-down. Theme resolution uses the selected list item string (aligned with `KryptonThemeListBox`). The same resolution logic is applied in `KryptonRibbonGroupThemeComboBox` for consistency. TestForm includes a small manual repro launched from the start screen.

## Root cause

`OnSelectedIndexChanged` passed `Text` into `CommonHelperThemeSelectors.OnSelectedIndexChanged` as the theme name. The hosted `KryptonComboBox` uses owner drawing; in that configuration `Text` can be empty or not yet match the selected row when `SelectedIndex` is assigned in code. `ThemeManager.GetThemeManagerMode` then treated the selection as `PaletteMode.Global`, the helper reported failure, and the control reset `SelectedIndex` to the current global palette, so programmatic changes appeared to do nothing.

Separately, when the control had no handle yet, the handler returned early and skipped applying the theme, so code that set `SelectedIndex` before the handle was created never drove the global palette.

## Changes

- **`Krypton.Toolkit` / `KryptonThemeComboBox.cs`**
  - Added `GetSelectedThemeName()` to prefer `SelectedItem` as a non-empty string, falling back to `Text`.
  - Use that value in the deferred `BeginInvoke` path and when `!IsHandleCreated`, so the correct theme is applied and the pre-handle scenario is covered.

- **`Krypton.Ribbon` / `KryptonRibbonGroupThemeComboBox.cs`**
  - Same `GetSelectedThemeName()` pattern when applying the theme from `OnSelectedIndexChanged`, so ribbon-hosted theme selectors stay consistent.

- **`TestForm`**
  - Added `Bug3283ThemeComboBoxProgrammaticTest` (code + designer): instructions, status lines for selection vs `KryptonManager.CurrentGlobalPaletteMode`, buttons to cycle or jump `SelectedIndex`, and an optional action that parents a new `KryptonThemeComboBox` after setting `SelectedIndex` before its handle exists.
  - Registered on **`StartScreen.cs`** as **“Bug 3283 ThemeComboBox programmatic”**.

## Testing

1. Build and run TestForm (`dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj"` or your usual flow).
2. Open the start screen entry **Bug 3283 ThemeComboBox programmatic** (search filter `3283` if needed).
3. Confirm that after **Cycle SelectedIndex (+1)** or **Jump to ~25% / ~75% index**, `KryptonManager.CurrentGlobalPaletteMode` matches the theme implied by the combo’s selected item.
4. Confirm the drop-down still changes the theme when used manually.
5. Optional: use **Add fresh KryptonThemeComboBox (index set before handle)** and confirm the global palette matches the pre-assigned index after the control is shown.

No automated test project exists for this area; validation is manual via TestForm per repository guidelines.

## Risk / compatibility

Behavior change is limited to making programmatic `SelectedIndex` changes match user-driven selection. Public API surface is unchanged. Ribbon theme combo behavior is aligned with the toolkit control.

<img width="679" height="246" alt="image" src="https://github.com/user-attachments/assets/ec05ab36-453b-4d34-9805-289ba5bc0abb" />
