### PR TITLE
* `KryptonThemeComboBox` does not change theme when `SelectedIndex` (…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## Table of Contents
 
+* [2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026](#2026-07-20---build-2607-version-105-lts---patch-3---july-2026)
 * [2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026](#2026-04-20---build-2604-version-105-lts---patch-2---april-2026)
 * [2026-01-19 - Build 2501 (Version 100-LTS - Patch 1) - January 2026](#2026-01-19---build-2501-version-100-lts---patch-1---january-2026)
 * [2025-11-24 - Build 2511 (V100 RTM) - November 2025](#2025-11-24---build-2511-v100-rtm---november-2025)
@@ -41,6 +42,12 @@
 * [2020-03-01 - Build 2003 - March 2020](#2020-03-01---build-2003---march-2020)
 * [2020-02-07 - Build 2002.1 - February 2020 (Update 1)](#2020-02-07---build-20021---february-2020-update-1)
 * [2020-02-01 - Build 2002 - February 2020](#2020-02-01---build-2002---february-2020)
+
+====
+
+ ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
+
+ * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 
 ====
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -94,6 +94,20 @@ public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryp
     #region Implementation
 
     /// <summary>
+    /// Resolves the theme label from the combo's selected list item when possible, so programmatic
+    /// index changes still apply the correct palette (Toolkit #3283).
+    /// </summary>
+    private string GetSelectedThemeName()
+    {
+        if (SelectedIndex > -1 && SelectedItem is string { Length: > 0 } s)
+        {
+            return s;
+        }
+
+        return Text ?? string.Empty;
+    }
+
+    /// <summary>
     /// This method will run when the KryptonManager.GlobalPaletteChanged event is fired.<br/>
     /// It will synchronize the SelectedIndex with the newly assigned Global Palette.
     /// </summary>
@@ -162,7 +176,7 @@ public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryp
     /// <inheritdoc />
     protected override void OnSelectedIndexChanged(EventArgs e)
     {
-        if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, Text, _manager, _kryptonCustomPalette))
+        if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
         {
             //theme change went wrong, make the active theme the selected theme in the list.
             SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -82,6 +82,22 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
     #region Implementation
 
     /// <summary>
+    /// Theme resolution must use the list item string (same approach as <see cref="KryptonThemeListBox"/>).
+    /// For an owner-draw <see cref="KryptonComboBox"/>, <see cref="Control.Text"/> can lag or stay empty when
+    /// <see cref="ComboBox.SelectedIndex"/> is set programmatically, which would otherwise map to
+    /// <see cref="PaletteMode.Global"/> and revert the selection (see #3283).
+    /// </summary>
+    private string GetSelectedThemeName()
+    {
+        if (SelectedIndex > -1 && SelectedItem is string { Length: > 0 } s)
+        {
+            return s;
+        }
+
+        return Text ?? string.Empty;
+    }
+
+    /// <summary>
     /// Routine that will be executed when the control is fully instantiated.
     /// </summary>
     /// <param name="e">EventArgs param. Not used in this implementation.</param>
@@ -95,8 +111,8 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
     /// This method will run when the KryptonManager.GlobalPaletteChanged event is fired.<br/>
     /// It will synchronize the SelectedIndex with the newly assigned Global Palette.
     /// </summary>
-    /// <param name="sender">Object that intiated the call.</param>
-    /// <param name="e">Eventargs object data (not used).</param>
+    /// <param name="sender">Object that initiated the call.</param>
+    /// <param name="e">Event args object data (not used).</param>
     private void KryptonManagerGlobalPaletteChanged(object? sender, EventArgs e)
     {
         if (_isLocalUpdate)
@@ -159,6 +175,10 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
 
         if (!IsHandleCreated)
         {
+            if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
+            {
+                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            }
             base.OnSelectedIndexChanged(e);
             return;
         }
@@ -173,7 +193,7 @@ public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
             ThemeChangeCoordinator.Begin(FindForm());
             try
             {
-                if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, Text, _manager, _kryptonCustomPalette))
+                if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, GetSelectedThemeName(), _manager, _kryptonCustomPalette))
                 {
                     // theme change failed; resync index to current global palette
                     SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);


### PR DESCRIPTION
…V105)

# Fix: `KryptonThemeComboBox` applies theme when `SelectedIndex` is set programmatically

Fixes [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283)

## Summary

`KryptonThemeComboBox` now applies the global palette when `SelectedIndex` is changed in code, not only when the user selects an entry from the drop-down. Theme resolution uses the selected list item string (aligned with `KryptonThemeListBox`). The same resolution logic is applied in `KryptonRibbonGroupThemeComboBox` for consistency. TestForm includes a small manual repro launched from the start screen.

## Root cause

`OnSelectedIndexChanged` passed `Text` into `CommonHelperThemeSelectors.OnSelectedIndexChanged` as the theme name. The hosted `KryptonComboBox` uses owner drawing; in that configuration `Text` can be empty or not yet match the selected row when `SelectedIndex` is assigned in code. `ThemeManager.GetThemeManagerMode` then treated the selection as `PaletteMode.Global`, the helper reported failure, and the control reset `SelectedIndex` to the current global palette, so programmatic changes appeared to do nothing.

Separately, when the control had no handle yet, the handler returned early and skipped applying the theme, so code that set `SelectedIndex` before the handle was created never drove the global palette.

## Changes

- **`Krypton.Toolkit` / `KryptonThemeComboBox.cs`**
  - Added `GetSelectedThemeName()` to prefer `SelectedItem` as a non-empty string, falling back to `Text`.
  - Use that value in the deferred `BeginInvoke` path and when `!IsHandleCreated`, so the correct theme is applied and the pre-handle scenario is covered.

- **`Krypton.Ribbon` / `KryptonRibbonGroupThemeComboBox.cs`**
  - Same `GetSelectedThemeName()` pattern when applying the theme from `OnSelectedIndexChanged`, so ribbon-hosted theme selectors stay consistent.

- **`TestForm`**
  - Added `Bug3283ThemeComboBoxProgrammaticTest` (code + designer): instructions, status lines for selection vs `KryptonManager.CurrentGlobalPaletteMode`, buttons to cycle or jump `SelectedIndex`, and an optional action that parents a new `KryptonThemeComboBox` after setting `SelectedIndex` before its handle exists.
  - Registered on **`StartScreen.cs`** as **“Bug 3283 ThemeComboBox programmatic”**.

## Testing

1. Build and run TestForm (`dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj"` or your usual flow).
2. Open the start screen entry **Bug 3283 ThemeComboBox programmatic** (search filter `3283` if needed).
3. Confirm that after **Cycle SelectedIndex (+1)** or **Jump to ~25% / ~75% index**, `KryptonManager.CurrentGlobalPaletteMode` matches the theme implied by the combo’s selected item.
4. Confirm the drop-down still changes the theme when used manually.
5. Optional: use **Add fresh KryptonThemeComboBox (index set before handle)** and confirm the global palette matches the pre-assigned index after the control is shown.

No automated test project exists for this area; validation is manual via TestForm per repository guidelines.

## Risk / compatibility

Behavior change is limited to making programmatic `SelectedIndex` changes match user-driven selection. Public API surface is unchanged. Ribbon theme combo behavior is aligned with the toolkit control.