### PR TITLE
* `KryptonTextBox`, text flickers when resizing the control (multilin…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
  ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+ * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
  * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 
 ====

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -104,6 +104,9 @@ public class KryptonTextBox : VisualControlBase,
         {
             switch (m.Msg)
             {
+                case PI.WM_.ERASEBKGND:
+                    // Prevent two-stage erase/paint redraw during resize, which causes visible text flicker.
+                    break;
                 case PI.WM_.NCHITTEST:
                     if (_kryptonTextBox.InTransparentDesignMode)
                     {
@@ -135,6 +138,17 @@ public class KryptonTextBox : VisualControlBase,
                 case PI.WM_.PRINTCLIENT:
                 case PI.WM_.PAINT:
                 {
+                    bool hasCueHintText = !string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText);
+                    bool hasUserText = !string.IsNullOrEmpty(_kryptonTextBox.Text);
+
+                    // Use native edit-control painting for the common enabled text path.
+                    // Custom cue-hint/disabled rendering remains below.
+                    if (_kryptonTextBox.Enabled && (!hasCueHintText || hasUserText))
+                    {
+                        base.WndProc(ref m);
+                        break;
+                    }
+
                     var ps = new PI.PAINTSTRUCT();
 
                     // Do we need to BeginPaint or just take the given HDC?
@@ -152,9 +166,7 @@ public class KryptonTextBox : VisualControlBase,
                     Size borderSize = SystemInformation.BorderSize;
                     rect.left -= borderSize.Width + 1;
 
-                    if (!string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText)
-                        && string.IsNullOrEmpty(_kryptonTextBox.Text)
-                       )
+                    if (hasCueHintText && !hasUserText)
                     {
                         // Go perform the drawing of the CueHint
                         using var backBrush = new SolidBrush(BackColor);
@@ -1580,11 +1592,30 @@ public class KryptonTextBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnResize(EventArgs e)
     {
-        // Let base class raise events
-        base.OnResize(e);
+        bool freezeTextBoxRedraw = Multiline && _textBox.IsHandleCreated;
 
-        // We must have a layout calculation
-        ForceControlLayout();
+        if (freezeTextBoxRedraw)
+        {
+            PI.SendMessage(_textBox.Handle, PI.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        try
+        {
+            // Let base class raise events
+            base.OnResize(e);
+
+            // We must have a layout calculation
+            ForceControlLayout();
+        }
+        finally
+        {
+            if (freezeTextBoxRedraw)
+            {
+                PI.SendMessage(_textBox.Handle, PI.SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                _textBox.Invalidate();
+                _textBox.Update();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
…e active) (V105 LTS)

## Summary

- Fixes [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342): reduce multiline `KryptonTextBox` text flicker during resize, especially horizontal resizing.
- Updates `KryptonTextBox.InternalTextBox` painting logic to avoid redundant erase/paint cycles and to use native painting in the common enabled-text path.
- Adds a dedicated TestForm repro/demo (`Bug3342KryptonTextBoxResizeFlickerDemo`) with side-by-side native `TextBox` vs `KryptonTextBox` and stress-resize tooling.

## What Changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs`
  - Suppress `WM_ERASEBKGND` in the internal edit control to avoid two-stage background erase + repaint flicker.
  - Route standard enabled-text painting through native `base.WndProc` for `WM_PAINT`/`WM_PRINTCLIENT`.
  - Keep custom painting only where needed (cue hint rendering and disabled text rendering).
  - During multiline resize (`OnResize`), temporarily disable inner edit redraw (`WM_SETREDRAW`), perform layout, then re-enable redraw and repaint once.

## Why

The remaining flicker was caused by repeated intermediate redraw operations while width changed, combined with unnecessary custom background work in common paint paths. This PR reduces redraw churn and aligns the default enabled multiline path with native edit control behavior.

## Risks / Notes

- Custom cue hint and disabled text rendering paths are preserved.
- Resize redraw suppression is scoped to multiline resize on the inner textbox handle and restored in a `finally` block.