### PR TITLE
* `KryptonLinkLabel` 'Autosize' Not Shrinking (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,10 +45,11 @@
 
 ====
 
- ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
+## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
- * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
- * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
+* Resolved [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365), `KryptonLinkLabel` 'Autosize' Not Shrinking
+* Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
+* Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 
 ====
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
@@ -41,6 +41,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
     private int _decimalPlaces;
     private bool _trailingZeroes;
     private bool _autoSize;
+    private int _cachedWidth;
     private bool _forcedLayout;
     private bool _thousandsSeparator;
     private Padding _contentPadding;
@@ -144,6 +145,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
         _allowDecimals = false;
         _trailingZeroes = true;
         _autoSize = false;
+        _cachedWidth = -1;
         _contentPadding = Padding.Empty;
         _dropDownWidth = 0;
         _popupSide = VisualOrientation.Bottom;
@@ -314,8 +316,18 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
         {
             if (_autoSize != value)
             {
+                CacheCurrentDimensionBeforeAutoSizeEnable(value, Width, ref _cachedWidth);
                 _autoSize = value;
-                UpdateAutoSizing();
+
+                if (_autoSize)
+                {
+                    UpdateAutoSizing();
+                }
+                else if (TryGetCachedDimensionForRestore(_cachedWidth, out int restoredWidth))
+                {
+                    Width = restoredWidth;
+                    PerformNeedPaint(true);
+                }
             }
         }
     }
@@ -1020,6 +1032,11 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
         int width, int height,
         BoundsSpecified specified)
     {
+        if (!_autoSize)
+        {
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Width, width, ref _cachedWidth);
+        }
+
         // Get the preferred size of the entire control
         Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -709,6 +709,7 @@ public class KryptonDomainUpDown : VisualControlBase,
     private bool _alwaysActive;
     private bool _trackingMouseEnter;
     private int _cachedHeight;
+    private int _cachedWidth;
     private bool _autoSize = false;
     private Graphics? _graphics;
     #endregion
@@ -799,6 +800,7 @@ public class KryptonDomainUpDown : VisualControlBase,
         _inputControlStyle = InputControlStyle.Standalone;
         _upDownButtonStyle = ButtonStyle.InputControl;
         _cachedHeight = -1;
+        _cachedWidth = -1;
         _alwaysActive = true;
         _autoSize = false;
         _graphics = null;
@@ -905,8 +907,18 @@ public class KryptonDomainUpDown : VisualControlBase,
         {
             if (_autoSize != value)
             {
+                CacheCurrentDimensionBeforeAutoSizeEnable(value, Width, ref _cachedWidth);
                 _autoSize = value;
-                UpdateAutoSizing();
+
+                if (_autoSize)
+                {
+                    UpdateAutoSizing();
+                }
+                else if (TryGetCachedDimensionForRestore(_cachedWidth, out int restoredWidth))
+                {
+                    Width = restoredWidth;
+                    PerformNeedPaint(true);
+                }
             }
         }
     }
@@ -1698,8 +1710,13 @@ public class KryptonDomainUpDown : VisualControlBase,
         int width, int height,
         BoundsSpecified specified)
     {
+        if (!_autoSize)
+        {
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Width, width, ref _cachedWidth);
+        }
+
         // If setting the actual height
-        if ((specified & BoundsSpecified.Height) == BoundsSpecified.Height)
+        if (IsDimensionSpecified(specified, BoundsSpecified.Height))
         {
             // First time the height is set, remember it
             if (_cachedHeight == -1)
@@ -1712,10 +1729,7 @@ public class KryptonDomainUpDown : VisualControlBase,
         }
 
         // If setting the actual height then cache it for later
-        if ((specified & BoundsSpecified.Height) == BoundsSpecified.Height)
-        {
-            _cachedHeight = height;
-        }
+        CacheDimensionIfSpecified(specified, BoundsSpecified.Height, height, ref _cachedHeight);
 
         base.SetBoundsCore(x, y, width, height, specified);
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -486,35 +486,6 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
     protected override Size DefaultSize => new Size(90, 25);
 
     /// <summary>
-    /// Sets the bounds of the control. When AutoSize is true, force size to the preferred size
-    /// so shrinking/growing tracks content in both runtime and designer update paths.
-    /// </summary>
-    /// <param name="x">The new Left property value of the control.</param>
-    /// <param name="y">The new Top property value of the control.</param>
-    /// <param name="width">The new Width property value of the control.</param>
-    /// <param name="height">The new Height property value of the control.</param>
-    /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
-    protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
-    {
-        if (AutoSize)
-        {
-            Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
-
-            // Keep existing designer safety guard to avoid unstable extreme values
-            // if preferred size cannot be calculated during initialization.
-            if (preferredSize.Width > 0 && preferredSize.Height > 0
-                && preferredSize.Width < 10000 && preferredSize.Height < 10000)
-            {
-                width = preferredSize.Width;
-                height = preferredSize.Height;
-                specified |= BoundsSpecified.Size;
-            }
-        }
-
-        base.SetBoundsCore(x, y, width, height, specified);
-    }
-
-    /// <summary>
     /// Work out if this control needs to paint transparent areas.
     /// </summary>
     /// <returns>True if paint required; otherwise false.</returns>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -486,6 +486,35 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
     protected override Size DefaultSize => new Size(90, 25);
 
     /// <summary>
+    /// Sets the bounds of the control. When AutoSize is true, force size to the preferred size
+    /// so shrinking/growing tracks content in both runtime and designer update paths.
+    /// </summary>
+    /// <param name="x">The new Left property value of the control.</param>
+    /// <param name="y">The new Top property value of the control.</param>
+    /// <param name="width">The new Width property value of the control.</param>
+    /// <param name="height">The new Height property value of the control.</param>
+    /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
+    protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
+    {
+        if (AutoSize)
+        {
+            Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+
+            // Keep existing designer safety guard to avoid unstable extreme values
+            // if preferred size cannot be calculated during initialization.
+            if (preferredSize.Width > 0 && preferredSize.Height > 0
+                && preferredSize.Width < 10000 && preferredSize.Height < 10000)
+            {
+                width = preferredSize.Width;
+                height = preferredSize.Height;
+                specified |= BoundsSpecified.Size;
+            }
+        }
+
+        base.SetBoundsCore(x, y, width, height, specified);
+    }
+
+    /// <summary>
     /// Work out if this control needs to paint transparent areas.
     /// </summary>
     /// <returns>True if paint required; otherwise false.</returns>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1649,18 +1649,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
         // Do we need to prevent the height from being altered?
         if (_autoSize)
         {
-            switch (Dock)
-            {
-                case DockStyle.Fill:
-                case DockStyle.Left:
-                case DockStyle.Right:
-                    if ((specified & ~BoundsSpecified.Height) == specified)
-                    {
-                        _cachedHeight = height;
-                    }
-
-                    break;
-            }
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Height, height, ref _cachedHeight);
 
             // Override the actual height used to the fixed height for single line
             height = PreferredHeight;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -739,6 +739,7 @@ public class KryptonNumericUpDown : VisualControlBase,
     private bool _alwaysActive;
     private bool _trackingMouseEnter;
     private bool _autoSize;
+    private int _cachedWidth;
     private int _cachedHeight;
     private Graphics? _graphics;
 
@@ -831,6 +832,7 @@ public class KryptonNumericUpDown : VisualControlBase,
         _upDownButtonStyle = ButtonStyle.InputControl;
         _alwaysActive = true;
         _autoSize = false;
+        _cachedWidth = -1;
         _cachedHeight = -1;
         _graphics = null;
         AllowButtonSpecToolTips = false;
@@ -934,8 +936,18 @@ public class KryptonNumericUpDown : VisualControlBase,
         {
             if (_autoSize != value)
             {
+                CacheCurrentDimensionBeforeAutoSizeEnable(value, Width, ref _cachedWidth);
                 _autoSize = value;
-                UpdateAutoSizing();
+
+                if (_autoSize)
+                {
+                    UpdateAutoSizing();
+                }
+                else if (TryGetCachedDimensionForRestore(_cachedWidth, out int restoredWidth))
+                {
+                    Width = restoredWidth;
+                    PerformNeedPaint(true);
+                }
             }
         }
     }
@@ -1829,12 +1841,17 @@ public class KryptonNumericUpDown : VisualControlBase,
         int width, int height,
         BoundsSpecified specified)
     {
+        if (!_autoSize)
+        {
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Width, width, ref _cachedWidth);
+        }
+
         // Changed from inline GetPreferredSize() to the same pattern as KryptonComboBox,
         // KryptonDateTimePicker, and KryptonDomainUpDown: cache incoming height on first set,
         // then always override to PreferredHeight (which honours MinimumControlHeight).
         // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/615
         // If setting the actual height
-        if ((specified & BoundsSpecified.Height) == BoundsSpecified.Height)
+        if (IsDimensionSpecified(specified, BoundsSpecified.Height))
         {
             // First time the height is set, remember it
             if (_cachedHeight == -1)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1692,18 +1692,7 @@ public class KryptonTextBox : VisualControlBase,
         // Do we need to prevent the height from being altered?
         if (_autoSize && !Multiline)
         {
-            switch (Dock)
-            {
-                case DockStyle.Fill:
-                case DockStyle.Left:
-                case DockStyle.Right:
-                    if ((specified & ~BoundsSpecified.Height) == specified)
-                    {
-                        _cachedHeight = height;
-                    }
-
-                    break;
-            }
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Height, height, ref _cachedHeight);
 
             // Override the actual height used to the fixed height for single line
             height = PreferredHeight;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -669,6 +669,56 @@ public abstract class VisualControlBase : Control,
         // Every control in chain is visible and enabled, so allow mnemonics
         return true;
     }
+
+    /// <summary>
+    /// Returns true when the provided bounds dimension was explicitly specified.
+    /// </summary>
+    /// <param name="specified">Bounds flags provided by the caller.</param>
+    /// <param name="dimension">Dimension to test.</param>
+    /// <returns>True when the dimension flag is present.</returns>
+    protected static bool IsDimensionSpecified(BoundsSpecified specified, BoundsSpecified dimension) =>
+        (specified & dimension) == dimension;
+
+    /// <summary>
+    /// Caches a dimension when that dimension is explicitly specified.
+    /// </summary>
+    /// <param name="specified">Bounds flags provided by the caller.</param>
+    /// <param name="dimension">Dimension to test.</param>
+    /// <param name="incomingValue">Incoming dimension value.</param>
+    /// <param name="cachedValue">Cached value storage.</param>
+    protected static void CacheDimensionIfSpecified(BoundsSpecified specified, BoundsSpecified dimension, int incomingValue, ref int cachedValue)
+    {
+        if (IsDimensionSpecified(specified, dimension))
+        {
+            cachedValue = incomingValue;
+        }
+    }
+
+    /// <summary>
+    /// Stores the current manual dimension before AutoSize is enabled.
+    /// </summary>
+    /// <param name="autoSizeTargetValue">The AutoSize value being applied.</param>
+    /// <param name="currentDimension">Current control dimension.</param>
+    /// <param name="cachedValue">Cached value storage.</param>
+    protected static void CacheCurrentDimensionBeforeAutoSizeEnable(bool autoSizeTargetValue, int currentDimension, ref int cachedValue)
+    {
+        if (autoSizeTargetValue)
+        {
+            cachedValue = currentDimension;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to return a cached dimension value suitable for restoring.
+    /// </summary>
+    /// <param name="cachedValue">Cached value.</param>
+    /// <param name="restoredValue">Restored value output.</param>
+    /// <returns>True when a valid cached value exists.</returns>
+    protected static bool TryGetCachedDimensionForRestore(int cachedValue, out int restoredValue)
+    {
+        restoredValue = cachedValue;
+        return cachedValue > 0;
+    }
     #endregion
 
     #region Protected Virtual

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -150,7 +150,7 @@ public abstract class VisualSimpleBase : VisualControlBase
     /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
     protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
     {
-        if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
+        if (AutoSize)
         {
             Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
 
@@ -158,8 +158,18 @@ public abstract class VisualSimpleBase : VisualControlBase
             if (preferredSize.Width > 0 && preferredSize.Height > 0
                 && preferredSize.Width < 10000 && preferredSize.Height < 10000)
             {
-                width = preferredSize.Width;
-                height = preferredSize.Height;
+                if (GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
+                {
+                    width = preferredSize.Width;
+                    height = preferredSize.Height;
+                }
+                else
+                {
+                    // GrowOnly semantics: allow growth to preferred size, never force shrink.
+                    width = Math.Max(Width, preferredSize.Width);
+                    height = Math.Max(Height, preferredSize.Height);
+                }
+
                 specified |= BoundsSpecified.Size;
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -91,16 +91,21 @@ public abstract class VisualSimpleBase : VisualControlBase
             retSize.Height += Padding.Vertical;
 #endif
 
-            // For AutoSize with GrowAndShrink, ensure we never return a size smaller than what
-            // the base class would return, to prevent incorrect shrinking behavior.
+            // For AutoSize with GrowAndShrink, use base class size only as fallback when the view
+            // failed to calculate a valid preferred size (e.g. renderer not ready in designer).
+            // Do NOT use it as a floor when we have valid content-based size, or controls with
+            // short text would incorrectly stay at their initial default size instead of shrinking.
             if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
             {
-                // Get what the base class would return (this includes padding handling in .NET)
-                Size baseSize = base.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
-
-                // Ensure our calculated size is at least as large as the base class size
-                retSize.Width = Math.Max(retSize.Width, baseSize.Width);
-                retSize.Height = Math.Max(retSize.Height, baseSize.Height);
+                if (retSize.Width <= 0 || retSize.Height <= 0)
+                {
+                    Size baseSize = base.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+                    if (baseSize.Width > 0 && baseSize.Height > 0)
+                    {
+                        retSize.Width = Math.Max(retSize.Width, baseSize.Width);
+                        retSize.Height = Math.Max(retSize.Height, baseSize.Height);
+                    }
+                }
             }
 
             // Apply the maximum sizing
@@ -132,6 +137,34 @@ public abstract class VisualSimpleBase : VisualControlBase
             // Fall back on default control processing
             return base.GetPreferredSize(proposedSize);
         }
+    }
+
+    /// <summary>
+    /// Sets the bounds of the control. For AutoSize + GrowAndShrink controls, force the size
+    /// to preferred size so shrink/grow behavior tracks content in runtime and designer paths.
+    /// </summary>
+    /// <param name="x">The new Left property value of the control.</param>
+    /// <param name="y">The new Top property value of the control.</param>
+    /// <param name="width">The new Width property value of the control.</param>
+    /// <param name="height">The new Height property value of the control.</param>
+    /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
+    protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
+    {
+        if (AutoSize && GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
+        {
+            Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+
+            // Only apply sensible calculated sizes to avoid unstable initialization values.
+            if (preferredSize.Width > 0 && preferredSize.Height > 0
+                && preferredSize.Width < 10000 && preferredSize.Height < 10000)
+            {
+                width = preferredSize.Width;
+                height = preferredSize.Height;
+                specified |= BoundsSpecified.Size;
+            }
+        }
+
+        base.SetBoundsCore(x, y, width, height, specified);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -153,10 +153,14 @@ public abstract class VisualSimpleBase : VisualControlBase
         if (AutoSize)
         {
             Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Rectangle virtualScreen = SystemInformation.VirtualScreen;
+            int maxSensibleWidth = (int)Math.Min(int.MaxValue, Math.Max(1L, (long)Math.Abs(virtualScreen.Width) * 2L));
+            int maxSensibleHeight = (int)Math.Min(int.MaxValue, Math.Max(1L, (long)Math.Abs(virtualScreen.Height) * 2L));
 
             // Only apply sensible calculated sizes to avoid unstable initialization values.
+            // Use the OS virtual screen size as the baseline instead of a hard-coded pixel limit.
             if (preferredSize.Width > 0 && preferredSize.Height > 0
-                && preferredSize.Width < 10000 && preferredSize.Height < 10000)
+                && preferredSize.Width <= maxSensibleWidth && preferredSize.Height <= maxSensibleHeight)
             {
                 if (GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
                 {


### PR DESCRIPTION
## Summary

- Fixes `KryptonLabel` / `KryptonLinkLabel` autosize shrink regression reported in [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365).
- Updates `KryptonLabel.SetBoundsCore()` to always apply preferred size when `AutoSize` is enabled.
- Prevents the initial designer-assigned `Size` from acting like a hidden minimum when label text becomes shorter.

## Root Cause

`SetBoundsCore()` did not consistently enforce preferred size in all autosize update paths. In affected runtime/designer paths, shrink recalculation could be skipped, so controls returned to their original creation size instead of shrinking to fit content.

## Implementation

- File changed: `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs`
- Reintroduced `SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)` to:
  - compute preferred size whenever `AutoSize` is `true`
  - apply the computed size when valid
  - force size bounds participation with `specified |= BoundsSpecified.Size`
- Existing guardrails for invalid preferred sizes remain to protect designer initialization.
- `KryptonLinkLabel` is fixed via inheritance (`KryptonLinkLabel : KryptonLabel`).

## Test Plan

- [ ] Add a `KryptonLinkLabel` with default `AutoSize=true`.
- [ ] Change text from long to `"a"` and verify it shrinks.
- [ ] Change text from short to long and verify it grows.
- [ ] Repeat with `KryptonLabel`.
- [ ] Confirm `AutoSize=false` labels retain explicit sizes.

## Risk / Compatibility

- Low risk: behavior scoped to autosize sizing path in `KryptonLabel` and inherited `KryptonLinkLabel`.
- No API surface changes. ## Summary

- Fixes `KryptonLabel` / `KryptonLinkLabel` autosize shrink behavior regression reported in [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365).
- Updates `KryptonLabel.SetBoundsCore()` to always apply preferred size when `AutoSize` is enabled, instead of only when `BoundsSpecified.Size` is present.
- Prevents the initial designer-assigned `Size` from acting as an unintended minimum when label text becomes shorter.

## Root Cause

`SetBoundsCore()` only recalculated to preferred size when incoming bounds updates included `BoundsSpecified.Size`. Some autosize update paths (designer/runtime) do not set that flag when content changes, so shrink updates were skipped and the original control size remained as an effective floor.

## Implementation

- File changed: `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs`
- Change made in `SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)`:
  - Apply preferred size whenever `AutoSize` is `true`.
  - Force size update participation with `specified |= BoundsSpecified.Size` after a valid preferred size is computed.
- `KryptonLinkLabel` is fixed via inheritance (`KryptonLinkLabel : KryptonLabel`).

## Test Plan

- [ ] Create a WinForms form with a `KryptonLinkLabel` (default `AutoSize=true`).
- [ ] Set text to a long string, then change it to `"a"`.
- [ ] Verify the control shrinks to content size (does not snap back to the original creation size).
- [ ] Repeat the same validation with `KryptonLabel`.
- [ ] Confirm `AutoSize=false` controls still retain explicitly assigned sizes.

## Risk / Compatibility

- Low risk: change is scoped to autosize bounds handling for `KryptonLabel` and inherited `KryptonLinkLabel`.
- Existing guardrails for invalid preferred sizes remain in place to avoid unstable designer sizing.