### PR TITLE
* Fix backup sync workflow

### DIFF
--- a/.github/workflows/alpha-backup-sync.yml
+++ b/.github/workflows/alpha-backup-sync.yml
@@ -196,7 +196,7 @@ jobs:
           cd backup-repo
           git checkout -b "$branch" 2>/dev/null || git checkout "$branch" 2>/dev/null || true
           mkdir -p "$dir_name"
-          rsync -a --exclude='.git' ../. "$dir_name/"
+          rsync -a --exclude='.git' --exclude='backup-repo' ../. "$dir_name/"
           git add "$dir_name"
           git commit -m "chore: backup alpha to $dir_name (automated)"
           git push origin "$branch"


### PR DESCRIPTION
# Fix backup repo push: exclude `backup-repo` from rsync

## Summary

The “Push alpha to backup repository (dated directory)” step in **Alpha to Alpha-Backup Sync** failed when copying the main checkout into the dated backup folder. The job reported path length errors because `rsync` was including the local `backup-repo` clone in the source tree while the destination directory lives **inside** that clone, which produced self-referential nesting and extremely long paths.

## Root cause

After `cd backup-repo`, the command:

```bash
rsync -a --exclude='.git' ../. "$dir_name/"
```

synced the entire workspace parent (`../`), including the `backup-repo` directory. The target `$dir_name` is created under `backup-repo`, so the source tree contained the same repository tree that was receiving the copy. That led to nested `backup-repo/<dated-dir>/backup-repo/...` structures and filesystem max-path failures (for example, errors mentioning that a filename overflows max path length).

## Change

Add `backup-repo` to the rsync exclude list so the backup snapshot contains only the real repository contents (the checked-out alpha tree), not the transient clone used for the push:

```bash
rsync -a --exclude='.git' --exclude='backup-repo' ../. "$dir_name/"
```

## Testing

- Not run in CI from this branch; validate by running the workflow (or `workflow_dispatch`) with `BACKUP_REPO` and `BACKUP_REPO_TOKEN` configured and confirming the backup step completes and the dated directory contains the expected tree without nested `backup-repo` copies.

## Files

- `.github/workflows/alpha-backup-sync.yml`