### PR TITLE
* `TestForm` build workflow

### DIFF
--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -71,8 +71,10 @@ jobs:
           }
           "@ | Out-File -Encoding utf8 global.json
 
-      - name: Cache NuGet
-        uses: actions/cache@v5
+      - name: Restore NuGet cache
+        id: stable-nuget-cache-restore
+        uses: actions/cache/restore@v4
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-testform-stable-${{ hashFiles('**/*.csproj') }}
@@ -134,6 +136,14 @@ jobs:
       - name: Build TestForm
         run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false
 
+      - name: Save NuGet cache
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.stable-nuget-cache-restore.outputs.cache-primary-key }}
+
   Preview:
     name: Preview
     runs-on: windows-2025-vs2026
@@ -189,8 +199,10 @@ jobs:
           }
           "@ | Out-File -Encoding utf8 global.json
 
-      - name: Cache NuGet
-        uses: actions/cache@v5
+      - name: Restore NuGet cache
+        id: preview-nuget-cache-restore
+        uses: actions/cache/restore@v4
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-testform-preview-${{ hashFiles('**/*.csproj') }}
@@ -251,3 +263,11 @@ jobs:
 
       - name: Build TestForm
         run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false
+
+      - name: Save NuGet cache
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.preview-nuget-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -6,6 +6,11 @@ name: Build TestForm
 permissions:
   contents: read
 
+# When a new .NET preview ships, bump these (e.g. 12.0.x + 12.0) so the Preview job tracks it.
+env:
+  DOTNET_PREVIEW_SETUP_VERSION: '11.0.x'
+  DOTNET_PREVIEW_SDK_BAND: '11.0'
+
 on:
   pull_request:
     branches: ['**']
@@ -21,7 +26,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  testform:
+  Stable:
+    name: Stable
     runs-on: windows-2025-vs2026
     if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')
 
@@ -36,25 +42,31 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Setup .NET 11 (Preview)
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 11.0.x
-          dotnet-quality: preview
-
-      - name: Force .NET 10 SDK via global.json
+      - name: Pin stable SDK via global.json
         shell: pwsh
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            $sdkVersion = (dotnet --list-sdks | Select-String "9.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          $stableLine = dotnet --list-sdks |
+            Where-Object { $_ -match '^10\.0\.[0-9]+\s' } |
+            Select-Object -Last 1
+          $sdkVersion = $null
+          if ($stableLine -match '^(\d+\.\d+\.\d+)\s') {
+            $sdkVersion = $Matches[1]
           }
-          Write-Output "Using SDK $sdkVersion"
+          if (-not $sdkVersion) {
+            $fallback = dotnet --list-sdks | Where-Object { $_ -match '^9\.0\.[0-9]+\s' } | Select-Object -Last 1
+            if ($fallback -match '^(\d+\.\d+\.\d+)\s') { $sdkVersion = $Matches[1] }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'No 10.0.x or 9.0.x SDK found after setup-dotnet.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {
               "version": "$sdkVersion",
-              "rollForward": "latestFeature"
+              "rollForward": "latestPatch",
+              "allowPrerelease": false
             }
           }
           "@ | Out-File -Encoding utf8 global.json
@@ -63,12 +75,81 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-testform-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-testform-stable-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-testform-
+            ${{ runner.os }}-nuget-testform-stable-
             ${{ runner.os }}-nuget-
 
-      # MSBuild (e.g. .NET 11 preview) rejects -c/--configuration when forwarded literally; use -p: instead.
+      - name: Restore TestForm
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
+
+      - name: Build TestForm
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all
+
+  Preview:
+    name: Preview
+    runs-on: windows-2025-vs2026
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Setup .NET (preview band)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_PREVIEW_SETUP_VERSION }}
+          dotnet-quality: preview
+
+      - name: Pin preview SDK via global.json
+        shell: pwsh
+        env:
+          SDK_BAND: ${{ env.DOTNET_PREVIEW_SDK_BAND }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $band = $env:SDK_BAND
+          if (-not $band) {
+            Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set.'
+          }
+          $escaped = [regex]::Escape($band)
+          $pick = dotnet --list-sdks |
+            Where-Object { $_ -match "^$escaped\." } |
+            Select-Object -Last 1
+          if (-not $pick) {
+            Write-Error "No preview SDK found for band '$band'. Check DOTNET_PREVIEW_SETUP_VERSION / DOTNET_PREVIEW_SDK_BAND in the workflow env."
+          }
+          if ($pick -match '^(\S+)\s') {
+            $sdkVersion = $Matches[1]
+          } else {
+            Write-Error "Could not parse SDK version from line: $pick"
+          }
+          Write-Host "Using preview SDK $sdkVersion (band $band)"
+          @"
+          {
+            "sdk": {
+              "version": "$sdkVersion",
+              "rollForward": "latestFeature",
+              "allowPrerelease": true
+            }
+          }
+          "@ | Out-File -Encoding utf8 global.json
+
+      - name: Cache NuGet
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-testform-preview-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-testform-preview-
+            ${{ runner.os }}-nuget-
+
       - name: Restore TestForm
         run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
 

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -68,8 +68,9 @@ jobs:
             ${{ runner.os }}-nuget-testform-
             ${{ runner.os }}-nuget-
 
+      # MSBuild (e.g. .NET 11 preview) rejects -c/--configuration when forwarded literally; use -p: instead.
       - name: Restore TestForm
-        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" --configuration Release -p:TFMs=all
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
 
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" --configuration Release --no-restore -p:TFMs=all
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -69,7 +69,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Restore TestForm
-        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -c Release -p:TFMs=all
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" --configuration Release -p:TFMs=all
 
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -c Release --no-restore -p:TFMs=all
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" --configuration Release --no-restore -p:TFMs=all

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -1,0 +1,75 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+
+name: Build TestForm
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ['**']
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
+      - alpha
+      - canary
+      - gold
+      - V105-LTS
+    paths-ignore: ['.git*', '.vscode']
+  workflow_dispatch:
+
+jobs:
+  testform:
+    runs-on: windows-2025-vs2026
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Setup .NET 11 (Preview)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 11.0.x
+          dotnet-quality: preview
+
+      - name: Force .NET 10 SDK via global.json
+        shell: pwsh
+        run: |
+          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          if (-not $sdkVersion) {
+            $sdkVersion = (dotnet --list-sdks | Select-String "9.0").ToString().Split(" ")[0]
+          }
+          Write-Output "Using SDK $sdkVersion"
+          @"
+          {
+            "sdk": {
+              "version": "$sdkVersion",
+              "rollForward": "latestFeature"
+            }
+          }
+          "@ | Out-File -Encoding utf8 global.json
+
+      - name: Cache NuGet
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-testform-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-testform-
+            ${{ runner.os }}-nuget-
+
+      - name: Restore TestForm
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -c Release -p:TFMs=all
+
+      - name: Build TestForm
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -c Release --no-restore -p:TFMs=all

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -83,8 +83,56 @@ jobs:
       - name: Restore TestForm
         run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
 
+      - name: Validate TestForm linked resources
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
+          $resxFiles = @(
+            Join-Path $projectDir 'Properties\Resources.resx'
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+          )
+
+          $missing = New-Object System.Collections.Generic.List[string]
+          foreach ($resxPath in $resxFiles) {
+            if (-not (Test-Path -LiteralPath $resxPath)) {
+              $missing.Add("Missing .resx file: $resxPath")
+              continue
+            }
+
+            [xml]$resx = Get-Content -LiteralPath $resxPath
+            $resxDir = Split-Path -Parent $resxPath
+
+            foreach ($data in $resx.root.data) {
+              if ($data.type -ne 'System.Resources.ResXFileRef, System.Windows.Forms') {
+                continue
+              }
+
+              $valueText = [string]$data.value
+              if ([string]::IsNullOrWhiteSpace($valueText)) {
+                continue
+              }
+
+              $parts = $valueText.Split(';', 2)
+              $relativePath = $parts[0].Trim()
+              if ([string]::IsNullOrWhiteSpace($relativePath)) {
+                continue
+              }
+
+              $fullPath = [System.IO.Path]::GetFullPath((Join-Path $resxDir $relativePath))
+              if (-not (Test-Path -LiteralPath $fullPath)) {
+                $resourceName = [string]$data.name
+                $missing.Add("$resxPath -> data '$resourceName' references missing file '$fullPath'")
+              }
+            }
+          }
+
+          if ($missing.Count -gt 0) {
+            Write-Error ("Linked resource validation failed:`n" + ($missing -join "`n"))
+          }
+
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false
 
   Preview:
     name: Preview
@@ -153,5 +201,53 @@ jobs:
       - name: Restore TestForm
         run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
 
+      - name: Validate TestForm linked resources
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
+          $resxFiles = @(
+            Join-Path $projectDir 'Properties\Resources.resx'
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+          )
+
+          $missing = New-Object System.Collections.Generic.List[string]
+          foreach ($resxPath in $resxFiles) {
+            if (-not (Test-Path -LiteralPath $resxPath)) {
+              $missing.Add("Missing .resx file: $resxPath")
+              continue
+            }
+
+            [xml]$resx = Get-Content -LiteralPath $resxPath
+            $resxDir = Split-Path -Parent $resxPath
+
+            foreach ($data in $resx.root.data) {
+              if ($data.type -ne 'System.Resources.ResXFileRef, System.Windows.Forms') {
+                continue
+              }
+
+              $valueText = [string]$data.value
+              if ([string]::IsNullOrWhiteSpace($valueText)) {
+                continue
+              }
+
+              $parts = $valueText.Split(';', 2)
+              $relativePath = $parts[0].Trim()
+              if ([string]::IsNullOrWhiteSpace($relativePath)) {
+                continue
+              }
+
+              $fullPath = [System.IO.Path]::GetFullPath((Join-Path $resxDir $relativePath))
+              if (-not (Test-Path -LiteralPath $fullPath)) {
+                $resourceName = [string]$data.name
+                $missing.Add("$resxPath -> data '$resourceName' references missing file '$fullPath'")
+              }
+            }
+          }
+
+          if ($missing.Count -gt 0) {
+            Write-Error ("Linked resource validation failed:`n" + ($missing -join "`n"))
+          }
+
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,9 +83,15 @@
 		</Otherwise>
 	</Choose>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+	<!-- Binary .resx entries (icons/images) require preserialized resources and this package when using the SDK
+	     resource pipeline (see MSB3822/3823). Apply to WinForms multitarget libs, not net10-only. -->
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
+		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Nightly'">
 		<DefineConstants>$(DefineConstants);NIGHTLY</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,16 +83,6 @@
 		</Otherwise>
 	</Choose>
 
-	<!-- Binary .resx entries (icons/images) require preserialized resources and this package when using the SDK
-	     resource pipeline (see MSB3822/3823). Apply to WinForms multitarget libs, not net10-only. -->
-	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
-		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	</PropertyGroup>
-
-	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
-		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
-	</ItemGroup>
-
 	<PropertyGroup Condition="'$(Configuration)' == 'Nightly'">
 		<DefineConstants>$(DefineConstants);NIGHTLY</DefineConstants>
 	</PropertyGroup>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -1,6 +1,16 @@
 <Project>
 	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
 
+	<!-- MSB3822/3823: binary .resx (images/icons) need preserialized GenerateResource + System.Resources.Extensions.
+	     Defined here (not repo root) so it applies after SDK props; all projects under this folder are WinForms SDK. -->
+	<PropertyGroup>
+		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+	</ItemGroup>
+
 	<!--Sets up the language version.-->
 	<!--https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#configure-multiple-projects-->
 	<PropertyGroup>


### PR DESCRIPTION
# Add GitHub Actions workflow: Build TestForm

## Summary

Introduces a dedicated CI workflow that restores and builds `Source/Krypton Components/TestForm/TestForm.csproj` on Windows with the same SDK and `TFMs=all` conventions as the existing Build workflow. This verifies that the TestForm sample and its referenced Krypton projects compile together.

## Motivation

The main PR build runs `Scripts/Build/nightly.proj`, which only builds projects under `Source/Krypton Components/Krypton.*/*.csproj`. **TestForm is not included** in that glob, so regressions in the sample app (or in APIs used only from TestForm) were not caught by CI. Building TestForm explicitly closes that gap.

## Changes

- **New:** `.github/workflows/build-testform.yml`
  - Triggers aligned with `.github/workflows/build.yml` (pull requests, pushes to `master` / `alpha` / `canary` / `gold` / `V105-LTS`, `workflow_dispatch`, same `paths-ignore` on push).
  - Runner: `windows-2025-vs2026`, with the same fork–PR guard as the main Build job.
  - .NET SDK setup (9, 10, 11 preview) and dynamic `global.json` (prefer .NET 10, fallback to 9), consistent with `build.yml`.
  - NuGet package cache.
  - `dotnet restore` / `dotnet build` on TestForm with `-c Release` and `-p:TFMs=all`.

## Not in scope

- No WebView2 populate step (only used on alpha/canary in `build.yml`); can be added later if this job fails without it.
- No MSBuild/nightly.proj integration; this job is intentionally minimal and project-scoped.

## How to validate

1. Push this branch and open a PR (or run **Actions → Build TestForm → Run workflow** after merge).
2. Confirm the **Build TestForm** workflow completes successfully on the target runner.

## Checklist

- [ ] Actions run green on this PR (or on default branch after merge, via `workflow_dispatch`).