### PR TITLE
* Vertical text centering on a rounded-corner `KryptonButton` (V105 LTS)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,9 +83,14 @@
 		</Otherwise>
 	</Choose>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+	<!-- MSB3822/3823: non-string .resx entries need preserialized resources + this package for the SDK GenerateResource task. -->
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
+		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Nightly'">
 		<DefineConstants>$(DefineConstants);NIGHTLY</DefineConstants>

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,10 +45,11 @@
 
 ====
 
- ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
+## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
- * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
- * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
+* Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
+* Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
+* Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 
 ====
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -150,9 +150,23 @@ public abstract class RenderBase : Component,
     /// <param name="state">State associated with rendering.</param>
     /// <param name="orientation">Visual orientation of the border.</param>
     /// <returns>Padding structure detailing all four edges.</returns>
+    public virtual Padding GetBorderDisplayPadding(IPaletteBorder? palette,
+        PaletteState state,
+        VisualOrientation orientation) =>
+        GetBorderDisplayPadding(palette, state, orientation, Size.Empty);
+
+    /// <summary>
+    /// Gets the padding used to position display elements completely inside border drawing.
+    /// </summary>
+    /// <param name="palette">Palette used for drawing.</param>
+    /// <param name="state">State associated with rendering.</param>
+    /// <param name="orientation">Visual orientation of the border.</param>
+    /// <param name="borderOuterSize">Outer size of the bordered area; use <see cref="Size.Empty"/> for legacy behaviour.</param>
+    /// <returns>Padding structure detailing all four edges.</returns>
     public abstract Padding GetBorderDisplayPadding(IPaletteBorder? palette,
         PaletteState state,
-        VisualOrientation orientation);
+        VisualOrientation orientation,
+        Size borderOuterSize);
 
     /// <summary>
     /// Generate a graphics path that is the outside edge of the border.

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
@@ -105,6 +105,20 @@ public interface IRenderBorder
         VisualOrientation orientation);
 
     /// <summary>
+    /// Gets the padding used to position display elements completely inside border drawing,
+    /// clamping corner rounding to fit <paramref name="borderOuterSize"/> the same way as the border path when width and height are greater than zero.
+    /// </summary>
+    /// <param name="palette">Palette used for drawing.</param>
+    /// <param name="state">State associated with rendering.</param>
+    /// <param name="orientation">Visual orientation of the border.</param>
+    /// <param name="borderOuterSize">Outer bounds of the border; use (0,0) for legacy padding from palette rounding alone.</param>
+    /// <returns>Padding structure detailing all four edges.</returns>
+    Padding GetBorderDisplayPadding(IPaletteBorder? palette,
+        PaletteState state,
+        VisualOrientation orientation,
+        Size borderOuterSize);
+
+    /// <summary>
     /// Generate a graphics path that is the outside edge of the border.
     /// </summary>
     /// <param name="context">Rendering context.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMaterial.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMaterial.cs
@@ -63,12 +63,12 @@ public sealed class RenderMaterial : RenderOffice2010
     }
 
     /// <inheritdoc />
-    public override Padding GetBorderDisplayPadding(IPaletteBorder? palette, PaletteState state, VisualOrientation orientation)
+    public override Padding GetBorderDisplayPadding(IPaletteBorder? palette, PaletteState state, VisualOrientation orientation, Size borderOuterSize)
     {
         // Prefer minimal interior insets; fall back to base for overrides or unknowns
         if (CommonHelper.IsOverrideState(state))
         {
-            return base.GetBorderDisplayPadding(palette, state, orientation);
+            return base.GetBorderDisplayPadding(palette, state, orientation, borderOuterSize);
         }
 
         return Padding.Empty;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -476,11 +476,13 @@ public class RenderStandard : RenderBase
 	/// <param name="palette">Palette used for drawing.</param>
 	/// <param name="state">State associated with rendering.</param>
 	/// <param name="orientation">Visual orientation of the border.</param>
+	/// <param name="borderOuterSize">When width and height are positive, corner rounding is clamped to fit these bounds the same way as when building the rounded border path, so layout matches drawing and clipping (GitHub #3381).</param>
 	/// <exception cref="ArgumentNullException"></exception>
 	/// <returns>Padding structure detailing all four edges.</returns>
 	public override Padding GetBorderDisplayPadding(IPaletteBorder? palette,
 		PaletteState state,
-		VisualOrientation orientation)
+		VisualOrientation orientation,
+		Size borderOuterSize)
 	{
 		Debug.Assert(palette != null);
 
@@ -496,10 +498,24 @@ public class RenderStandard : RenderBase
 		if (CommonHelper.HasABorder(borders))
 		{
 			var borderWidth = palette.GetBorderWidth(state);
+			float paletteRounding = palette.GetBorderRounding(state);
+			float roundingForPadding = paletteRounding;
+
+			// Match CreateBorderBackPath: rounding must fit inside the outer rectangle (#3381)
+			if (borderOuterSize.Width > 0 && borderOuterSize.Height > 0)
+			{
+				float maxRounding = Math.Min(borderOuterSize.Width / 2f, borderOuterSize.Height / 2f) - borderWidth;
+				if (maxRounding < 0f)
+				{
+					maxRounding = 0f;
+				}
+
+				roundingForPadding = Math.Min(paletteRounding, maxRounding);
+			}
 
 			// Divide the rounding effect by PI to get the actual pixel distance needed
 			// for offsetting. But add 2, so it starts indenting on a rounding of just 1.
-			int roundPadding = Convert.ToInt16((palette.GetBorderRounding(state) + borderWidth + 2) / Math.PI);
+			int roundPadding = Convert.ToInt16((roundingForPadding + borderWidth + 2) / Math.PI);
 
 			// If not involving rounding then padding for an edge is just the border width
 			var squarePadding = borderWidth;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -391,7 +391,8 @@ public class ViewDrawCanvas : ViewComposite
             DrawTabBorder
                 ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, _paletteBorder!, State, Orientation,
                     TabBorderStyle)
-                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation));
+                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation,
+                    context.DisplayRectangle.Size));
 
         // Do we have a metric source for additional padding?
         if (_paletteMetric != null)
@@ -440,7 +441,8 @@ public class ViewDrawCanvas : ViewComposite
         Padding padding = DrawTabBorder
             ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, _paletteBorder!, State,
                 Orientation, TabBorderStyle)
-            : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation);
+            : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation,
+                ClientRectangle.Size);
 
         // Apply the padding to the client rectangle
         context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, padding);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
@@ -339,11 +339,11 @@ public class ViewDrawDocker : ViewDrawCanvas
             // Apply space the border takes up
             if (IgnoreBorderSpace)
             {
-                borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation));
+                borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation, originalRect.Size));
             }
             else
             {
-                var padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation);
+                var padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder!, State, Orientation, originalRect.Size);
                 preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                 displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
             }
@@ -408,11 +408,11 @@ public class ViewDrawDocker : ViewDrawCanvas
             // Apply space the border takes up
             if (IgnoreBorderSpace)
             {
-                borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation));
+                borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size));
             }
             else
             {
-                var padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation);
+                var padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size);
                 preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                 displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
             }
@@ -629,7 +629,7 @@ public class ViewDrawDocker : ViewDrawCanvas
             var borderWidth = _paletteBorder!.GetBorderWidth(State);
 
             // Update padding to reflect the orientation we are using
-            padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation);
+            padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, ClientRectangle.Size);
             padding = CommonHelper.OrientatePadding(Orientation, padding);
 
             // If docking content extends beyond the border rounding effects then we can adjust 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -416,7 +416,8 @@ public class ViewDrawSplitCanvas : ViewComposite
             DrawTabBorder
                 ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, PaletteBorder!, State, Orientation,
                     TabBorderStyle)
-                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder!, State, Orientation));
+                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder!, State, Orientation,
+                    context.DisplayRectangle.Size));
 
         // Do we have a metric source for additional padding?
         if (PaletteMetric != null && _metricPadding != PaletteMetricPadding.None)
@@ -465,7 +466,8 @@ public class ViewDrawSplitCanvas : ViewComposite
         var padding = DrawTabBorder
             ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, PaletteBorder!, State,
                 Orientation, TabBorderStyle)
-            : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder!, State, Orientation);
+            : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder!, State, Orientation,
+                ClientRectangle.Size);
 
         // Apply the padding to the client rectangle
         context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, padding);

--- a/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs
@@ -1,0 +1,238 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class Bug3381KryptonButtonRoundedTextCenteringDemo
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support — do not modify the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            _lblIntro = new KryptonWrapLabel();
+            _root = new TableLayoutPanel();
+            SuspendLayout();
+            _root.SuspendLayout();
+            //
+            // _lblIntro
+            //
+            _lblIntro.Dock = DockStyle.Top;
+            _lblIntro.AutoSize = false;
+            _lblIntro.Padding = new Padding(0, 0, 0, 8);
+            _lblIntro.Height = 120;
+            _lblIntro.Text =
+                @"GitHub issue #3381: With large StateCommon.Border.Rounding compared to button height, short text should stay visually centered (horizontal and vertical) inside the pill shape." + Environment.NewLine +
+                @"What to check: Cyrillic + large font on a wide short bar; tall narrow capsule; low rounding baseline; then use the live controls to sweep rounding, vertical alignment, font size, and button height. Resize the form — layout should track the border path, not the uncapped palette rounding value.";
+            //
+            // _root
+            //
+            _root.Dock = DockStyle.Fill;
+            _root.Padding = new Padding(12, 0, 12, 12);
+            _root.AutoSize = false;
+            _root.ColumnCount = 1;
+            _root.Margin = new Padding(0);
+            _root.Name = "tableLayoutRoot";
+
+            int row = 0;
+            void AddRow(RowStyle style, Control c)
+            {
+                _root.RowStyles.Add(style);
+                _root.Controls.Add(c, 0, row++);
+            }
+
+            AddRow(new RowStyle(SizeType.AutoSize), NewSectionHeader(@"1) Wide × short — matches reporter setup (large rounding vs height)"));
+            var btnWideIssueShape = CreatePillButton(@"Начать", 40f, 100f);
+            AddRow(new RowStyle(SizeType.Absolute, 102), NewFillPanel(102, btnWideIssueShape));
+
+            AddRow(new RowStyle(SizeType.AutoSize), NewSectionHeader(@"2) Two equal-height bars — different font sizes (metrics stress)"));
+            var tlpPair = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2,
+                RowCount = 1,
+                Margin = new Padding(0)
+            };
+            tlpPair.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+            tlpPair.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+            tlpPair.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+            var btnSideBySideLeft = CreatePillButton(@"Start — 22pt", 22f, 100f);
+            var btnSideBySideRight = CreatePillButton(@"Начать — 40pt", 40f, 100f);
+            tlpPair.Controls.Add(NewFillPanel(86, btnSideBySideLeft), 0, 0);
+            tlpPair.Controls.Add(NewFillPanel(86, btnSideBySideRight), 1, 0);
+            AddRow(new RowStyle(SizeType.Absolute, 86), tlpPair);
+
+            AddRow(new RowStyle(SizeType.AutoSize), NewSectionHeader(@"3) Tall narrow capsule (rounding clamped by width)"));
+            var btnTallNarrow = CreatePillButton(@"OK", 28f, 72f);
+            var tlpTall = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                Height = 200,
+                ColumnCount = 3,
+                RowCount = 1,
+                Margin = new Padding(0)
+            };
+            tlpTall.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+            tlpTall.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 140f));
+            tlpTall.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+            tlpTall.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+            tlpTall.Controls.Add(new Panel { Dock = DockStyle.Fill, Margin = new Padding(0) }, 0, 0);
+            tlpTall.Controls.Add(btnTallNarrow, 1, 0);
+            btnTallNarrow.Dock = DockStyle.Fill;
+            tlpTall.Controls.Add(new Panel { Dock = DockStyle.Fill, Margin = new Padding(0) }, 2, 0);
+            AddRow(new RowStyle(SizeType.Absolute, 200), tlpTall);
+
+            AddRow(new RowStyle(SizeType.AutoSize), NewSectionHeader(@"4) Low rounding baseline (rounding ≈ 4)"));
+            var btnLowRounding = CreatePillButton(@"Centered reference", 18f, 4f);
+            AddRow(new RowStyle(SizeType.Absolute, 52), NewFillPanel(52, btnLowRounding));
+
+            AddRow(new RowStyle(SizeType.AutoSize), NewSectionHeader(@"5) Live — rounding, TextV, font size, button height"));
+            _btnLive = CreatePillButton(@"Live preview", 36f, 100f);
+            var liveHost = BuildLiveSectionPanel();
+            AddRow(new RowStyle(SizeType.Percent, 100f), liveHost);
+
+            var body = new Panel { Dock = DockStyle.Fill, Margin = new Padding(0) };
+            body.Controls.Add(_root);
+            body.Controls.Add(_lblIntro);
+
+            Controls.Add(body);
+            _lblIntro.BringToFront();
+            //
+            // Bug3381KryptonButtonRoundedTextCenteringDemo
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(980, 760);
+            MinimumSize = new Size(720, 620);
+            Name = "Bug3381KryptonButtonRoundedTextCenteringDemo";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = @"Bug #3381 — KryptonButton rounded corners + text centering";
+            _root.ResumeLayout(false);
+            ResumeLayout(false);
+        }
+
+        private Panel BuildLiveSectionPanel()
+        {
+            var wrap = new Panel { Dock = DockStyle.Fill, Margin = new Padding(0) };
+
+            _trackRounding = new TrackBar
+            {
+                Minimum = 0,
+                Maximum = 120,
+                TickFrequency = 10,
+                SmallChange = 2,
+                LargeChange = 10,
+                Value = 100,
+                Width = 360,
+                Height = 42,
+                Margin = new Padding(12, 4, 0, 0)
+            };
+            _lblRoundingValue = new Label
+            {
+                AutoSize = true,
+                Text = @"Rounding: 100",
+                Margin = new Padding(0, 10, 0, 0)
+            };
+            _trackRounding.ValueChanged += OnTrackRoundingValueChanged;
+
+            _cmbTextV = new ComboBox
+            {
+                DropDownStyle = ComboBoxStyle.DropDownList,
+                Width = 200,
+                Margin = new Padding(12, 4, 0, 0)
+            };
+            _cmbTextV.Items.AddRange(new object[] { @"TextV: Center", @"TextV: Near (top)", @"TextV: Far (bottom)" });
+            _cmbTextV.SelectedIndex = 0;
+            _cmbTextV.SelectedIndexChanged += OnCmbTextVSelectedIndexChanged;
+
+            _nudFontSize = new NumericUpDown
+            {
+                Minimum = 10,
+                Maximum = 96,
+                Value = 36,
+                Width = 72,
+                Margin = new Padding(8, 4, 0, 0)
+            };
+            _nudFontSize.ValueChanged += OnNudFontSizeValueChanged;
+
+            _nudLiveHeight = new NumericUpDown
+            {
+                Minimum = 48,
+                Maximum = 220,
+                Value = 96,
+                Width = 72,
+                Margin = new Padding(8, 4, 0, 0)
+            };
+            _nudLiveHeight.ValueChanged += OnNudLiveHeightValueChanged;
+
+            var topFlow = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                AutoSize = true,
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = true,
+                Padding = new Padding(0, 0, 0, 8)
+            };
+            topFlow.Controls.Add(_lblRoundingValue);
+            topFlow.Controls.Add(_trackRounding);
+            topFlow.Controls.Add(_cmbTextV);
+            topFlow.Controls.Add(new Label { AutoSize = true, Text = @"Font (pt):", Margin = new Padding(12, 10, 0, 0) });
+            topFlow.Controls.Add(_nudFontSize);
+            topFlow.Controls.Add(new Label { AutoSize = true, Text = @"Btn height:", Margin = new Padding(12, 10, 0, 0) });
+            topFlow.Controls.Add(_nudLiveHeight);
+
+            _pLiveButtonHost = new Panel
+            {
+                Dock = DockStyle.Top,
+                Height = 96,
+                Margin = new Padding(0)
+            };
+            _pLiveButtonHost.Controls.Add(_btnLive);
+            _btnLive.Dock = DockStyle.Fill;
+
+            wrap.Controls.Add(_pLiveButtonHost);
+            wrap.Controls.Add(topFlow);
+
+            return wrap;
+        }
+
+        #endregion
+
+        private KryptonWrapLabel _lblIntro;
+        private TableLayoutPanel _root;
+        private KryptonButton _btnLive;
+        private TrackBar _trackRounding;
+        private Label _lblRoundingValue;
+        private ComboBox _cmbTextV;
+        private NumericUpDown _nudFontSize;
+        private NumericUpDown _nudLiveHeight;
+        private Panel _pLiveButtonHost;
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.cs
@@ -1,0 +1,122 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Manual demo for GitHub #3381: vertical text alignment on <see cref="KryptonButton"/> with large corner rounding
+/// relative to control height (wide pill bar, large font, centered text).
+/// </summary>
+public partial class Bug3381KryptonButtonRoundedTextCenteringDemo : KryptonForm
+{
+    public Bug3381KryptonButtonRoundedTextCenteringDemo()
+    {
+        InitializeComponent();
+    }
+
+    private static Control NewSectionHeader(string text) =>
+        new KryptonLabel
+        {
+            Text = text,
+            Margin = new Padding(0, 12, 0, 4),
+            AutoSize = true
+        };
+
+    private static Panel NewFillPanel(int height, Control inner)
+    {
+        var p = new Panel { Height = height, Dock = DockStyle.Fill, Margin = new Padding(0) };
+        p.Controls.Add(inner);
+        inner.Dock = DockStyle.Fill;
+        return p;
+    }
+
+    private void OnTrackRoundingValueChanged(object? sender, EventArgs e)
+    {
+        float v = _trackRounding.Value;
+        _lblRoundingValue.Text = string.Format(CultureInfo.InvariantCulture, @"Rounding: {0:0}", v);
+        ApplyRounding(_btnLive, v);
+        RequestLiveRelayout();
+    }
+
+    private void OnCmbTextVSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        PaletteRelativeAlign align = _cmbTextV.SelectedIndex switch
+        {
+            1 => PaletteRelativeAlign.Near,
+            2 => PaletteRelativeAlign.Far,
+            _ => PaletteRelativeAlign.Center
+        };
+        _btnLive.StateCommon.Content.ShortText.TextV = align;
+        RequestLiveRelayout();
+    }
+
+    private void OnNudFontSizeValueChanged(object? sender, EventArgs e)
+    {
+        float pt = (float)_nudFontSize.Value;
+        string familyName = _btnLive.StateCommon.Content.ShortText.Font?.FontFamily?.Name ?? FontFamily.GenericSansSerif.Name;
+        _btnLive.StateCommon.Content.ShortText.Font = new Font(familyName, pt, FontStyle.Regular, GraphicsUnit.Point);
+        RequestLiveRelayout();
+    }
+
+    private void OnNudLiveHeightValueChanged(object? sender, EventArgs e)
+    {
+        int h = (int)_nudLiveHeight.Value;
+        _pLiveButtonHost.Height = Math.Max(48, h);
+        RequestLiveRelayout();
+    }
+
+    private void RequestLiveRelayout()
+    {
+        _btnLive.Invalidate(true);
+        _root.PerformLayout();
+    }
+
+    private static KryptonButton CreatePillButton(string text, float fontSizePt, float rounding)
+    {
+        var b = new KryptonButton
+        {
+            Values = { Text = text },
+            AutoSize = false
+        };
+        StylePillSurface(b);
+        b.StateCommon.Content.ShortText.Font = new Font(@"Segoe UI", fontSizePt, FontStyle.Regular, GraphicsUnit.Point);
+        b.StateCommon.Content.ShortText.TextH = PaletteRelativeAlign.Center;
+        b.StateCommon.Content.ShortText.TextV = PaletteRelativeAlign.Center;
+        b.StateCommon.Content.ShortText.Hint = PaletteTextHint.AntiAlias;
+        ApplyRounding(b, rounding);
+        return b;
+    }
+
+    private static void StylePillSurface(KryptonButton b)
+    {
+        Color fill = Color.YellowGreen;
+        Color edge = Color.YellowGreen;
+        b.StateCommon.Back.Color1 = fill;
+        b.StateCommon.Back.Color2 = fill;
+        b.StateCommon.Border.Color1 = edge;
+        b.StateCommon.Border.DrawBorders = PaletteDrawBorders.All;
+        b.StateCommon.Border.Width = 2;
+        b.StateCommon.Content.ShortText.Color1 = Color.White;
+        b.OverrideDefault.Back.Color1 = fill;
+        b.OverrideDefault.Back.Color2 = fill;
+        b.OverrideDefault.Border.Color1 = edge;
+        b.OverrideDefault.Border.DrawBorders = PaletteDrawBorders.All;
+    }
+
+    private static void ApplyRounding(KryptonButton b, float rounding)
+    {
+        b.StateCommon.Border.Rounding = rounding;
+    }
+
+    protected override void OnLoad(EventArgs e)
+    {
+        base.OnLoad(e);
+        OnNudLiveHeightValueChanged(null, EventArgs.Empty);
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.resx
+++ b/Source/Krypton Components/TestForm/Bug3381KryptonButtonRoundedTextCenteringDemo.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -58,6 +58,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
+        CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
         CreateButton<ControlStylesForm>("Control Styles", string.Empty);
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -47,9 +47,18 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="Bug3381KryptonButtonRoundedTextCenteringDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs">
+      <DependentUpon>Bug3381KryptonButtonRoundedTextCenteringDemo.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Bug3381KryptonButtonRoundedTextCenteringDemo.resx">
+      <DependentUpon>Bug3381KryptonButtonRoundedTextCenteringDemo.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Update="KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>KryptonTaskDialogDemoResources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
# Fix vertical text centering on rounded `KryptonButton` (#3381)

## Summary

Fixes incorrect vertical (and overall) text alignment on `KryptonButton` when `StateCommon.Border.Rounding` is large relative to the control’s height—typical for wide “pill” buttons with centered short text and large fonts. Adds a **TestForm** repro and designer assets for ongoing verification.

**Closes:** [Issue #3381 — Vertical text centering on a rounded-corner `KryptonButton`](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381)

---

## Problem

`RenderStandard.GetBorderDisplayPadding` computed layout insets from the **palette** rounding value (`GetBorderRounding`) using the existing \(\pi\)-based heuristic, but the **drawn** border path (and child clip region in `ViewDrawSplitCanvas`) clamps rounding to what fits in the rectangle:

text{effectiveRounding} = min(text{paletteRounding}, min(w/2,\ h/2) - text{borderWidth})

When the palette requested a much larger rounding than the path (e.g. very wide, short button with `Rounding = 100`), the **content layout rectangle** no longer matched the **true interior** of the rounded shape. Text stayed “centered” in the wrong box, which reads as text drifting downward (or generally misaligned), especially with large fonts and Cyrillic sample text as in the report.

---

## Solution

1. **Border display padding**
   - Extended `IRenderBorder` / `RenderBase` with an overload `GetBorderDisplayPadding(IPaletteBorder? palette, PaletteState state, VisualOrientation orientation, Size borderOuterSize)`.
   - When `borderOuterSize.Width` and `Height` are both greater than zero, the rounding fed into the padding heuristic is **clamped** with the same rule as `CreateBorderBackPath`, so layout matches drawing and clipping.
   - The original three-argument overload remains as a **virtual** forwarder to `borderOuterSize: Size.Empty` (legacy behaviour where outer bounds are unknown).

2. **Call sites** Canvas / docker views that know the outer client size now pass it into the four-argument overload: `ViewDrawSplitCanvas`, `ViewDrawCanvas`, `ViewDrawDocker` (layout and non-child sizing paths).

3. **`RenderMaterial`** Overrides the four-argument overload and delegates to the base implementation for override states (same rules as before).

4. **Test harness**
   - `Bug3381KryptonButtonRoundedTextCenteringDemo` (`.cs`, `.Designer.cs`, `.resx`) with scenarios from the issue plus live controls (rounding slider, `TextV`, font size, button height).
   - Registered on `StartScreen`.
   - `TestForm.csproj`: `SubType` / `DependentUpon` for Solution Explorer nesting.

---

## API / compatibility

| Area | Note |
|------|------|
| **`IRenderBorder`** | New member; **third-party implementations** of `IRenderBorder` must implement the four-argument overload. | | **In-repo renderers** | All derive from `RenderBase` / `RenderStandard`; covered by the change. | | **Behaviour** | Three-argument call path unchanged (equivalent to empty outer size). |

---

## Files changed (reference)

**Krypton.Toolkit**

- `Rendering/RenderDefinitions.cs` — interface overload
- `Rendering/RenderBase.cs` — virtual 3-arg + abstract 4-arg
- `Rendering/RenderStandard.cs` — clamp rounding when outer size provided
- `Rendering/RenderMaterial.cs` — 4-arg override
- `View Draw/ViewDrawSplitCanvas.cs` — pass outer size
- `View Draw/ViewDrawCanvas.cs` — pass outer size
- `View Draw/ViewDrawDocker.cs` — pass outer size

**TestForm**

- `Bug3381KryptonButtonRoundedTextCenteringDemo.cs`
- `Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs`
- `Bug3381KryptonButtonRoundedTextCenteringDemo.resx`
- `StartScreen.cs` — launcher entry
- `TestForm.csproj` — form subtype and `DependentUpon`

**Changelog**

- If this PR lands separately from other work, ensure `Documents/Changelog/Changelog.md` includes a line for **#3381** under the appropriate build section (an entry may already exist under V110 nightly—avoid duplicates).

---

## How to test (manual)

1. Build and run TestForm: `dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj" -c Debug`
2. Open **Bug 3381 KryptonButton Rounded Text Centering** from the start list (filter: `3381`).
3. Confirm:
   - Wide short bar with **Начать** / large rounding: text visually centered in the pill.
   - Side-by-side bars: both centered; different font sizes do not skew vertical centering incorrectly.
   - Tall narrow capsule: centered.
   - Low rounding row: baseline.
   - **Live** section: sweep rounding 0–120, `TextV`, font size, and button height; resize the form; no progressive vertical drift vs. the green pill interior.
4. Optional: reproduce the original designer-style scenario (dock fill, large `Rounding`, large font) in a real form and confirm alignment.

---

## Screenshots

_Add before/after screenshots or a short GIF of the TestForm demo (wide pill + live slider) for the PR thread._

---

## Checklist

- [x] Fix aligns layout padding with border path rounding when bounds are known
- [x] Legacy 3-arg `GetBorderDisplayPadding` preserved
- [x] TestForm demo + designer/resx + start screen entry

---

## Suggested commit / PR titles

- `Fix KryptonButton text centering with large border rounding (#3381)`
- `3381 Align border display padding with clamped rounding; add TestForm demo`