### PR TITLE
* `Krypton.Standard.Toolkit` NuGet package does not contain all binaries

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377), `Krypton.Standard.Toolkit` NuGet package does not contain all binaries
 * Resolved [#3164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3164), Font properties with no explicit value were not correctly serialized/deserialized in exported XML
 * Resolved [#3183](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3183), Small square rendered next to Close button on KryptonForm when using a custom theme
 * Implemented [#908](https://github.com/Krypton-Suite/Standard-Toolkit/issues/908), Create new items via 'New Item/Project'

--- a/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
+++ b/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
@@ -181,8 +181,9 @@
 		  This mapping is required because NuGet packages use a specific version string format for .NET Core/5+ Windows TFMs
 		  Example: net10.0-windows -> net10.0-windows7.0 in the package lib folder
 	
-		The files are located in: Bin\$(Configuration)\$(TargetFramework)\
-		And are placed in the package at: lib\$(_LibFolderName)\
+		Primary lookup: $(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\ (shared output from Directory.Build.targets).
+		Legacy fallback: each project's bin\$(Configuration)\$(TargetFramework)\ when the central folder has no copy.
+		Package layout: lib\$(_LibFolderName)\
 	
 		All files are conditionally included only if they exist, ensuring the build succeeds even if some files are missing.
 	-->
@@ -196,57 +197,59 @@
 			<_LibFolderName Condition="'$(TargetFramework)' == 'net11.0-windows'">net11.0-windows7.0</_LibFolderName>
 			<!-- For .NET Framework TFMs, use the TFM as-is -->
 			<_LibFolderName Condition="'$(_LibFolderName)' == ''">$(TargetFramework)</_LibFolderName>
+			<!-- Directory.Build.targets: shared Bin\ or artifacts\bin\ (see KryptonBuildOutputRoot). Prefer this over per-project bin\ so pack never picks stale partial outputs. -->
+			<_KryptonPackLibDir>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</_KryptonPackLibDir>
 		</PropertyGroup>
 
 		<!-- Include referenced DLL files for all referenced projects -->
 		<ItemGroup>
 			<!-- Include DLL files -->
-			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.dll" Condition="Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Docking.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Docking.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Docking.dll" Condition="!Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Docking.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Docking.dll') And Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll" Condition="Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Navigator.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll" Condition="!Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Navigator.dll') And Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll" Condition="Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.Utilities.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll" Condition="!Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.dll') And Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll" Condition="Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Ribbon.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Ribbon.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll" Condition="!Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Ribbon.dll') And Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll" Condition="Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Toolkit.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll" Condition="!Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Toolkit.dll') And Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll" Condition="Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll" Condition="!Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.dll') And Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll" Condition="Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Utilities.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Utilities.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll" Condition="!Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Utilities.dll') And Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll" Condition="Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Workspace.dll" Condition="Exists('$(_KryptonPackLibDir)Krypton.Workspace.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll" Condition="!Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll')">
+			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Workspace.dll') And Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.dll')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
 
@@ -268,78 +271,102 @@
 			</TfmSpecificPackageFile>
 
 			<!-- Include XML documentation files for IntelliSense support -->
-			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.xml" Condition="Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Docking.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Docking.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Docking.xml" Condition="!Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Docking.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Docking.xml') And Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml" Condition="Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Navigator.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml" Condition="!Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Navigator.xml') And Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml" Condition="Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.Utilities.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml" Condition="!Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.xml') And Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml" Condition="Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Ribbon.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Ribbon.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml" Condition="!Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Ribbon.xml') And Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml" Condition="Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Toolkit.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml" Condition="!Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Toolkit.xml') And Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml" Condition="Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml" Condition="!Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.xml') And Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml" Condition="Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Utilities.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Utilities.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml" Condition="!Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Utilities.xml') And Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml" Condition="Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Workspace.xml" Condition="Exists('$(_KryptonPackLibDir)Krypton.Workspace.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml" Condition="!Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml') And Exists('$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml')">
+			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml" Condition="!Exists('$(_KryptonPackLibDir)Krypton.Workspace.xml') And Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.xml')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
 
 			<!-- Include PDB symbol files (only when IncludeSymbols is true, e.g., for Nightly/Canary configurations) -->
-			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.pdb')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Docking.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Docking.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.pdb')">
+			<TfmSpecificPackageFile Include="..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Docking.pdb') And Exists('..\Krypton.Docking\bin\$(Configuration)\$(TargetFramework)\Krypton.Docking.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.pdb')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Navigator.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.pdb')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Navigator.pdb') And Exists('..\Krypton.Navigator\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.pdb')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Navigator.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.pdb')">
+			<TfmSpecificPackageFile Include="..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Navigator.Utilities.pdb') And Exists('..\Krypton.Navigator.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Navigator.Utilities.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.pdb')">
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Ribbon.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Ribbon.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
-			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.pdb')">
+			<TfmSpecificPackageFile Include="..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Ribbon.pdb') And Exists('..\Krypton.Ribbon\bin\$(Configuration)\$(TargetFramework)\Krypton.Ribbon.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Toolkit.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Toolkit.pdb') And Exists('..\Krypton.Toolkit\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Toolkit.JumpList.pdb') And Exists('..\Krypton.Toolkit.JumpList\bin\$(Configuration)\$(TargetFramework)\Krypton.Toolkit.JumpList.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Utilities.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Utilities.pdb') And Exists('..\Krypton.Utilities\bin\$(Configuration)\$(TargetFramework)\Krypton.Utilities.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(_KryptonPackLibDir)Krypton.Workspace.pdb" Condition="'$(IncludeSymbols)' == 'true' And Exists('$(_KryptonPackLibDir)Krypton.Workspace.pdb')">
+				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.pdb" Condition="'$(IncludeSymbols)' == 'true' And !Exists('$(_KryptonPackLibDir)Krypton.Workspace.pdb') And Exists('..\Krypton.Workspace\bin\$(Configuration)\$(TargetFramework)\Krypton.Workspace.pdb')">
 				<PackagePath>lib\$(_LibFolderName)\</PackagePath>
 			</TfmSpecificPackageFile>
 


### PR DESCRIPTION
# Fix `Krypton.Standard.Toolkit` NuGet pack picking wrong assembly paths

## Summary

Resolves packaging for the aggregate `Krypton.Standard.Toolkit` package so Pack consistently includes the full set of binaries (and matching documentation and symbols) from the **shared build output** used by `Directory.Build.targets`, instead of stale or partial copies under each project’s `bin\` folder.

Fixes [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377).

## Problem

The published `Krypton.Standard.Toolkit` package could be far smaller than expected (for example on the order of ~1.5 MB instead of tens of MB), with `lib\` missing most assemblies across target frameworks. Consumers effectively got metadata and ancillary files without the bundled toolkit DLLs.

## Root cause

The `AddReferencedAssembliesToPackage` target in `Krypton.Standard.Toolkit.csproj` resolved referenced assemblies in this order:

1. `..\Krypton.<Project>\bin\$(Configuration)\$(TargetFramework)\*.dll` (and the same for `.xml` / `.pdb`)
2. Only if those paths were missing: `$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\` (i.e. repo `Bin\…` or `artifacts\bin\…` when `UseArtifactsOutput=true`, as used in CI per [#998](https://github.com/Krypton-Suite/Standard-Toolkit/issues/998))

Actual builds place outputs under `KryptonBuildOutputRoot` via `Source/Krypton Components/Directory.Build.targets`. If anything left **existing** files under legacy `bin\…` (partial build, older layout, IDE artifacts), Pack preferred those first. That could pull an incomplete or wrong set of files while ignoring the correct centralized outputs, producing an under-filled package.

## Solution

- Introduce `_KryptonPackLibDir` as `$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\`.
- For every bundled **DLL**, **XML doc**, and **PDB** (when `IncludeSymbols` is true), **prefer `$(_KryptonPackLibDir)` first**, then fall back to `..\…\bin\…` only when the central path has no file.
- Update the target comment block to describe primary vs legacy lookup.

No change to package identity, dependency suppression, or `lib\` TFM folder naming (`net*.0-windows7.0`, etc.).

## Files changed

| Path | Change |
|------|--------|
| `Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj` | Reorder `TfmSpecificPackageFile` conditions; add `_KryptonPackLibDir`; document lookup order |

## How to verify

1. Run a full pack the same way CI does (for example `Scripts/Build/build.proj` with `/t:Pack` and `/p:UseArtifactsOutput=true` and the intended `Configuration` / `TFMs`).
2. Inspect the produced `Krypton.Standard.Toolkit.*.nupkg` (rename to `.zip` or use NuGet Package Explorer):
   - Under `lib\`, each expected TFM folder should contain the Krypton module DLLs (Docking, Navigator, Navigator.Utilities, Ribbon, Toolkit, Toolkit.JumpList, Utilities, Workspace) plus matching `.xml` where generated.
   - For Canary/Nightly symbol builds, confirm `.pdb` files appear beside those assemblies when symbols are enabled.
3. Optional: leave stale DLLs under one project’s `bin\Release\<tfm>\` and confirm Pack still picks the full set from `Bin\` or `artifacts\bin\`.

## Breaking changes

None. Layout and package ID are unchanged; only the source path priority for existing pack items is corrected.

## Checklist (for maintainers)

- [ ] Linked issue: #3377
- [ ] Changelog entry added if your release process requires it for this branch
- [ ] Pack/publish pipeline run once to confirm package size and `lib\` contents