### PR TITLE
* Vertical text centering on a rounded-corner `KryptonButton` (V85 LTS)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,8 @@
 =======
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
+
+* Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
 
 =======

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -158,9 +158,23 @@ namespace Krypton.Toolkit
         /// <param name="state">State associated with rendering.</param>
         /// <param name="orientation">Visual orientation of the border.</param>
         /// <returns>Padding structure detailing all four edges.</returns>
-        public abstract Padding GetBorderDisplayPadding(IPaletteBorder palette,
+        public virtual Padding GetBorderDisplayPadding(IPaletteBorder? palette,
+        PaletteState state,
+        VisualOrientation orientation) =>
+        GetBorderDisplayPadding(palette, state, orientation, Size.Empty);
+
+        /// <summary>
+        /// Gets the padding used to position display elements completely inside border drawing.
+        /// </summary>
+        /// <param name="palette">Palette used for drawing.</param>
+        /// <param name="state">State associated with rendering.</param>
+        /// <param name="orientation">Visual orientation of the border.</param>
+        /// <param name="borderOuterSize">Outer size of the bordered area; use <see cref="Size.Empty"/> for legacy behaviour.</param>
+        /// <returns>Padding structure detailing all four edges.</returns>
+        public abstract Padding GetBorderDisplayPadding(IPaletteBorder? palette,
                                                         PaletteState state,
-                                                        VisualOrientation orientation);
+                                                        VisualOrientation orientation,
+                                                        Size borderOuterSize);
 
         /// <summary>
         /// Generate a graphics path that is the outside edge of the border.

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
@@ -105,6 +105,20 @@ namespace Krypton.Toolkit
                                         VisualOrientation orientation);
 
         /// <summary>
+        /// Gets the padding used to position display elements completely inside border drawing,
+        /// clamping corner rounding to fit <paramref name="borderOuterSize"/> the same way as the border path when width and height are greater than zero.
+        /// </summary>
+        /// <param name="palette">Palette used for drawing.</param>
+        /// <param name="state">State associated with rendering.</param>
+        /// <param name="orientation">Visual orientation of the border.</param>
+        /// <param name="borderOuterSize">Outer bounds of the border; use (0,0) for legacy padding from palette rounding alone.</param>
+        /// <returns>Padding structure detailing all four edges.</returns>
+        Padding GetBorderDisplayPadding(IPaletteBorder? palette,
+            PaletteState state,
+            VisualOrientation orientation,
+            Size borderOuterSize);
+
+        /// <summary>
         /// Generate a graphics path that is the outside edge of the border.
         /// </summary>
         /// <param name="context">Rendering context.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -480,10 +480,12 @@ namespace Krypton.Toolkit
         /// <param name="state">State associated with rendering.</param>
         /// <param name="orientation">Visual orientation of the border.</param>
         /// <exception cref="ArgumentNullException"></exception>
+        /// <param name="borderOuterSize">When width and height are positive, corner rounding is clamped to fit these bounds the same way as when building the rounded border path, so layout matches drawing and clipping (GitHub #3381).</param>
         /// <returns>Padding structure detailing all four edges.</returns>
         public override Padding GetBorderDisplayPadding([DisallowNull] IPaletteBorder palette,
                                                         PaletteState state,
-                                                        VisualOrientation orientation)
+                                                        VisualOrientation orientation,
+                                                        Size borderOuterSize)
         {
             Debug.Assert(palette != null);
 
@@ -500,9 +502,24 @@ namespace Krypton.Toolkit
             {
                 var borderWidth = palette.GetBorderWidth(state);
 
+                float paletteRounding = palette.GetBorderRounding(state);
+                float roundingForPadding = paletteRounding;
+
+                // Match CreateBorderBackPath: rounding must fit inside the outer rectangle (#3381)
+                if (borderOuterSize.Width > 0 && borderOuterSize.Height > 0)
+                {
+                    float maxRounding = Math.Min(borderOuterSize.Width / 2f, borderOuterSize.Height / 2f) - borderWidth;
+                    if (maxRounding < 0f)
+                    {
+                        maxRounding = 0f;
+                    }
+
+                    roundingForPadding = Math.Min(paletteRounding, maxRounding);
+                }
+
                 // Divide the rounding effect by PI to get the actual pixel distance needed
                 // for offsetting. But add 2 so it starts indenting on a rounding of just 1.
-                int roundPadding = Convert.ToInt16((palette.GetBorderRounding(state) + borderWidth + 2) / Math.PI);
+                int roundPadding = Convert.ToInt16((roundingForPadding + borderWidth + 2) / Math.PI);
 
                 // If not involving rounding then padding for an edge is just the border width
                 var squarePadding = borderWidth;

--- a/Source/Krypton Components/Krypton.Toolkit/ResourceFiles/UAC/UACShieldIconResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ResourceFiles/UAC/UACShieldIconResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.ResourceFiles.UAC {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class UACShieldIconResources {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -382,7 +382,7 @@ namespace Krypton.Toolkit
                 DrawTabBorder
                     ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, _paletteBorder, State, Orientation,
                         TabBorderStyle)
-                    : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation));
+                    : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, context.DisplayRectangle.Size));
 
             // Do we have a metric source for additional padding?
             if (_paletteMetric != null)
@@ -426,7 +426,7 @@ namespace Krypton.Toolkit
             Padding padding = DrawTabBorder
                 ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, _paletteBorder, State,
                     Orientation, TabBorderStyle)
-                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation);
+                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, context.DisplayRectangle.Size);
 
             // Apply the padding to the client rectangle
             context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, padding);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
@@ -319,11 +319,11 @@ namespace Krypton.Toolkit
                 // Apply space the border takes up
                 if (IgnoreBorderSpace)
                 {
-                    borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation));
+                    borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size));
                 }
                 else
                 {
-                    Padding padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation);
+                    Padding padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size);
                     preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                     displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
                 }
@@ -378,11 +378,11 @@ namespace Krypton.Toolkit
                 // Apply space the border takes up
                 if (IgnoreBorderSpace)
                 {
-                    borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation));
+                    borderSize = CommonHelper.ApplyPadding(Orientation, borderSize, context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size));
                 }
                 else
                 {
-                    Padding padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation);
+                    Padding padding = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_paletteBorder, State, Orientation, originalRect.Size);
                     preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                     displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -400,7 +400,7 @@ namespace Krypton.Toolkit
                 DrawTabBorder
                     ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, PaletteBorder, State, Orientation,
                         TabBorderStyle)
-                    : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder, State, Orientation));
+                    : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder, State, Orientation, context.DisplayRectangle.Size));
 
             // Do we have a metric source for additional padding?
             if ((PaletteMetric != null) && (_metricPadding != PaletteMetricPadding.None))
@@ -444,7 +444,7 @@ namespace Krypton.Toolkit
             Padding padding = DrawTabBorder
                 ? context.Renderer.RenderTabBorder.GetTabBorderDisplayPadding(context, PaletteBorder, State,
                     Orientation, TabBorderStyle)
-                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder, State, Orientation);
+                : context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(PaletteBorder, State, Orientation, context.DisplayRectangle.Size);
 
             // Apply the padding to the client rectangle
             context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, padding);


### PR DESCRIPTION
# Fix vertical text centering on rounded `KryptonButton` (#3381)

## Summary

Fixes incorrect vertical (and overall) text alignment on `KryptonButton` when `StateCommon.Border.Rounding` is large relative to the control’s height—typical for wide “pill” buttons with centered short text and large fonts. Adds a **TestForm** repro and designer assets for ongoing verification.

**Closes:** [Issue #3381 — Vertical text centering on a rounded-corner `KryptonButton`](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381)

---

## Problem

`RenderStandard.GetBorderDisplayPadding` computed layout insets from the **palette** rounding value (`GetBorderRounding`) using the existing \(\pi\)-based heuristic, but the **drawn** border path (and child clip region in `ViewDrawSplitCanvas`) clamps rounding to what fits in the rectangle:

text{effectiveRounding} = min(text{paletteRounding}, min(w/2,\ h/2) - text{borderWidth})

When the palette requested a much larger rounding than the path (e.g. very wide, short button with `Rounding = 100`), the **content layout rectangle** no longer matched the **true interior** of the rounded shape. Text stayed “centered” in the wrong box, which reads as text drifting downward (or generally misaligned), especially with large fonts and Cyrillic sample text as in the report.

---

## Solution

1. **Border display padding**
   - Extended `IRenderBorder` / `RenderBase` with an overload `GetBorderDisplayPadding(IPaletteBorder? palette, PaletteState state, VisualOrientation orientation, Size borderOuterSize)`.
   - When `borderOuterSize.Width` and `Height` are both greater than zero, the rounding fed into the padding heuristic is **clamped** with the same rule as `CreateBorderBackPath`, so layout matches drawing and clipping.
   - The original three-argument overload remains as a **virtual** forwarder to `borderOuterSize: Size.Empty` (legacy behaviour where outer bounds are unknown).

2. **Call sites** Canvas / docker views that know the outer client size now pass it into the four-argument overload: `ViewDrawSplitCanvas`, `ViewDrawCanvas`, `ViewDrawDocker` (layout and non-child sizing paths).

3. **`RenderMaterial`** Overrides the four-argument overload and delegates to the base implementation for override states (same rules as before).

4. **Test harness**
   - `Bug3381KryptonButtonRoundedTextCenteringDemo` (`.cs`, `.Designer.cs`, `.resx`) with scenarios from the issue plus live controls (rounding slider, `TextV`, font size, button height).
   - Registered on `StartScreen`.
   - `TestForm.csproj`: `SubType` / `DependentUpon` for Solution Explorer nesting.

---

## API / compatibility

| Area | Note |
|------|------|
| **`IRenderBorder`** | New member; **third-party implementations** of `IRenderBorder` must implement the four-argument overload. | | **In-repo renderers** | All derive from `RenderBase` / `RenderStandard`; covered by the change. | | **Behaviour** | Three-argument call path unchanged (equivalent to empty outer size). |

---

## Files changed (reference)

**Krypton.Toolkit**

- `Rendering/RenderDefinitions.cs` — interface overload
- `Rendering/RenderBase.cs` — virtual 3-arg + abstract 4-arg
- `Rendering/RenderStandard.cs` — clamp rounding when outer size provided
- `Rendering/RenderMaterial.cs` — 4-arg override
- `View Draw/ViewDrawSplitCanvas.cs` — pass outer size
- `View Draw/ViewDrawCanvas.cs` — pass outer size
- `View Draw/ViewDrawDocker.cs` — pass outer size

**TestForm**

- `Bug3381KryptonButtonRoundedTextCenteringDemo.cs`
- `Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs`
- `Bug3381KryptonButtonRoundedTextCenteringDemo.resx`
- `StartScreen.cs` — launcher entry
- `TestForm.csproj` — form subtype and `DependentUpon`

**Changelog**

- If this PR lands separately from other work, ensure `Documents/Changelog/Changelog.md` includes a line for **#3381** under the appropriate build section (an entry may already exist under V110 nightly—avoid duplicates).

---

## How to test (manual)

1. Build and run TestForm: `dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj" -c Debug`
2. Open **Bug 3381 KryptonButton Rounded Text Centering** from the start list (filter: `3381`).
3. Confirm:
   - Wide short bar with **Начать** / large rounding: text visually centered in the pill.
   - Side-by-side bars: both centered; different font sizes do not skew vertical centering incorrectly.
   - Tall narrow capsule: centered.
   - Low rounding row: baseline.
   - **Live** section: sweep rounding 0–120, `TextV`, font size, and button height; resize the form; no progressive vertical drift vs. the green pill interior.
4. Optional: reproduce the original designer-style scenario (dock fill, large `Rounding`, large font) in a real form and confirm alignment.

---

## Screenshots

_Add before/after screenshots or a short GIF of the TestForm demo (wide pill + live slider) for the PR thread._

---

## Checklist

- [x] Fix aligns layout padding with border path rounding when bounds are known
- [x] Legacy 3-arg `GetBorderDisplayPadding` preserved
- [x] TestForm demo + designer/resx + start screen entry

---

## Suggested commit / PR titles

- `Fix KryptonButton text centering with large border rounding (#3381)`