### PR TITLE
* Memory Retention in Krypton Controls via SystemEvents (V85 LTS)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents
 * Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirect class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirect(PaletteBase? target)
+        public PaletteRedirect(PaletteBase? target) : base(attachUserPreferenceChanged: false)
         {
             Id = CommonHelper.NextId;
             // Remember incoming target

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2026. All rights reserved. 
  *  
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -21,10 +21,16 @@ namespace Krypton.Toolkit
         #region Instance Fields
 
         private bool _useKryptonFileDialogs;
+
         private BasePaletteType _basePaletteType;
+        
         private Padding? _inputControlPadding;
+        
         private PaletteDragFeedback _dragFeedback;
+        
         private string _themeName;
+
+        private readonly bool _systemEventsUserPreferenceSubscribed;
 
         private readonly Font _defaultFontStyle = new Font("Segoe UI", 9f, FontStyle.Regular);
 
@@ -82,11 +88,27 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Identity
+
         /// <summary>Initializes a new instance of the <see cref="PaletteBase" /> class.</summary>
-        protected PaletteBase()
+        public PaletteBase() : this(attachUserPreferenceChanged: true)
         {
-            // We need to notice when system color settings change
-            SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+            
+        }
+
+        /// <summary>
+        /// Initializes palette identity; optionally skips <see cref="SystemEvents.UserPreferenceChanged"/> so
+        /// <see cref="PaletteRedirect"/> (often never disposed) is not rooted by a static event (#3385).
+        /// </summary>
+        /// <param name="attachUserPreferenceChanged">When <see langword="true"/>, subscribes to user preference changes.</param>
+        protected PaletteBase(bool attachUserPreferenceChanged)
+        {
+            _systemEventsUserPreferenceSubscribed = attachUserPreferenceChanged;
+
+            if (attachUserPreferenceChanged)
+            {
+                // We need to notice when system color settings change
+                SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+            }
 
             // Inherit means we need to calculate the value next time it is requested
             _dragFeedback = PaletteDragFeedback.Inherit;
@@ -2015,8 +2037,11 @@ namespace Krypton.Toolkit
         {
             if (disposing)
             {
-                // Detach from static SystemEvents to prevent memory leaks.
-                SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+                if (_systemEventsUserPreferenceSubscribed)
+                {
+                    // Detach from static SystemEvents to prevent memory leaks.
+                    SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+                }
 
                 // Dispose any font resources we created.
                 DisposeFonts();


### PR DESCRIPTION
# Fix memory retention from `SystemEvents.UserPreferenceChanged` on undisposed `PaletteRedirect` (#3385)

## Summary

Krypton controls could remain reachable after disposal because `PaletteBase` always subscribed to the static `Microsoft.Win32.SystemEvents.UserPreferenceChanged` event. `PaletteRedirect` (and derived types) inherit that behaviour but are often **never disposed**—for example each `VisualControlBase` owns a `Redirector` instance that is not disposed on control teardown—so the static event kept redirect palettes, `NeedPaintHandler`, and the control graph alive.

This change **centralises** subscription policy in `PaletteBase`: redirect palettes opt out at construction time; builtin and other real palettes continue to subscribe as before.

Fixes: https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385

## Technical approach

1. **`PaletteBase`**
   - Parameterless constructor chains to `PaletteBase(attachUserPreferenceChanged: true)` (unchanged behaviour for all existing callers).
   - New `protected PaletteBase(bool attachUserPreferenceChanged)` only registers `SystemEvents.UserPreferenceChanged` when `attachUserPreferenceChanged` is `true`.
   - Field `_systemEventsUserPreferenceSubscribed` records whether a subscription was made.
   - `Dispose(bool)` removes the handler **only** when that subscription exists, so redirect instances that never subscribed do not rely on a redundant `-=`.

2. **`PaletteRedirect`**
   - Constructor calls `: base(attachUserPreferenceChanged: false)` so redirect instances **do not** attach to `SystemEvents`.
   - Theme / user-preference updates still propagate through the **target** palette (global or builtin palettes remain subscribed and disposed with their normal lifecycle).

## Files changed

| Area | File |
|------|------|
| Core | `Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs` | | Core | `Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs` |

## Breaking changes

None intended. Public surface of `PaletteBase` gains an additional `protected` constructor overload; existing derived types that use the implicit parameterless `PaletteBase()` path are unchanged.

## Manual verification

1. Build `Krypton.Toolkit` (e.g. `dotnet build` on `Krypton.Toolkit 2022.csproj` for a `-windows` TFM).
2. Reproduce the scenario from the issue (e.g. WinForms user control with Krypton controls hosted in WPF via `WindowsFormsHost`, open/close/dispose, force GC).
3. Capture a memory snapshot (e.g. dotMemory) and confirm disposed controls are no longer rooted via `SystemEvents.UserPreferenceChanged` → `PaletteRedirect*` / `CheckBoxImages` / `NeedPaintHandler` → control.

## Follow-up (optional)

Other code paths still subscribe to `SystemEvents` directly (e.g. some `KryptonColorTable*` types, `KryptonManager`, `VisualForm`, certain theme classes). If profiling shows remaining roots, those can be addressed separately; they are outside the `PaletteRedirect` / `PaletteBase` chain described in #3385.

## Checklist for reviewers

- [ ] Behaviour after Windows theme / high-contrast / related user preference changes is acceptable for Krypton controls using redirect palettes.
- [ ] No regression for long-lived forms and global palette instances.