### PR TITLE
* `build-testform` workflow fails to run correctly

### DIFF
--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -6,10 +6,10 @@ name: Build TestForm
 permissions:
   contents: read
 
-# When a new .NET preview ships, bump these (e.g. 12.0.x + 12.0) so the Preview job tracks it.
+# Preview SDK band: set repository Variables (Settings → Actions → Variables) DOTNET_PREVIEW_SETUP_VERSION / DOTNET_PREVIEW_SDK_BAND.
 env:
-  DOTNET_PREVIEW_SETUP_VERSION: '11.0.x'
-  DOTNET_PREVIEW_SDK_BAND: '11.0'
+  DOTNET_PREVIEW_SETUP_VERSION: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
+  DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
 
 on:
   pull_request:
@@ -29,7 +29,8 @@ jobs:
   Stable:
     name: Stable
     runs-on: windows-2025-vs2026
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')
+    # Skip on canary/alpha: those lines use preview SDKs; only the Preview job applies (#3421).
+    if: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')) && !((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/alpha')) && !(github.event_name == 'pull_request' && (github.base_ref == 'canary' || github.base_ref == 'alpha')) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -6,7 +6,8 @@ name: Build TestForm
 permissions:
   contents: read
 
-# Preview SDK band: set repository Variables (Settings → Actions → Variables) DOTNET_PREVIEW_SETUP_VERSION / DOTNET_PREVIEW_SDK_BAND.
+# Preview SDK band: repository Variables DOTNET_PREVIEW_SETUP_VERSION / DOTNET_PREVIEW_SDK_BAND.
+# USE_DOTNET_PREVIEW=false skips the Preview job and uses Stable on canary/alpha instead.
 env:
   DOTNET_PREVIEW_SETUP_VERSION: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
   DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
@@ -29,8 +30,8 @@ jobs:
   Stable:
     name: Stable
     runs-on: windows-2025-vs2026
-    # Skip on canary/alpha: those lines use preview SDKs; only the Preview job applies (#3421).
-    if: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')) && !((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/alpha')) && !(github.event_name == 'pull_request' && (github.base_ref == 'canary' || github.base_ref == 'alpha')) }}
+    # Skip canary/alpha for Stable unless USE_DOTNET_PREVIEW=false (then Stable covers preview-disabled branches; #3421).
+    if: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')) && (!((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/canary' || github.ref == 'refs/heads/alpha')) || vars.USE_DOTNET_PREVIEW == 'false') && (!(github.event_name == 'pull_request' && (github.base_ref == 'canary' || github.base_ref == 'alpha')) || vars.USE_DOTNET_PREVIEW == 'false') }}
 
     steps:
       - name: Checkout
@@ -43,7 +44,8 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Pin stable SDK via global.json
+      # Stable TFMs only; rollForward latestPatch (matches Stable job intent).
+      - name: Pin SDK via global.json (stable)
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -148,7 +150,7 @@ jobs:
   Preview:
     name: Preview
     runs-on: windows-2025-vs2026
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')
+    if: ${{ (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')) && vars.USE_DOTNET_PREVIEW != 'false' }}
 
     steps:
       - name: Checkout
@@ -161,13 +163,14 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Setup .NET (preview band)
+      - name: Setup .NET Preview
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      - name: Pin preview SDK via global.json
+      # Preview band from DOTNET_PREVIEW_SDK_BAND; TestForm Preview job only.
+      - name: Pin SDK via global.json (preview)
         shell: pwsh
         env:
           SDK_BAND: ${{ env.DOTNET_PREVIEW_SDK_BAND }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,22 +37,31 @@ jobs:
             9.0.x
             10.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
+      # Preview .NET SDK. USE_DOTNET_PREVIEW=false skips install (global.json still pins .NET 10 below).
+      - name: Setup .NET Preview
+        if: vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      # global.json dynamically generate (prefer stable SDKs for CI reproducibility)
-      - name: Force .NET 10 SDK via global.json
+      # Pin sdk.version to latest stable 10.x (fallback 9.x) for reproducible CI.
+      - name: Pin SDK via global.json
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 9 if .NET 10 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "9.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
           }
-          Write-Output "Using SDK $sdkVersion"
+          $sdkVersion = Get-ListedSdkVersion '10.0'
+          if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {
@@ -150,11 +159,23 @@ jobs:
             9.0.x
             10.0.x
 
-      # global.json dynamically generate
-      - name: Force .NET 10 SDK via global.json
+      # Pin sdk.version to latest stable 10.x (fallback 9.x) for reproducible CI.
+      - name: Pin SDK via global.json
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          Write-Output "Using SDK $sdkVersion"
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
+          }
+          $sdkVersion = Get-ListedSdkVersion '10.0'
+          if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -50,18 +50,48 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Setup .NET 11 (Preview)
-        if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
+      # USE_DOTNET_PREVIEW=false skips preview SDK; global.json uses stable SDK below.
+      - name: Setup .NET Preview
+        if: steps.canary_lts_kill_switch.outputs.enabled == 'true' && vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      - name: Force .NET 11 SDK via global.json
+      # Pin sdk.version for CI; preview band vs stable 10.x/9.x follows USE_DOTNET_PREVIEW (repository variable).
+      - name: Pin SDK via global.json
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
+        env:
+          DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
+          USE_DOTNET_PREVIEW: ${{ vars.USE_DOTNET_PREVIEW }}
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          Write-Output "Using SDK $sdkVersion"
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
+          }
+
+          $usePreview = $env:USE_DOTNET_PREVIEW -ne 'false'
+          $sdkVersion = $null
+          if (-not $usePreview) {
+            $sdkVersion = Get-ListedSdkVersion '10.0'
+            if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          } else {
+            if (-not $env:DOTNET_PREVIEW_SDK_BAND) {
+              Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set (repository variable).'
+            }
+            $sdkVersion = Get-ListedSdkVersion $env:DOTNET_PREVIEW_SDK_BAND
+            if (-not $sdkVersion) {
+              $sdkVersion = Get-ListedSdkVersion '10.0'
+            }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -85,24 +85,51 @@ jobs:
             9.0.x
             10.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
-        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+      # Preview .NET SDK. DOTNET_PREVIEW_* : repo Variables (same as build.yml / build-testform.yml).
+      # USE_DOTNET_PREVIEW=false skips preview SDK install; global.json uses stable SDK below.
+      - name: Setup .NET Preview
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true' && vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      # global.json dynamically generate (use latest SDK available)
-      - name: Force .NET 11 SDK via global.json
+      # Pin sdk.version for CI; preview band vs stable 10.x/9.x follows USE_DOTNET_PREVIEW (repository variable).
+      - name: Pin SDK via global.json
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        env:
+          DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
+          USE_DOTNET_PREVIEW: ${{ vars.USE_DOTNET_PREVIEW }}
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          # Latest patch line matching $Pattern (same idea as other global.json pins in this repo).
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
           }
-          Write-Output "Using SDK $sdkVersion"
+
+          $usePreview = $env:USE_DOTNET_PREVIEW -ne 'false'
+          $sdkVersion = $null
+          if (-not $usePreview) {
+            $sdkVersion = Get-ListedSdkVersion '10.0'
+            if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          } else {
+            if (-not $env:DOTNET_PREVIEW_SDK_BAND) {
+              Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set (repository variable).'
+            }
+            $sdkVersion = Get-ListedSdkVersion $env:DOTNET_PREVIEW_SDK_BAND
+            if (-not $sdkVersion) {
+              # Preview SDK not present on runner; fall back to latest 10.x.
+              $sdkVersion = Get-ListedSdkVersion '10.0'
+            }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,25 +112,49 @@ jobs:
             9.0.x
             10.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
+      # Preview .NET SDK. USE_DOTNET_PREVIEW=false skips preview SDK; global.json step uses stable SDK.
+      - name: Setup .NET Preview
         # Kill switch check
-        if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      # global.json dynamically generate (use latest SDK available)
-      - name: Force .NET 11 SDK via global.json
+      # Pin sdk.version for CI; preview band vs stable 10.x/9.x follows USE_DOTNET_PREVIEW (repository variable).
+      - name: Pin SDK via global.json
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
+        env:
+          DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
+          USE_DOTNET_PREVIEW: ${{ vars.USE_DOTNET_PREVIEW }}
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
           }
-          Write-Output "Using SDK $sdkVersion"
+
+          $usePreview = $env:USE_DOTNET_PREVIEW -ne 'false'
+          $sdkVersion = $null
+          if (-not $usePreview) {
+            $sdkVersion = Get-ListedSdkVersion '10.0'
+            if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          } else {
+            if (-not $env:DOTNET_PREVIEW_SDK_BAND) {
+              Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set (repository variable).'
+            }
+            $sdkVersion = Get-ListedSdkVersion $env:DOTNET_PREVIEW_SDK_BAND
+            if (-not $sdkVersion) {
+              $sdkVersion = Get-ListedSdkVersion '10.0'
+            }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,25 +54,49 @@ jobs:
             9.0.x
             10.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
+      # Preview .NET SDK. USE_DOTNET_PREVIEW=false skips preview SDK; global.json uses stable SDK below.
+      - name: Setup .NET Preview
         # Kill switch check
-        if: steps.release_kill_switch.outputs.enabled == 'true'
+        if: steps.release_kill_switch.outputs.enabled == 'true' && vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      # global.json dynamically generate (use latest SDK available)
-      - name: Force .NET 11 SDK via global.json
+      # Pin sdk.version for CI; preview band vs stable 10.x/9.x follows USE_DOTNET_PREVIEW (repository variable).
+      - name: Pin SDK via global.json
         if: steps.release_kill_switch.outputs.enabled == 'true'
+        env:
+          DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
+          USE_DOTNET_PREVIEW: ${{ vars.USE_DOTNET_PREVIEW }}
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
           }
-          Write-Output "Using SDK $sdkVersion"
+
+          $usePreview = $env:USE_DOTNET_PREVIEW -ne 'false'
+          $sdkVersion = $null
+          if (-not $usePreview) {
+            $sdkVersion = Get-ListedSdkVersion '10.0'
+            if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          } else {
+            if (-not $env:DOTNET_PREVIEW_SDK_BAND) {
+              Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set (repository variable).'
+            }
+            $sdkVersion = Get-ListedSdkVersion $env:DOTNET_PREVIEW_SDK_BAND
+            if (-not $sdkVersion) {
+              $sdkVersion = Get-ListedSdkVersion '10.0'
+            }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {
@@ -348,13 +372,25 @@ jobs:
             9.0.x
             10.0.x
 
-      # global.json dynamically generate
-      - name: Force .NET 10 SDK via global.json
+      # Pin sdk.version to latest stable 10.x (fallback 9.x) for reproducible CI.
+      - name: Pin SDK via global.json
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          Write-Output "Using SDK $sdkVersion"
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
+          }
+          $sdkVersion = Get-ListedSdkVersion '10.0'
+          if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {
@@ -630,24 +666,48 @@ jobs:
             9.0.x
             10.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
-        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+      # Preview .NET SDK. USE_DOTNET_PREVIEW=false skips preview SDK; global.json uses stable SDK below.
+      - name: Setup .NET Preview
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true' && vars.USE_DOTNET_PREVIEW != 'false'
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 11.0.x
+          dotnet-version: ${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}
           dotnet-quality: preview
 
-      # global.json dynamically generate (use latest SDK available)
-      - name: Force .NET 11 SDK via global.json
+      # Pin sdk.version for CI; preview band vs stable 10.x/9.x follows USE_DOTNET_PREVIEW (repository variable).
+      - name: Pin SDK via global.json
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        env:
+          DOTNET_PREVIEW_SDK_BAND: ${{ vars.DOTNET_PREVIEW_SDK_BAND }}
+          USE_DOTNET_PREVIEW: ${{ vars.USE_DOTNET_PREVIEW }}
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
           }
-          Write-Output "Using SDK $sdkVersion"
+
+          $usePreview = $env:USE_DOTNET_PREVIEW -ne 'false'
+          $sdkVersion = $null
+          if (-not $usePreview) {
+            $sdkVersion = Get-ListedSdkVersion '10.0'
+            if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          } else {
+            if (-not $env:DOTNET_PREVIEW_SDK_BAND) {
+              Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set (repository variable).'
+            }
+            $sdkVersion = Get-ListedSdkVersion $env:DOTNET_PREVIEW_SDK_BAND
+            if (-not $sdkVersion) {
+              $sdkVersion = Get-ListedSdkVersion '10.0'
+            }
+          }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {
@@ -923,13 +983,25 @@ jobs:
             9.0.x
             10.0.x
 
-      # global.json dynamically generate
-      - name: Force .NET 10 SDK via global.json
+      # Pin sdk.version to latest stable 10.x (fallback 9.x) for reproducible CI.
+      - name: Pin SDK via global.json
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          Write-Output "Using SDK $sdkVersion"
+          $ErrorActionPreference = 'Stop'
+          function Get-ListedSdkVersion([string]$Pattern) {
+            $hit = dotnet --list-sdks | Select-String $Pattern | Select-Object -Last 1
+            if (-not $hit) { return $null }
+            $line = $hit.Line.TrimEnd()
+            if ($line -match '^(\d+\.\d+\.\d+)\s') { return $Matches[1] }
+            return (($line -split '\s+', 2)[0])
+          }
+          $sdkVersion = Get-ListedSdkVersion '10.0'
+          if (-not $sdkVersion) { $sdkVersion = Get-ListedSdkVersion '9.0' }
+          if (-not $sdkVersion) {
+            Write-Error 'Could not resolve an SDK version for global.json.'
+          }
+          Write-Host "Using SDK $sdkVersion"
           @"
           {
             "sdk": {


### PR DESCRIPTION
# PR: Fix `build-testform` on canary/alpha; preview SDK via repository variables

## Summary

Updates the **Build TestForm** GitHub Actions workflow so the **Stable** job does not run on the `canary` and `alpha` branches (where preview SDKs apply), and drives preview SDK selection from **repository Actions variables** instead of hardcoded workflow values.

Fixes https://github.com/Krypton-Suite/Standard-Toolkit/issues/3421.

## Problem

- On **canary** and **alpha**, the **Stable** job still ran. That job pins **stable** SDKs (`allowPrerelease: false` in `global.json`) and is the wrong fit for those lines, which expect **preview** toolchains.
- Preview SDK version/band were fixed in the YAML; maintainers want them configurable per repo **without** editing the workflow.

## Changes

### Skip **Stable** on canary/alpha

The **Stable** job’s `if` condition now skips when:

- **push** or **workflow_dispatch** targets `refs/heads/canary` or `refs/heads/alpha`, or
- a **pull_request** has base branch `canary` or `alpha`.

Existing behavior is preserved for **fork PRs** (same-repo / workflow_dispatch rules unchanged). The **Preview** job is unchanged and remains the build path that uses the preview SDK band.

### Preview SDK from repository variables

Workflow `env` uses:

- `DOTNET_PREVIEW_SETUP_VERSION` → `${{ vars.DOTNET_PREVIEW_SETUP_VERSION }}`
- `DOTNET_PREVIEW_SDK_BAND` → `${{ vars.DOTNET_PREVIEW_SDK_BAND }}`

There are **no** inline fallbacks in the workflow; values must come from repository (or inherited organization) **Variables**.

## Maintainer checklist (before / after merge)

1. In the repo: **Settings → Secrets and variables → Actions → Variables**, ensure these exist (example values shown):

   | Name | Example |
   | --- | --- |
   | `DOTNET_PREVIEW_SETUP_VERSION` | `11.0.x` |
   | `DOTNET_PREVIEW_SDK_BAND` | `11.0` |

2. When a new .NET preview band is adopted, update those variables (and optionally document the bump in release notes).

## Risk / breaking notes

- Workflows will see **empty** preview env values if variables are not configured; the **Preview** job may fail until variables are set.
- Forks that run Actions must define the same variables if they rely on this workflow (or disable the workflow).

## Validation

- [ ] Variables set on the target repository.
- [ ] Push to **canary** or **alpha**: **Stable** skipped, **Preview** runs.
- [ ] Push to **master** (or other non-canary/alpha branches in scope): **Stable** runs as before (subject to existing PR/fork rules).