### PR TITLE
* Lines when using `CueHint` for `KryptonTextBox` (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,13 +47,14 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365), `KryptonLinkLabel` 'Autosize' Not Shrinking
 * Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
 * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
- * Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents
- * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
- * Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
+* Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents
+* Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
+* Resolved [#3283](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3283), `KryptonThemeComboBox` does not change theme when `SelectedIndex` is changed
 
 ====
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -226,6 +226,8 @@ public class KryptonRichTextBox : VisualControlBase,
                         IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
                         using (Graphics g = Graphics.FromHdc(hdc))
                         {
+                            g.ResetClip();
+
                             // Grab the client area of the control
                             PI.GetClientRect(Handle, out PI.RECT rect);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -156,6 +156,11 @@ public class KryptonTextBox : VisualControlBase,
 
                     // Paint the entire area in the background color
                     using Graphics g = Graphics.FromHdc(hdc);
+
+                    // BeginPaint can restrict the clip to the update region; cue rendering needs a solid full-client
+                    // background so fringe pixels from prior paints do not remain as top/left edge streaks.
+                    g.ResetClip();
+
                     // Grab the client area of the control
                     PI.GetClientRect(Handle, out PI.RECT rect);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -127,39 +127,14 @@ public class PaletteCueHintText : PaletteInputControlContentStates
 
     internal void PerformPaint(VisualControlBase textBox, Graphics? g, Rectangle layoutRectangle, SolidBrush backBrush)
     {
-        using var old = new GraphicsHint(g, PaletteGraphicsHint.HighQuality);
-        using var old1 = new GraphicsTextHint(g!, CommonHelper.PaletteTextHintToRenderingHint(_contentTextHint));
-        // Define the string formatting requirements
-        var stringFormat = new StringFormat
+        if (g == null)
         {
-            Trimming = StringTrimming.None,
-            LineAlignment = StringAlignment.Near
-        };
-        stringFormat.Alignment = GetContentShortTextH(PaletteState.Normal) switch
-        {
-            PaletteRelativeAlign.Near => textBox.RightToLeft == RightToLeft.Yes
-                ? StringAlignment.Far
-                : StringAlignment.Near,
-            PaletteRelativeAlign.Far => textBox.RightToLeft == RightToLeft.Yes
-                ? StringAlignment.Near
-                : StringAlignment.Far,
-            PaletteRelativeAlign.Center => StringAlignment.Center,
-            _ => StringAlignment.Near
-        };
-        // This is most applicable to the multi-line controls
-        stringFormat.LineAlignment = GetContentShortTextV(PaletteState.Normal) switch
-        {
-            PaletteRelativeAlign.Near => StringAlignment.Near,
-            //PaletteRelativeAlign.Center => StringAlignment.Center,
-            PaletteRelativeAlign.Far => StringAlignment.Far,
-            _ => StringAlignment.Center
-        };
+            return;
+        }
 
-        // Use the correct prefix setting
-        stringFormat.HotkeyPrefix = HotkeyPrefix.None;
-
-        // Draw entire client area in the background color
-        g?.FillRectangle(backBrush, layoutRectangle);
+        // Fill background first. Avoid applying GraphicsHint/HighQuality smoothing before this fill — it can leave
+        // edge pixels that read as top/left "lines" when combined with GDI+ DrawString and the cue foreground colour.
+        g.FillRectangle(backBrush, layoutRectangle);
 
         var padding = GetBorderContentPadding(null, PaletteState.Normal);
         if (!padding.Equals(CommonHelper.InheritPadding))
@@ -170,10 +145,119 @@ public class PaletteCueHintText : PaletteInputControlContentStates
             layoutRectangle.Height -= padding.Top + padding.Bottom;
         }
 
+        if (layoutRectangle.Width <= 0 || layoutRectangle.Height <= 0)
+        {
+            return;
+        }
+
         using var font = GetContentShortTextNewFont(PaletteState.Normal);
-        using var foreBrush = new SolidBrush(GetContentShortTextColor1(PaletteState.Normal));
+        var foreColor = GetContentShortTextColor1(PaletteState.Normal);
         var drawText = string.IsNullOrEmpty(CueHintText) ? textBox.Text : CueHintText;
-        g?.DrawString(drawText, font, foreBrush, layoutRectangle, stringFormat);
+
+        if (ShouldUseGdiPlusMultilineCue(textBox))
+        {
+            DrawCueHintMultiline(textBox, g, drawText, font, foreColor, layoutRectangle);
+        }
+        else
+        {
+            TextFormatFlags tf = BuildCueTextRendererFormatFlags(textBox);
+            TextRenderer.DrawText(g, drawText, font, layoutRectangle, foreColor, tf);
+        }
+    }
+
+    private static bool ShouldUseGdiPlusMultilineCue(VisualControlBase textBox)
+    {
+        if (textBox is KryptonRichTextBox)
+        {
+            return true;
+        }
+
+        return textBox is KryptonTextBox multilineTextBox && multilineTextBox.Multiline;
+    }
+
+    private TextFormatFlags BuildCueTextRendererFormatFlags(VisualControlBase textBox)
+    {
+        TextFormatFlags tf = TextFormatFlags.NoPrefix
+            | TextFormatFlags.SingleLine
+            | TextFormatFlags.EndEllipsis
+            | TextFormatFlags.NoPadding;
+
+        bool rtl = textBox.RightToLeft == RightToLeft.Yes;
+        if (rtl)
+        {
+            tf |= TextFormatFlags.RightToLeft;
+        }
+
+        PaletteRelativeAlign hAlign = GetContentShortTextH(PaletteState.Normal);
+        if (rtl)
+        {
+            tf |= hAlign switch
+            {
+                PaletteRelativeAlign.Near => TextFormatFlags.Right,
+                PaletteRelativeAlign.Far => TextFormatFlags.Left,
+                PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                _ => TextFormatFlags.Right
+            };
+        }
+        else
+        {
+            tf |= hAlign switch
+            {
+                PaletteRelativeAlign.Near => TextFormatFlags.Left,
+                PaletteRelativeAlign.Far => TextFormatFlags.Right,
+                PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                _ => TextFormatFlags.Left
+            };
+        }
+
+        PaletteRelativeAlign vAlign = GetContentShortTextV(PaletteState.Normal);
+        tf |= vAlign switch
+        {
+            PaletteRelativeAlign.Near => TextFormatFlags.Top,
+            PaletteRelativeAlign.Far => TextFormatFlags.Bottom,
+            _ => TextFormatFlags.VerticalCenter
+        };
+
+        return tf;
+    }
+
+    private void DrawCueHintMultiline(VisualControlBase textBox,
+        Graphics g,
+        string drawText,
+        Font font,
+        Color foreColor,
+        Rectangle layoutRectangle)
+    {
+        using (new GraphicsHint(g, PaletteGraphicsHint.HighQuality))
+        using (new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(_contentTextHint)))
+        {
+            var stringFormat = new StringFormat
+            {
+                Trimming = StringTrimming.None,
+                LineAlignment = StringAlignment.Near
+            };
+            stringFormat.Alignment = GetContentShortTextH(PaletteState.Normal) switch
+            {
+                PaletteRelativeAlign.Near => textBox.RightToLeft == RightToLeft.Yes
+                    ? StringAlignment.Far
+                    : StringAlignment.Near,
+                PaletteRelativeAlign.Far => textBox.RightToLeft == RightToLeft.Yes
+                    ? StringAlignment.Near
+                    : StringAlignment.Far,
+                PaletteRelativeAlign.Center => StringAlignment.Center,
+                _ => StringAlignment.Near
+            };
+            stringFormat.LineAlignment = GetContentShortTextV(PaletteState.Normal) switch
+            {
+                PaletteRelativeAlign.Near => StringAlignment.Near,
+                PaletteRelativeAlign.Far => StringAlignment.Far,
+                _ => StringAlignment.Center
+            };
+            stringFormat.HotkeyPrefix = HotkeyPrefix.None;
+
+            using var foreBrush = new SolidBrush(foreColor);
+            g.DrawString(drawText, font, foreBrush, layoutRectangle, stringFormat);
+        }
     }
 
     #region TextV
@@ -208,7 +292,7 @@ public class PaletteCueHintText : PaletteInputControlContentStates
     /// </summary>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>RelativeAlignment value.</returns>
-    public override PaletteRelativeAlign GetContentShortTextV(PaletteState state) => _shortTextV != PaletteRelativeAlign.Inherit ? _shortTextH : Inherit.GetContentShortTextV(state);
+    public override PaletteRelativeAlign GetContentShortTextV(PaletteState state) => _shortTextV != PaletteRelativeAlign.Inherit ? _shortTextV : Inherit.GetContentShortTextV(state);
 
     // Use the base class
     //protected virtual Padding GetContentPadding(PaletteState state) => !_padding.Equals(CommonHelper.InheritPadding) ? _padding : Inherit.GetContentPadding(state);


### PR DESCRIPTION
# Fix: CueHint artefacts on `KryptonTextBox` (Issue #3382)

## Summary

Fixes incorrect cue-hint vertical alignment, removes GDI+ text-fringe “lines” (often L-shaped, matching cue colour), and adds a TestForm demo. Reported in [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382).

## Problem

When showing a **CueHint** on `KryptonTextBox` (empty value, enabled), users could see:

- Faint **top** and/or **left** streaks that looked like borders (often the same colour as the cue text).
- **Vertical alignment** that followed **horizontal** (`TextH`) by mistake, so with `TextH = Near` the cue was pinned to the **top** instead of respecting **`TextV`** (e.g. **Center**).

Symptoms often worsened when the cue **font differed** from the control content font; they could disappear after focus/typing when native edit painting took over.

## Root cause

1. **`PaletteCueHintText.GetContentShortTextV`** returned **`_shortTextH`** instead of **`_shortTextV`**, so vertical layout used horizontal alignment for the non-inherit path.
2. **GDI+ `DrawString`** plus **`GraphicsHint`** / smoothing applied around the full paint path left anti-aliased edge pixels that read as thin **top/left** lines, especially with `DarkGray` cue colour.
3. **`BeginPaint`** could leave a **clip** that did not cover the full client area; background fill did not always clear prior pixels at the edges.

## Solution

| Area | Change |
|------|--------|
| `PaletteCueHintText` | Return **`_shortTextV`** from **`GetContentShortTextV`** when not `Inherit`. | | `PaletteCueHintText.PerformPaint` | Fill background **first** without high-quality smoothing on that step; use **`TextRenderer.DrawText`** for **single-line** cue (typical `KryptonTextBox`, `KryptonComboBox`); keep **GDI+ `DrawString`** for **multiline** `KryptonTextBox` and `KryptonRichTextBox` only. | | `KryptonTextBox` (internal `TextBox`) | **`Graphics.ResetClip()`** after **`FromHdc`** in the custom **`WM_PAINT`** path so cue painting can clear the full client. | | `KryptonRichTextBox` | Same **`ResetClip()`** before cue **`PerformPaint`**. | | TestForm | **`Bug3382CueHintLinesDemo`** (with **`.Designer.cs`**) plus **Start Screen** entry for manual verification. |

## How to test

1. Run TestForm and open **“Bug 3382 CueHint line artefacts”**.
2. Confirm single-line boxes: **no** faint top/left streaks; Cyrillic cue **vertically centred** with **`TextH = Near`** and default **`TextV`**.
3. Resize/unfocus/repaint and compare **mixed cue/content fonts** vs **matched fonts** rows.
4. Spot-check **KryptonComboBox** cue and **multiline** `KryptonTextBox` cue if applicable.

## Related

- Closes / Fixes [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382)

## Checklist

- [x] Toolkit builds (e.g. `net472`).
- [ ] Visual verification on Windows (designer + runtime) for single-line cue.
- [ ] No regression called out for multiline / `KryptonRichTextBox` cue (still uses GDI+ path).