### PR TITLE
* Lines when using `CueHint` for `KryptonTextBox` (V85 LTS)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1,1689 +1,100 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
 
-namespace Krypton.Toolkit
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provide a RichTextBox with Krypton styling applied.
+/// </summary>
+[ToolboxItem(true)]
+[ToolboxBitmap(typeof(KryptonRichTextBox), "ToolboxBitmaps.KryptonRichTextBox.bmp")]
+[DefaultEvent(nameof(TextChanged))]
+[DefaultProperty(nameof(Text))]
+[DefaultBindingProperty(nameof(Text))]
+[Designer(typeof(KryptonRichTextBoxDesigner))]
+[DesignerCategory(@"code")]
+[Description(@"Enables the user to enter text, and provides multi-line editing and password character masking.")]
+public class KryptonRichTextBox : VisualControlBase,
+    IContainedInputControl
 {
-    /// <summary>
-    /// Provide a RichTextBox with Krypton styling applied.
-    /// </summary>
-    [ToolboxItem(true)]
-    [ToolboxBitmap(typeof(KryptonRichTextBox), "ToolboxBitmaps.KryptonRichTextBox.bmp")]
-    [DefaultEvent(nameof(TextChanged))]
-    [DefaultProperty(nameof(Text))]
-    [DefaultBindingProperty(nameof(Text))]
-    [Designer(typeof(KryptonRichTextBoxDesigner))]
-    [DesignerCategory(@"code")]
-    [Description(@"Enables the user to enter text, and provides multi-line editing and password character masking.")]
-    public class KryptonRichTextBox : VisualControlBase,
-                                      IContainedInputControl
+    #region Classes
+    private class InternalRichTextBox : RichTextBox
     {
-        #region Classes
-        private class InternalRichTextBox : RichTextBox
-        {
-            #region Static Fields
+        #region Static Fields
 
-            private const double AN_INCH = 14.4;
+        private const double AN_INCH = 14.4;
 
-            #endregion
-
-            #region Instance Fields
-            private readonly KryptonRichTextBox _kryptonRichTextBox;
-            private bool _mouseOver;
-            #endregion
-
-            #region Events
-            /// <summary>
-            /// Occurs when the mouse enters the InternalComboBox.
-            /// </summary>
-            public event EventHandler? TrackMouseEnter;
-
-            /// <summary>
-            /// Occurs when the mouse leaves the InternalComboBox.
-            /// </summary>
-            public event EventHandler? TrackMouseLeave;
-            #endregion
-
-            #region Identity
-            /// <summary>
-            /// Initialize a new instance of the InternalTextBox class.
-            /// </summary>
-            /// <param name="kryptonRichTextBox">Reference to owning control.</param>
-            public InternalRichTextBox(KryptonRichTextBox kryptonRichTextBox)
-            {
-                _kryptonRichTextBox = kryptonRichTextBox;
-
-                // Remove from view until size for the first time by the Krypton control
-                Size = Size.Empty;
-
-                // We provide the border manually
-                BorderStyle = BorderStyle.None;
-            }
-            #endregion
-
-            #region Public
-            /// <summary>
-            /// Gets and sets if the mouse is currently over the combo box.
-            /// </summary>
-            public bool MouseOver
-            {
-                get => _mouseOver;
-
-                set
-                {
-                    // Only interested in changes
-                    if (_mouseOver != value)
-                    {
-                        _mouseOver = value;
-
-                        // Generate appropriate change event
-                        if (_mouseOver)
-                        {
-                            OnTrackMouseEnter(EventArgs.Empty);
-                        }
-                        else
-                        {
-                            OnTrackMouseLeave(EventArgs.Empty);
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Print the specified range of characters.
-            /// </summary>
-            /// <param name="charFrom">Start character.</param>
-            /// <param name="charTo">End character.</param>
-            /// <param name="gr">Graphics instance to use.</param>
-            /// <param name="bounds">Drawing bounds.</param>
-            /// <returns>Pointer to returned result.</returns>
-            public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds)
-            {
-                //Calculate the area to render and print
-                PI.RECT rectToPrint;
-                rectToPrint.top = 0;
-                rectToPrint.bottom = (int)(bounds.Height * AN_INCH);
-                rectToPrint.left = 0;
-                rectToPrint.right = (int)(bounds.Width * AN_INCH);
-
-                //Calculate the size of the page
-                PI.RECT rectPage;
-                rectPage.top = 0;
-                rectPage.bottom = (int)(gr.ClipBounds.Height * AN_INCH);
-                rectPage.left = 0;
-                rectPage.right = (int)(gr.ClipBounds.Right * AN_INCH);
-
-                var hdc = gr.GetHdc();
-
-                PI.FORMATRANGE fmtRange;
-                fmtRange.chrg.cpMax = charTo;
-                fmtRange.chrg.cpMin = charFrom;
-                fmtRange.hdc = hdc;
-                fmtRange.hdcTarget = hdc;
-                fmtRange.rc = rectToPrint;
-                fmtRange.rcPage = rectPage;
-
-                var wparam = new IntPtr(1);
-
-                //Get the pointer to the FORMATRANGE structure in memory
-                var lparam = Marshal.AllocCoTaskMem(Marshal.SizeOf(fmtRange));
-                Marshal.StructureToPtr(fmtRange, lparam, false);
-
-                //Send the rendered data for printing 
-                var res = (IntPtr)PI.SendMessage(Handle, PI.EM_FORMATRANGE, wparam, lparam);
-
-                //Free the block of memory allocated
-                Marshal.FreeCoTaskMem(lparam);
-
-                //Release the device context handle obtained by a previous call
-                gr.ReleaseHdc(hdc);
-
-                //Return last + 1 character printer
-                return (int)res.ToInt64();
-            }
-            #endregion
-
-            #region Protected
-            protected override void OnEnabledChanged(EventArgs e)
-            {
-                // Do not forward, to allow the correct Background for disabled state
-                // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/722
-            }
-
-            /// <summary>
-            /// Process Windows-based messages.
-            /// </summary>
-            /// <param name="m">A Windows-based message.</param>
-            protected override void WndProc(ref Message m)
-            {
-                switch (m.Msg)
-                {
-                    case PI.WM_.NCHITTEST:
-                        if (_kryptonRichTextBox.InTransparentDesignMode)
-                        {
-                            m.Result = (IntPtr)PI.HT.TRANSPARENT;
-                        }
-                        else
-                        {
-                            base.WndProc(ref m);
-                        }
-
-                        break;
-                    case PI.WM_.MOUSELEAVE:
-                        // Mouse is not over the control
-                        MouseOver = false;
-                        _kryptonRichTextBox.PerformNeedPaint(true);
-                        Invalidate();
-                        base.WndProc(ref m);
-                        break;
-                    case PI.WM_.MOUSEMOVE:
-                        // Mouse is over the control
-                        if (!MouseOver)
-                        {
-                            MouseOver = true;
-                            _kryptonRichTextBox.PerformNeedPaint(true);
-                            Invalidate();
-                        }
-                        base.WndProc(ref m);
-                        break;
-                    case PI.WM_.CONTEXTMENU:
-                        // Only interested in overriding the behavior when we have a krypton context menu...
-                        if (_kryptonRichTextBox.KryptonContextMenu != null)
-                        {
-                            // Extract the screen mouse position (if might not actually be provided)
-                            var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
-
-                            // If keyboard activated, the menu position is centered
-                            if (((int)(long)m.LParam) == -1)
-                            {
-                                mousePt = PointToScreen(new Point(Width / 2, Height / 2));
-                            }
-
-                            // Show the context menu
-                            _kryptonRichTextBox.KryptonContextMenu.Show(_kryptonRichTextBox, mousePt);
-
-                            // We eat the message!
-                            return;
-                        }
-                        base.WndProc(ref m);
-                        break;
-                    case PI.WM_.PAINT:
-                        if (!string.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
-                            && (_kryptonRichTextBox.TextLength == 0)
-                        )
-                        {
-                            var ps = new PI.PAINTSTRUCT();
-                            // Do we need to BeginPaint or just take the given HDC?
-                            var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
-                            using (Graphics g = Graphics.FromHdc(hdc))
-                            {
-                                // Grab the client area of the control
-                                PI.GetClientRect(Handle, out PI.RECT rect);
-
-                                PaletteState state = _kryptonRichTextBox.Enabled
-                                    ? _kryptonRichTextBox.IsActive
-                                        ? PaletteState.Tracking
-                                        : PaletteState.Normal
-                                    : PaletteState.Disabled;
-                                var states = _kryptonRichTextBox.GetTripleState();
-
-                                // Drawn entire client area in the background color
-                                using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
-                                // Go perform the drawing of the CueHint
-                                _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, rect, backBrush);
-                            }
-
-                            // Do we need to match the original BeginPaint?
-                            if (m.WParam == IntPtr.Zero)
-                            {
-                                PI.EndPaint(Handle, ref ps);
-                            }
-                        }
-                        base.WndProc(ref m);
-                        break;
-                    default:
-                        base.WndProc(ref m);
-                        break;
-                }
-            }
-
-            /// <summary>
-            /// Raises the TrackMouseEnter event.
-            /// </summary>
-            /// <param name="e">An EventArgs containing the event data.</param>
-            protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
-
-            /// <summary>
-            /// Raises the TrackMouseLeave event.
-            /// </summary>
-            /// <param name="e">An EventArgs containing the event data.</param>
-            protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
-
-            /// <summary>
-            /// Raises the OnMouseMove event.
-            /// </summary>
-            /// <param name="e">An EventArgs containing the event data.</param>
-            protected override void OnMouseMove(MouseEventArgs e)
-            {
-                base.OnMouseMove(e);
-
-                _kryptonRichTextBox.OnMouseMove(e);
-            }
-            #endregion
-        }
-        #endregion
-
-        #region Type Definitions
-        /// <summary>
-        /// Collection for managing ButtonSpecAny instances.
-        /// </summary>
-        public class RichTextBoxButtonSpecCollection : ButtonSpecCollection<ButtonSpecAny>
-        {
-            #region Identity
-            /// <summary>
-            /// Initialize a new instance of the RichTextBoxButtonSpecCollection class.
-            /// </summary>
-            /// <param name="owner">Reference to owning object.</param>
-            public RichTextBoxButtonSpecCollection(KryptonRichTextBox owner)
-                : base(owner)
-            {
-            }
-            #endregion
-        }
         #endregion
 
         #region Instance Fields
-
-        private VisualPopupToolTip? _visualPopupToolTip;
-        private readonly ButtonSpecManagerLayout _buttonManager;
-        private readonly ViewLayoutDocker _drawDockerInner;
-        private readonly ViewDrawDocker _drawDockerOuter;
-        private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalRichTextBox _richTextBox;
-        private InputControlStyle _inputControlStyle;
-        private bool? _fixedActive;
-        private bool _forcedLayout;
-        private bool _autoSize;
+        private readonly KryptonRichTextBox _kryptonRichTextBox;
         private bool _mouseOver;
-        private bool _alwaysActive;
-        private bool _trackingMouseEnter;
-        private bool _firstPaint;
-        private float _cornerRoundingRadius;
-
         #endregion
 
         #region Events
         /// <summary>
-        /// Occurs when the value of the AcceptsTab property changes.
+        /// Occurs when the mouse enters the InternalComboBox.
         /// </summary>
-        [Description(@"Occurs when the value of the AcceptsTab property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? AcceptsTabChanged;
-
-        /// <summary>
-        /// Occurs when the value of the HideSelection property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the HideSelection property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? HideSelectionChanged;
-
-        /// <summary>
-        /// Occurs when the value of the Modified property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the Modified property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? ModifiedChanged;
-
-        /// <summary>
-        /// Occurs when the value of the Multiline property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the Multiline property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? MultilineChanged;
-
-        /// <summary>
-        /// Occurs when the value of the ReadOnly property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the ReadOnly property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? ReadOnlyChanged;
-
-        /// <summary>
-        /// Occurs when the current selection has changed.
-        /// </summary>
-        [Description(@"Occurs when the current selection has changed.")]
-        [Category(@"Behavior")]
-        public event EventHandler? SelectionChanged;
-
-        /// <summary>
-        /// Occurs when the user takes an action that would change a protected range of text.
-        /// </summary>
-        [Description(@"Occurs when the user takes an action that would change a protected range of text.")]
-        [Category(@"Behavior")]
-        public event EventHandler? Protected;
-
-        /// <summary>
-        /// Occurs when a hyperlink in the text is clicked.
-        /// </summary>
-        [Description(@"Occurs when a hyperlink in the text is clicked.")]
-        [Category(@"Behavior")]
-        public event LinkClickedEventHandler? LinkClicked;
-
-        /// <summary>
-        /// Occurs when the horizontal scroll bar is clicked.
-        /// </summary>
-        [Description(@"Occurs when the horizontal scroll bar is clicked.")]
-        [Category(@"Behavior")]
-        public event EventHandler? HScroll;
-
-        /// <summary>
-        /// Occurs when the vertical scroll bar is clicked.
-        /// </summary>
-        [Description(@"Occurs when the vertical scroll bar is clicked.")]
-        [Category(@"Behavior")]
-        public event EventHandler? VScroll;
-
-        /// <summary>
-        /// Occurs when the mouse enters the control.
-        /// </summary>
-        [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
-        [Category(@"Mouse")]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseEnter;
 
         /// <summary>
-        /// Occurs when the mouse leaves the control.
+        /// Occurs when the mouse leaves the InternalComboBox.
         /// </summary>
-        [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
-        [Category(@"Mouse")]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseLeave;
-
-        /// <summary>
-        /// Occurs when the value of the BackColor property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackColorChanged;
-
-        /// <summary>
-        /// Occurs when the value of the BackgroundImage property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackgroundImageChanged;
-
-        /// <summary>
-        /// Occurs when the value of the BackgroundImageLayout property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackgroundImageLayoutChanged;
-
-        /// <summary>
-        /// Occurs when the value of the ForeColor property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? ForeColorChanged;
         #endregion
 
         #region Identity
         /// <summary>
-        /// Initialize a new instance of the KryptonRichTextBox class.
+        /// Initialize a new instance of the InternalTextBox class.
         /// </summary>
-        public KryptonRichTextBox()
+        /// <param name="kryptonRichTextBox">Reference to owning control.</param>
+        public InternalRichTextBox(KryptonRichTextBox kryptonRichTextBox)
         {
-            // Contains another control and needs marking as such for validation to work
-            SetStyle(ControlStyles.ContainerControl, true);
+            _kryptonRichTextBox = kryptonRichTextBox;
 
-            // Cannot select this control, only the child TextBox
-            SetStyle(ControlStyles.Selectable, false);
+            // Remove from view until size for the first time by the Krypton control
+            Size = Size.Empty;
 
-            // Defaults
-            _autoSize = false;
-            _alwaysActive = true;
-            AllowButtonSpecToolTips = false;
-            AllowButtonSpecToolTipPriority = false;
-            _firstPaint = true;
-            _inputControlStyle = InputControlStyle.Standalone;
-
-            // Create storage properties
-            ButtonSpecs = new RichTextBoxButtonSpecCollection(this);
-
-            // Create the palette storage
-            StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
-            StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
-
-            // Create the internal text box used for containing content
-            _richTextBox = new InternalRichTextBox(this);
-            _richTextBox.TrackMouseEnter += OnRichTextBoxMouseChange;
-            _richTextBox.TrackMouseLeave += OnRichTextBoxMouseChange;
-            _richTextBox.AcceptsTabChanged += OnRichTextBoxAcceptsTabChanged;
-            _richTextBox.TextChanged += OnRichTextBoxTextChanged;
-            _richTextBox.HideSelectionChanged += OnRichTextBoxHideSelectionChanged;
-            _richTextBox.ModifiedChanged += OnRichTextBoxModifiedChanged;
-            _richTextBox.MultilineChanged += OnRichTextBoxMultilineChanged;
-            _richTextBox.ReadOnlyChanged += OnRichTextBoxReadOnlyChanged;
-            _richTextBox.GotFocus += OnRichTextBoxGotFocus;
-            _richTextBox.LostFocus += OnRichTextBoxLostFocus;
-            _richTextBox.KeyDown += OnRichTextBoxKeyDown;
-            _richTextBox.KeyUp += OnRichTextBoxKeyUp;
-            _richTextBox.KeyPress += OnRichTextBoxKeyPress;
-            _richTextBox.PreviewKeyDown += OnRichTextBoxPreviewKeyDown;
-            _richTextBox.LinkClicked += OnRichTextBoxLinkClicked;
-            _richTextBox.Protected += OnRichTextBoxProtected;
-            _richTextBox.SelectionChanged += OnRichTextBoxSelectionChanged;
-            _richTextBox.HScroll += OnRichTextBoxHScroll;
-            _richTextBox.VScroll += OnRichTextBoxVScroll;
-            _richTextBox.Validating += OnRichTextBoxValidating;
-            _richTextBox.Validated += OnRichTextBoxValidated;
-
-            // Create the element that fills the remainder space and remembers fill rectangle
-            _layoutFill = new ViewLayoutFill(_richTextBox);
-
-            // Create inner view for placing inside the drawing docker
-            _drawDockerInner = new ViewLayoutDocker
-            {
-                { _layoutFill, ViewDockStyle.Fill }
-            };
-
-            // Create view for the control border and background
-            _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
-            {
-                { _drawDockerInner, ViewDockStyle.Fill }
-            };
-
-            // Create the view manager instance
-            ViewManager = new ViewManager(this, _drawDockerOuter);
-
-            // Create button specification collection manager
-            _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
-                                                         new[] { _drawDockerInner },
-                                                         new IPaletteMetric[] { StateCommon },
-                                                         new[] { PaletteMetricInt.HeaderButtonEdgeInsetInputControl },
-                                                         new[] { PaletteMetricPadding.HeaderButtonPaddingInputControl },
-                                                         CreateToolStripRenderer,
-                                                         NeedPaintDelegate);
-
-            // Create the manager for handling tooltips
-            ToolTipManager = new ToolTipManager(ToolTipValues);
-            ToolTipManager.ShowToolTip += OnShowToolTip;
-            ToolTipManager.CancelToolTip += OnCancelToolTip;
-            _buttonManager.ToolTipManager = ToolTipManager;
-
-            // Add text box to the controls collection
-            ((KryptonReadOnlyControls)Controls).AddInternal(_richTextBox);
-
-            // Update the back/fore/font from the palette settings
-            UpdateStateAndPalettes();
-            _richTextBox.BackColor = StateActive.PaletteBack.GetBackColor1(PaletteState.Tracking);
-            _richTextBox.ForeColor = StateActive.PaletteContent.GetContentShortTextColor1(PaletteState.Tracking);
-
-            // Only set the font if the rich text box has been created
-            if (_richTextBox.Handle != IntPtr.Zero)
-            {
-                _richTextBox.Font = StateActive.PaletteContent.GetContentShortTextFont(PaletteState.Tracking);
-            }
-
-            _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
-        }
-
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // Remove any showing tooltip
-                OnCancelToolTip(this, EventArgs.Empty);
-
-                // Remember to pull down the manager instance
-                _buttonManager.Destruct();
-            }
-
-            base.Dispose(disposing);
+            // We provide the border manually
+            BorderStyle = BorderStyle.None;
         }
         #endregion
 
         #region Public
-
-        /// <summary>Gets or sets the corner rounding radius.</summary>
-        /// <value>The corner rounding radius.</value>
-        [Category(@"Visuals"), DefaultValue(GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE), Description(@"Defines the corner roundness on the current window (-1 is the default look).")]
-        public float CornerRoundingRadius
-        {
-            get => _cornerRoundingRadius;
-            set => SetCornerRoundingRadius(value);
-        }
-
-        [Category(@"Visuals")]
-        [Description(@"Set a watermark/prompt message for the user.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteCueHintText CueHint { get; }
-
-        private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
-
         /// <summary>
-        /// Gets and sets if the control is in the tab chain.
-        /// </summary>
-        public new bool TabStop
-        {
-            get => _richTextBox.TabStop;
-            set => _richTextBox.TabStop = value;
-        }
-
-        /// <summary>
-        /// Gets and sets if the control is in the ribbon design mode.
+        /// Gets and sets if the mouse is currently over the combo box.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public bool InRibbonDesignMode { get; set; }
-
-        /// <summary>
-        /// Gets access to the contained RichTextBox instance.
-        /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(false)]
-        public RichTextBox? RichTextBox => _richTextBox;
-
-        /// <summary>
-        /// Gets access to the contained input control.
-        /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(false)]
-        public Control ContainedControl => RichTextBox;
-
-        /// <summary>
-        /// Gets a value indicating whether the control has input focus.
-        /// </summary>
-        [Browsable(false)]
-        public override bool Focused => RichTextBox.Focused;
-
-        /// <summary>
-        /// Gets or sets the ability to drag/drop onto the control.
-        /// </summary>
-        [Browsable(false)]
-        public override bool AllowDrop
+        public bool MouseOver
         {
-            get => base.AllowDrop;
-            set => base.AllowDrop = value;
-        }
-
-        /// <summary>
-        /// Gets and sets a value indicating if the control is automatically sized.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue(false)]
-        public override bool AutoSize
-        {
-            get => _autoSize;
-            set => _autoSize = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the background color for the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        public override Color BackColor
-        {
-            get => base.BackColor;
-            set => base.BackColor = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the font of the text Displayed by the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        [AmbientValue(null)]
-        [AllowNull]
-        public override Font Font
-        {
-            get => base.Font;
-            set => base.Font = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the foreground color for the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        public override Color ForeColor
-        {
-            get => base.ForeColor;
-            set => base.ForeColor = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the internal padding space.
-        /// </summary>
-        [Browsable(false)]
-        [Localizable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new Padding Padding
-        {
-            get => base.Padding;
-            set => base.Padding = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the text associated associated with the control.
-        /// </summary>
-        [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
-        [AllowNull]
-        public override string Text
-        {
-            get => _richTextBox.Text;
-            set => _richTextBox.Text = value;
-        }
-
-        private bool ShouldSerializeText() =>
-            // Must always persist the text value if even when it is the default. Otherwise when
-            // you first move over the control which has been given RTF it resets the fonts.
-            true;
-
-        /// <summary>
-        /// Gets the length of text in the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int TextLength => _richTextBox.TextLength;
-
-        /// <summary>
-        /// Gets and sets the associated context menu strip.
-        /// </summary>
-        public override ContextMenuStrip? ContextMenuStrip
-        {
-            get => base.ContextMenuStrip;
+            get => _mouseOver;
 
             set
             {
-                base.ContextMenuStrip = value;
-                _richTextBox.ContextMenuStrip = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets if the control can redo a previously undo operation.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool CanRedo => _richTextBox.CanRedo;
-
-        /// <summary>
-        /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool CanUndo => _richTextBox.CanUndo;
-
-        /// <summary>
-        /// Gets a value indicating whether the contents have changed since last last.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool Modified => _richTextBox.Modified;
-
-        /// <summary>
-        /// Gets and sets the language option.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public RichTextBoxLanguageOptions LanguageOption
-        {
-            get => _richTextBox.LanguageOption;
-            set => _richTextBox.LanguageOption = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the name of the action to be redone.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string RedoActionName => _richTextBox.RedoActionName;
-
-        /// <summary>
-        /// Gets and sets the name of the action to be undone.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string UndoActionName => _richTextBox.UndoActionName;
-
-        /// <summary>
-        /// Gets and sets if keyboard shortcuts are enabled.
-        /// </summary>
-        [Browsable(false)]
-        [DefaultValue(true)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool RichTextShortcutsEnabled
-        {
-            get => _richTextBox.RichTextShortcutsEnabled;
-            set => _richTextBox.RichTextShortcutsEnabled = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the text in rich text format.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [RefreshProperties(RefreshProperties.All)]
-        public string Rtf
-        {
-            get => _richTextBox.Rtf;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.Rtf = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the selection portion of the rich text format.
-        /// </summary>
-        [Browsable(false)]
-        [DefaultValue("")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string SelectedRtf
-        {
-            get => _richTextBox.SelectedRtf;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectedRtf = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the selected text within the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string SelectedText
-        {
-            get => _richTextBox.SelectedText;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectedText = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the alignment of the selection.
-        /// </summary>
-        [Browsable(false)]
-        [DefaultValue(HorizontalAlignment.Left)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public HorizontalAlignment SelectionAlignment
-        {
-            get => _richTextBox.SelectionAlignment;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionAlignment = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the background color of the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Color SelectionBackColor
-        {
-            get => _richTextBox.SelectionBackColor;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionBackColor = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the bullet indentation of the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool SelectionBullet
-        {
-            get => _richTextBox.SelectionBullet;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionBullet = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the character offset of the selection.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionCharOffset
-        {
-            get => _richTextBox.SelectionCharOffset;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionCharOffset = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the text color of the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Color SelectionColor
-        {
-            get => _richTextBox.SelectionColor;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionColor = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the text font for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Font SelectionFont
-        {
-            get => _richTextBox.SelectionFont;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionFont = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the hanging indent for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionHangingIndent
-        {
-            get => _richTextBox.SelectionHangingIndent;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionHangingIndent = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the indent for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionIndent
-        {
-            get => _richTextBox.SelectionIndent;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionIndent = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the selection length for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionLength
-        {
-            get => _richTextBox.SelectionLength;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionLength = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the protected setting for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionProtected
-        {
-            get => _richTextBox.SelectionLength;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionLength = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the right indent for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionRightIndent
-        {
-            get => _richTextBox.SelectionRightIndent;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionRightIndent = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the starting point of text selected in the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionStart
-        {
-            get => _richTextBox.SelectionStart;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionStart = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the tab settings for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int[] SelectionTabs
-        {
-            get => _richTextBox.SelectionTabs;
-
-            set
-            {
-                PerformNeedPaint(true);
-                _richTextBox.SelectionTabs = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the type of selection.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public RichTextBoxSelectionTypes SelectionType => _richTextBox.SelectionType;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"Defines if mnemonic characters generate click events for button specs.")]
-        [DefaultValue(true)]
-        public bool UseMnemonic
-        {
-            get => _buttonManager.UseMnemonic;
-
-            set
-            {
-                if (_buttonManager.UseMnemonic != value)
+                // Only interested in changes
+                if (_mouseOver != value)
                 {
-                    _buttonManager.UseMnemonic = value;
-                    PerformNeedPaint(true);
+                    _mouseOver = value;
+
+                    // Generate appropriate change event
+                    if (_mouseOver)
+                    {
+                        OnTrackMouseEnter(EventArgs.Empty);
+                    }
+                    else
+                    {
+                        OnTrackMouseLeave(EventArgs.Empty);
+                    }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
-        [DefaultValue(true)]
-        public bool AlwaysActive
-        {
-            get => _alwaysActive;
-
-            set
-            {
-                if (_alwaysActive != value)
-                {
-                    _alwaysActive = value;
-                    PerformNeedPaint(true);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the lines of text in a multiline edit, as an array of String values.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"The lines of text in a multiline edit, as an array of String values.")]
-        [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [MergableProperty(false)]
-        [Localizable(true)]
-        public string[] Lines
-        {
-            get => _richTextBox.Lines;
-            set => _richTextBox.Lines = value;
-        }
-
-        /// <summary>
-        /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
-        [DefaultValue(RichTextBoxScrollBars.Both)]
-        [Localizable(true)]
-        public RichTextBoxScrollBars ScrollBars
-        {
-            get => _richTextBox.ScrollBars;
-            set => _richTextBox.ScrollBars = value;
-        }
-
-        /// <summary>
-        /// Indicates if lines are automatically word-wrapped for multiline edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
-        [DefaultValue(true)]
-        [Localizable(true)]
-        public bool WordWrap
-        {
-            get => _richTextBox.WordWrap;
-            set => _richTextBox.WordWrap = value;
-        }
-
-        /// <summary>
-        /// Defines the right margin dimensions.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Defines the right margin dimensions.")]
-        [DefaultValue(0)]
-        [Localizable(true)]
-        public int RightMargin
-        {
-            get => _richTextBox.RightMargin;
-            set => _richTextBox.RightMargin = value;
-        }
-
-        /// <summary>
-        /// Turns on/off the selection margin.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Turns on/off the selection margin.")]
-        [DefaultValue(false)]
-        public bool ShowSelectionMargin
-        {
-            get => _richTextBox.ShowSelectionMargin;
-            set => _richTextBox.ShowSelectionMargin = value;
-        }
-
-        /// <summary>
-        /// Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.")]
-        [DefaultValue(1.0f)]
-        [Localizable(true)]
-        public float ZoomFactor
-        {
-            get => _richTextBox.ZoomFactor;
-            set => _richTextBox.ZoomFactor = value;
-        }
-
-        /// <summary>
-        /// Gets and sets whether the text in the control can span more than one line.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Control whether the text in the control can span more than one line.")]
-        [RefreshProperties(RefreshProperties.All)]
-        [DefaultValue(true)]
-        [Localizable(true)]
-        public bool Multiline
-        {
-            get => _richTextBox.Multiline;
-            set => _richTextBox.Multiline = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
-        [DefaultValue(false)]
-        public bool AcceptsTab
-        {
-            get => _richTextBox.AcceptsTab;
-            set => _richTextBox.AcceptsTab = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
-        [DefaultValue(true)]
-        public bool HideSelection
-        {
-            get => _richTextBox.HideSelection;
-            set => _richTextBox.HideSelection = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum number of characters that can be entered into the edit control.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
-        [DefaultValue(0x7fffffff)]
-        [Localizable(true)]
-        public int MaxLength
-        {
-            get => _richTextBox.MaxLength;
-            set => _richTextBox.MaxLength = value;
-        }
-
-        /// <summary>
-        /// Turns on/off automatic word selection.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Turns on/off automatic word selection.")]
-        [DefaultValue(false)]
-        public bool AutoWordSelection
-        {
-            get => _richTextBox.AutoWordSelection;
-            set => _richTextBox.AutoWordSelection = value;
-        }
-
-        /// <summary>
-        /// Defines the indent for bullets in the control.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Defines the indent for bullets in the control.")]
-        [DefaultValue(0)]
-        [Localizable(true)]
-        public int BulletIndent
-        {
-            get => _richTextBox.BulletIndent;
-            set => _richTextBox.BulletIndent = value;
-        }
-
-        /// <summary>
-        /// Indicates whether URLs are automatically formatted as links.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates whether URLs are automatically formatted as links.")]
-        [DefaultValue(true)]
-        public bool DetectUrls
-        {
-            get => _richTextBox.DetectUrls;
-            set => _richTextBox.DetectUrls = value;
-        }
-
-        /// <summary>
-        /// Enable drag/drop of text, pictures and other data.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Enable drag/drop of text, pictures and other data.")]
-        [DefaultValue(false)]
-        public bool EnableAutoDragDrop
-        {
-            get => _richTextBox.EnableAutoDragDrop;
-            set => _richTextBox.EnableAutoDragDrop = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Controls whether the text in the edit control can be changed or not.")]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue(false)]
-        public bool ReadOnly
-        {
-            get => _richTextBox.ReadOnly;
-            set => _richTextBox.ReadOnly = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
-        [DefaultValue(true)]
-        public bool ShortcutsEnabled
-        {
-            get => _richTextBox.ShortcutsEnabled;
-            set => _richTextBox.ShortcutsEnabled = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the input control style.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Input control style.")]
-        public InputControlStyle InputControlStyle
-        {
-            get => _inputControlStyle;
-
-            set
-            {
-                if (_inputControlStyle != value)
-                {
-                    _inputControlStyle = value;
-                    StateCommon.SetStyles(value);
-                    PerformNeedPaint(true);
-                }
-            }
-        }
-
-        private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
-
-        private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
-
-        /// <summary>
-        /// Gets and sets a value indicating if tooltips should be Displayed for button specs.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Should tooltips be Displayed for button specs.")]
-        [DefaultValue(false)]
-        public bool AllowButtonSpecToolTips { get; set; }
-
-        /// <summary>
-        /// Gets and sets a value indicating if button spec tooltips should remove the parent tooltip.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Should button spec tooltips should remove the parent tooltip")]
-        [DefaultValue(false)]
-        public bool AllowButtonSpecToolTipPriority { get; set; }
-
-        /// <summary>
-        /// Gets the collection of button specifications.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Collection of button specifications.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public RichTextBoxButtonSpecCollection ButtonSpecs { get; }
-
-        /// <summary>
-        /// Gets access to the common textbox appearance entries that other states can override.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining common textbox appearance that other states can override.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleRedirect StateCommon { get; }
-
-        private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
-
-        /// <summary>
-        /// Gets access to the disabled textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining disabled textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateDisabled { get; }
-
-        private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
-
-        /// <summary>
-        /// Gets access to the normal textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining normal textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateNormal { get; }
-
-        private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
-
-        /// <summary>
-        /// Gets access to the active textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining active textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateActive { get; }
-
-        private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
-
-        /// <summary>
-        /// Appends text to the current text of a rich text box.
-        /// </summary>
-        /// <param name="text">The text to append to the current contents of the text box.</param>
-        public void AppendText(string text) => _richTextBox.AppendText(text);
-
-        /// <summary>
-        /// Clears all text from the text box control.
-        /// </summary>
-        public void Clear() => _richTextBox.Clear();
-
-        /// <summary>
-        /// Clears information about the most recent operation from the undo buffer of the rich text box. 
-        /// </summary>
-        public void ClearUndo() => _richTextBox.ClearUndo();
-
-        /// <summary>
-        /// Copies the current selection in the text box to the Clipboard.
-        /// </summary>
-        public void Copy() => _richTextBox.Copy();
-
-        /// <summary>
-        /// Moves the current selection in the text box to the Clipboard.
-        /// </summary>
-        public void Cut() => _richTextBox.Cut();
-
-        /// <summary>
-        /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
-        /// </summary>
-        public void DeselectAll() => _richTextBox.DeselectAll();
-
-        /// <summary>
-        /// Determines whether you can paste information from the Clipboard in the specified data format.
-        /// </summary>
-        /// <param name="clipFormat">One of the System.Windows.Forms.DataFormats.Format values.</param>
-        /// <returns>true if you can paste data from the Clipboard in the specified data format; otherwise, false.</returns>
-        public bool CanPaste(DataFormats.Format clipFormat) => _richTextBox.CanPaste(clipFormat);
-
-        /// <summary>
-        /// Searches the text in a RichTextBox control for a string.
-        /// </summary>
-        /// <param name="str">The text to locate in the control.</param>
-        /// <returns>The location within the control where the search text was found or -1 if the search string is not found or an empty search string is specified in the str parameter.</returns>
-        public int Find(string str) => _richTextBox.Find(str);
-
-        /// <summary>
-        /// Searches the text of a RichTextBox control for the first instance of a character from a list of characters.
-        /// </summary>
-        /// <param name="characterSet">The array of characters to search for.</param>
-        /// <returns>The location within the control where the search characters were found or -1 if the search characters are not found or an empty search character set is specified in the char parameter.</returns>
-        public int Find(char[] characterSet) => _richTextBox.Find(characterSet);
-
-        /// <summary>
-        /// Searches the text of a RichTextBox control, at a specific starting point, for the first instance of a character from a list of characters.
-        /// </summary>
-        /// <param name="characterSet">The array of characters to search for.</param>
-        /// <param name="start">The location within the control's text at which to begin searching.</param>
-        /// <returns>The location within the control where the search characters are found.</returns>
-        public int Find(char[] characterSet, int start) => _richTextBox.Find(characterSet, start);
-
-        /// <summary>
-        /// Searches the text in a RichTextBox control for a string with specific options applied to the search.
-        /// </summary>
-        /// <param name="str">The text to locate in the control.</param>
-        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-        /// <returns>The location within the control where the search text was found.</returns>
-        public int Find(string str, RichTextBoxFinds options) => _richTextBox.Find(str, options);
-
-        /// <summary>
-        /// Searches a range of text in a RichTextBox control for the first instance of a character from a list of characters.
-        /// </summary>
-        /// <param name="characterSet">The array of characters to search for.</param>
-        /// <param name="start">The location within the control's text at which to begin searching.</param>
-        /// <param name="end">The location within the control's text at which to end searching.</param>
-        /// <returns>The location within the control where the search characters are found.</returns>
-        public int Find(char[] characterSet, int start, int end) => _richTextBox.Find(characterSet, start, end);
-
-        /// <summary>
-        /// Searches the text in a RichTextBox control for a string at a specific location within the control and with specific options applied to the search.
-        /// </summary>
-        /// <param name="str">The text to locate in the control.</param>
-        /// <param name="start">The location within the control's text at which to begin searching.</param>
-        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-        /// <returns>The location within the control where the search text was found.</returns>
-        public int Find(string str, int start, RichTextBoxFinds options) => _richTextBox.Find(str, start, options);
-
-        /// <summary>
-        /// Searches the text in a RichTextBox control for a string within a range of text within the control and with specific options applied to the search.
-        /// </summary>
-        /// <param name="str">The text to locate in the control.</param>
-        /// <param name="start">The location within the control's text at which to begin searching.</param>
-        /// <param name="end">The location within the control's text at which to end searching. This value must be equal to negative one (-1) or greater than or equal to the start parameter.</param>
-        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-        /// <returns></returns>
-        public int Find(string str, int start, int end, RichTextBoxFinds options) => _richTextBox.Find(str, start, end, options);
-
-        /// <summary>
-        /// Retrieves the character that is closest to the specified location within the control.
-        /// </summary>
-        /// <param name="pt">The location from which to seek the nearest character.</param>
-        /// <returns>The character at the specified location.</returns>
-        public int GetCharFromPosition(Point pt) => _richTextBox.GetCharFromPosition(pt);
-
-        /// <summary>
-        /// Retrieves the index of the character nearest to the specified location.
-        /// </summary>
-        /// <param name="pt">The location to search.</param>
-        /// <returns>The zero-based character index at the specified location.</returns>
-        public int GetCharIndexFromPosition(Point pt) => _richTextBox.GetCharIndexFromPosition(pt);
-
-        /// <summary>
-        /// Retrieves the index of the first character of a given line.
-        /// </summary>
-        /// <param name="lineNumber">The line for which to get the index of its first character.</param>
-        /// <returns>The zero-based character index in the specified line.</returns>
-        public int GetFirstCharIndexFromLine(int lineNumber) => _richTextBox.GetFirstCharIndexFromLine(lineNumber);
-
-        /// <summary>
-        /// Retrieves the index of the first character of the current line.
-        /// </summary>
-        /// <returns>The zero-based character index in the current line.</returns>
-        public int GetFirstCharIndexOfCurrentLine() => _richTextBox.GetFirstCharIndexOfCurrentLine();
-
-        /// <summary>
-        /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
-        /// </summary>
-        /// <param name="index">The character index position to search.</param>
-        /// <returns>The zero-based line number in which the character index is located.</returns>
-        public int GetLineFromCharIndex(int index) => _richTextBox.GetLineFromCharIndex(index);
-
-        /// <summary>
-        /// Retrieves the location within the control at the specified character index.
-        /// </summary>
-        /// <param name="index">The index of the character for which to retrieve the location.</param>
-        /// <returns>The location of the specified character.</returns>
-        public Point GetPositionFromCharIndex(int index) => _richTextBox.GetPositionFromCharIndex(index);
-
-        /// <summary>
-        /// Loads a rich text format (RTF) or standard ASCII text file into the RichTextBox control.
-        /// </summary>
-        /// <param name="path">The name and location of the file to load into the control.</param>
-        public void LoadFile(string path) => _richTextBox.LoadFile(path);
-
-        /// <summary>
-        /// Loads the contents of an existing data stream into the RichTextBox control.
-        /// </summary>
-        /// <param name="data">A stream of data to load into the RichTextBox control.</param>
-        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-        public void LoadFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(data, fileType);
-
-        /// <summary>
-        /// Loads a specific type of file into the RichTextBox control.
-        /// </summary>
-        /// <param name="path">The name and location of the file to load into the control.</param>
-        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-        public void LoadFile(string path, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(path, fileType);
-
-        /// <summary>
-        /// Replaces the current selection in the text box with the contents of the Clipboard.
-        /// </summary>
-        public void Paste() => _richTextBox.Paste();
-
-        /// <summary>
-        /// Undoes the last edit operation in the text box.
-        /// </summary>
-        public void Undo() => _richTextBox.Undo();
-
-        /// <summary>
-        /// Pastes the contents of the Clipboard in the specified Clipboard format.
-        /// </summary>
-        /// <param name="clipFormat">The Clipboard format in which the data should be obtained from the Clipboard.</param>
-        public void Paste(DataFormats.Format clipFormat) => _richTextBox.Paste(clipFormat);
-
-        /// <summary>
-        /// Reapplies the last operation that was undone in the control.
-        /// </summary>
-        public void Redo() => _richTextBox.Redo();
-
-        /// <summary>
-        /// Saves the contents of the RichTextBox to a rich text format (RTF) file.
-        /// </summary>
-        /// <param name="path">The name and location of the file to save.</param>
-        public void SaveFile(string path) => _richTextBox.SaveFile(path);
-
-        /// <summary>
-        /// Saves the contents of a RichTextBox control to an open data stream.
-        /// </summary>
-        /// <param name="data">The data stream that contains the file to save to.</param>
-        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-        public void SaveFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(data, fileType);
-
-        /// <summary>
-        /// Saves the contents of the KryptonRichTextBox to a specific type of file.
-        /// </summary>
-        /// <param name="path">The name and location of the file to save.</param>
-        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-        public void SaveFile(string path, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(path, fileType);
-
-        /// <summary>
-        /// Scrolls the contents of the control to the current caret position.
-        /// </summary>
-        public void ScrollToCaret() => _richTextBox.ScrollToCaret();
-
-        /// <summary>
-        /// Selects a range of text in the control.
-        /// </summary>
-        /// <param name="start">The position of the first character in the current text selection within the text box.</param>
-        /// <param name="length">The number of characters to select.</param>
-        public void Select(int start, int length) => _richTextBox.Select(start, length);
-
-        /// <summary>
-        /// Selects all text in the control.
-        /// </summary>
-        public void SelectAll() => _richTextBox.SelectAll();
-
-        /// <summary>
-        /// Sets the fixed state of the control.
-        /// </summary>
-        /// <param name="active">Should the control be fixed as active.</param>
-        public void SetFixedState(bool active) => _fixedActive = active;
-
-        /// <summary>
-        /// Gets access to the ToolTipManager used for displaying tool tips.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public ToolTipManager ToolTipManager { get; }
-
-        /// <summary>
-        /// Gets a value indicating if the input control is active.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive =>
-            _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
-
-        /// <summary>
-        /// Sets input focus to the control.
-        /// </summary>
-        /// <returns>true if the input focus request was successful; otherwise, false.</returns>
-        public new bool Focus() => RichTextBox != null && RichTextBox.Focus();
-
-        /// <summary>
-        /// Activates the control.
-        /// </summary>
-        public new void Select() => RichTextBox?.Select();
-
-        /// <summary>
-        /// Get the preferred size of the control based on a proposed size.
-        /// </summary>
-        /// <param name="proposedSize">Starting size proposed by the caller.</param>
-        /// <returns>Calculated preferred size.</returns>
-        public override Size GetPreferredSize(Size proposedSize)
-        {
-            // Do we have a manager to ask for a preferred size?
-            if (ViewManager != null)
-            {
-                // Ask the view to Perform a layout
-                Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
-
-                // Apply the maximum sizing
-                if (MaximumSize.Width > 0)
-                {
-                    retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
-                }
-
-                if (MaximumSize.Height > 0)
-                {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
-                }
-
-                // Apply the minimum sizing
-                if (MinimumSize.Width > 0)
-                {
-                    retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
-                }
-
-                if (MinimumSize.Height > 0)
-                {
-                    retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
-                }
-
-                return retSize;
-            }
-            else
-            {
-                // Fall back on default control processing
-                return base.GetPreferredSize(proposedSize);
-            }
-        }
-
-        /// <summary>
-        /// Gets the rectangle that represents the display area of the control.
-        /// </summary>
-        public override Rectangle DisplayRectangle
-        {
-            get
-            {
-                // Ensure that the layout is calculated in order to know the remaining display space
-                ForceViewLayout();
-
-                // The inside text box is the client rectangle size
-                return new Rectangle(_richTextBox.Location, _richTextBox.Size);
             }
         }
 
@@ -1695,127 +106,157 @@ namespace Krypton.Toolkit
         /// <param name="gr">Graphics instance to use.</param>
         /// <param name="bounds">Drawing bounds.</param>
         /// <returns>Pointer to returned result.</returns>
-        public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds) => _richTextBox.Print(charFrom, charTo, gr, bounds);
-
-        /// <summary>
-        /// Override the display padding for the layout fill.
-        /// </summary>
-        /// <param name="padding">Display padding value.</param>
-        public void SetLayoutDisplayPadding(Padding padding) => _layoutFill.DisplayPadding = padding;
-
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        /// <param name="pt">Mouse location.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public bool DesignerGetHitTest(Point pt)
+        public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds)
         {
-            // Ignore call as view builder is already destructed
-            if (IsDisposed)
-            {
-                return false;
-            }
+            //Calculate the area to render and print
+            PI.RECT rectToPrint;
+            rectToPrint.top = 0;
+            rectToPrint.bottom = (int)(bounds.Height * AN_INCH);
+            rectToPrint.left = 0;
+            rectToPrint.right = (int)(bounds.Width * AN_INCH);
 
-            // Check if any of the button specs want the point
-            return (_buttonManager != null) && _buttonManager.DesignerGetHitTest(pt);
+            //Calculate the size of the page
+            PI.RECT rectPage;
+            rectPage.top = 0;
+            rectPage.bottom = (int)(gr.ClipBounds.Height * AN_INCH);
+            rectPage.left = 0;
+            rectPage.right = (int)(gr.ClipBounds.Right * AN_INCH);
+
+            var hdc = gr.GetHdc();
+
+            PI.FORMATRANGE fmtRange;
+            fmtRange.chrg.cpMax = charTo;
+            fmtRange.chrg.cpMin = charFrom;
+            fmtRange.hdc = hdc;
+            fmtRange.hdcTarget = hdc;
+            fmtRange.rc = rectToPrint;
+            fmtRange.rcPage = rectPage;
+
+            var wParam = new IntPtr(1);
+
+            //Get the pointer to the FORMATRANGE structure in memory
+            var lParam = Marshal.AllocCoTaskMem(Marshal.SizeOf(fmtRange));
+            Marshal.StructureToPtr(fmtRange, lParam, false);
+
+            //Send the rendered data for printing 
+            var res = (IntPtr)PI.SendMessage(Handle, PI.EM_FORMATRANGE, wParam, lParam);
+
+            //Free the block of memory allocated
+            Marshal.FreeCoTaskMem(lParam);
+
+            //Release the device context handle obtained by a previous call
+            gr.ReleaseHdc(hdc);
+
+            //Return last + 1 character printer
+            return (int)res.ToInt64();
         }
-
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        /// <param name="pt">Mouse location.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public Component DesignerComponentFromPoint(Point pt) =>
-            // Ignore call as view builder is already destructed
-            IsDisposed ? null : ViewManager.ComponentFromPoint(pt);
-
-        // Ask the current view for a decision
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public void DesignerMouseLeave() =>
-            // Simulate the mouse leaving the control so that the tracking
-            // element that thinks it has the focus is informed it does not
-            OnMouseLeave(EventArgs.Empty);
-
         #endregion
 
         #region Protected
-        /// <summary>
-        /// Force the layout logic to size and position the controls.
-        /// </summary>
-        protected void ForceControlLayout()
+        protected override void OnEnabledChanged(EventArgs e)
         {
-            _forcedLayout = true;
-            OnLayout(new LayoutEventArgs(null, null));
-            _forcedLayout = false;
+            // Do not forward, to allow the correct Background for disabled state
+            // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/722
         }
-        #endregion
-
-        #region Protected Virtual
-        /// <summary>
-        /// Raises the AcceptsTabChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
 
         /// <summary>
-        /// Raises the HideSelectionChanged event.
+        /// Process Windows-based messages.
         /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
+        /// <param name="m">A Windows-based message.</param>
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case PI.WM_.NCHITTEST:
+                    if (_kryptonRichTextBox.InTransparentDesignMode)
+                    {
+                        m.Result = (IntPtr)PI.HT.TRANSPARENT;
+                    }
+                    else
+                    {
+                        base.WndProc(ref m);
+                    }
 
-        /// <summary>
-        /// Raises the ModifiedChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
+                    break;
+                case PI.WM_.MOUSELEAVE:
+                    // Mouse is not over the control
+                    MouseOver = false;
+                    _kryptonRichTextBox.PerformNeedPaint(true);
+                    Invalidate();
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.MOUSEMOVE:
+                    // Mouse is over the control
+                    if (!MouseOver)
+                    {
+                        MouseOver = true;
+                        _kryptonRichTextBox.PerformNeedPaint(true);
+                        Invalidate();
+                    }
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.CONTEXTMENU:
+                    // Only interested in overriding the behavior when we have a krypton context menu...
+                    if (_kryptonRichTextBox.KryptonContextMenu != null)
+                    {
+                        // Extract the screen mouse position (if might not actually be provided)
+                        var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
 
-        /// <summary>
-        /// Raises the MultilineChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
+                        // If keyboard activated, the menu position is centered
+                        if (((int)(long)m.LParam) == -1)
+                        {
+                            mousePt = PointToScreen(new Point(Width / 2, Height / 2));
+                        }
 
-        /// <summary>
-        /// Raises the ReadOnlyChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
+                        // Show the context menu
+                        _kryptonRichTextBox.KryptonContextMenu.Show(_kryptonRichTextBox, mousePt);
 
-        /// <summary>
-        /// Raises the VScroll event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnVScroll(EventArgs e) => VScroll?.Invoke(this, e);
+                        // We eat the message!
+                        return;
+                    }
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.PAINT:
+                    if (!string.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
+                        && (_kryptonRichTextBox.TextLength == 0)
+                       )
+                    {
+                        var ps = new PI.PAINTSTRUCT();
+                        // Do we need to BeginPaint or just take the given HDC?
+                        IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+                        using (Graphics g = Graphics.FromHdc(hdc))
+                        {
+                            g.ResetClip();
 
-        /// <summary>
-        /// Raises the HScroll event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnHScroll(EventArgs e) => HScroll?.Invoke(this, e);
+                            // Grab the client area of the control
+                            PI.GetClientRect(Handle, out PI.RECT rect);
 
-        /// <summary>
-        /// Raises the SelectionChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnSelectionChanged(EventArgs e) => SelectionChanged?.Invoke(this, e);
+                            PaletteState state = _kryptonRichTextBox.Enabled
+                                ? _kryptonRichTextBox.IsActive
+                                    ? PaletteState.Tracking
+                                    : PaletteState.Normal
+                                : PaletteState.Disabled;
+                            IPaletteTriple states = _kryptonRichTextBox.GetTripleState();
 
-        /// <summary>
-        /// Raises the Protected event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnProtected(EventArgs e) => Protected?.Invoke(this, e);
+                            // Drawn entire client area in the background color
+                            using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
+                            // Go perform the drawing of the CueHint
+                            _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, rect, backBrush);
+                        }
 
-        /// <summary>
-        /// Raises the LinkClicked event.
-        /// </summary>
-        /// <param name="e">A LinkClickedEventArgs that contains the event data.</param>
-        protected virtual void OnLinkClicked(LinkClickedEventArgs e) => LinkClicked?.Invoke(this, e);
+                        // Do we need to match the original BeginPaint?
+                        if (m.WParam == IntPtr.Zero)
+                        {
+                            PI.EndPaint(Handle, ref ps);
+                        }
+                    }
+                    base.WndProc(ref m);
+                    break;
+                default:
+                    base.WndProc(ref m);
+                    break;
+            }
+        }
 
         /// <summary>
         /// Raises the TrackMouseEnter event.
@@ -1828,468 +269,2434 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="e">An EventArgs containing the event data.</param>
         protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
-        #endregion
-
-        #region Protected Overrides
-        /// <summary>
-        /// Creates a new instance of the control collection for the KryptonTextBox.
-        /// </summary>
-        /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
         /// <summary>
-        /// Raises the HandleCreated event.
+        /// Raises the OnMouseMove event.
         /// </summary>
         /// <param name="e">An EventArgs containing the event data.</param>
-        protected override void OnHandleCreated(EventArgs e)
+        protected override void OnMouseMove(MouseEventArgs e)
         {
-            // Let base class do standard stuff
-            base.OnHandleCreated(e);
+            base.OnMouseMove(e);
 
-            // Force the font to be set into the text box child control
-            PerformNeedPaint(false);
+            _kryptonRichTextBox.OnMouseMove(e);
+        }
+        #endregion
+    }
+    #endregion
 
-            // We need a layout to occur before any painting
-            InvokeLayout();
+    #region Instance Fields
+
+    private VisualPopupToolTip? _visualPopupToolTip;
+    private readonly ViewLayoutDocker _drawDockerInner;
+    private readonly ViewDrawDocker _drawDockerOuter;
+    private readonly ViewLayoutFill _layoutFill;
+    private readonly InternalRichTextBox _richTextBox;
+    private InputControlStyle _inputControlStyle;
+    private bool? _fixedActive;
+    private bool _forcedLayout;
+    private bool _autoSize;
+    private bool _mouseOver;
+    private bool _alwaysActive;
+    private bool _trackingMouseEnter;
+    private bool _firstPaint;
+    private string? _originalRtf; // Store original RTF to restore when switching away from dark mode black themes
+
+    #endregion
+
+    #region Events
+    /// <summary>
+    /// Occurs when the value of the AcceptsTab property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the AcceptsTab property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? AcceptsTabChanged;
+
+    /// <summary>
+    /// Occurs when the value of the HideSelection property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the HideSelection property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? HideSelectionChanged;
+
+    /// <summary>
+    /// Occurs when the value of the Modified property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the Modified property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? ModifiedChanged;
+
+    /// <summary>
+    /// Occurs when the value of the Multiline property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the Multiline property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? MultilineChanged;
+
+    /// <summary>
+    /// Occurs when the value of the ReadOnly property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the ReadOnly property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? ReadOnlyChanged;
+
+    /// <summary>
+    /// Occurs when the current selection has changed.
+    /// </summary>
+    [Description(@"Occurs when the current selection has changed.")]
+    [Category(@"Behavior")]
+    public event EventHandler? SelectionChanged;
+
+    /// <summary>
+    /// Occurs when the user takes an action that would change a protected range of text.
+    /// </summary>
+    [Description(@"Occurs when the user takes an action that would change a protected range of text.")]
+    [Category(@"Behavior")]
+    public event EventHandler? Protected;
+
+    /// <summary>
+    /// Occurs when a hyperlink in the text is clicked.
+    /// </summary>
+    [Description(@"Occurs when a hyperlink in the text is clicked.")]
+    [Category(@"Behavior")]
+    public event LinkClickedEventHandler? LinkClicked;
+
+    /// <summary>
+    /// Occurs when the horizontal scroll bar is clicked.
+    /// </summary>
+    [Description(@"Occurs when the horizontal scroll bar is clicked.")]
+    [Category(@"Behavior")]
+    public event EventHandler? HScroll;
+
+    /// <summary>
+    /// Occurs when the vertical scroll bar is clicked.
+    /// </summary>
+    [Description(@"Occurs when the vertical scroll bar is clicked.")]
+    [Category(@"Behavior")]
+    public event EventHandler? VScroll;
+
+    /// <summary>
+    /// Occurs when the mouse enters the control.
+    /// </summary>
+    [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+    [Category(@"Mouse")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public event EventHandler? TrackMouseEnter;
+
+    /// <summary>
+    /// Occurs when the mouse leaves the control.
+    /// </summary>
+    [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
+    [Category(@"Mouse")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public event EventHandler? TrackMouseLeave;
+
+    /// <summary>
+    /// Occurs when the value of the BackColor property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackColorChanged;
+
+    /// <summary>
+    /// Occurs when the value of the BackgroundImage property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackgroundImageChanged;
+
+    /// <summary>
+    /// Occurs when the value of the BackgroundImageLayout property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackgroundImageLayoutChanged;
+
+    /// <summary>
+    /// Occurs when the value of the ForeColor property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? ForeColorChanged;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the KryptonRichTextBox class.
+    /// </summary>
+    public KryptonRichTextBox()
+    {
+        // Contains another control and needs marking as such for validation to work
+        SetStyle(ControlStyles.ContainerControl, true);
+
+        // Cannot select this control, only the child TextBox
+        SetStyle(ControlStyles.Selectable, false);
+
+        // Defaults
+        _autoSize = false;
+        _alwaysActive = true;
+        _firstPaint = true;
+        _inputControlStyle = InputControlStyle.Standalone;
+
+        // Create the palette storage
+        StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
+        StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
+
+        // Create the internal text box used for containing content
+        _richTextBox = new InternalRichTextBox(this);
+        _richTextBox.TrackMouseEnter += OnRichTextBoxMouseChange;
+        _richTextBox.TrackMouseLeave += OnRichTextBoxMouseChange;
+        _richTextBox.AcceptsTabChanged += OnRichTextBoxAcceptsTabChanged;
+        _richTextBox.TextChanged += OnRichTextBoxTextChanged;
+        _richTextBox.HideSelectionChanged += OnRichTextBoxHideSelectionChanged;
+        _richTextBox.ModifiedChanged += OnRichTextBoxModifiedChanged;
+        _richTextBox.MultilineChanged += OnRichTextBoxMultilineChanged;
+        _richTextBox.ReadOnlyChanged += OnRichTextBoxReadOnlyChanged;
+        _richTextBox.GotFocus += OnRichTextBoxGotFocus;
+        _richTextBox.LostFocus += OnRichTextBoxLostFocus;
+        _richTextBox.KeyDown += OnRichTextBoxKeyDown;
+        _richTextBox.KeyUp += OnRichTextBoxKeyUp;
+        _richTextBox.KeyPress += OnRichTextBoxKeyPress;
+        _richTextBox.PreviewKeyDown += OnRichTextBoxPreviewKeyDown;
+        _richTextBox.LinkClicked += OnRichTextBoxLinkClicked;
+        _richTextBox.Protected += OnRichTextBoxProtected;
+        _richTextBox.SelectionChanged += OnRichTextBoxSelectionChanged;
+        _richTextBox.HScroll += OnRichTextBoxHScroll;
+        _richTextBox.VScroll += OnRichTextBoxVScroll;
+        _richTextBox.Validating += OnRichTextBoxValidating;
+        _richTextBox.Validated += OnRichTextBoxValidated;
+
+        // Create the element that fills the remainder space and remembers fill rectangle
+        _layoutFill = new ViewLayoutFill(_richTextBox);
+
+        // Create inner view for placing inside the drawing docker
+        _drawDockerInner = new ViewLayoutDocker
+        {
+            { _layoutFill, ViewDockStyle.Fill }
+        };
+
+        // Create view for the control border and background
+        _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
+        {
+            { _drawDockerInner, ViewDockStyle.Fill }
+        };
+
+        // Create the view manager instance
+        ViewManager = new ViewManager(this, _drawDockerOuter);
+
+        // Create the manager for handling tooltips
+        ToolTipManager = new ToolTipManager(ToolTipValues);
+        ToolTipManager.ShowToolTip += OnShowToolTip;
+        ToolTipManager.CancelToolTip += OnCancelToolTip;
+
+        // Add text box to the controls collection
+        ((KryptonReadOnlyControls)Controls).AddInternal(_richTextBox);
+
+        // Update the back/fore/font from the palette settings
+        UpdateStateAndPalettes();
+        _richTextBox.BackColor = StateActive.PaletteBack.GetBackColor1(PaletteState.Tracking);
+        _richTextBox.ForeColor = StateActive.PaletteContent.GetContentShortTextColor1(PaletteState.Tracking);
+
+        // Only set the font if the rich text box has been created
+        if (_richTextBox.Handle != IntPtr.Zero)
+        {
+            _richTextBox.Font = StateActive.PaletteContent.GetContentShortTextFont(PaletteState.Tracking)!;
+        }
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Remove any showing tooltip
+            OnCancelToolTip(this, EventArgs.Empty);
         }
 
-        /// <summary>
-        /// Raises the EnabledChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnEnabledChanged(EventArgs e)
+        base.Dispose(disposing);
+    }
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// 
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Set a watermark/prompt message for the user.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteCueHintText CueHint { get; }
+
+    private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
+
+    /// <summary>
+    /// Gets and sets if the control is in the tab chain.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public new bool TabStop
+    {
+        get => _richTextBox.TabStop;
+        set => _richTextBox.TabStop = value;
+    }
+
+    /// <summary>
+    /// Gets and sets if the control is in the ribbon design mode.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public bool InRibbonDesignMode { get; set; }
+
+    /// <summary>
+    /// Gets access to the contained RichTextBox instance.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(false)]
+    public RichTextBox RichTextBox => _richTextBox;
+
+    /// <summary>
+    /// Gets access to the contained input control.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(false)]
+    public Control ContainedControl => RichTextBox;
+
+    /// <summary>
+    /// Gets a value indicating whether the control has input focus.
+    /// </summary>
+    [Browsable(false)]
+    public override bool Focused => RichTextBox.Focused;
+
+    /// <summary>
+    /// Gets or sets the ability to drag/drop onto the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public override bool AllowDrop
+    {
+        get => base.AllowDrop;
+        set => base.AllowDrop = value;
+    }
+
+    /// <summary>
+    /// Gets and sets a value indicating if the control is automatically sized.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    [DefaultValue(false)]
+    public override bool AutoSize
+    {
+        get => _autoSize;
+        set => _autoSize = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the background color for the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override Color BackColor
+    {
+        get => base.BackColor;
+        set => base.BackColor = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the font of the text Displayed by the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [AmbientValue(null)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [AllowNull]
+    public override Font Font
+    {
+        get => base.Font;
+        set => base.Font = value!;
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color for the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override Color ForeColor
+    {
+        get => base.ForeColor;
+        set => base.ForeColor = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the internal padding space.
+    /// </summary>
+    [Browsable(false)]
+    [Localizable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public new Padding Padding
+    {
+        get => base.Padding;
+        set => base.Padding = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the text associated with the control.
+    /// </summary>
+    [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+    [AllowNull]
+    public override string Text
+    {
+        get => _richTextBox.Text;
+        set => _richTextBox.Text = value;
+    }
+
+    private bool ShouldSerializeText() =>
+        // Must always persist the text value if even when it is the default. Otherwise when
+        // you first move over the control which has been given RTF it resets the fonts.
+        true;
+
+    /// <summary>
+    /// Gets the length of text in the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int TextLength => _richTextBox.TextLength;
+
+    /// <summary>
+    /// Gets and sets the associated context menu strip.
+    /// </summary>
+    [DefaultValue(null)]
+    public override ContextMenuStrip? ContextMenuStrip
+    {
+        get => base.ContextMenuStrip;
+
+        set
         {
-            // Change in enabled state requires a layout and repaint
-            UpdateStateAndPalettes();
-
-            // Update view elements
-            _drawDockerInner.Enabled = Enabled;
-            _drawDockerOuter.Enabled = Enabled;
-
-            // Update state to reflect change in enabled state
-            _buttonManager.RefreshButtons();
-
-            PerformNeedPaint(true);
-
-            // Let base class fire standard event
-            base.OnEnabledChanged(e);
+            base.ContextMenuStrip = value;
+            _richTextBox.ContextMenuStrip = value;
         }
+    }
 
-        /// <summary>
-        /// Raises the BackColorChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
+    /// <summary>
+    /// Gets and sets if the control can redo a previously undo operation.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool CanRedo => _richTextBox.CanRedo;
 
-        /// <summary>
-        /// Raises the BackgroundImageChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
+    /// <summary>
+    /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool CanUndo => _richTextBox.CanUndo;
 
-        /// <summary>
-        /// Raises the BackgroundImageLayoutChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
+    /// <summary>
+    /// Gets a value indicating whether the contents have changed since last.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool Modified => _richTextBox.Modified;
 
-        /// <summary>
-        /// Raises the ForeColorChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
+    /// <summary>
+    /// Gets and sets the language option.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextBoxLanguageOptions LanguageOption
+    {
+        get => _richTextBox.LanguageOption;
+        set => _richTextBox.LanguageOption = value;
+    }
 
-        /// <summary>
-        /// Raises the Resize event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnResize(EventArgs e)
+    /// <summary>
+    /// Gets and sets the name of the action to be redone.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public string? RedoActionName => _richTextBox.RedoActionName;
+
+    /// <summary>
+    /// Gets and sets the name of the action to be undone.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public string? UndoActionName => _richTextBox.UndoActionName;
+
+    /// <summary>
+    /// Gets and sets if keyboard shortcuts are enabled.
+    /// </summary>
+    [Browsable(false)]
+    [DefaultValue(true)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool RichTextShortcutsEnabled
+    {
+        get => _richTextBox.RichTextShortcutsEnabled;
+        set => _richTextBox.RichTextShortcutsEnabled = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the text in rich text format.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [RefreshProperties(RefreshProperties.All)]
+    [AllowNull]
+    public string? Rtf
+    {
+        get => _richTextBox.Rtf ?? string.Empty;
+
+        set
         {
-            // Let base class raise events
-            base.OnResize(e);
-
-            // We must have a layout calculation
-            ForceControlLayout();
-        }
-
-        /// <summary>
-        /// Raises the TabStop event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnTabStopChanged(EventArgs e)
-        {
-            RichTextBox.TabStop = TabStop;
-            base.OnTabStopChanged(e);
-        }
-
-        /// <summary>
-        /// Raises the CausesValidationChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnCausesValidationChanged(EventArgs e)
-        {
-            RichTextBox.CausesValidation = CausesValidation;
-            base.OnCausesValidationChanged(e);
-        }
-
-        /// <summary>
-        /// Raises the Layout event.
-        /// </summary>
-        /// <param name="levent">An EventArgs that contains the event data.</param>
-        protected override void OnLayout(LayoutEventArgs levent)
-        {
-            if (!IsDisposed && !Disposing)
+            // Store original RTF only when it's truly new content (not just restoration)
+            // Compare with current text to detect if content has actually changed
+            if (!string.IsNullOrEmpty(value))
             {
-                // Update with latest content padding for placing around the contained text box control
-                Padding contentPadding = GetTripleState().PaletteContent.GetContentPadding(_drawDockerOuter.State);
-                _layoutFill.DisplayPadding = contentPadding;
-            }
+                string currentText = _richTextBox.Text;
+                bool isNewContent = _originalRtf == null;
 
-            // Let base class calulcate fill rectangle
-            base.OnLayout(levent);
-
-            if (!IsDisposed && !Disposing)
-            {
-                // Only use layout logic if control is fully initialized or if being forced
-                // to allow a relayout or if in design mode.
-                if (_forcedLayout || (DesignMode && (_richTextBox != null)))
+                // If we have stored original, check if this is significantly different
+                // (palette modifications won't change text content, only RTF codes)
+                if (!isNewContent && _originalRtf != null)
                 {
-                    Rectangle fillRect = _layoutFill.FillRect;
-                    _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                    // If RTF is very different in length or structure, it's likely new content
+                    // Small differences are likely just palette-related modifications
+                    if (value != null)
+                    {
+                        int lengthDiff = Math.Abs(value.Length - _originalRtf.Length);
+                        if (lengthDiff > 100) // Significant difference suggests new content
+                        {
+                            isNewContent = true;
+                        }
+                    }
                 }
-            }
-        }
 
-        /// <summary>
-        /// Raises the MouseEnter event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnMouseEnter(EventArgs e)
-        {
-            _mouseOver = true;
-            PerformNeedPaint(true);
-            _richTextBox.Invalidate();
-            base.OnMouseEnter(e);
-        }
-
-        /// <summary>
-        /// Raises the MouseLeave event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnMouseLeave(EventArgs e)
-        {
-            _mouseOver = false;
-            PerformNeedPaint(true);
-            _richTextBox.Invalidate();
-            base.OnMouseLeave(e);
-        }
-
-        /// <summary>
-        /// Raises the GotFocus event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnGotFocus(EventArgs e)
-        {
-            base.OnGotFocus(e);
-            _richTextBox.Focus();
-        }
-
-        /// <summary>
-        /// Gets the default size of the control.
-        /// </summary>
-        protected override Size DefaultSize => new Size(100, 96);
-
-        /// <summary>
-        /// Processes a notification from palette storage of a paint and optional layout required.
-        /// </summary>
-        /// <param name="sender">Source of notification.</param>
-        /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
-        {
-            if (!e.NeedLayout)
-            {
-                _richTextBox.Invalidate();
+                if (isNewContent)
+                {
+                    _originalRtf = value;
+                }
             }
             else
             {
-                ForceControlLayout();
+                _originalRtf = null;
             }
 
-            if (!IsDisposed && !Disposing)
+            PerformNeedPaint(true);
+            _richTextBox.Rtf = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the selection portion of the rich text format.
+    /// </summary>
+    [Browsable(false)]
+    [DefaultValue("")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public string SelectedRtf
+    {
+        get => _richTextBox.SelectedRtf;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectedRtf = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the selected text within the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public string SelectedText
+    {
+        get => _richTextBox.SelectedText;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectedText = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the alignment of the selection.
+    /// </summary>
+    [Browsable(false)]
+    [DefaultValue(HorizontalAlignment.Left)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public HorizontalAlignment SelectionAlignment
+    {
+        get => _richTextBox.SelectionAlignment;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionAlignment = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the background color of the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public Color SelectionBackColor
+    {
+        get => _richTextBox.SelectionBackColor;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionBackColor = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the bullet indentation of the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool SelectionBullet
+    {
+        get => _richTextBox.SelectionBullet;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionBullet = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the character offset of the selection.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionCharOffset
+    {
+        get => _richTextBox.SelectionCharOffset;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionCharOffset = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the text color of the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public Color SelectionColor
+    {
+        get => _richTextBox.SelectionColor;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionColor = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the text font for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public Font SelectionFont
+    {
+        // Tested that: the System.WWindows.Forms.RichTextBox returns RichtTextBox.Font when no text has been selected.
+        // Null forgiving operator removes the warning.
+        get => _richTextBox.SelectionFont!;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionFont = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the hanging indent for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionHangingIndent
+    {
+        get => _richTextBox.SelectionHangingIndent;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionHangingIndent = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the indent for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionIndent
+    {
+        get => _richTextBox.SelectionIndent;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionIndent = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the selection length for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionLength
+    {
+        get => _richTextBox.SelectionLength;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionLength = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the protected setting for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionProtected
+    {
+        get => _richTextBox.SelectionLength;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionLength = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the right indent for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionRightIndent
+    {
+        get => _richTextBox.SelectionRightIndent;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionRightIndent = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the starting point of text selected in the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionStart
+    {
+        get => _richTextBox.SelectionStart;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionStart = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the tab settings for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int[] SelectionTabs
+    {
+        get => _richTextBox.SelectionTabs;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionTabs = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets the type of selection.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextBoxSelectionTypes SelectionType => _richTextBox.SelectionType;
+
+    /// <summary>
+    /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
+    [DefaultValue(true)]
+    public bool AlwaysActive
+    {
+        get => _alwaysActive;
+
+        set
+        {
+            if (_alwaysActive != value)
             {
-                // Update the back/fore/font from the palette settings
-                UpdateStateAndPalettes();
-                IPaletteTriple triple = GetTripleState();
-                PaletteState state = _drawDockerOuter.State;
+                _alwaysActive = value;
+                PerformNeedPaint(true);
+            }
+        }
+    }
 
-                Color backColor = triple.PaletteBack.GetBackColor1(state);
-                if (_richTextBox.BackColor != backColor)
+    /// <summary>
+    /// Gets or sets the lines of text in a multiline edit, as an array of String values.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"The lines of text in a multiline edit, as an array of String values.")]
+    [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [MergableProperty(false)]
+    [Localizable(true)]
+    public string[] Lines
+    {
+        get => _richTextBox.Lines;
+        set => _richTextBox.Lines = value;
+    }
+
+    /// <summary>
+    /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
+    [DefaultValue(RichTextBoxScrollBars.Both)]
+    [Localizable(true)]
+    public RichTextBoxScrollBars ScrollBars
+    {
+        get => _richTextBox.ScrollBars;
+        set => _richTextBox.ScrollBars = value;
+    }
+
+    /// <summary>
+    /// Indicates if lines are automatically word-wrapped for multiline edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
+    [DefaultValue(true)]
+    [Localizable(true)]
+    public bool WordWrap
+    {
+        get => _richTextBox.WordWrap;
+        set => _richTextBox.WordWrap = value;
+    }
+
+    /// <summary>
+    /// Defines the right margin dimensions.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Defines the right margin dimensions.")]
+    [DefaultValue(0)]
+    [Localizable(true)]
+    public int RightMargin
+    {
+        get => _richTextBox.RightMargin;
+        set => _richTextBox.RightMargin = value;
+    }
+
+    /// <summary>
+    /// Turns on/off the selection margin.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Turns on/off the selection margin.")]
+    [DefaultValue(false)]
+    public bool ShowSelectionMargin
+    {
+        get => _richTextBox.ShowSelectionMargin;
+        set => _richTextBox.ShowSelectionMargin = value;
+    }
+
+    /// <summary>
+    /// Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.")]
+    [DefaultValue(1.0f)]
+    [Localizable(true)]
+    public float ZoomFactor
+    {
+        get => _richTextBox.ZoomFactor;
+        set => _richTextBox.ZoomFactor = value;
+    }
+
+    /// <summary>
+    /// Gets and sets whether the text in the control can span more than one line.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Control whether the text in the control can span more than one line.")]
+    [RefreshProperties(RefreshProperties.All)]
+    [DefaultValue(true)]
+    [Localizable(true)]
+    public bool Multiline
+    {
+        get => _richTextBox.Multiline;
+        set => _richTextBox.Multiline = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
+    [DefaultValue(false)]
+    public bool AcceptsTab
+    {
+        get => _richTextBox.AcceptsTab;
+        set => _richTextBox.AcceptsTab = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
+    [DefaultValue(true)]
+    public bool HideSelection
+    {
+        get => _richTextBox.HideSelection;
+        set => _richTextBox.HideSelection = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters that can be entered into the edit control.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
+    [DefaultValue(0x7fffffff)]
+    [Localizable(true)]
+    public int MaxLength
+    {
+        get => _richTextBox.MaxLength;
+        set => _richTextBox.MaxLength = value;
+    }
+
+    /// <summary>
+    /// Turns on/off automatic word selection.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Turns on/off automatic word selection.")]
+    [DefaultValue(false)]
+    public bool AutoWordSelection
+    {
+        get => _richTextBox.AutoWordSelection;
+        set => _richTextBox.AutoWordSelection = value;
+    }
+
+    /// <summary>
+    /// Defines the indent for bullets in the control.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Defines the indent for bullets in the control.")]
+    [DefaultValue(0)]
+    [Localizable(true)]
+    public int BulletIndent
+    {
+        get => _richTextBox.BulletIndent;
+        set => _richTextBox.BulletIndent = value;
+    }
+
+    /// <summary>
+    /// Indicates whether URLs are automatically formatted as links.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether URLs are automatically formatted as links.")]
+    [DefaultValue(true)]
+    public bool DetectUrls
+    {
+        get => _richTextBox.DetectUrls;
+        set => _richTextBox.DetectUrls = value;
+    }
+
+    /// <summary>
+    /// Enable drag/drop of text, pictures and other data.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Enable drag/drop of text, pictures and other data.")]
+    [DefaultValue(false)]
+    public bool EnableAutoDragDrop
+    {
+        get => _richTextBox.EnableAutoDragDrop;
+        set => _richTextBox.EnableAutoDragDrop = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Controls whether the text in the edit control can be changed or not.")]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    [DefaultValue(false)]
+    public bool ReadOnly
+    {
+        get => _richTextBox.ReadOnly;
+        set => _richTextBox.ReadOnly = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
+    [DefaultValue(true)]
+    public bool ShortcutsEnabled
+    {
+        get => _richTextBox.ShortcutsEnabled;
+        set => _richTextBox.ShortcutsEnabled = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the input control style.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Input control style.")]
+    public InputControlStyle InputControlStyle
+    {
+        get => _inputControlStyle;
+
+        set
+        {
+            if (_inputControlStyle != value)
+            {
+                _inputControlStyle = value;
+                StateCommon.SetStyles(value);
+                PerformNeedPaint(true);
+            }
+        }
+    }
+
+    private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
+    private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
+
+    /// <summary>
+    /// Gets access to the common textbox appearance entries that other states can override.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining common textbox appearance that other states can override.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleRedirect StateCommon { get; }
+
+    private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
+
+    /// <summary>
+    /// Gets access to the disabled textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining disabled textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateDisabled { get; }
+
+    private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
+
+    /// <summary>
+    /// Gets access to the normal textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining normal textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateNormal { get; }
+
+    private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
+
+    /// <summary>
+    /// Gets access to the active textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining active textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateActive { get; }
+
+    private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
+
+    /// <summary>
+    /// Appends text to the current text of a rich text box.
+    /// </summary>
+    /// <param name="text">The text to append to the current contents of the text box.</param>
+    public void AppendText(string text) => _richTextBox.AppendText(text);
+
+    /// <summary>
+    /// Clears all text from the text box control.
+    /// </summary>
+    public void Clear() => _richTextBox.Clear();
+
+    /// <summary>
+    /// Clears information about the most recent operation from the undo buffer of the rich text box. 
+    /// </summary>
+    public void ClearUndo() => _richTextBox.ClearUndo();
+
+    /// <summary>
+    /// Copies the current selection in the text box to the Clipboard.
+    /// </summary>
+    public void Copy() => _richTextBox.Copy();
+
+    /// <summary>
+    /// Moves the current selection in the text box to the Clipboard.
+    /// </summary>
+    public void Cut() => _richTextBox.Cut();
+
+    /// <summary>
+    /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
+    /// </summary>
+    public void DeselectAll() => _richTextBox.DeselectAll();
+
+    /// <summary>
+    /// Determines whether you can paste information from the Clipboard in the specified data format.
+    /// </summary>
+    /// <param name="clipFormat">One of the System.Windows.Forms.DataFormats.Format values.</param>
+    /// <returns>true if you can paste data from the Clipboard in the specified data format; otherwise, false.</returns>
+    public bool CanPaste(DataFormats.Format clipFormat) => _richTextBox.CanPaste(clipFormat);
+
+    /// <summary>
+    /// Searches the text in a RichTextBox control for a string.
+    /// </summary>
+    /// <param name="str">The text to locate in the control.</param>
+    /// <returns>The location within the control where the search text was found or -1 if the search string is not found or an empty search string is specified in the str parameter.</returns>
+    public int Find(string str) => _richTextBox.Find(str);
+
+    /// <summary>
+    /// Searches the text of a RichTextBox control for the first instance of a character from a list of characters.
+    /// </summary>
+    /// <param name="characterSet">The array of characters to search for.</param>
+    /// <returns>The location within the control where the search characters were found or -1 if the search characters are not found or an empty search character set is specified in the char parameter.</returns>
+    public int Find(char[] characterSet) => _richTextBox.Find(characterSet);
+
+    /// <summary>
+    /// Searches the text of a RichTextBox control, at a specific starting point, for the first instance of a character from a list of characters.
+    /// </summary>
+    /// <param name="characterSet">The array of characters to search for.</param>
+    /// <param name="start">The location within the control's text at which to begin searching.</param>
+    /// <returns>The location within the control where the search characters are found.</returns>
+    public int Find(char[] characterSet, int start) => _richTextBox.Find(characterSet, start);
+
+    /// <summary>
+    /// Searches the text in a RichTextBox control for a string with specific options applied to the search.
+    /// </summary>
+    /// <param name="str">The text to locate in the control.</param>
+    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+    /// <returns>The location within the control where the search text was found.</returns>
+    public int Find(string str, RichTextBoxFinds options) => _richTextBox.Find(str, options);
+
+    /// <summary>
+    /// Searches a range of text in a RichTextBox control for the first instance of a character from a list of characters.
+    /// </summary>
+    /// <param name="characterSet">The array of characters to search for.</param>
+    /// <param name="start">The location within the control's text at which to begin searching.</param>
+    /// <param name="end">The location within the control's text at which to end searching.</param>
+    /// <returns>The location within the control where the search characters are found.</returns>
+    public int Find(char[] characterSet, int start, int end) => _richTextBox.Find(characterSet, start, end);
+
+    /// <summary>
+    /// Searches the text in a RichTextBox control for a string at a specific location within the control and with specific options applied to the search.
+    /// </summary>
+    /// <param name="str">The text to locate in the control.</param>
+    /// <param name="start">The location within the control's text at which to begin searching.</param>
+    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+    /// <returns>The location within the control where the search text was found.</returns>
+    public int Find(string str, int start, RichTextBoxFinds options) => _richTextBox.Find(str, start, options);
+
+    /// <summary>
+    /// Searches the text in a RichTextBox control for a string within a range of text within the control and with specific options applied to the search.
+    /// </summary>
+    /// <param name="str">The text to locate in the control.</param>
+    /// <param name="start">The location within the control's text at which to begin searching.</param>
+    /// <param name="end">The location within the control's text at which to end searching. This value must be equal to negative one (-1) or greater than or equal to the start parameter.</param>
+    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+    /// <returns></returns>
+    public int Find(string str, int start, int end, RichTextBoxFinds options) => _richTextBox.Find(str, start, end, options);
+
+    /// <summary>
+    /// Retrieves the character that is closest to the specified location within the control.
+    /// </summary>
+    /// <param name="pt">The location from which to seek the nearest character.</param>
+    /// <returns>The character at the specified location.</returns>
+    public int GetCharFromPosition(Point pt) => _richTextBox.GetCharFromPosition(pt);
+
+    /// <summary>
+    /// Retrieves the index of the character nearest to the specified location.
+    /// </summary>
+    /// <param name="pt">The location to search.</param>
+    /// <returns>The zero-based character index at the specified location.</returns>
+    public int GetCharIndexFromPosition(Point pt) => _richTextBox.GetCharIndexFromPosition(pt);
+
+    /// <summary>
+    /// Retrieves the index of the first character of a given line.
+    /// </summary>
+    /// <param name="lineNumber">The line for which to get the index of its first character.</param>
+    /// <returns>The zero-based character index in the specified line.</returns>
+    public int GetFirstCharIndexFromLine(int lineNumber) => _richTextBox.GetFirstCharIndexFromLine(lineNumber);
+
+    /// <summary>
+    /// Retrieves the index of the first character of the current line.
+    /// </summary>
+    /// <returns>The zero-based character index in the current line.</returns>
+    public int GetFirstCharIndexOfCurrentLine() => _richTextBox.GetFirstCharIndexOfCurrentLine();
+
+    /// <summary>
+    /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
+    /// </summary>
+    /// <param name="index">The character index position to search.</param>
+    /// <returns>The zero-based line number in which the character index is located.</returns>
+    public int GetLineFromCharIndex(int index) => _richTextBox.GetLineFromCharIndex(index);
+
+    /// <summary>
+    /// Retrieves the location within the control at the specified character index.
+    /// </summary>
+    /// <param name="index">The index of the character for which to retrieve the location.</param>
+    /// <returns>The location of the specified character.</returns>
+    public Point GetPositionFromCharIndex(int index) => _richTextBox.GetPositionFromCharIndex(index);
+
+    /// <summary>
+    /// Loads a rich text format (RTF) or standard ASCII text file into the RichTextBox control.
+    /// </summary>
+    /// <param name="path">The name and location of the file to load into the control.</param>
+    public void LoadFile(string path) => _richTextBox.LoadFile(path);
+
+    /// <summary>
+    /// Loads the contents of an existing data stream into the RichTextBox control.
+    /// </summary>
+    /// <param name="data">A stream of data to load into the RichTextBox control.</param>
+    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+    public void LoadFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(data, fileType);
+
+    /// <summary>
+    /// Loads a specific type of file into the RichTextBox control.
+    /// </summary>
+    /// <param name="path">The name and location of the file to load into the control.</param>
+    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+    public void LoadFile(string path, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(path, fileType);
+
+    /// <summary>
+    /// Replaces the current selection in the text box with the contents of the Clipboard.
+    /// </summary>
+    public void Paste() => _richTextBox.Paste();
+
+    /// <summary>
+    /// Undoes the last edit operation in the text box.
+    /// </summary>
+    public void Undo() => _richTextBox.Undo();
+
+    /// <summary>
+    /// Pastes the contents of the Clipboard in the specified Clipboard format.
+    /// </summary>
+    /// <param name="clipFormat">The Clipboard format in which the data should be obtained from the Clipboard.</param>
+    public void Paste(DataFormats.Format clipFormat) => _richTextBox.Paste(clipFormat);
+
+    /// <summary>
+    /// Reapplies the last operation that was undone in the control.
+    /// </summary>
+    public void Redo() => _richTextBox.Redo();
+
+    /// <summary>
+    /// Saves the contents of the RichTextBox to a rich text format (RTF) file.
+    /// </summary>
+    /// <param name="path">The name and location of the file to save.</param>
+    public void SaveFile(string path) => _richTextBox.SaveFile(path);
+
+    /// <summary>
+    /// Saves the contents of a RichTextBox control to an open data stream.
+    /// </summary>
+    /// <param name="data">The data stream that contains the file to save to.</param>
+    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+    public void SaveFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(data, fileType);
+
+    /// <summary>
+    /// Saves the contents of the KryptonRichTextBox to a specific type of file.
+    /// </summary>
+    /// <param name="path">The name and location of the file to save.</param>
+    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+    public void SaveFile(string path, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(path, fileType);
+
+    /// <summary>
+    /// Scrolls the contents of the control to the current caret position.
+    /// </summary>
+    public void ScrollToCaret() => _richTextBox.ScrollToCaret();
+
+    /// <summary>
+    /// Selects a range of text in the control.
+    /// </summary>
+    /// <param name="start">The position of the first character in the current text selection within the text box.</param>
+    /// <param name="length">The number of characters to select.</param>
+    public void Select(int start, int length) => _richTextBox.Select(start, length);
+
+    /// <summary>
+    /// Selects all text in the control.
+    /// </summary>
+    public void SelectAll() => _richTextBox.SelectAll();
+
+    /// <summary>
+    /// Sets the fixed state of the control.
+    /// </summary>
+    /// <param name="active">Should the control be fixed as active.</param>
+    public void SetFixedState(bool active) => _fixedActive = active;
+
+    /// <summary>
+    /// Gets access to the ToolTipManager used for displaying tool tips.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public ToolTipManager ToolTipManager { get; }
+
+    /// <summary>
+    /// Gets a value indicating if the input control is active.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsActive =>
+        _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
+
+    /// <summary>
+    /// Sets input focus to the control.
+    /// </summary>
+    /// <returns>true if the input focus request was successful; otherwise, false.</returns>
+    public new bool Focus() => RichTextBox.Focus();
+
+    /// <summary>
+    /// Activates the control.
+    /// </summary>
+    public new void Select() => RichTextBox.Select();
+
+    /// <summary>
+    /// Get the preferred size of the control based on a proposed size.
+    /// </summary>
+    /// <param name="proposedSize">Starting size proposed by the caller.</param>
+    /// <returns>Calculated preferred size.</returns>
+    public override Size GetPreferredSize(Size proposedSize)
+    {
+        // Do we have a manager to ask for a preferred size?
+        if (ViewManager != null)
+        {
+            // Ask the view to Perform a layout
+            Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
+
+            // Apply the maximum sizing
+            if (MaximumSize.Width > 0)
+            {
+                retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
+            }
+
+            if (MaximumSize.Height > 0)
+            {
+                retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
+            }
+
+            // Apply the minimum sizing
+            if (MinimumSize.Width > 0)
+            {
+                retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
+            }
+
+            if (MinimumSize.Height > 0)
+            {
+                retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
+            }
+
+            return retSize;
+        }
+        else
+        {
+            // Fall back on default control processing
+            return base.GetPreferredSize(proposedSize);
+        }
+    }
+
+    /// <summary>
+    /// Gets the rectangle that represents the display area of the control.
+    /// </summary>
+    public override Rectangle DisplayRectangle
+    {
+        get
+        {
+            // Ensure that the layout is calculated in order to know the remaining display space
+            ForceViewLayout();
+
+            // The inside text box is the client rectangle size
+            return new Rectangle(_richTextBox.Location, _richTextBox.Size);
+        }
+    }
+
+    /// <summary>
+    /// Print the specified range of characters.
+    /// </summary>
+    /// <param name="charFrom">Start character.</param>
+    /// <param name="charTo">End character.</param>
+    /// <param name="gr">Graphics instance to use.</param>
+    /// <param name="bounds">Drawing bounds.</param>
+    /// <returns>Pointer to returned result.</returns>
+    public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds) => _richTextBox.Print(charFrom, charTo, gr, bounds);
+
+    /// <summary>
+    /// Override the display padding for the layout fill.
+    /// </summary>
+    /// <param name="padding">Display padding value.</param>
+    public void SetLayoutDisplayPadding(Padding padding) => _layoutFill.DisplayPadding = padding;
+
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    /// <param name="pt">Mouse location.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public bool DesignerGetHitTest(Point pt)
+    {
+        // Ignore call as view builder is already destructed
+        return !IsDisposed;
+    }
+
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    /// <param name="pt">Mouse location.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public Component? DesignerComponentFromPoint(Point pt) =>
+        // Ignore call as view builder is already destructed
+        IsDisposed ? null : ViewManager?.ComponentFromPoint(pt);
+
+    // Ask the current view for a decision
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public void DesignerMouseLeave() =>
+        // Simulate the mouse leaving the control so that the tracking
+        // element that thinks it has the focus is informed it does not
+        OnMouseLeave(EventArgs.Empty);
+
+    #endregion
+
+    #region Protected
+    /// <summary>
+    /// Force the layout logic to size and position the controls.
+    /// </summary>
+    protected void ForceControlLayout()
+    {
+        _forcedLayout = true;
+        OnLayout(new LayoutEventArgs(null, null));
+        _forcedLayout = false;
+    }
+    #endregion
+
+    #region Protected Virtual
+    /// <summary>
+    /// Raises the AcceptsTabChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the HideSelectionChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ModifiedChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the MultilineChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ReadOnlyChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the VScroll event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnVScroll(EventArgs e) => VScroll?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the HScroll event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnHScroll(EventArgs e) => HScroll?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the SelectionChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnSelectionChanged(EventArgs e) => SelectionChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the Protected event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnProtected(EventArgs e) => Protected?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the LinkClicked event.
+    /// </summary>
+    /// <param name="e">A LinkClickedEventArgs that contains the event data.</param>
+    protected virtual void OnLinkClicked(LinkClickedEventArgs e) => LinkClicked?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the TrackMouseEnter event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the TrackMouseLeave event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
+    #endregion
+
+    #region Protected Overrides
+    /// <summary>
+    /// Creates a new instance of the control collection for the KryptonTextBox.
+    /// </summary>
+    /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
+
+    /// <summary>
+    /// Creates the accessibility object for the KryptonRichTextBox control.
+    /// </summary>
+    /// <returns>A new KryptonRichTextBoxAccessibleObject instance for the control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonRichTextBoxAccessibleObject(this);
+
+    /// <summary>
+    /// Raises the HandleCreated event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        // Let base class do standard stuff
+        base.OnHandleCreated(e);
+
+        // Force the font to be set into the text box child control
+        PerformNeedPaint(false);
+
+        // We need a layout to occur before any painting
+        InvokeLayout();
+    }
+
+    /// <summary>
+    /// Raises the EnabledChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnEnabledChanged(EventArgs e)
+    {
+        // Change in enabled state requires a layout and repaint
+        UpdateStateAndPalettes();
+
+        // Update view elements
+        _drawDockerInner.Enabled = Enabled;
+        _drawDockerOuter.Enabled = Enabled;
+
+        PerformNeedPaint(true);
+
+        // Let base class fire standard event
+        base.OnEnabledChanged(e);
+    }
+
+    /// <summary>
+    /// Raises the BackColorChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the BackgroundImageChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the BackgroundImageLayoutChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ForeColorChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the Resize event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnResize(EventArgs e)
+    {
+        // Let base class raise events
+        base.OnResize(e);
+
+        // We must have a layout calculation
+        ForceControlLayout();
+    }
+
+    /// <summary>
+    /// Raises the TabStop event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnTabStopChanged(EventArgs e)
+    {
+        RichTextBox.TabStop = TabStop;
+        base.OnTabStopChanged(e);
+    }
+
+    /// <summary>
+    /// Raises the CausesValidationChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnCausesValidationChanged(EventArgs e)
+    {
+        RichTextBox.CausesValidation = CausesValidation;
+        base.OnCausesValidationChanged(e);
+    }
+
+    /// <summary>
+    /// Raises the Layout event.
+    /// </summary>
+    /// <param name="levent">An EventArgs that contains the event data.</param>
+    protected override void OnLayout(LayoutEventArgs levent)
+    {
+        if (!IsDisposed && !Disposing)
+        {
+            // Update with latest content padding for placing around the contained text box control
+            Padding contentPadding = GetTripleState().PaletteContent!.GetBorderContentPadding(null, _drawDockerOuter.State);
+            _layoutFill.DisplayPadding = contentPadding;
+        }
+
+        // Let base class calculate fill rectangle
+        base.OnLayout(levent);
+
+        if (!IsDisposed && !Disposing)
+        {
+            // Only use layout logic if control is fully initialized or if being forced
+            // to allow a relayout or if in design mode.
+            if (_forcedLayout || DesignMode)
+            {
+                Rectangle fillRect = _layoutFill.FillRect;
+                _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raises the MouseEnter event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnMouseEnter(EventArgs e)
+    {
+        _mouseOver = true;
+        PerformNeedPaint(true);
+        _richTextBox.Invalidate();
+        base.OnMouseEnter(e);
+    }
+
+    /// <summary>
+    /// Raises the MouseLeave event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnMouseLeave(EventArgs e)
+    {
+        _mouseOver = false;
+        PerformNeedPaint(true);
+        _richTextBox.Invalidate();
+        base.OnMouseLeave(e);
+    }
+
+    /// <summary>
+    /// Raises the GotFocus event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnGotFocus(EventArgs e)
+    {
+        base.OnGotFocus(e);
+        _richTextBox.Focus();
+    }
+
+    /// <summary>
+    /// Gets the default size of the control.
+    /// </summary>
+    protected override Size DefaultSize => new Size(100, 96);
+
+    /// <summary>
+    /// Processes a notification from palette storage of a paint and optional layout required.
+    /// </summary>
+    /// <param name="sender">Source of notification.</param>
+    /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
+    protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+    {
+        if (!e.NeedLayout)
+        {
+            _richTextBox.Invalidate();
+        }
+        else
+        {
+            ForceControlLayout();
+        }
+
+        if (!IsDisposed && !Disposing)
+        {
+            // IMPORTANT: Save RTF content BEFORE any property changes that might reset formatting
+            // Setting BackColor, ForeColor, or Font can reset RTF formatting in RichTextBox
+            string? savedRtf = null;
+            bool hasRtfFormatting = false;
+
+            if (_richTextBox.Handle != IntPtr.Zero && _richTextBox.TextLength > 0)
+            {
+                savedRtf = _richTextBox.Rtf;
+
+                // Check if the RichTextBox has RTF formatting by examining the Rtf property
+                // If Rtf contains character-level formatting codes, preserve formatting
+                if (!string.IsNullOrEmpty(savedRtf))
                 {
-                    _richTextBox.BackColor = backColor;
+                    int rtfLength = savedRtf.Length;
+                    string plainText = _richTextBox.Text;
+                    int plainTextLength = plainText?.Length ?? 0;
+
+                    // Quick length check first (fastest check - O(1))
+                    bool rtfMuchLonger = plainTextLength > 0 && rtfLength > (plainTextLength + 200);
+                    if (rtfMuchLonger)
+                    {
+                        hasRtfFormatting = true;
+                    }
+                    else
+                    {
+                        // Single-pass character scan for maximum efficiency (O(n) worst case, but exits early)
+                        // Look for backslash followed by formatting codes: \b, \i, \ul, \fs, \cf, \highlight, or \f[1-9]
+                        bool foundFormatting = false;
+                        bool foundCustomFont = false;
+                        ReadOnlySpan<char> savedRtfSpan = savedRtf;
+
+                        // Exit early once we find either formatting or custom font (either indicates RTF formatting)
+                        for (int i = 0; i < savedRtfSpan.Length - 1 && !foundFormatting && !foundCustomFont; i++)
+                        {
+                            if (savedRtfSpan[i] == '\\')
+                            {
+                                char nextChar = savedRtfSpan[i + 1];
+
+                                // Check for formatting codes: b, i, u, f, c, h, s
+                                switch (nextChar)
+                                {
+                                    case 'b': // \b (bold)
+                                    case 'i': // \i (italic)
+                                        foundFormatting = true;
+                                        break;
+                                    case 'u': // \ul (underline) - check for 'l' next
+                                        if (i + 2 < savedRtfSpan.Length && savedRtfSpan[i + 2] == 'l')
+                                        {
+                                            foundFormatting = true;
+                                        }
+                                        break;
+                                    case 'f': // \f (font) - check for non-zero digit
+                                        if (i + 2 < savedRtfSpan.Length)
+                                        {
+                                            char fontDigit = savedRtfSpan[i + 2];
+                                            if (char.IsDigit(fontDigit) && fontDigit != '0')
+                                            {
+                                                foundCustomFont = true;
+                                            }
+                                        }
+                                        break;
+                                    case 'c': // \cf (color) - check for 'f' next
+                                        if (i + 2 < savedRtfSpan.Length && savedRtfSpan[i + 2] == 'f')
+                                        {
+                                            foundFormatting = true;
+                                        }
+                                        break;
+                                    case 'h': // \highlight - check character by character to avoid Substring
+                                        if (i + 9 < savedRtfSpan.Length)
+                                        {
+                                            // Check for "highlight" without Substring allocation
+                                            if (savedRtfSpan[i + 2] == 'i' && savedRtfSpan[i + 3] == 'g' &&
+                                                savedRtfSpan[i + 4] == 'h' && savedRtfSpan[i + 5] == 'l' &&
+                                                savedRtfSpan[i + 6] == 'i' && savedRtfSpan[i + 7] == 'g' &&
+                                                savedRtfSpan[i + 8] == 'h' && savedRtfSpan[i + 9] == 't')
+                                            {
+                                                foundFormatting = true;
+                                            }
+                                        }
+                                        break;
+                                    case 's': // \fs (font size) - check for digit after 's'
+                                        if (i + 2 < savedRtfSpan.Length && char.IsDigit(savedRtfSpan[i + 2]))
+                                        {
+                                            foundFormatting = true;
+                                        }
+                                        break;
+                                }
+                            }
+                        }
+
+                        hasRtfFormatting = foundFormatting || foundCustomFont;
+                    }
                 }
-
-                Color foreColor = triple.PaletteContent.GetContentShortTextColor1(state);
-                if (_richTextBox.ForeColor != foreColor)
+                else if (!string.IsNullOrEmpty(savedRtf))
                 {
-                    _richTextBox.ForeColor = foreColor;
+                    // Even if text length is 0, if RTF exists and has structure beyond minimal, preserve it
+                    // This handles edge cases where text might be empty but RTF structure exists
+                    hasRtfFormatting = savedRtf.Length > 50; // Minimal RTF is usually ~30-40 chars
                 }
+            }
 
-                // Only set the font if the rich text box has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
-                if ((_richTextBox.Handle != IntPtr.Zero) && !_richTextBox.Font.Equals(font))
+            // Update the back/fore/font from the palette settings
+            UpdateStateAndPalettes();
+            IPaletteTriple triple = GetTripleState();
+            PaletteState state = _drawDockerOuter.State;
+
+            Color backColor = triple.PaletteBack.GetBackColor1(state);
+            if (_richTextBox.BackColor != backColor)
+            {
+                _richTextBox.BackColor = backColor;
+            }
+
+            Color foreColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+            if (_richTextBox.ForeColor != foreColor)
+            {
+                _richTextBox.ForeColor = foreColor;
+            }
+
+            // Only set the font if the rich text box has been created
+            // IMPORTANT: Do not set Font property if RichTextBox has RTF formatting,
+            // as setting Font will reset all RTF formatting. Only set font for plain text.
+            Font? font = triple.PaletteContent.GetContentShortTextFont(state);
+            if ((_richTextBox.Handle != IntPtr.Zero) && font != null && !_richTextBox.Font.Equals(font))
+            {
+                if (!hasRtfFormatting)
                 {
+                    // Only set font for plain text to avoid losing RTF formatting
                     _richTextBox.Font = font;
                 }
             }
 
-            base.OnNeedPaint(sender, e);
-        }
-
-        /// <summary>
-        /// Raises the Paint event.
-        /// </summary>
-        /// <param name="e">A PaintEventArgs containing the event data.</param>
-        protected override void OnPaint(PaintEventArgs e)
-        {
-            if (_firstPaint)
+            // If we detected RTF formatting, restore it after property changes
+            // This ensures formatting is preserved even if BackColor/ForeColor changes reset it
+            if (hasRtfFormatting && !string.IsNullOrEmpty(savedRtf) && _richTextBox.Handle != IntPtr.Zero)
             {
-                _firstPaint = false;
-                ForceControlLayout();
-            }
+                // Store original RTF if not already stored or if RTF content has changed
+                // We need to detect if this is a new RTF (different from stored original)
+                // by checking if the text content matches (RTF might be modified but text is same)
+                string currentText = _richTextBox.Text;
+                bool isNewRtf = _originalRtf == null;
 
-            base.OnPaint(e);
-        }
-
-        /// <summary>
-        /// Process Windows-based messages.
-        /// </summary>
-        /// <param name="m">A Windows-based message.</param>
-        protected override void WndProc(ref Message m)
-        {
-            switch (m.Msg)
-            {
-                case PI.WM_.NCHITTEST:
-                    if (InTransparentDesignMode)
+                // If we have stored original, check if text matches to determine if it's the same RTF
+                if (!isNewRtf && _originalRtf != null)
+                {
+                    // Try to get text from original RTF to compare
+                    // If text doesn't match, it's a new RTF
+                    // For simplicity, we'll compare the saved RTF with original
+                    // If they're significantly different, it's likely new content
+                    if (savedRtf != _originalRtf && savedRtf != null && Math.Abs(savedRtf.Length - _originalRtf.Length) > 50)
                     {
-                        m.Result = (IntPtr)PI.HT.TRANSPARENT;
+                        isNewRtf = true;
+                    }
+                }
+
+                if (isNewRtf)
+                {
+                    // Store the original RTF before any modifications
+                    _originalRtf = savedRtf;
+                }
+
+                // Check if we're in a dark mode black theme that requires black text handling
+                PaletteMode currentMode = KryptonManager.CurrentGlobalPaletteMode;
+                bool isDarkModeBlackTheme = currentMode is PaletteMode.Office2007BlackDarkMode or PaletteMode.Office2010BlackDarkMode or PaletteMode.Microsoft365BlackDarkMode;
+
+                string? rtfToRestore;
+
+                if (isDarkModeBlackTheme && _originalRtf != null)
+                {
+                    // In dark mode black themes, check if original RTF contains black text
+                    // If so, replace black color codes with white for visibility
+                    bool hasBlackText = HasBlackTextInRtf(_originalRtf);
+                    if (hasBlackText)
+                    {
+                        // Replace black color codes with white in original RTF
+                        rtfToRestore = RemoveBlackColorCodes(_originalRtf);
                     }
                     else
                     {
-                        base.WndProc(ref m);
+                        // No black text, use original RTF
+                        rtfToRestore = _originalRtf;
                     }
-
-                    break;
-                default:
-                    base.WndProc(ref m);
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Fixes the cursor changing issue.
-        /// </summary>
-        /// <param name="e"></param>
-        protected override void OnCursorChanged(EventArgs e)
-        {
-            base.OnCursorChanged(e);
-
-            _richTextBox.Cursor = Cursor;
-        }
-        #endregion
-
-        #region Internal
-        internal bool InTransparentDesignMode => InRibbonDesignMode;
-
-        #endregion
-
-        #region Implementation
-
-        private void UpdateStateAndPalettes()
-        {
-            // Get the correct palette settings to use
-            IPaletteTriple tripleState = GetTripleState();
-            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder);
-
-            // Update enabled state
-            _drawDockerOuter.Enabled = Enabled;
-
-            // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
-
-            _drawDockerOuter.ElementState = state;
-        }
-
-        private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
-
-        private void OnRichTextBoxMouseChange(object sender, EventArgs e)
-        {
-            // Change in tracking state?
-            if (_richTextBox.MouseOver != _trackingMouseEnter)
-            {
-                _trackingMouseEnter = _richTextBox.MouseOver;
-
-                // Raise appropriate event
-                if (_trackingMouseEnter)
-                {
-                    OnTrackMouseEnter(EventArgs.Empty);
-                    OnMouseEnter(e);
                 }
                 else
                 {
-                    OnTrackMouseLeave(EventArgs.Empty);
-                    OnMouseLeave(e);
-                }
-            }
-        }
-
-        private void OnRichTextBoxAcceptsTabChanged(object sender, EventArgs e) => OnAcceptsTabChanged(e);
-
-        private void OnRichTextBoxTextChanged(object sender, EventArgs e)
-        {
-            if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
-                && TextLength <= 1)
-            {
-                // Needed to prevent character turds being left behind
-                // Oh, and to get rid of the initial cuetext drawing ;-)
-                _richTextBox.Invalidate();
-            }
-
-            OnTextChanged(e);
-        }
-
-        private void OnRichTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
-
-        private void OnRichTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
-
-        private void OnRichTextBoxMultilineChanged(object sender, EventArgs e) => OnMultilineChanged(e);
-
-        private void OnRichTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
-
-        private void OnRichTextBoxGotFocus(object sender, EventArgs e)
-        {
-            UpdateStateAndPalettes();
-            PerformNeedPaint(true);
-            OnGotFocus(e);
-        }
-
-        private void OnRichTextBoxLostFocus(object sender, EventArgs e)
-        {
-            UpdateStateAndPalettes();
-            PerformNeedPaint(true);
-            OnLostFocus(e);
-        }
-
-        private void OnRichTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
-
-        private void OnRichTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
-
-        private void OnRichTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
-
-        private void OnRichTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
-
-        private void OnRichTextBoxVScroll(object sender, EventArgs e) => OnVScroll(e);
-
-        private void OnRichTextBoxHScroll(object sender, EventArgs e) => OnHScroll(e);
-
-        private void OnRichTextBoxSelectionChanged(object sender, EventArgs e) => OnSelectionChanged(e);
-
-        private void OnRichTextBoxProtected(object sender, EventArgs e) => OnProtected(e);
-
-        private void OnRichTextBoxLinkClicked(object sender, LinkClickedEventArgs e) => OnLinkClicked(e);
-
-        private void OnRichTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
-
-        private void OnRichTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
-
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
-        {
-            if (!IsDisposed && !Disposing)
-            {
-                // Do not show tooltips when the form we are in does not have focus
-                Form? topForm = FindForm();
-                if (topForm is { ContainsFocus: false })
-                {
-                    return;
+                    // Not in dark mode black theme - restore original RTF with all formatting
+                    rtfToRestore = _originalRtf ?? savedRtf;
                 }
 
-                // Never show tooltips are design time
-                if (!DesignMode)
+                // Check if RTF was modified (lost formatting) and restore it
+                if (_richTextBox != null)
                 {
-                    IContentValues? sourceContent = null;
-                    var toolTipStyle = LabelStyle.ToolTip;
-
-                    var shadow = true;
-
-                    // Find the button spec associated with the tooltip request
-                    ButtonSpec? buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
-
-                    // If the tooltip is for a button spec
-                    if (buttonSpec != null)
+                    string? currentRtf = _richTextBox.Rtf;
+                    if (currentRtf != rtfToRestore)
                     {
-                        // Are we allowed to show page related tooltips
-                        if (AllowButtonSpecToolTips)
-                        {
-                            // Create a helper object to provide tooltip values
-                            var buttonSpecMapping = new ButtonSpecToContent(Redirector, buttonSpec);
-
-                            // Is there actually anything to show for the tooltip
-                            if (buttonSpecMapping.HasContent)
-                            {
-                                sourceContent = buttonSpecMapping;
-                                toolTipStyle = buttonSpec.ToolTipStyle;
-                                shadow = buttonSpec.ToolTipShadow;
-                            }
-                        }
-                    }
-
-                    if (sourceContent != null)
-                    {
-                        // Remove any currently showing tooltip
-                        _visualPopupToolTip?.Dispose();
-
-                        if (AllowButtonSpecToolTipPriority)
-                        {
-                            visualBasePopupToolTip?.Dispose();
-                        }
-
-                        // Create the actual tooltip popup object
-                        _visualPopupToolTip = new VisualPopupToolTip(Redirector,
-                                                                     sourceContent,
-                                                                     Renderer,
-                                                                     PaletteBackStyle.ControlToolTip,
-                                                                     PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
-                                                                     shadow);
-
-                        _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
-                        _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
+                        // Restore the RTF (either modified for dark mode or original)
+                        _richTextBox.Rtf = rtfToRestore;
                     }
                 }
             }
+            else if (!hasRtfFormatting)
+            {
+                // Plain text - clear stored original RTF
+                _originalRtf = null;
+            }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
-            // Remove any currently showing tooltip
-            _visualPopupToolTip?.Dispose();
-
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
-        {
-            // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
-            popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
-
-            // Not showing a popup page any more
-            _visualPopupToolTip = null;
-        }
-
-        private void SetCornerRoundingRadius(float? radius)
-        {
-            _cornerRoundingRadius = radius ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
-
-            StateCommon.Border.Rounding = _cornerRoundingRadius;
-        }
-
-        #endregion
+        base.OnNeedPaint(sender, e);
     }
+
+    /// <summary>
+    /// Raises the Paint event.
+    /// </summary>
+    /// <param name="e">A PaintEventArgs containing the event data.</param>
+    protected override void OnPaint(PaintEventArgs? e)
+    {
+        if (_firstPaint)
+        {
+            _firstPaint = false;
+            ForceControlLayout();
+        }
+
+        base.OnPaint(e);
+    }
+
+    /// <summary>
+    /// Process Windows-based messages.
+    /// </summary>
+    /// <param name="m">A Windows-based message.</param>
+    protected override void WndProc(ref Message m)
+    {
+        switch (m.Msg)
+        {
+            case PI.WM_.NCHITTEST:
+                if (InTransparentDesignMode)
+                {
+                    m.Result = (IntPtr)PI.HT.TRANSPARENT;
+                }
+                else
+                {
+                    base.WndProc(ref m);
+                }
+
+                break;
+            default:
+                base.WndProc(ref m);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Fixes the cursor changing issue.
+    /// </summary>
+    /// <param name="e"></param>
+    protected override void OnCursorChanged(EventArgs e)
+    {
+        base.OnCursorChanged(e);
+
+        _richTextBox.Cursor = Cursor;
+    }
+    #endregion
+
+    #region Internal
+    internal bool InTransparentDesignMode => InRibbonDesignMode;
+
+    #endregion
+
+    #region Implementation
+
+    private void UpdateStateAndPalettes()
+    {
+        // Get the correct palette settings to use
+        IPaletteTriple tripleState = GetTripleState();
+        _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
+
+        // Update enabled state
+        _drawDockerOuter.Enabled = Enabled;
+
+        // Find the new state of the main view element
+        PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
+
+        _drawDockerOuter.ElementState = state;
+    }
+
+    private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
+
+    private void OnRichTextBoxMouseChange(object? sender, EventArgs e)
+    {
+        // Change in tracking state?
+        if (_richTextBox.MouseOver != _trackingMouseEnter)
+        {
+            _trackingMouseEnter = _richTextBox.MouseOver;
+
+            // Raise appropriate event
+            if (_trackingMouseEnter)
+            {
+                OnTrackMouseEnter(EventArgs.Empty);
+                OnMouseEnter(e);
+            }
+            else
+            {
+                OnTrackMouseLeave(EventArgs.Empty);
+                OnMouseLeave(e);
+            }
+        }
+    }
+
+    private void OnRichTextBoxAcceptsTabChanged(object? sender, EventArgs e) => OnAcceptsTabChanged(e);
+
+    private void OnRichTextBoxTextChanged(object? sender, EventArgs e)
+    {
+        if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
+            && TextLength <= 1)
+        {
+            // Needed to prevent character turds being left behind
+            // Oh, and to get rid of the initial cuetext drawing ;-)
+            _richTextBox.Invalidate();
+        }
+
+        OnTextChanged(e);
+    }
+
+    private void OnRichTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
+
+    private void OnRichTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
+
+    private void OnRichTextBoxMultilineChanged(object? sender, EventArgs e) => OnMultilineChanged(e);
+
+    private void OnRichTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
+
+    private void OnRichTextBoxGotFocus(object? sender, EventArgs e)
+    {
+        UpdateStateAndPalettes();
+        PerformNeedPaint(true);
+        OnGotFocus(e);
+    }
+
+    private void OnRichTextBoxLostFocus(object? sender, EventArgs e)
+    {
+        UpdateStateAndPalettes();
+        PerformNeedPaint(true);
+        OnLostFocus(e);
+    }
+
+    private void OnRichTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
+
+    private void OnRichTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
+
+    private void OnRichTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
+
+    private void OnRichTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+
+    private void OnRichTextBoxVScroll(object? sender, EventArgs e) => OnVScroll(e);
+
+    private void OnRichTextBoxHScroll(object? sender, EventArgs e) => OnHScroll(e);
+
+    private void OnRichTextBoxSelectionChanged(object? sender, EventArgs e) => OnSelectionChanged(e);
+
+    private void OnRichTextBoxProtected(object? sender, EventArgs e) => OnProtected(e);
+
+    private void OnRichTextBoxLinkClicked(object? sender, LinkClickedEventArgs e) => OnLinkClicked(e);
+
+    private void OnRichTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
+
+    private void OnRichTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
+
+    private void OnShowToolTip(object? sender, ToolTipEventArgs e)
+    {
+        if (!IsDisposed && !Disposing)
+        {
+            // Do not show tooltips when the form we are in does not have focus
+            Form? topForm = FindForm();
+            if (topForm is { ContainsFocus: false })
+            {
+                return;
+            }
+
+            // Never show tooltips are design time
+            if (!DesignMode)
+            {
+                IContentValues? sourceContent = null;
+                var toolTipStyle = LabelStyle.ToolTip;
+
+                var shadow = true;
+
+                if (sourceContent != null)
+                {
+                    // Remove any currently showing tooltip
+                    _visualPopupToolTip?.Dispose();
+
+                    // Create the actual tooltip popup object
+                    _visualPopupToolTip = new VisualPopupToolTip(Redirector,
+                        sourceContent,
+                        Renderer,
+                        PaletteBackStyle.ControlToolTip,
+                        PaletteBorderStyle.ControlToolTip,
+                        CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                        shadow);
+
+                    _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
+                    _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
+                }
+            }
+        }
+    }
+
+    private void OnCancelToolTip(object? sender, EventArgs e) =>
+        // Remove any currently showing tooltip
+        _visualPopupToolTip?.Dispose();
+
+    private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
+    {
+        // Unhook events from the specific instance that generated event
+        VisualPopupToolTip popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
+        popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
+
+        // Not showing a popup page anymore
+        _visualPopupToolTip = null;
+    }
+
+    /// <summary>
+    /// Checks if RTF contains black text (color index 0, which is typically black).
+    /// </summary>
+    /// <param name="rtf">The RTF content to check.</param>
+    /// <returns>True if black text is detected, false otherwise.</returns>
+    private static bool HasBlackTextInRtf(ReadOnlySpan<char> rtf)
+    {
+        if (rtf.IsEmpty)
+        {
+            return false;
+        }
+
+        // Check for \cf0 (color index 0, which is typically black in RTF)
+        // This is the most common way black text is specified in RTF
+        // We check for \cf0 followed by space, digit, backslash, or end of string
+        for (int i = 0; i < rtf.Length - 3; i++)
+        {
+            if (rtf[i] == '\\' && rtf[i + 1] == 'c' && rtf[i + 2] == 'f' && rtf[i + 3] == '0')
+            {
+                // Verify it's a complete color code (followed by space, backslash, or end)
+                if (i + 4 >= rtf.Length ||
+                    rtf[i + 4] == ' ' ||
+                    rtf[i + 4] == '\\' ||
+                    rtf[i + 4] == '\r' ||
+                    rtf[i + 4] == '\n' ||
+                    rtf[i + 4] == '\t' ||
+                    !char.IsDigit(rtf[i + 4]))
+                {
+                    return true;
+                }
+
+                i += 3;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Replaces black color codes (\cf0) and default black color with white color in RTF for visibility on dark backgrounds.
+    /// </summary>
+    /// <param name="rtf">The RTF content to modify.</param>
+    /// <returns>RTF with black color codes replaced with white.</returns>
+    private static string RemoveBlackColorCodes(string rtf)
+    {
+        if (string.IsNullOrEmpty(rtf))
+        {
+            return rtf;
+        }
+
+        ReadOnlySpan<char> rtfSpan = rtf;
+
+        // Find or add white color to color table
+        ReadOnlySpan<char> colortblPattern = @"{\colortbl".AsSpan();
+        int colorTableStart = rtfSpan.IndexOf(colortblPattern, StringComparison.Ordinal);
+        int whiteColorIndex = -1;
+        string modifiedRtf = rtf;
+
+        if (colorTableStart >= 0)
+        {
+            // Find the end of color table
+            int braceCount = 0;
+            int colorTableEnd = colorTableStart;
+            bool inColorTable = false;
+
+            for (int i = colorTableStart; i < rtfSpan.Length; i++)
+            {
+                if (rtfSpan[i] == '{')
+                {
+                    braceCount++;
+                    inColorTable = true;
+                }
+                else if (rtfSpan[i] == '}')
+                {
+                    braceCount--;
+                    if (inColorTable && braceCount == 0)
+                    {
+                        colorTableEnd = i;
+                        break;
+                    }
+                }
+            }
+
+            if (colorTableEnd > colorTableStart)
+            {
+                ReadOnlySpan<char> colorTable = rtfSpan.Slice(colorTableStart, colorTableEnd - colorTableStart + 1);
+
+                // Check if white color already exists: \red255\green255\blue255
+                ReadOnlySpan<char> red255Green255Blue255 = @"\red255\green255\blue255".AsSpan();
+                ReadOnlySpan<char> red255Green255Blue255Spaced = @"\red255 \green255 \blue255".AsSpan();
+                bool hasWhite = colorTable.Contains(red255Green255Blue255, StringComparison.Ordinal) ||
+                               colorTable.Contains(red255Green255Blue255Spaced, StringComparison.Ordinal);
+
+                if (hasWhite)
+                {
+                    // Find the index of white color
+                    // Count colors before white (each color ends with ;)
+                    ReadOnlySpan<char> red255 = @"\red255".AsSpan();
+                    int whitePos = colorTable.IndexOf(red255);
+                    if (whitePos > 0)
+                    {
+                        ReadOnlySpan<char> beforeWhite = colorTable.Slice(0, whitePos);
+                        whiteColorIndex = CountColorTableEntries(beforeWhite);
+                    }
+                }
+                else
+                {
+                    // White color doesn't exist, add it to color table
+                    // Insert before the closing brace
+                    string whiteColorDef = @";\red255\green255\blue255";
+                    modifiedRtf = rtf.Insert(colorTableEnd, whiteColorDef);
+
+                    // Calculate white color index (count existing colors)
+                    whiteColorIndex = CountColorTableEntries(colorTable);
+                }
+
+                // IMPORTANT: Replace the default color (index 0, black) with white in the color table
+                // This makes all text without explicit color codes use white instead of black
+                // In RTF, index 0 is the first entry after the opening semicolon
+                // Pattern: {\colortbl ;\red0\green0\blue0;... or {\colortbl ;... (implicit black)
+                int firstSemicolon = colorTable.IndexOf(';');
+                if (firstSemicolon >= 0)
+                {
+                    // Find where the first color definition starts (after the semicolon)
+                    int firstColorStart = firstSemicolon + 1;
+
+                    // Check if there's an explicit color definition for index 0
+                    // Look for \red, \green, \blue patterns
+                    ReadOnlySpan<char> redPattern = @"\red".AsSpan();
+                    ReadOnlySpan<char> searchSpan = colorTable.Slice(firstColorStart);
+                    int redIndexRelative = searchSpan.IndexOf(redPattern);
+                    int redIndex = redIndexRelative >= 0 ? firstColorStart + redIndexRelative : -1;
+                    int nextSemicolonRelative = searchSpan.IndexOf(';');
+                    int nextSemicolon = nextSemicolonRelative >= 0 ? firstColorStart + nextSemicolonRelative : -1;
+                    int colorEnd = nextSemicolon > 0 ? nextSemicolon : colorTable.Length;
+                    bool hasExplicitFirstColor = redIndex >= 0 && redIndex < colorEnd;
+
+                    if (hasExplicitFirstColor)
+                    {
+                        // Find where the first explicit color ends (next semicolon or closing brace)
+                        ReadOnlySpan<char> searchSpanForEnd = colorTable.Slice(firstColorStart);
+                        int firstColorEndRelative = searchSpanForEnd.IndexOf(';');
+                        int firstColorEnd = firstColorEndRelative >= 0 ? firstColorStart + firstColorEndRelative : -1;
+                        if (firstColorEnd < 0)
+                        {
+                            int braceEndRelative = searchSpanForEnd.IndexOf('}');
+                            firstColorEnd = braceEndRelative >= 0 ? firstColorStart + braceEndRelative : -1;
+                        }
+
+                        if (firstColorEnd > firstColorStart)
+                        {
+                            // Replace the explicit first color (black) with white
+                            string newColorTable = colorTable.Slice(0, firstColorStart).ToString() +
+                                                  @"\red255\green255\blue255" +
+                                                  colorTable.Slice(firstColorEnd).ToString();
+
+                            // Replace the color table in the RTF
+                            modifiedRtf = rtf.Substring(0, colorTableStart) +
+                                         newColorTable +
+                                         rtf.Substring(colorTableEnd + 1);
+
+                            // White is now at index 0
+                            whiteColorIndex = 0;
+                        }
+                    }
+                    else
+                    {
+                        // Index 0 is implicit (no explicit color definition)
+                        // Insert white as the explicit first color
+                        string whiteColorDef = @"\red255\green255\blue255";
+                        string newColorTable = colorTable.Slice(0, firstColorStart).ToString() +
+                                              whiteColorDef +
+                                              colorTable.Slice(firstColorStart).ToString();
+
+                        // Replace the color table in the RTF
+                        modifiedRtf = rtf.Substring(0, colorTableStart) +
+                                     newColorTable +
+                                     rtf.Substring(colorTableEnd + 1);
+
+                        // White is now at index 0
+                        whiteColorIndex = 0;
+                    }
+                }
+            }
+        }
+        else
+        {
+            // No color table exists, create one with white as default
+            // Find insertion point after font table
+            ReadOnlySpan<char> newlinePattern = @"}\n".AsSpan();
+            int fontTableEnd = rtfSpan.IndexOf(newlinePattern, StringComparison.Ordinal);
+            if (fontTableEnd < 0)
+            {
+                ReadOnlySpan<char> crlfPattern = @"}\r\n".AsSpan();
+                fontTableEnd = rtfSpan.IndexOf(crlfPattern, StringComparison.Ordinal);
+            }
+            if (fontTableEnd < 0)
+            {
+                fontTableEnd = rtfSpan.IndexOf('}');
+            }
+
+            if (fontTableEnd >= 0)
+            {
+                // Create color table with white as index 0 (default color)
+                string colorTable = @"{\colortbl ;\red255\green255\blue255;}";
+                modifiedRtf = rtf.Insert(fontTableEnd + 1, colorTable);
+                whiteColorIndex = 0; // White is now the default (index 0)
+            }
+        }
+
+        // If we couldn't determine white color index, default to removing \cf0
+        if (whiteColorIndex < 0)
+        {
+            // Fallback: just remove \cf0
+            var result = new System.Text.StringBuilder(modifiedRtf);
+            ReadOnlySpan<char> resultSpan = result.ToString();
+            for (int i = resultSpan.Length - 4; i >= 0; i--)
+            {
+                if (resultSpan[i] == '\\' && resultSpan[i + 1] == 'c' && resultSpan[i + 2] == 'f' && resultSpan[i + 3] == '0')
+                {
+                    if (i + 4 >= resultSpan.Length ||
+                        resultSpan[i + 4] == ' ' ||
+                        resultSpan[i + 4] == '\\' ||
+                        resultSpan[i + 4] == '\r' ||
+                        resultSpan[i + 4] == '\n' ||
+                        resultSpan[i + 4] == '\t' ||
+                        !char.IsDigit(resultSpan[i + 4]))
+                    {
+                        result.Remove(i, 4);
+                        resultSpan = result.ToString();
+                        i -= 3;
+                    }
+                    else
+                    {
+                        i -= 3;
+                    }
+                }
+            }
+            return result.ToString();
+        }
+
+        // Replace \cf0 with \cf{whiteColorIndex} (which is now 0, but we keep the code for clarity)
+        var finalResult = new System.Text.StringBuilder(modifiedRtf);
+        string replacement = $@"\cf{whiteColorIndex}";
+        ReadOnlySpan<char> finalResultSpan = finalResult.ToString();
+
+        // Scan backwards to avoid index shifting issues
+        for (int i = finalResultSpan.Length - 4; i >= 0; i--)
+        {
+            if (finalResultSpan[i] == '\\' && finalResultSpan[i + 1] == 'c' && finalResultSpan[i + 2] == 'f' && finalResultSpan[i + 3] == '0')
+            {
+                // Verify it's a complete color code
+                if (i + 4 >= finalResultSpan.Length ||
+                    finalResultSpan[i + 4] == ' ' ||
+                    finalResultSpan[i + 4] == '\\' ||
+                    finalResultSpan[i + 4] == '\r' ||
+                    finalResultSpan[i + 4] == '\n' ||
+                    finalResultSpan[i + 4] == '\t' ||
+                    !char.IsDigit(finalResultSpan[i + 4]))
+                {
+                    // Replace \cf0 with white color code
+                    finalResult.Remove(i, 4);
+                    finalResult.Insert(i, replacement);
+                    finalResultSpan = finalResult.ToString();
+                    i -= 3;
+                }
+                else
+                {
+                    i -= 3;
+                }
+            }
+        }
+
+        return finalResult.ToString();
+    }
+
+    /// <summary>
+    /// Counts the number of color entries in a color table string.
+    /// </summary>
+    /// <param name="colorTable">The color table string to count.</param>
+    /// <returns>The number of color entries (semicolons indicate entries).</returns>
+    private static int CountColorTableEntries(ReadOnlySpan<char> colorTable)
+    {
+        if (colorTable.IsEmpty)
+        {
+            return 0;
+        }
+
+#if NET5_0_OR_GREATER
+        // Use Span.Count method available in .NET 5.0 and later
+        int count = MemoryExtensions.Count(colorTable, ';') + 1;
+#else
+        // Fallback for older frameworks without Span.Count
+        int count = 1;
+
+        // Count semicolons to determine number of colors
+        for (int i = 0; i < colorTable.Length; i++)
+        {
+            // Each semicolon indicates a color entry
+            if (colorTable[i] == ';')
+            {
+                // Increment count for each semicolon found
+                count++;
+            }
+        }
+#endif
+
+        // First semicolon is after the opening brace, so subtract 1
+        return count - 1;
+    }
+
+    #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1,1810 +1,100 @@
-﻿#region BSD License
+#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
-namespace Krypton.Toolkit
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provide a TextBox with Krypton styling applied.
+/// </summary>
+[ToolboxItem(true)]
+[ToolboxBitmap(typeof(KryptonTextBox), "ToolboxBitmaps.KryptonTextBox.bmp")]
+[DefaultEvent(nameof(TextChanged))]
+[DefaultProperty(nameof(Text))]
+[DefaultBindingProperty(nameof(Text))]
+[Designer(typeof(KryptonTextBoxDesigner))]
+[DesignerCategory(@"code")]
+[Description(@"Enables the user to enter text, and provides multiline editing and password character masking.")]
+public class KryptonTextBox : VisualControlBase,
+    IContainedInputControl
 {
-    /// <summary>
-    /// Provide a TextBox with Krypton styling applied.
-    /// </summary>
-    [ToolboxItem(true)]
-    [ToolboxBitmap(typeof(KryptonTextBox), "ToolboxBitmaps.KryptonTextBox.bmp")]
-    [DefaultEvent(nameof(TextChanged))]
-    [DefaultProperty(nameof(Text))]
-    [DefaultBindingProperty(nameof(Text))]
-    [Designer(typeof(KryptonTextBoxDesigner))]
-    [DesignerCategory(@"code")]
-    [Description(@"Enables the user to enter text, and provides multiline editing and password character masking.")]
-    public class KryptonTextBox : VisualControlBase,
-                                  IContainedInputControl
+    #region Classes
+    private class InternalTextBox : TextBox
     {
-        #region Classes
-        private class InternalTextBox : TextBox
-        {
-            #region Instance Fields
-            private readonly KryptonTextBox _kryptonTextBox;
-            private bool _mouseOver;
-            #endregion
-
-            #region Events
-            /// <summary>
-            /// Occurs when the mouse enters the InternalTextBox.
-            /// </summary>
-            public event EventHandler? TrackMouseEnter;
-
-            /// <summary>
-            /// Occurs when the mouse leaves the InternalTextBox.
-            /// </summary>
-            public event EventHandler? TrackMouseLeave;
-            #endregion
-
-            #region Identity
-            /// <summary>
-            /// Initialize a new instance of the InternalTextBox class.
-            /// </summary>
-            /// <param name="kryptonTextBox">Reference to owning control.</param>
-            public InternalTextBox(KryptonTextBox kryptonTextBox)
-            {
-                _kryptonTextBox = kryptonTextBox;
-
-                // Remove from view until size for the first time by the Krypton control
-                Size = Size.Empty;
-
-                // We provide the border manually
-                BorderStyle = BorderStyle.None;
-            }
-            #endregion
-
-            #region MouseOver
-            /// <summary>
-            /// Gets and sets if the mouse is currently over the combo box.
-            /// </summary>
-            public bool MouseOver
-            {
-                get => _mouseOver;
-
-                set
-                {
-                    // Only interested in changes
-                    if (_mouseOver != value)
-                    {
-                        _mouseOver = value;
-
-                        // Generate appropriate change event
-                        if (_mouseOver)
-                        {
-                            OnTrackMouseEnter(EventArgs.Empty);
-                        }
-                        else
-                        {
-                            OnTrackMouseLeave(EventArgs.Empty);
-                        }
-                    }
-                }
-            }
-            #endregion
-
-            #region Protected
-
-            /// <summary>
-            /// Process Windows-based messages.
-            /// </summary>
-            /// <param name="m">A Windows-based message.</param>
-            protected override void WndProc(ref Message m)
-            {
-                switch (m.Msg)
-                {
-                    case PI.WM_.ERASEBKGND:
-                        // Prevent two-stage erase/paint redraw during resize, which causes visible text flicker.
-                        break;
-                    case PI.WM_.NCHITTEST:
-                        if (_kryptonTextBox.InTransparentDesignMode)
-                        {
-                            m.Result = (IntPtr)PI.HT.TRANSPARENT;
-                        }
-                        else
-                        {
-                            base.WndProc(ref m);
-                        }
-
-                        break;
-                    case PI.WM_.MOUSELEAVE:
-                        // Mouse is not over the control
-                        MouseOver = false;
-                        _kryptonTextBox.PerformNeedPaint(true);
-                        Invalidate();
-                        base.WndProc(ref m);
-                        break;
-                    case PI.WM_.MOUSEMOVE:
-                        // Mouse is over the control
-                        if (!MouseOver)
-                        {
-                            MouseOver = true;
-                            _kryptonTextBox.PerformNeedPaint(true);
-                            Invalidate();
-                        }
-                        base.WndProc(ref m);
-                        break;
-                    case PI.WM_.PRINTCLIENT:
-                    case PI.WM_.PAINT:
-                        {
-                            bool hasCueHintText = !string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText);
-                            bool hasUserText = !string.IsNullOrEmpty(_kryptonTextBox.Text);
-
-                            // Use native edit-control painting for the common enabled text path.
-                            // Custom cue-hint/disabled rendering remains below.
-                            if (_kryptonTextBox.Enabled && (!hasCueHintText || hasUserText))
-                            {
-                                base.WndProc(ref m);
-                                break;
-                            }
-
-                            var ps = new PI.PAINTSTRUCT();
-
-                            // Do we need to BeginPaint or just take the given HDC?
-                            var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
-
-                            // Paint the entire area in the background color
-                            using Graphics g = Graphics.FromHdc(hdc);
-                            // Grab the client area of the control
-                            PI.GetClientRect(Handle, out PI.RECT rect);
-
-                            var textRectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
-
-                            // Create rect for the text area
-                            Size borderSize = SystemInformation.BorderSize;
-                            rect.left -= borderSize.Width + 1;
-
-                            if (hasCueHintText && !hasUserText)
-                            {
-                                // Go perform the drawing of the CueHint
-                                using var backBrush = new SolidBrush(BackColor);
-                                _kryptonTextBox.CueHint.PerformPaint(_kryptonTextBox, g, rect, backBrush);
-                            }
-                            else
-                            {
-                                using (var backBrush = new SolidBrush(BackColor))
-                                {
-                                    // Draw entire client area in the background color
-                                    g.FillRectangle(backBrush,
-                                        new Rectangle(rect.left, rect.top, rect.right - rect.left,
-                                            rect.bottom - rect.top));
-                                }
-
-                                // If enabled then let the combo draw the text area
-                                if (_kryptonTextBox.Enabled)
-                                {
-                                    // Let base implementation draw the actual text area
-                                    if (m.WParam == IntPtr.Zero)
-                                    {
-                                        m.WParam = hdc;
-                                        DefWndProc(ref m);
-                                        m.WParam = IntPtr.Zero;
-                                    }
-                                    else
-                                    {
-                                        DefWndProc(ref m);
-                                    }
-                                }
-                                else
-                                {
-                                    // Set the correct text rendering hint for the text drawing. We only draw if the edit text is disabled so we
-                                    // just always grab the disable state value. Without this line the wrong hint can occur because it inherits
-                                    // it from the device context. Resulting in blurred text.
-                                    // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
-                                    using (new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(
-                                        _kryptonTextBox.StateDisabled.PaletteContent.GetContentShortTextHint(PaletteState.Disabled))))
-                                    {
-                                        // Define the string formatting requirements
-                                        var stringFormat = new StringFormat
-                                        {
-                                            Trimming = StringTrimming.None,
-                                            LineAlignment = StringAlignment.Near
-                                        };
-                                        if (!_kryptonTextBox.Multiline)
-                                        {
-                                            stringFormat.FormatFlags |= StringFormatFlags.NoWrap;
-                                        }
-
-                                        stringFormat.Alignment = _kryptonTextBox.TextAlign switch
-                                        {
-                                            HorizontalAlignment.Left => RightToLeft == RightToLeft.Yes
-                                                ? StringAlignment.Far
-                                                : StringAlignment.Near,
-                                            HorizontalAlignment.Right => RightToLeft == RightToLeft.Yes
-                                                ? StringAlignment.Near
-                                                : StringAlignment.Far,
-                                            HorizontalAlignment.Center => StringAlignment.Center,
-                                            _ => stringFormat.Alignment
-                                        };
-
-                                        // Use the correct prefix setting
-                                        stringFormat.HotkeyPrefix = HotkeyPrefix.None;
-
-                                        // Decide on the text to draw disabled
-                                        var drawString = Text;
-                                        if (PasswordChar != '\0')
-                                        {
-                                            drawString = new string(PasswordChar, Text.Length);
-                                        }
-
-                                        // Define the font to use for disabled painting – always query the palette first.
-                                        // Avoids exception - magnitudes faster than another repaint AND try/catch.
-                                        var disabledFont = _kryptonTextBox
-                                                               .GetTripleState()
-                                                               .PaletteContent?
-                                                               .GetContentShortTextFont(PaletteState.Disabled)
-                                                           ?? Font; // Fallback: current Font if palette returns null
-                                        using var foreBrush = new SolidBrush(ForeColor);
-                                        g.DrawString(drawString, disabledFont, foreBrush,
-                                            textRectangle,
-                                            stringFormat);
-                                    }
-                                }
-
-                                // Remove clipping settings
-                                PI.SelectClipRgn(hdc, IntPtr.Zero);
-                            }
-
-                            // Do we need to match the original BeginPaint?
-                            if (m.WParam == IntPtr.Zero)
-                            {
-                                PI.EndPaint(Handle, ref ps);
-                            }
-                        }
-                        break;
-                    case PI.WM_.CONTEXTMENU:
-                        // Only interested in overriding the behavior when we have a krypton context menu...
-                        if (_kryptonTextBox.KryptonContextMenu != null)
-                        {
-                            // Extract the screen mouse position (if might not actually be provided)
-                            var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
-
-                            // If keyboard activated, the menu position is centered
-                            if (((int)(long)m.LParam) == -1)
-                            {
-                                mousePt = PointToScreen(new Point(Width / 2, Height / 2));
-                            }
-
-                            // Show the context menu
-                            _kryptonTextBox.KryptonContextMenu.Show(_kryptonTextBox, mousePt);
-
-                            // We eat the message!
-                            return;
-                        }
-                        base.WndProc(ref m);
-                        break;
-                    default:
-                        base.WndProc(ref m);
-                        break;
-                }
-            }
-
-            /// <summary>
-            /// Raises the TrackMouseEnter event.
-            /// </summary>
-            /// <param name="e">An EventArgs containing the event data.</param>
-            protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
-
-            /// <summary>
-            /// Raises the TrackMouseLeave event.
-            /// </summary>
-            /// <param name="e">An EventArgs containing the event data.</param>
-            protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
-            #endregion
-        }
-
-        #endregion
-
-        #region Type Definitions
-        /// <summary>
-        /// Collection for managing ButtonSpecAny instances.
-        /// </summary>
-        public class TextBoxButtonSpecCollection : ButtonSpecCollection<ButtonSpecAny>
-        {
-            #region Identity
-            /// <summary>
-            /// Initialize a new instance of the TextBoxButtonSpecCollection class.
-            /// </summary>
-            /// <param name="owner">Reference to owning object.</param>
-            public TextBoxButtonSpecCollection(KryptonTextBox owner)
-                : base(owner)
-            {
-            }
-            #endregion
-        }
-        #endregion
-
         #region Instance Fields
-
-        private VisualPopupToolTip? _visualPopupToolTip;
-        private readonly ButtonSpecManagerLayout? _buttonManager;
-        private readonly ViewLayoutDocker _drawDockerInner;
-        private readonly ViewDrawDocker _drawDockerOuter;
-        private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalTextBox _textBox;
-        private InputControlStyle _inputControlStyle;
-        private bool? _fixedActive;
-        private bool _forcedLayout;
-        private bool _autoSize;
+        private readonly KryptonTextBox _kryptonTextBox;
         private bool _mouseOver;
-        private bool _alwaysActive;
-        private bool _trackingMouseEnter;
-        private int _cachedHeight;
-        private bool _multilineStringEditor;
-        private bool _showEllipsisButton;
-        //private bool _isInAlphaNumericMode;
-        private readonly ButtonSpecAny _editorButton;
-        private float _cornerRoundingRadius;
 
         #endregion
 
         #region Events
         /// <summary>
-        /// Occurs when the value of the AcceptsTab property changes.
+        /// Occurs when the mouse enters the InternalTextBox.
         /// </summary>
-        [Description(@"Occurs when the value of the AcceptsTab property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? AcceptsTabChanged;
-
-        /// <summary>
-        /// Occurs when the value of the HideSelection property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the HideSelection property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? HideSelectionChanged;
-
-        /// <summary>
-        /// Occurs when the value of the TextAlign property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the TextAlign property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? TextAlignChanged;
-
-        /// <summary>
-        /// Occurs when the value of the Modified property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the Modified property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? ModifiedChanged;
-
-        /// <summary>
-        /// Occurs when the value of the Multiline property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the Multiline property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? MultilineChanged;
-
-        /// <summary>
-        /// Occurs when the value of the ReadOnly property changes.
-        /// </summary>
-        [Description(@"Occurs when the value of the ReadOnly property changes.")]
-        [Category(@"Property Changed")]
-        public event EventHandler? ReadOnlyChanged;
-
-        /// <summary>
-        /// Occurs when the mouse enters the control.
-        /// </summary>
-        [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
-        [Category(@"Mouse")]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseEnter;
 
         /// <summary>
-        /// Occurs when the mouse leaves the control.
+        /// Occurs when the mouse leaves the InternalTextBox.
         /// </summary>
-        [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
-        [Category(@"Mouse")]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseLeave;
-
-        /// <summary>
-        /// Occurs when the value of the BackColor property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackColorChanged;
-
-        /// <summary>
-        /// Occurs when the value of the BackgroundImage property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackgroundImageChanged;
-
-        /// <summary>
-        /// Occurs when the value of the BackgroundImageLayout property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? BackgroundImageLayoutChanged;
-
-        /// <summary>
-        /// Occurs when the value of the ForeColor property changes.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new event EventHandler? ForeColorChanged;
         #endregion
 
         #region Identity
         /// <summary>
-        /// Initialize a new instance of the KryptonTextBox class.
+        /// Initialize a new instance of the InternalTextBox class.
         /// </summary>
-        public KryptonTextBox()
+        /// <param name="kryptonTextBox">Reference to owning control.</param>
+        public InternalTextBox(KryptonTextBox kryptonTextBox)
         {
-            // Contains another control and needs marking as such for validation to work
-            SetStyle(ControlStyles.ContainerControl, true);
+            _kryptonTextBox = kryptonTextBox;
 
-            // By default we are not multiline and so the height is fixed
-            SetStyle(ControlStyles.FixedHeight, true);
+            // Remove from view until size for the first time by the Krypton control
+            Size = Size.Empty;
 
-            // Cannot select this control, only the child TextBox, and does not generate a click event
-            SetStyle(ControlStyles.Selectable | ControlStyles.StandardClick, false);
-
-            // Defaults
-            _inputControlStyle = InputControlStyle.Standalone;
-            _autoSize = true;
-            _cachedHeight = -1;
-            _alwaysActive = true;
-            AllowButtonSpecToolTips = false;
-            AllowButtonSpecToolTipPriority = false;
-
-            // Create storage properties
-            ButtonSpecs = new TextBoxButtonSpecCollection(this);
-
-            // Create the palette storage
-            StateCommon = new PaletteInputControlTripleRedirect(Redirector!, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
-            StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-            CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
-
-            // Create the internal text box used for containing content
-            _textBox = new InternalTextBox(this);
-            _textBox.DoubleClick += OnDoubleClick;
-            _textBox.MouseDoubleClick += OnMouseDoubleClick;
-            _textBox.TrackMouseEnter += OnTextBoxMouseChange;
-            _textBox.TrackMouseLeave += OnTextBoxMouseChange;
-            _textBox.AcceptsTabChanged += OnTextBoxAcceptsTabChanged;
-            _textBox.TextAlignChanged += OnTextBoxTextAlignChanged;
-            _textBox.TextChanged += OnTextBoxTextChanged;
-            _textBox.HideSelectionChanged += OnTextBoxHideSelectionChanged;
-            _textBox.ModifiedChanged += OnTextBoxModifiedChanged;
-            _textBox.MultilineChanged += OnTextBoxMultilineChanged;
-            _textBox.ReadOnlyChanged += OnTextBoxReadOnlyChanged;
-            _textBox.GotFocus += OnTextBoxGotFocus;
-            _textBox.LostFocus += OnTextBoxLostFocus;
-            _textBox.KeyDown += OnTextBoxKeyDown;
-            _textBox.KeyUp += OnTextBoxKeyUp;
-            _textBox.KeyPress += OnTextBoxKeyPress;
-            _textBox.PreviewKeyDown += OnTextBoxPreviewKeyDown;
-            _textBox.Validating += OnTextBoxValidating;
-            _textBox.Validated += OnTextBoxValidated;
-            _textBox.Click += OnTextBoxClick;  // SKC: make sure that the default click is also routed.
-
-            // Create the element that fills the remainder space and remembers fill rectangle
-            _layoutFill = new ViewLayoutFill(_textBox);
-
-            // Create inner view for placing inside the drawing docker
-            _drawDockerInner = new ViewLayoutDocker
-            {
-                { _layoutFill, ViewDockStyle.Fill }
-            };
-
-            // Create view for the control border and background
-            _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
-            {
-                { _drawDockerInner, ViewDockStyle.Fill }
-            };
-
-            // Create the view manager instance
-            ViewManager = new ViewManager(this, _drawDockerOuter);
-
-            // Create button specification collection manager
-            _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
-                                                         new[] { _drawDockerInner },
-                                                         new IPaletteMetric[] { StateCommon },
-                                                         new[] { PaletteMetricInt.HeaderButtonEdgeInsetInputControl },
-                                                         new[] { PaletteMetricPadding.HeaderButtonPaddingInputControl },
-                                                         CreateToolStripRenderer,
-                                                         NeedPaintDelegate);
-
-            // Create the manager for handling tooltips
-            ToolTipManager = new ToolTipManager(ToolTipValues);
-            ToolTipManager.ShowToolTip += OnShowToolTip;
-            ToolTipManager.CancelToolTip += OnCancelToolTip;
-            _buttonManager.ToolTipManager = ToolTipManager;
-
-            // Create the button spec for the multiline editor button.
-            _editorButton = new ButtonSpecAny
-            {
-                Image = GenericImageResources.SelectParentControlFlipped,
-                Style = PaletteButtonStyle.ButtonSpec,
-                Type = PaletteButtonSpecStyle.Generic
-            };
-            _editorButton.Click += OnEditorButtonClicked;
-
-            // Add text box to the controls collection
-            ((KryptonReadOnlyControls)Controls).AddInternal(_textBox);
-
-            _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
-
-            //_isInAlphaNumericMode = false;
-
-            _showEllipsisButton = false;
-        }
-
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // Remove any showing tooltip
-                OnCancelToolTip(this, EventArgs.Empty);
-
-                // Remember to pull down the manager instance
-                _buttonManager?.Destruct();
-            }
-
-            base.Dispose(disposing);
+            // We provide the border manually
+            BorderStyle = BorderStyle.None;
         }
         #endregion
 
-        #region Public
-
-        // TODO: Return to this...
-        /*
-        /// <summary>Gets or sets a value indicating whether this instance is in alpha numeric mode.</summary>
-        /// <value><c>true</c> if this instance is in alpha numeric mode; otherwise, <c>false</c>.</value>
-        [Category(@"Data"), DefaultValue(false), Description(@"Only allow numerical input.")]
-        public bool IsInAlphaNumericMode { get => _isInAlphaNumericMode; set { _isInAlphaNumericMode = value; SetIsInAlphaNumericMode(this); } }
-        */
-
-        /// <summary>Gets or sets the corner rounding radius.</summary>
-        /// <value>The corner rounding radius.</value>
-        [Category(@"Visuals"), DefaultValue(GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE), Description(@"Defines the corner roundness on the current window (-1 is the default look).")]
-        public float CornerRoundingRadius
-        {
-            get => _cornerRoundingRadius;
-            set => SetCornerRoundingRadius(value);
-        }
-
+        #region MouseOver
         /// <summary>
-        /// Gets access to the common textbox appearance entries that other states can override.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Set a watermark/prompt message for the user.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteCueHintText CueHint { get; }
-
-        /// <summary>
-        /// Gets and sets control watermark.
+        /// Gets and sets if the mouse is currently over the combo box.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        [Obsolete("Deprecated - Use CueHint.CueHintText")]
-        public string Hint
+        public bool MouseOver
         {
-            get => CueHint.CueHintText;
-            set
-            {
-                CueHint.CueHintText = value;
-
-                // Force a repaint
-                Invalidate();
-            }
-        }
-
-        private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
-
-
-        /// <summary>
-        /// Gets and sets if the control is in the tab chain.
-        /// </summary>
-        public new bool TabStop
-        {
-            get => _textBox.TabStop;
-            set => _textBox.TabStop = value;
-        }
-
-        /// <summary>
-        /// Gets and sets if the control is in the ribbon design mode.
-        /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public bool InRibbonDesignMode { get; set; }
-
-        /// <summary>
-        /// Gets and sets if the control uses the multiline string editor widget.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if the control uses the multiline string editor widget.")]
-        [DefaultValue(false)]
-        public bool MultilineStringEditor
-        {
-            get => _multilineStringEditor;
-            set
-            {
-                if (_multilineStringEditor != value)
-                {
-                    SetMultilineStringEditor(value);
-                }
-            }
-        }
-
-        /// <summary>Gets or sets a value indicating whether [show ellipsis button].</summary>
-        /// <value><c>true</c> if [show ellipsis button]; otherwise, <c>false</c>.</value>
-        [Category(@"Visuals")]
-        [Description(@"Shows a ellipsis (...) button in the textbox.")]
-        [DefaultValue(false)]
-        public bool ShowEllipsisButton { get => _showEllipsisButton; set { _showEllipsisButton = value; ToggleEllipsisButtonVisibility(value); } }
-
-        /// <summary>
-        /// Gets access to the contained TextBox instance.
-        /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(false)]
-        public TextBox TextBox => _textBox;
-
-        /// <summary>
-        /// Gets access to the contained input control.
-        /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(false)]
-        public Control ContainedControl => TextBox;
-
-        /// <summary>
-        /// Gets and sets a value indicating if the control is automatically sized.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        public override bool AutoSize
-        {
-            get => _autoSize;
+            get => _mouseOver;
 
             set
             {
-                if (_autoSize != value)
+                // Only interested in changes
+                if (_mouseOver != value)
                 {
-                    _autoSize = value;
-
-                    // Multiline allows a variable height, otherwise we are fixed in height
-                    SetStyle(ControlStyles.FixedHeight, !Multiline && _autoSize);
-
-                    // Add adjust actual height to match new setting
-                    AdjustHeight(false);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the control has input focus.
-        /// </summary>
-        [Browsable(false)]
-        public override bool Focused => TextBox.Focused;
-
-        /// <summary>
-        /// Gets or sets the background color for the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        public override Color BackColor
-        {
-            get => base.BackColor;
-            set => base.BackColor = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the font of the text Displayed by the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        [AmbientValue(null)]
-        [AllowNull]
-        public override Font Font
-        {
-            get => base.Font;
-            set => base.Font = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the foreground color for the control.
-        /// </summary>
-        [Browsable(false)]
-        [Bindable(false)]
-        public override Color ForeColor
-        {
-            get => base.ForeColor;
-            set => base.ForeColor = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the internal padding space.
-        /// </summary>
-        [Browsable(false)]
-        [Localizable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new Padding Padding
-        {
-            get => base.Padding;
-            set => base.Padding = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the text associated with the control.
-        /// </summary>
-        [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
-        [AllowNull]
-        public override string Text
-        {
-            get => _textBox.Text;
-            set => _textBox.Text = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the associated context menu strip.
-        /// </summary>
-        public override ContextMenuStrip? ContextMenuStrip
-        {
-            get => base.ContextMenuStrip;
-
-            set
-            {
-                base.ContextMenuStrip = value;
-                _textBox.ContextMenuStrip = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool CanUndo => _textBox.CanUndo;
-
-        /// <summary>
-        /// Gets a value indicating whether the contents have changed since last last.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool Modified => _textBox.Modified;
-
-        /// <summary>
-        /// Gets and sets the selected text within the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string SelectedText
-        {
-            get => _textBox.SelectedText;
-            set => _textBox.SelectedText = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the selection length for the selected area.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionLength
-        {
-            get => _textBox.SelectionLength;
-            set => _textBox.SelectionLength = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the starting point of text selected in the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int SelectionStart
-        {
-            get => _textBox.SelectionStart;
-            set => _textBox.SelectionStart = value;
-        }
-
-        /// <summary>
-        /// Gets the length of text in the control.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int TextLength => _textBox.TextLength;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"Defines if mnemonic characters generate click events for button specs.")]
-        [DefaultValue(true)]
-        public bool UseMnemonic
-        {
-            get => _buttonManager.UseMnemonic;
-
-            set
-            {
-                if (_buttonManager.UseMnemonic != value)
-                {
-                    _buttonManager.UseMnemonic = value;
-                    PerformNeedPaint(true);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
-        [DefaultValue(true)]
-        public bool AlwaysActive
-        {
-            get => _alwaysActive;
-
-            set
-            {
-                if (_alwaysActive != value)
-                {
-                    _alwaysActive = value;
-                    PerformNeedPaint(true);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the lines of text in a multiline edit, as an array of String values.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"The lines of text in a multiline edit, as an array of String values.")]
-        [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [MergableProperty(false)]
-        [Localizable(true)]
-        public string[] Lines
-        {
-            get => _textBox.Lines;
-            set => _textBox.Lines = value;
-        }
-
-        /// <summary>
-        /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
-        [DefaultValue(ScrollBars.None)]
-        [Localizable(true)]
-        public ScrollBars ScrollBars
-        {
-            get => _textBox.ScrollBars;
-            set => _textBox.ScrollBars = value;
-        }
-
-        /// <summary>
-        /// Gets or sets how the text should be aligned for edit controls.
-        /// </summary>
-        [Category(@"Appearance")]
-        [Description(@"Indicates how the text should be aligned for edit controls.")]
-        [DefaultValue(HorizontalAlignment.Left)]
-        [Localizable(true)]
-        public HorizontalAlignment TextAlign
-        {
-            get => _textBox.TextAlign;
-            set => _textBox.TextAlign = value;
-        }
-
-        /// <summary>
-        /// Indicates if lines are automatically word-wrapped for multiline edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
-        [DefaultValue(true)]
-        [Localizable(true)]
-        public bool WordWrap
-        {
-            get => _textBox.WordWrap;
-            set => _textBox.WordWrap = value;
-        }
-
-        /// <summary>
-        /// Gets and sets whether the text in the control can span more than one line.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Control whether the text in the control can span more than one line.")]
-        [RefreshProperties(RefreshProperties.All)]
-        [DefaultValue(false)]
-        [Localizable(true)]
-        public bool Multiline
-        {
-            get => _textBox.Multiline;
-
-            set
-            {
-                if (_textBox.Multiline != value)
-                {
-                    _textBox.Multiline = value;
-
-                    // Multiline allows a variable height, otherwise we are fixed in height
-                    SetStyle(ControlStyles.FixedHeight, !value && _autoSize);
-
-                    // Add adjust actual height to match new setting
-                    AdjustHeight(false);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating if return characters are accepted as input for multiline edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if return characters are accepted as input for multiline edit controls.")]
-        [DefaultValue(false)]
-        public bool AcceptsReturn
-        {
-            get => _textBox.AcceptsReturn;
-            set => _textBox.AcceptsReturn = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
-        [DefaultValue(false)]
-        public bool AcceptsTab
-        {
-            get => _textBox.AcceptsTab;
-            set => _textBox.AcceptsTab = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating if all the characters should be left alone or converted to uppercase or lowercase.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if all the characters should be left alone or converted to uppercase or lowercase.")]
-        [DefaultValue(CharacterCasing.Normal)]
-        public CharacterCasing CharacterCasing
-        {
-            get => _textBox.CharacterCasing;
-            set => _textBox.CharacterCasing = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
-        [DefaultValue(true)]
-        public bool HideSelection
-        {
-            get => _textBox.HideSelection;
-            set => _textBox.HideSelection = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the maximum number of characters that can be entered into the edit control.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
-        [DefaultValue(32767)]
-        [Localizable(true)]
-        public int MaxLength
-        {
-            get => _textBox.MaxLength;
-            set => _textBox.MaxLength = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Controls whether the text in the edit control can be changed or not.")]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue(false)]
-        public bool ReadOnly
-        {
-            get => _textBox.ReadOnly;
-            set => _textBox.ReadOnly = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
-        [DefaultValue(true)]
-        public bool ShortcutsEnabled
-        {
-            get => _textBox.ShortcutsEnabled;
-            set => _textBox.ShortcutsEnabled = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a the character to display for password input for single-line edit controls.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates the character to display for password input for single-line edit controls.")]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue('\0')]
-        [Localizable(true)]
-        public char PasswordChar
-        {
-            get => _textBox.PasswordChar;
-            set => _textBox.PasswordChar = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating if the text in the edit control should appear as the default password character.
-        /// </summary>
-        [Category(@"Behavior")]
-        [Description(@"Indicates if the text in the edit control should appear as the default password character.")]
-        [RefreshProperties(RefreshProperties.Repaint)]
-        [DefaultValue(false)]
-        public bool UseSystemPasswordChar
-        {
-            get => _textBox.UseSystemPasswordChar;
-            set => _textBox.UseSystemPasswordChar = value;
-        }
-
-        /// <summary>
-        /// Gets and sets the input control style.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Input control style.")]
-        public InputControlStyle InputControlStyle
-        {
-            get => _inputControlStyle;
-
-            set
-            {
-                if (_inputControlStyle != value)
-                {
-                    _inputControlStyle = value;
-                    StateCommon.SetStyles(value);
-                    PerformNeedPaint(true);
-                }
-            }
-        }
-
-        private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
-
-        private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
-
-        /// <summary>
-        /// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
-        /// </summary>
-        [Description(@"The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
-        [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor", typeof(UITypeEditor))]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Localizable(true)]
-        [Browsable(true)]
-        public AutoCompleteStringCollection AutoCompleteCustomSource
-        {
-            get => _textBox.AutoCompleteCustomSource;
-            set => _textBox.AutoCompleteCustomSource = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the text completion behavior of the textbox.
-        /// </summary>
-        [Description(@"Indicates the text completion behavior of the textbox.")]
-        [DefaultValue(AutoCompleteMode.None)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(true)]
-        public AutoCompleteMode AutoCompleteMode
-        {
-            get => _textBox.AutoCompleteMode;
-            set => _textBox.AutoCompleteMode = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.
-        /// </summary>
-        [Description(@"The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
-        [DefaultValue(AutoCompleteSource.None)]
-        [EditorBrowsable(EditorBrowsableState.Always)]
-        [Browsable(true)]
-        public AutoCompleteSource AutoCompleteSource
-        {
-            get => _textBox.AutoCompleteSource;
-            set => _textBox.AutoCompleteSource = value;
-        }
-
-        /// <summary>
-        /// Gets and sets a value indicating if tooltips should be Displayed for button specs.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Should tooltips be Displayed for button specs.")]
-        [DefaultValue(false)]
-        public bool AllowButtonSpecToolTips { get; set; }
-
-        /// <summary>
-        /// Gets and sets a value indicating if button spec tooltips should remove the parent tooltip.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Should button spec tooltips should remove the parent tooltip")]
-        [DefaultValue(false)]
-        public bool AllowButtonSpecToolTipPriority { get; set; }
-
-        /// <summary>
-        /// Gets the collection of button specifications.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Collection of button specifications.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public TextBoxButtonSpecCollection ButtonSpecs { get; }
-
-        /// <summary>
-        /// Gets access to the common textbox appearance entries that other states can override.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining common textbox appearance that other states can override.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleRedirect StateCommon { get; }
-
-        private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
-
-        /// <summary>
-        /// Gets access to the disabled textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining disabled textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateDisabled { get; }
-
-        private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
-
-        /// <summary>
-        /// Gets access to the normal textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining normal textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateNormal { get; }
-
-        private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
-
-        /// <summary>
-        /// Gets access to the active textbox appearance entries.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Overrides for defining active textbox appearance.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public PaletteInputControlTripleStates StateActive { get; }
-
-        private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
-
-        /// <summary>
-        /// Appends text to the current text of a rich text box.
-        /// </summary>
-        /// <param name="text">The text to append to the current contents of the text box.</param>
-        public void AppendText(string text) => _textBox.AppendText(text);
-
-        /// <summary>
-        /// Clears all text from the text box control.
-        /// </summary>
-        public void Clear() => _textBox.Clear();
-
-        /// <summary>
-        /// Clears information about the most recent operation from the undo buffer of the rich text box. 
-        /// </summary>
-        public void ClearUndo() => _textBox.ClearUndo();
-
-        /// <summary>
-        /// Copies the current selection in the text box to the Clipboard.
-        /// </summary>
-        public void Copy() => _textBox.Copy();
-
-        /// <summary>
-        /// Moves the current selection in the text box to the Clipboard.
-        /// </summary>
-        public void Cut() => _textBox.Cut();
-
-        /// <summary>
-        /// Replaces the current selection in the text box with the contents of the Clipboard.
-        /// </summary>
-        public void Paste() => _textBox.Paste();
-
-        /// <summary>
-        /// Scrolls the contents of the control to the current caret position.
-        /// </summary>
-        public void ScrollToCaret() => _textBox.ScrollToCaret();
-
-        /// <summary>
-        /// Selects a range of text in the control.
-        /// </summary>
-        /// <param name="start">The position of the first character in the current text selection within the text box.</param>
-        /// <param name="length">The number of characters to select.</param>
-        public void Select(int start, int length) => _textBox.Select(start, length);
-
-        /// <summary>
-        /// Selects all text in the control.
-        /// </summary>
-        public void SelectAll() => _textBox.SelectAll();
-
-        /// <summary>
-        /// Undoes the last edit operation in the text box.
-        /// </summary>
-        public void Undo() => _textBox.Undo();
-
-        /// <summary>
-        /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
-        /// </summary>
-        public void DeselectAll() => _textBox.DeselectAll();
-
-        /// <summary>
-        /// Retrieves the character that is closest to the specified location within the control.
-        /// </summary>
-        /// <param name="pt">The location from which to seek the nearest character.</param>
-        /// <returns>The character at the specified location.</returns>
-        public int GetCharFromPosition(Point pt) => _textBox.GetCharFromPosition(pt);
-
-        /// <summary>
-        /// Retrieves the index of the character nearest to the specified location.
-        /// </summary>
-        /// <param name="pt">The location to search.</param>
-        /// <returns>The zero-based character index at the specified location.</returns>
-        public int GetCharIndexFromPosition(Point pt) => _textBox.GetCharIndexFromPosition(pt);
-
-        /// <summary>
-        /// Retrieves the index of the first character of a given line.
-        /// </summary>
-        /// <param name="lineNumber">The line for which to get the index of its first character.</param>
-        /// <returns>The zero-based character index in the specified line.</returns>
-        public int GetFirstCharIndexFromLine(int lineNumber) => _textBox.GetFirstCharIndexFromLine(lineNumber);
-
-        /// <summary>
-        /// Retrieves the index of the first character of the current line.
-        /// </summary>
-        /// <returns>The zero-based character index in the current line.</returns>
-        public int GetFirstCharIndexOfCurrentLine() => _textBox.GetFirstCharIndexOfCurrentLine();
-
-        /// <summary>
-        /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
-        /// </summary>
-        /// <param name="index">The character index position to search.</param>
-        /// <returns>The zero-based line number in which the character index is located.</returns>
-        public int GetLineFromCharIndex(int index) => _textBox.GetLineFromCharIndex(index);
-
-        /// <summary>
-        /// Retrieves the location within the control at the specified character index.
-        /// </summary>
-        /// <param name="index">The index of the character for which to retrieve the location.</param>
-        /// <returns>The location of the specified character.</returns>
-        public Point GetPositionFromCharIndex(int index) => _textBox.GetPositionFromCharIndex(index);
-
-        /// <summary>
-        /// Sets the fixed state of the control.
-        /// </summary>
-        /// <param name="active">Should the control be fixed as active.</param>
-        public void SetFixedState(bool active) => _fixedActive = active;
-
-        /// <summary>
-        /// Gets access to the ToolTipManager used for displaying tool tips.
-        /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public ToolTipManager ToolTipManager { get; }
-
-        /// <summary>
-        /// Gets a value indicating if the input control is active.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver;
-
-        /// <summary>
-        /// Sets input focus to the control.
-        /// </summary>
-        /// <returns>true if the input focus request was successful; otherwise, false.</returns>
-        public new bool Focus() => TextBox.Focus() == true;
-
-        /// <summary>
-        /// Activates the control.
-        /// </summary>
-        public new void Select() => TextBox.Select();
-
-        /// <summary>
-        /// Get the preferred size of the control based on a proposed size.
-        /// </summary>
-        /// <param name="proposedSize">Starting size proposed by the caller.</param>
-        /// <returns>Calculated preferred size.</returns>
-        public override Size GetPreferredSize(Size proposedSize)
-        {
-            // Do we have a manager to ask for a preferred size?
-            if (ViewManager != null)
-            {
-                // Ask the view to perform a layout
-                Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
-
-                // Apply the maximum sizing
-                if (MaximumSize.Width > 0)
-                {
-                    retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
-                }
-
-                if (MaximumSize.Height > 0)
-                {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
-                }
-
-                // Apply the minimum sizing
-                if (MinimumSize.Width > 0)
-                {
-                    retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
-                }
-
-                if (MinimumSize.Height > 0)
-                {
-                    retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
-                }
-
-                return retSize;
-            }
-            else
-            {
-                // Fall back on default control processing
-                return base.GetPreferredSize(proposedSize);
-            }
-        }
-
-        /// <summary>
-        /// Gets the rectangle that represents the display area of the control.
-        /// </summary>
-        public override Rectangle DisplayRectangle
-        {
-            get
-            {
-                // Ensure that the layout is calculated in order to know the remaining display space
-                ForceViewLayout();
-
-                // The inside text box is the client rectangle size
-                return new Rectangle(_textBox.Location, _textBox.Size);
-            }
-        }
-
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        /// <param name="pt">Mouse location.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public bool DesignerGetHitTest(Point pt)
-        {
-            // Ignore call as view builder is already destructed
-            if (IsDisposed)
-            {
-                return false;
-            }
-
-            // Check if any of the button specs want the point
-            return (_buttonManager != null) && _buttonManager.DesignerGetHitTest(pt);
-        }
-
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        /// <param name="pt">Mouse location.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public Component? DesignerComponentFromPoint(Point pt) =>
-            // Ignore call as view builder is already destructed
-            IsDisposed ? null : ViewManager.ComponentFromPoint(pt);
-
-        // Ask the current view for a decision
-        /// <summary>
-        /// Internal design time method.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Browsable(false)]
-        public void DesignerMouseLeave() =>
-            // Simulate the mouse leaving the control so that the tracking
-            // element that thinks it has the focus is informed it does not
-            OnMouseLeave(EventArgs.Empty);
-
-        #endregion
-
-        #region Protected
-        /// <summary>
-        /// Force the layout logic to size and position the controls.
-        /// </summary>
-        protected void ForceControlLayout()
-        {
-            if (!IsHandleCreated)
-            {
-                _forcedLayout = true;
-                OnLayout(new LayoutEventArgs(null, null));
-                _forcedLayout = false;
-            }
-        }
-
-        /// <summary>
-        /// Sets up the multiline string editor for the control.
-        /// </summary>
-        /// <param name="value">
-        /// true to enable the multiline string editor; otherwise false.
-        /// </param>
-        protected void SetMultilineStringEditor(bool value)
-        {
-            _multilineStringEditor = value;
-            // FIXME: This should probably rather be drawn as a glyph or something and not be
-            // added to the ButtonSpecs that can be modified by the user, but I lack the
-            // familiarity with the Krypton Framework and the time to figure out how to implement
-            // this the proper way.
-            if (value == false)
-            {
-                ButtonSpecs.Remove(_editorButton);
-            }
-            else
-            {
-                if (!ButtonSpecs.Contains(_editorButton))
-                {
-                    ButtonSpecs.Add(_editorButton);
+                    _mouseOver = value;
+
+                    // Generate appropriate change event
+                    if (_mouseOver)
+                    {
+                        OnTrackMouseEnter(EventArgs.Empty);
+                    }
+                    else
+                    {
+                        OnTrackMouseLeave(EventArgs.Empty);
+                    }
                 }
             }
         }
         #endregion
 
-        #region Protected Virtual
-        // ReSharper disable VirtualMemberNeverOverridden.Global
-        /// <summary>
-        /// Raises the AcceptsTabChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the TextAlignChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        protected virtual void OnTextAlignChanged(EventArgs e) => TextAlignChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the HideSelectionChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the ModifiedChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the MultilineChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the ReadOnlyChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the TrackMouseEnter event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        [Description(@"Raises the TrackMouseEnter event.")]
-        protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the TrackMouseLeave event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        [Description(@"Raises the TrackMouseLeave event.")]
-        protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
-        // ReSharper restore VirtualMemberNeverOverridden.Global
-        #endregion
-
-        #region Protected Overrides
-        /// <summary>
-        /// Creates a new instance of the control collection for the KryptonTextBox.
-        /// </summary>
-        /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
-
-        /// <summary>
-        /// Raises the HandleCreated event.
-        /// </summary>
-        /// <param name="e">An EventArgs containing the event data.</param>
-        protected override void OnHandleCreated(EventArgs e)
-        {
-            // Let base class do standard stuff
-            base.OnHandleCreated(e);
-
-            // Force the font to be set into the text box child control
-            PerformNeedPaint(false);
-
-            // We need a layout to occur before any painting
-            InvokeLayout();
-
-            // We need to recalculate the correct height
-            AdjustHeight(true);
-        }
-
-        /// <summary>
-        /// Raises the EnabledChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnEnabledChanged(EventArgs e)
-        {
-            // Change in enabled state requires a layout and repaint
-            UpdateStateAndPalettes();
-
-            // Update view elements
-            _drawDockerInner.Enabled = Enabled;
-            _drawDockerOuter.Enabled = Enabled;
-
-            // Update state to reflect change in enabled state
-            _buttonManager?.RefreshButtons();
-
-            PerformNeedPaint(true);
-
-            // Let base class fire standard event
-            base.OnEnabledChanged(e);
-        }
-
-        /// <summary>
-        /// Raises the GotFocus event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnGotFocus(EventArgs e)
-        {
-            base.OnGotFocus(e);
-            _textBox.Focus();
-        }
-
-        /// <summary>
-        /// Raises the BackColorChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the BackgroundImageChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the BackgroundImageLayoutChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the ForeColorChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the Resize event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnResize(EventArgs e)
-        {
-            bool freezeTextBoxRedraw = Multiline && _textBox.IsHandleCreated;
-
-            if (freezeTextBoxRedraw)
-            {
-                PI.SendMessage(_textBox.Handle, PI.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
-            }
-
-            try
-            {
-                // Let base class raise events
-                base.OnResize(e);
-
-                // We must have a layout calculation
-                ForceControlLayout();
-            }
-            finally
-            {
-                if (freezeTextBoxRedraw)
-                {
-                    PI.SendMessage(_textBox.Handle, PI.SETREDRAW, (IntPtr)1, IntPtr.Zero);
-                    _textBox.Invalidate();
-                    _textBox.Update();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Raises the Layout event.
-        /// </summary>
-        /// <param name="levent">An EventArgs that contains the event data.</param>
-        protected override void OnLayout(LayoutEventArgs levent)
-        {
-            if (!IsDisposed && !Disposing)
-            {
-                // Update with latest content padding for placing around the contained text box control
-                var paletteContent = GetTripleState().PaletteContent;
-                if (paletteContent != null)
-                {
-                    Padding contentPadding = paletteContent.GetContentPadding(_drawDockerOuter.State);
-                    _layoutFill.DisplayPadding = contentPadding;
-                }
-            }
-
-            // Ensure the height is correct
-            AdjustHeight(false);
-
-            // Let base class calculate fill rectangle
-            base.OnLayout(levent);
-
-            // Only use layout logic if control is fully initialized or if being forced
-            // to allow a relayout or if in design mode.
-            if (IsHandleCreated || _forcedLayout || (DesignMode && (_textBox != null)))
-            {
-                Rectangle fillRect = _layoutFill.FillRect;
-                //  for centering the inner text field vertically
-                var y = Height / 2 - _textBox.Height / 2;
-
-                _textBox.SetBounds(fillRect.X, y, fillRect.Width, fillRect.Height);
-            }
-        }
-
-        /// <summary>
-        /// Raises the MouseEnter event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnMouseEnter(EventArgs e)
-        {
-            _mouseOver = true;
-            PerformNeedPaint(true);
-            _textBox.Invalidate();
-            base.OnMouseEnter(e);
-        }
-
-        /// <summary>
-        /// Raises the MouseLeave event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnMouseLeave(EventArgs e)
-        {
-            _mouseOver = false;
-            PerformNeedPaint(true);
-            _textBox.Invalidate();
-            base.OnMouseLeave(e);
-        }
-
-        /// <summary>
-        /// Performs the work of setting the specified bounds of this control.
-        /// </summary>
-        /// <param name="x">The new Left property value of the control.</param>
-        /// <param name="y">The new Top property value of the control.</param>
-        /// <param name="width">The new Width property value of the control.</param>
-        /// <param name="height">The new Height property value of the control.</param>
-        /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
-        protected override void SetBoundsCore(int x, int y,
-                                              int width, int height,
-                                              BoundsSpecified specified)
-        {
-            // Do we need to prevent the height from being altered?
-            if (_autoSize && !Multiline)
-            {
-                switch (Dock)
-                {
-                    case DockStyle.Fill:
-                    case DockStyle.Left:
-                    case DockStyle.Right:
-                        if ((specified & ~BoundsSpecified.Height) == specified)
-                        {
-                            _cachedHeight = height;
-                        }
-
-                        break;
-                }
-
-                // Override the actual height used to the fixed height for single line
-                height = PreferredHeight;
-            }
-            else
-            {
-                _cachedHeight = height;
-            }
-
-            base.SetBoundsCore(x, y, width, height, specified);
-        }
-
-        /// <summary>
-        /// Gets the default size of the control.
-        /// </summary>
-        protected override Size DefaultSize => new Size(100, PreferredHeight);
-
-        /// <summary>
-        /// Processes a notification from palette storage of a paint and optional layout required.
-        /// </summary>
-        /// <param name="sender">Source of notification.</param>
-        /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
-        {
-            if (IsHandleCreated && !e.NeedLayout)
-            {
-                _textBox.Invalidate();
-            }
-            else
-            {
-                ForceControlLayout();
-            }
-
-            if (!IsDisposed && !Disposing)
-            {
-                // Update the back/fore/font from the palette settings
-                UpdateStateAndPalettes();
-                IPaletteTriple triple = GetTripleState();
-                PaletteState state = _drawDockerOuter.State;
-                _textBox.BackColor = triple.PaletteBack.GetBackColor1(state);
-                _textBox.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
-
-                // Only set the font if the text box has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
-                if ((_textBox.Handle != IntPtr.Zero) && !_textBox.Font.Equals(font))
-                {
-                    _textBox.Font = font;
-                }
-            }
-
-            base.OnNeedPaint(sender, e);
-        }
-
-        /// <summary>
-        /// Raises the PaddingChanged event.
-        /// </summary>
-        /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaddingChanged(EventArgs e)
-        {
-            base.OnPaddingChanged(e);
-
-            // Add adjust actual height to match new setting
-            AdjustHeight(false);
-        }
-
-        /// <summary>
-        /// Raises the Paint event.
-        /// </summary>
-        /// <param name="e">A PaintEventArgs containing the event data.</param>
-        protected override void OnPaint(PaintEventArgs e) => base.OnPaint(e);
-
-        /// <summary>
-        /// Raises the TabStop event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnTabStopChanged(EventArgs e)
-        {
-            TextBox.TabStop = TabStop;
-            base.OnTabStopChanged(e);
-        }
-
-        /// <summary>
-        /// Raises the CausesValidationChanged event.
-        /// </summary>
-        /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnCausesValidationChanged(EventArgs e)
-        {
-            TextBox.CausesValidation = CausesValidation;
-            base.OnCausesValidationChanged(e);
-        }
+        #region Protected
 
         /// <summary>
         /// Process Windows-based messages.
@@ -1814,8 +104,11 @@ namespace Krypton.Toolkit
         {
             switch (m.Msg)
             {
+                case PI.WM_.ERASEBKGND:
+                    // Prevent two-stage erase/paint redraw during resize, which causes visible text flicker.
+                    break;
                 case PI.WM_.NCHITTEST:
-                    if (InTransparentDesignMode)
+                    if (_kryptonTextBox.InTransparentDesignMode)
                     {
                         m.Result = (IntPtr)PI.HT.TRANSPARENT;
                     }
@@ -1825,7 +118,175 @@ namespace Krypton.Toolkit
                     }
 
                     break;
-                case PI.WM_.LBUTTONDOWN:
+                case PI.WM_.MOUSELEAVE:
+                    // Mouse is not over the control
+                    MouseOver = false;
+                    _kryptonTextBox.PerformNeedPaint(true);
+                    Invalidate();
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.MOUSEMOVE:
+                    // Mouse is over the control
+                    if (!MouseOver)
+                    {
+                        MouseOver = true;
+                        _kryptonTextBox.PerformNeedPaint(true);
+                        Invalidate();
+                    }
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.PRINTCLIENT:
+                case PI.WM_.PAINT:
+                {
+                    bool hasCueHintText = !string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText);
+                    bool hasUserText = !string.IsNullOrEmpty(_kryptonTextBox.Text);
+
+                    // Use native edit-control painting for the common enabled text path.
+                    // Custom cue-hint/disabled rendering remains below.
+                    if (_kryptonTextBox.Enabled && (!hasCueHintText || hasUserText))
+                    {
+                        base.WndProc(ref m);
+                        break;
+                    }
+
+                    var ps = new PI.PAINTSTRUCT();
+
+                    // Do we need to BeginPaint or just take the given HDC?
+                    var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+
+                    // Paint the entire area in the background color
+                    using Graphics g = Graphics.FromHdc(hdc);
+
+                    // BeginPaint can restrict the clip to the update region; cue rendering needs a solid full-client
+                    // background so fringe pixels from prior paints do not remain as top/left edge streaks.
+                    g.ResetClip();
+
+                    // Grab the client area of the control
+                    PI.GetClientRect(Handle, out PI.RECT rect);
+
+                    var textRectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left,
+                        rect.bottom - rect.top);
+
+                    // Create rect for the text area
+                    Size borderSize = SystemInformation.BorderSize;
+                    rect.left -= borderSize.Width + 1;
+
+                    if (hasCueHintText && !hasUserText)
+                    {
+                        // Go perform the drawing of the CueHint
+                        using var backBrush = new SolidBrush(BackColor);
+                        _kryptonTextBox.CueHint.PerformPaint(_kryptonTextBox, g, textRectangle, backBrush);
+                    }
+                    else
+                    {
+                        using (var backBrush = new SolidBrush(BackColor))
+                        {
+                            // Draw entire client area in the background color
+                            g.FillRectangle(backBrush,
+                                textRectangle);
+                        }
+
+                        // If enabled then let the combo draw the text area
+                        if (_kryptonTextBox.Enabled)
+                        {
+                            // Let base implementation draw the actual text area
+                            if (m.WParam == IntPtr.Zero)
+                            {
+                                m.WParam = hdc;
+                                DefWndProc(ref m);
+                                m.WParam = IntPtr.Zero;
+                            }
+                            else
+                            {
+                                DefWndProc(ref m);
+                            }
+                        }
+                        else
+                        {
+                                // Set the correct text rendering hint for the text drawing. We only draw if the edit text is disabled so we
+                                // just always grab the disable state value. Without this line the wrong hint can occur because it inherits
+                                // it from the device context. Resulting in blurred text.
+                                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
+                                using (new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(
+                                    _kryptonTextBox.StateDisabled.PaletteContent.GetContentShortTextHint(PaletteState.Disabled))))
+                                {
+                                    // Define the string formatting requirements
+                                    var stringFormat = new StringFormat
+                                    {
+                                        Trimming = StringTrimming.None,
+                                        LineAlignment = StringAlignment.Near
+                                    };
+                                    if (!_kryptonTextBox.Multiline)
+                                    {
+                                        stringFormat.FormatFlags |= StringFormatFlags.NoWrap;
+                                    }
+
+                                    stringFormat.Alignment = _kryptonTextBox.TextAlign switch
+                                    {
+                                        HorizontalAlignment.Left => RightToLeft == RightToLeft.Yes
+                                            ? StringAlignment.Far
+                                            : StringAlignment.Near,
+                                        HorizontalAlignment.Right => RightToLeft == RightToLeft.Yes
+                                            ? StringAlignment.Near
+                                            : StringAlignment.Far,
+                                        HorizontalAlignment.Center => StringAlignment.Center,
+                                        _ => stringFormat.Alignment
+                                    };
+
+                                    // Use the correct prefix setting
+                                    stringFormat.HotkeyPrefix = HotkeyPrefix.None;
+
+                                    // Decide on the text to draw disabled
+                                    var drawString = Text;
+                                    if (PasswordChar != '\0')
+                                    {
+                                        drawString = new string(PasswordChar, Text.Length);
+                                    }
+
+                                    // Define the font to use for disabled painting – always query the palette first.
+                                    // Avoids exception - magnitudes faster than another repaint AND try/catch.
+                                    var disabledFont = _kryptonTextBox
+                                                           .GetTripleState()
+                                                           .PaletteContent?
+                                                           .GetContentShortTextFont(PaletteState.Disabled)
+                                                       ?? Font; // Fallback: current Font if palette returns null
+                                    using var foreBrush = new SolidBrush(ForeColor);
+                                    g.DrawString(drawString, disabledFont, foreBrush,
+                                        textRectangle,
+                                        stringFormat);
+                                }
+                        }
+
+                        // Remove clipping settings
+                        PI.SelectClipRgn(hdc, IntPtr.Zero);
+                    }
+
+                    // Do we need to match the original BeginPaint?
+                    if (m.WParam == IntPtr.Zero)
+                    {
+                        PI.EndPaint(Handle, ref ps);
+                    }
+                }
+                    break;
+                case PI.WM_.CONTEXTMENU:
+                    // Only interested in overriding the behavior when we have a krypton context menu...
+                    if (_kryptonTextBox.KryptonContextMenu != null)
+                    {
+                        // Extract the screen mouse position (if might not actually be provided)
+                        var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
+
+                        // If keyboard activated, the menu position is centered
+                        if (((int)(long)m.LParam) == -1)
+                        {
+                            mousePt = PointToScreen(new Point(Width / 2, Height / 2));
+                        }
+
+                        // Show the context menu
+                        _kryptonTextBox.KryptonContextMenu.Show(_kryptonTextBox, mousePt);
+
+                        // We eat the message!
+                        return;
+                    }
                     base.WndProc(ref m);
                     break;
                 default:
@@ -1834,254 +295,1768 @@ namespace Krypton.Toolkit
             }
         }
 
+        /// <summary>
+        /// Raises the TrackMouseEnter event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the TrackMouseLeave event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
         #endregion
+    }
 
-        #region Internal
-        internal bool InTransparentDesignMode => InRibbonDesignMode;
+    #endregion
 
+    #region Type Definitions
+    /// <summary>
+    /// Collection for managing ButtonSpecAny instances.
+    /// </summary>
+    public class TextBoxButtonSpecCollection : ButtonSpecCollection<ButtonSpecAny>
+    {
+        #region Identity
+        /// <summary>
+        /// Initialize a new instance of the TextBoxButtonSpecCollection class.
+        /// </summary>
+        /// <param name="owner">Reference to owning object.</param>
+        public TextBoxButtonSpecCollection(KryptonTextBox owner)
+            : base(owner)
+        {
+        }
         #endregion
+    }
+    #endregion
 
-        #region Implementation
+    #region Instance Fields
 
-        private void UpdateStateAndPalettes()
+    private VisualPopupToolTip? _visualPopupToolTip;
+    private readonly ButtonSpecManagerLayout? _buttonManager;
+    private readonly ViewLayoutDocker _drawDockerInner;
+    private readonly ViewDrawDocker _drawDockerOuter;
+    private readonly ViewLayoutFill _layoutFill;
+    private readonly InternalTextBox _textBox;
+    private InputControlStyle _inputControlStyle;
+    private bool? _fixedActive;
+    private bool _forcedLayout;
+    private bool _autoSize;
+    private bool _mouseOver;
+    private bool _alwaysActive;
+    private bool _trackingMouseEnter;
+    private int _cachedHeight;
+    private bool _multilineStringEditor;
+    private bool _showEllipsisButton;
+    //private bool _isInAlphaNumericMode;
+    private readonly ButtonSpecAny _editorButton;
+
+    #endregion
+
+    #region Events
+    /// <summary>
+    /// Occurs when the value of the AcceptsTab property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the AcceptsTab property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? AcceptsTabChanged;
+
+    /// <summary>
+    /// Occurs when the value of the HideSelection property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the HideSelection property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? HideSelectionChanged;
+
+    /// <summary>
+    /// Occurs when the value of the TextAlign property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the TextAlign property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? TextAlignChanged;
+
+    /// <summary>
+    /// Occurs when the value of the Modified property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the Modified property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? ModifiedChanged;
+
+    /// <summary>
+    /// Occurs when the value of the Multiline property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the Multiline property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? MultilineChanged;
+
+    /// <summary>
+    /// Occurs when the value of the ReadOnly property changes.
+    /// </summary>
+    [Description(@"Occurs when the value of the ReadOnly property changes.")]
+    [Category(@"Property Changed")]
+    public event EventHandler? ReadOnlyChanged;
+
+    /// <summary>
+    /// Occurs when the mouse enters the control.
+    /// </summary>
+    [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+    [Category(@"Mouse")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public event EventHandler? TrackMouseEnter;
+
+    /// <summary>
+    /// Occurs when the mouse leaves the control.
+    /// </summary>
+    [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
+    [Category(@"Mouse")]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public event EventHandler? TrackMouseLeave;
+
+    /// <summary>
+    /// Occurs when the value of the BackColor property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackColorChanged;
+
+    /// <summary>
+    /// Occurs when the value of the BackgroundImage property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackgroundImageChanged;
+
+    /// <summary>
+    /// Occurs when the value of the BackgroundImageLayout property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? BackgroundImageLayoutChanged;
+
+    /// <summary>
+    /// Occurs when the value of the ForeColor property changes.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? ForeColorChanged;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the KryptonTextBox class.
+    /// </summary>
+    public KryptonTextBox()
+    {
+        // Contains another control and needs marking as such for validation to work
+        SetStyle(ControlStyles.ContainerControl, true);
+
+        // By default, we are not multiline and so the height is fixed
+        SetStyle(ControlStyles.FixedHeight, true);
+
+        // Cannot select this control, only the child TextBox, and does not generate a click event
+        SetStyle(ControlStyles.Selectable | ControlStyles.StandardClick, false);
+
+        // Defaults
+        _inputControlStyle = InputControlStyle.Standalone;
+        _autoSize = true;
+        _cachedHeight = -1;
+        _alwaysActive = true;
+        AllowButtonSpecToolTips = false;
+        AllowButtonSpecToolTipPriority = false;
+
+        // Create storage properties
+        ButtonSpecs = new TextBoxButtonSpecCollection(this);
+
+        // Create the palette storage
+        StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
+        StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+        CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
+
+        // Create the internal text box used for containing content
+        _textBox = new InternalTextBox(this);
+        _textBox.DoubleClick += OnDoubleClick;
+        _textBox.MouseDoubleClick += OnMouseDoubleClick;
+        _textBox.TrackMouseEnter += OnTextBoxMouseChange;
+        _textBox.TrackMouseLeave += OnTextBoxMouseChange;
+        _textBox.AcceptsTabChanged += OnTextBoxAcceptsTabChanged;
+        _textBox.TextAlignChanged += OnTextBoxTextAlignChanged;
+        _textBox.TextChanged += OnTextBoxTextChanged;
+        _textBox.HideSelectionChanged += OnTextBoxHideSelectionChanged;
+        _textBox.ModifiedChanged += OnTextBoxModifiedChanged;
+        _textBox.MultilineChanged += OnTextBoxMultilineChanged;
+        _textBox.ReadOnlyChanged += OnTextBoxReadOnlyChanged;
+        _textBox.GotFocus += OnTextBoxGotFocus;
+        _textBox.LostFocus += OnTextBoxLostFocus;
+        _textBox.KeyDown += OnTextBoxKeyDown;
+        _textBox.KeyUp += OnTextBoxKeyUp;
+        _textBox.KeyPress += OnTextBoxKeyPress;
+        _textBox.PreviewKeyDown += OnTextBoxPreviewKeyDown;
+        _textBox.Validating += OnTextBoxValidating;
+        _textBox.Validated += OnTextBoxValidated;
+        _textBox.Click += OnTextBoxClick;  // SKC: make sure that the default click is also routed.
+
+        // Create the element that fills the remainder space and remembers fill rectangle
+        _layoutFill = new ViewLayoutFill(_textBox);
+
+        // Create inner view for placing inside the drawing docker
+        _drawDockerInner = new ViewLayoutDocker
         {
-            // Get the correct palette settings to use
-            IPaletteTriple tripleState = GetTripleState();
-            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder);
+            { _layoutFill, ViewDockStyle.Fill }
+        };
 
-            // Update enabled state
-            _drawDockerOuter.Enabled = Enabled;
+        // Create view for the control border and background
+        _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
+        {
+            { _drawDockerInner, ViewDockStyle.Fill }
+        };
 
-            // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+        // Create the view manager instance
+        ViewManager = new ViewManager(this, _drawDockerOuter);
 
-            _drawDockerOuter.ElementState = state;
+        // Create button specification collection manager
+        _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
+            [_drawDockerInner],
+            [StateCommon],
+            [PaletteMetricInt.HeaderButtonEdgeInsetInputControl],
+            [PaletteMetricPadding.HeaderButtonPaddingInputControl],
+            CreateToolStripRenderer,
+            NeedPaintDelegate);
+
+        // Create the manager for handling tooltips
+        ToolTipManager = new ToolTipManager(ToolTipValues);
+        ToolTipManager.ShowToolTip += OnShowToolTip;
+        ToolTipManager.CancelToolTip += OnCancelToolTip;
+        _buttonManager.ToolTipManager = ToolTipManager;
+
+        // Create the button spec for the multiline editor button.
+        _editorButton = new ButtonSpecAny
+        {
+            Image = GenericImageResources.SelectParentControlFlipped,
+            Style = PaletteButtonStyle.ButtonSpec,
+            Type = PaletteButtonSpecStyle.Generic
+        };
+        _editorButton.Click += OnEditorButtonClicked;
+
+        // Add text box to the controls collection
+        ((KryptonReadOnlyControls)Controls).AddInternal(_textBox);
+
+        //_isInAlphaNumericMode = false;
+
+        _showEllipsisButton = false;
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Remove any showing tooltip
+            OnCancelToolTip(this, EventArgs.Empty);
+
+            // Remember to pull down the manager instance
+            _buttonManager?.Destruct();
         }
 
-        internal IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
+        base.Dispose(disposing);
+    }
+    #endregion
 
-        private int PreferredHeight
+    #region Public
+
+    // TODO: Return to this...
+    /*
+    /// <summary>Gets or sets a value indicating whether this instance is in alpha numeric mode.</summary>
+    /// <value><c>true</c> if this instance is in alpha numeric mode; otherwise, <c>false</c>.</value>
+    [Category(@"Data"), DefaultValue(false), Description(@"Only allow numerical input.")]
+    public bool IsInAlphaNumericMode { get => _isInAlphaNumericMode; set { _isInAlphaNumericMode = value; SetIsInAlphaNumericMode(this); } }
+    */
+
+    /// <summary>
+    /// Gets access to the common textbox appearance entries that other states can override.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Set a watermark/prompt message for the user.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteCueHintText CueHint { get; }
+
+    private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
+
+
+    /// <summary>
+    /// Gets and sets if the control is in the tab chain.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public new bool TabStop
+    {
+        get => _textBox.TabStop;
+        set => _textBox.TabStop = value;
+    }
+
+    /// <summary>
+    /// Gets and sets if the control is in the ribbon design mode.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public bool InRibbonDesignMode { get; set; }
+
+    /// <summary>
+    /// Gets and sets if the control uses the multiline string editor widget.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if the control uses the multiline string editor widget.")]
+    [DefaultValue(false)]
+    public bool MultilineStringEditor
+    {
+        get => _multilineStringEditor;
+        set
         {
-            get
+            if (_multilineStringEditor != value)
             {
-                // Get the preferred size of the entire control
-                Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+                SetMultilineStringEditor(value);
+            }
+        }
+    }
 
-                // We only need to the height
-                return preferredSize.Height;
+    /// <summary>Gets or sets a value indicating whether [show ellipsis button].</summary>
+    /// <value><c>true</c> if [show ellipsis button]; otherwise, <c>false</c>.</value>
+    [Category(@"Visuals")]
+    [Description(@"Shows a ellipsis (...) button in the textbox.")]
+    [DefaultValue(false)]
+    public bool ShowEllipsisButton { get => _showEllipsisButton; set { _showEllipsisButton = value; ToggleEllipsisButtonVisibility(value); } }
+
+    /// <summary>
+    /// Gets access to the contained TextBox instance.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(false)]
+    public TextBox TextBox => _textBox;
+
+    /// <summary>
+    /// Gets access to the contained input control.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(false)]
+    public Control ContainedControl => TextBox;
+
+    /// <summary>
+    /// Gets and sets a value indicating if the control is automatically sized.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [DefaultValue(false)]
+    public override bool AutoSize
+    {
+        get => _autoSize;
+
+        set
+        {
+            if (_autoSize != value)
+            {
+                _autoSize = value;
+
+                // Multiline allows a variable height, otherwise we are fixed in height
+                SetStyle(ControlStyles.FixedHeight, !Multiline && _autoSize);
+
+                // Add adjust actual height to match new setting
+                AdjustHeight(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the control has input focus.
+    /// </summary>
+    [Browsable(false)]
+    public override bool Focused => TextBox.Focused;
+
+    /// <summary>
+    /// Gets or sets the background color for the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override Color BackColor
+    {
+        get => base.BackColor;
+        set => base.BackColor = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the font of the text Displayed by the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [AmbientValue(null)]
+    [AllowNull]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override Font Font
+    {
+        get => base.Font;
+        set => base.Font = value!;
+    }
+
+    /// <summary>
+    /// Gets or sets the foreground color for the control.
+    /// </summary>
+    [Browsable(false)]
+    [Bindable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override Color ForeColor
+    {
+        get => base.ForeColor;
+        set => base.ForeColor = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the internal padding space.
+    /// </summary>
+    [Browsable(false)]
+    [Localizable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public new Padding Padding
+    {
+        get => base.Padding;
+        set => base.Padding = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the text associated with the control.
+    /// </summary>
+    [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+    [AllowNull]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public override string Text
+    {
+        get => _textBox.Text;
+        set => _textBox.Text = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the associated context menu strip.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public override ContextMenuStrip? ContextMenuStrip
+    {
+        get => base.ContextMenuStrip;
+
+        set
+        {
+            base.ContextMenuStrip = value;
+            _textBox.ContextMenuStrip = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool CanUndo => _textBox.CanUndo;
+
+    /// <summary>
+    /// Gets a value indicating whether the contents have changed since last last.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool Modified => _textBox.Modified;
+
+    /// <summary>
+    /// Gets and sets the selected text within the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public string SelectedText
+    {
+        get => _textBox.SelectedText;
+        set => _textBox.SelectedText = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the selection length for the selected area.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionLength
+    {
+        get => _textBox.SelectionLength;
+        set => _textBox.SelectionLength = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the starting point of text selected in the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int SelectionStart
+    {
+        get => _textBox.SelectionStart;
+        set => _textBox.SelectionStart = value;
+    }
+
+    /// <summary>
+    /// Gets the length of text in the control.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public int TextLength => _textBox.TextLength;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"Defines if mnemonic characters generate click events for button specs.")]
+    [DefaultValue(true)]
+    public bool UseMnemonic
+    {
+        get => _buttonManager!.UseMnemonic;
+
+        set
+        {
+            if (_buttonManager!.UseMnemonic != value)
+            {
+                _buttonManager.UseMnemonic = value;
+                PerformNeedPaint(true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
+    [DefaultValue(true)]
+    public bool AlwaysActive
+    {
+        get => _alwaysActive;
+
+        set
+        {
+            if (_alwaysActive != value)
+            {
+                _alwaysActive = value;
+                PerformNeedPaint(true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the lines of text in a multiline edit, as an array of String values.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"The lines of text in a multiline edit, as an array of String values.")]
+    [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [MergableProperty(false)]
+    [Localizable(true)]
+    public string[] Lines
+    {
+        get => _textBox.Lines;
+        set => _textBox.Lines = value;
+    }
+
+    /// <summary>
+    /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
+    [DefaultValue(ScrollBars.None)]
+    [Localizable(true)]
+    public ScrollBars ScrollBars
+    {
+        get => _textBox.ScrollBars;
+        set => _textBox.ScrollBars = value;
+    }
+
+    /// <summary>
+    /// Gets or sets how the text should be aligned for edit controls.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"Indicates how the text should be aligned for edit controls.")]
+    [DefaultValue(HorizontalAlignment.Left)]
+    [Localizable(true)]
+    public HorizontalAlignment TextAlign
+    {
+        get => _textBox.TextAlign;
+        set => _textBox.TextAlign = value;
+    }
+
+    /// <summary>
+    /// Indicates if lines are automatically word-wrapped for multiline edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
+    [DefaultValue(true)]
+    [Localizable(true)]
+    public bool WordWrap
+    {
+        get => _textBox.WordWrap;
+        set => _textBox.WordWrap = value;
+    }
+
+    /// <summary>
+    /// Gets and sets whether the text in the control can span more than one line.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Control whether the text in the control can span more than one line.")]
+    [RefreshProperties(RefreshProperties.All)]
+    [DefaultValue(false)]
+    [Localizable(true)]
+    public bool Multiline
+    {
+        get => _textBox.Multiline;
+
+        set
+        {
+            if (_textBox.Multiline != value)
+            {
+                _textBox.Multiline = value;
+
+                // Multiline allows a variable height, otherwise we are fixed in height
+                SetStyle(ControlStyles.FixedHeight, !value && _autoSize);
+
+                // Add adjust actual height to match new setting
+                AdjustHeight(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if return characters are accepted as input for multiline edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if return characters are accepted as input for multiline edit controls.")]
+    [DefaultValue(false)]
+    public bool AcceptsReturn
+    {
+        get => _textBox.AcceptsReturn;
+        set => _textBox.AcceptsReturn = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
+    [DefaultValue(false)]
+    public bool AcceptsTab
+    {
+        get => _textBox.AcceptsTab;
+        set => _textBox.AcceptsTab = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if all the characters should be left alone or converted to uppercase or lowercase.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if all the characters should be left alone or converted to uppercase or lowercase.")]
+    [DefaultValue(CharacterCasing.Normal)]
+    public CharacterCasing CharacterCasing
+    {
+        get => _textBox.CharacterCasing;
+        set => _textBox.CharacterCasing = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
+    [DefaultValue(true)]
+    public bool HideSelection
+    {
+        get => _textBox.HideSelection;
+        set => _textBox.HideSelection = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters that can be entered into the edit control.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
+    [DefaultValue(32767)]
+    [Localizable(true)]
+    public int MaxLength
+    {
+        get => _textBox.MaxLength;
+        set => _textBox.MaxLength = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Controls whether the text in the edit control can be changed or not.")]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    [DefaultValue(false)]
+    public bool ReadOnly
+    {
+        get => _textBox.ReadOnly;
+        set => _textBox.ReadOnly = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
+    [DefaultValue(true)]
+    public bool ShortcutsEnabled
+    {
+        get => _textBox.ShortcutsEnabled;
+        set => _textBox.ShortcutsEnabled = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the character to display for password input for single-line edit controls.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates the character to display for password input for single-line edit controls.")]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    [DefaultValue('\0')]
+    [Localizable(true)]
+    public char PasswordChar
+    {
+        get => _textBox.PasswordChar;
+        set => _textBox.PasswordChar = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if the text in the edit control should appear as the default password character.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Indicates if the text in the edit control should appear as the default password character.")]
+    [RefreshProperties(RefreshProperties.Repaint)]
+    [DefaultValue(false)]
+    public bool UseSystemPasswordChar
+    {
+        get => _textBox.UseSystemPasswordChar;
+        set => _textBox.UseSystemPasswordChar = value;
+    }
+
+    /// <summary>
+    /// Gets and sets the input control style.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Input control style.")]
+    public InputControlStyle InputControlStyle
+    {
+        get => _inputControlStyle;
+
+        set
+        {
+            if (_inputControlStyle != value)
+            {
+                _inputControlStyle = value;
+                StateCommon.SetStyles(value);
+                PerformNeedPaint(true);
+            }
+        }
+    }
+
+    private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
+
+    private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
+
+    /// <summary>
+    /// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
+    /// </summary>
+    [Description(@"The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
+    [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor", typeof(UITypeEditor))]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Localizable(true)]
+    [Browsable(true)]
+    public AutoCompleteStringCollection AutoCompleteCustomSource
+    {
+        get => _textBox.AutoCompleteCustomSource;
+        set => _textBox.AutoCompleteCustomSource = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the text completion behavior of the textbox.
+    /// </summary>
+    [Description(@"Indicates the text completion behavior of the textbox.")]
+    [DefaultValue(AutoCompleteMode.None)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(true)]
+    public AutoCompleteMode AutoCompleteMode
+    {
+        get => _textBox.AutoCompleteMode;
+        set => _textBox.AutoCompleteMode = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.
+    /// </summary>
+    [Description(@"The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
+    [DefaultValue(AutoCompleteSource.None)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [Browsable(true)]
+    public AutoCompleteSource AutoCompleteSource
+    {
+        get => _textBox.AutoCompleteSource;
+        set => _textBox.AutoCompleteSource = value;
+    }
+
+    /// <summary>
+    /// Gets and sets a value indicating if tooltips should be Displayed for button specs.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should tooltips be Displayed for button specs.")]
+    [DefaultValue(false)]
+    public bool AllowButtonSpecToolTips { get; set; }
+
+    /// <summary>
+    /// Gets and sets a value indicating if button spec tooltips should remove the parent tooltip.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should button spec tooltips should remove the parent tooltip")]
+    [DefaultValue(false)]
+    public bool AllowButtonSpecToolTipPriority { get; set; }
+
+    /// <summary>
+    /// Gets the collection of button specifications.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Collection of button specifications.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public TextBoxButtonSpecCollection ButtonSpecs { get; }
+
+    /// <summary>
+    /// Gets access to the common textbox appearance entries that other states can override.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining common textbox appearance that other states can override.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleRedirect StateCommon { get; }
+
+    private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
+
+    /// <summary>
+    /// Gets access to the disabled textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining disabled textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateDisabled { get; }
+
+    private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
+
+    /// <summary>
+    /// Gets access to the normal textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining normal textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateNormal { get; }
+
+    private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
+
+    /// <summary>
+    /// Gets access to the active textbox appearance entries.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining active textbox appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteInputControlTripleStates StateActive { get; }
+
+    private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
+
+    /// <summary>
+    /// Appends text to the current text of a rich text box.
+    /// </summary>
+    /// <param name="text">The text to append to the current contents of the text box.</param>
+    public void AppendText(string text) => _textBox.AppendText(text);
+
+    /// <summary>
+    /// Clears all text from the text box control.
+    /// </summary>
+    public void Clear() => _textBox.Clear();
+
+    /// <summary>
+    /// Clears information about the most recent operation from the undo buffer of the rich text box.
+    /// </summary>
+    public void ClearUndo() => _textBox.ClearUndo();
+
+    /// <summary>
+    /// Copies the current selection in the text box to the Clipboard.
+    /// </summary>
+    public void Copy() => _textBox.Copy();
+
+    /// <summary>
+    /// Moves the current selection in the text box to the Clipboard.
+    /// </summary>
+    public void Cut() => _textBox.Cut();
+
+    /// <summary>
+    /// Replaces the current selection in the text box with the contents of the Clipboard.
+    /// </summary>
+    public void Paste() => _textBox.Paste();
+
+    /// <summary>
+    /// Scrolls the contents of the control to the current caret position.
+    /// </summary>
+    public void ScrollToCaret() => _textBox.ScrollToCaret();
+
+    /// <summary>
+    /// Selects a range of text in the control.
+    /// </summary>
+    /// <param name="start">The position of the first character in the current text selection within the text box.</param>
+    /// <param name="length">The number of characters to select.</param>
+    public void Select(int start, int length) => _textBox.Select(start, length);
+
+    /// <summary>
+    /// Selects all text in the control.
+    /// </summary>
+    public void SelectAll() => _textBox.SelectAll();
+
+    /// <summary>
+    /// Undoes the last edit operation in the text box.
+    /// </summary>
+    public void Undo() => _textBox.Undo();
+
+    /// <summary>
+    /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
+    /// </summary>
+    public void DeselectAll() => _textBox.DeselectAll();
+
+    /// <summary>
+    /// Retrieves the character that is closest to the specified location within the control.
+    /// </summary>
+    /// <param name="pt">The location from which to seek the nearest character.</param>
+    /// <returns>The character at the specified location.</returns>
+    public int GetCharFromPosition(Point pt) => _textBox.GetCharFromPosition(pt);
+
+    /// <summary>
+    /// Retrieves the index of the character nearest to the specified location.
+    /// </summary>
+    /// <param name="pt">The location to search.</param>
+    /// <returns>The zero-based character index at the specified location.</returns>
+    public int GetCharIndexFromPosition(Point pt) => _textBox.GetCharIndexFromPosition(pt);
+
+    /// <summary>
+    /// Retrieves the index of the first character of a given line.
+    /// </summary>
+    /// <param name="lineNumber">The line for which to get the index of its first character.</param>
+    /// <returns>The zero-based character index in the specified line.</returns>
+    public int GetFirstCharIndexFromLine(int lineNumber) => _textBox.GetFirstCharIndexFromLine(lineNumber);
+
+    /// <summary>
+    /// Retrieves the index of the first character of the current line.
+    /// </summary>
+    /// <returns>The zero-based character index in the current line.</returns>
+    public int GetFirstCharIndexOfCurrentLine() => _textBox.GetFirstCharIndexOfCurrentLine();
+
+    /// <summary>
+    /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
+    /// </summary>
+    /// <param name="index">The character index position to search.</param>
+    /// <returns>The zero-based line number in which the character index is located.</returns>
+    public int GetLineFromCharIndex(int index) => _textBox.GetLineFromCharIndex(index);
+
+    /// <summary>
+    /// Retrieves the location within the control at the specified character index.
+    /// </summary>
+    /// <param name="index">The index of the character for which to retrieve the location.</param>
+    /// <returns>The location of the specified character.</returns>
+    public Point GetPositionFromCharIndex(int index) => _textBox.GetPositionFromCharIndex(index);
+
+    /// <summary>
+    /// Sets the fixed state of the control.
+    /// </summary>
+    /// <param name="active">Should the control be fixed as active.</param>
+    public void SetFixedState(bool active) => _fixedActive = active;
+
+    /// <summary>
+    /// Gets access to the ToolTipManager used for displaying tool tips.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public ToolTipManager ToolTipManager { get; }
+
+    /// <summary>
+    /// Gets a value indicating if the input control is active.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsActive => (_fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver);
+
+    /// <summary>
+    /// Sets input focus to the control.
+    /// </summary>
+    /// <returns>true if the input focus request was successful; otherwise, false.</returns>
+    public new bool Focus() => TextBox.Focus();
+
+    /// <summary>
+    /// Activates the control.
+    /// </summary>
+    public new void Select() => TextBox.Select();
+
+    /// <summary>
+    /// Get the preferred size of the control based on a proposed size.
+    /// </summary>
+    /// <param name="proposedSize">Starting size proposed by the caller.</param>
+    /// <returns>Calculated preferred size.</returns>
+    public override Size GetPreferredSize(Size proposedSize)
+    {
+        // Do we have a manager to ask for a preferred size?
+        if (ViewManager != null)
+        {
+            // Ask the view to perform a layout
+            Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
+
+            // Apply the maximum sizing
+            if (MaximumSize.Width > 0)
+            {
+                retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
+            }
+
+            if (MaximumSize.Height > 0)
+            {
+                retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
+            }
+
+            // Apply the minimum sizing
+            if (MinimumSize.Width > 0)
+            {
+                retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
+            }
+
+            if (MinimumSize.Height > 0)
+            {
+                retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
+            }
+
+            if (MinimumControlHeight > 0)
+            {
+                retSize.Height = Math.Max(MinimumControlHeight, retSize.Height);
+            }
+
+            return retSize;
+        }
+        else
+        {
+            // Fall back on default control processing
+            return base.GetPreferredSize(proposedSize);
+        }
+    }
+
+    /// <summary>
+    /// Gets the rectangle that represents the display area of the control.
+    /// </summary>
+    public override Rectangle DisplayRectangle
+    {
+        get
+        {
+            // Ensure that the layout is calculated in order to know the remaining display space
+            ForceViewLayout();
+
+            // The inside text box is the client rectangle size
+            return new Rectangle(_textBox.Location, _textBox.Size);
+        }
+    }
+
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    /// <param name="pt">Mouse location.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public bool DesignerGetHitTest(Point pt)
+    {
+        // Ignore call as view builder is already destructed
+        if (IsDisposed)
+        {
+            return false;
+        }
+
+        // Check if any of the button specs want the point
+        return (_buttonManager != null) && _buttonManager.DesignerGetHitTest(pt);
+    }
+
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    /// <param name="pt">Mouse location.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public Component? DesignerComponentFromPoint(Point pt) =>
+        // Ignore call as view builder is already destructed
+        IsDisposed ? null : ViewManager?.ComponentFromPoint(pt);
+
+    // Ask the current view for a decision
+    /// <summary>
+    /// Internal design time method.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Browsable(false)]
+    public void DesignerMouseLeave() =>
+        // Simulate the mouse leaving the control so that the tracking
+        // element that thinks it has the focus is informed it does not
+        OnMouseLeave(EventArgs.Empty);
+
+    #endregion
+
+    #region Protected
+    /// <summary>
+    /// Force the layout logic to size and position the controls.
+    /// </summary>
+    protected void ForceControlLayout()
+    {
+        if (!IsHandleCreated)
+        {
+            _forcedLayout = true;
+            OnLayout(new LayoutEventArgs(null, null));
+            _forcedLayout = false;
+        }
+    }
+
+    /// <summary>
+    /// Sets up the multiline string editor for the control.
+    /// </summary>
+    /// <param name="value">
+    /// true to enable the multiline string editor; otherwise false.
+    /// </param>
+    protected void SetMultilineStringEditor(bool value)
+    {
+        _multilineStringEditor = value;
+        // FIXME: This should probably rather be drawn as a glyph or something and not be
+        // added to the ButtonSpecs that can be modified by the user, but I lack the
+        // familiarity with the Krypton Framework and the time to figure out how to implement
+        // this the proper way.
+        if (value == false)
+        {
+            ButtonSpecs.Remove(_editorButton);
+        }
+        else
+        {
+            if (!ButtonSpecs.Contains(_editorButton))
+            {
+                ButtonSpecs.Add(_editorButton);
+            }
+        }
+    }
+    #endregion
+
+    #region Protected Virtual
+    // ReSharper disable VirtualMemberNeverOverridden.Global
+    /// <summary>
+    /// Raises the AcceptsTabChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the TextAlignChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected virtual void OnTextAlignChanged(EventArgs e) => TextAlignChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the HideSelectionChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ModifiedChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the MultilineChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ReadOnlyChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the TrackMouseEnter event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    [Description(@"Raises the TrackMouseEnter event.")]
+    protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the TrackMouseLeave event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    [Description(@"Raises the TrackMouseLeave event.")]
+    protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
+    // ReSharper restore VirtualMemberNeverOverridden.Global
+    #endregion
+
+    #region Protected Overrides
+    /// <summary>
+    /// Creates a new instance of the control collection for the KryptonTextBox.
+    /// </summary>
+    /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
+
+    /// <summary>
+    /// Creates the accessibility object for the KryptonTextBox control.
+    /// </summary>
+    /// <returns>A new KryptonTextBoxAccessibleObject instance for the control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonTextBoxAccessibleObject(this);
+
+    /// <summary>
+    /// Raises the HandleCreated event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        // Let base class do standard stuff
+        base.OnHandleCreated(e);
+
+        // Force the font to be set into the text box child control
+        PerformNeedPaint(false);
+
+        // We need a layout to occur before any painting
+        InvokeLayout();
+
+        // We need to recalculate the correct height
+        AdjustHeight(true);
+    }
+
+    /// <summary>
+    /// Raises the EnabledChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnEnabledChanged(EventArgs e)
+    {
+        // Change in enabled state requires a layout and repaint
+        UpdateStateAndPalettes();
+
+        // Update view elements
+        _drawDockerInner.Enabled = Enabled;
+        _drawDockerOuter.Enabled = Enabled;
+
+        // Update state to reflect change in enabled state
+        _buttonManager?.RefreshButtons();
+
+        PerformNeedPaint(true);
+
+        // Let base class fire standard event
+        base.OnEnabledChanged(e);
+    }
+
+    /// <summary>
+    /// Raises the GotFocus event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnGotFocus(EventArgs e)
+    {
+        base.OnGotFocus(e);
+        _textBox.Focus();
+    }
+
+    /// <summary>
+    /// Raises the BackColorChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the BackgroundImageChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the BackgroundImageLayoutChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the ForeColorChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the Resize event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnResize(EventArgs e)
+    {
+        bool freezeTextBoxRedraw = Multiline && _textBox.IsHandleCreated;
+
+        if (freezeTextBoxRedraw)
+        {
+            PI.SendMessage(_textBox.Handle, PI.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        try
+        {
+            // Let base class raise events
+            base.OnResize(e);
+
+            // We must have a layout calculation
+            ForceControlLayout();
+        }
+        finally
+        {
+            if (freezeTextBoxRedraw)
+            {
+                PI.SendMessage(_textBox.Handle, PI.SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                _textBox.Invalidate();
+                _textBox.Update();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raises the Layout event.
+    /// </summary>
+    /// <param name="levent">An EventArgs that contains the event data.</param>
+    protected override void OnLayout(LayoutEventArgs levent)
+    {
+        if (!IsDisposed && !Disposing)
+        {
+            // Update with latest content padding for placing around the contained text box control
+            var paletteContent = GetTripleState().PaletteContent;
+            if (paletteContent != null)
+            {
+                Padding contentPadding = paletteContent.GetBorderContentPadding(null, _drawDockerOuter.State);
+                _layoutFill.DisplayPadding = contentPadding;
             }
         }
 
-        private void AdjustHeight(bool ignoreAnchored)
+        // Ensure the height is correct
+        AdjustHeight(false);
+
+        // Let base class calculate fill rectangle
+        base.OnLayout(levent);
+
+        // Only use layout logic if control is fully initialized or if being forced
+        // to allow a relayout or if in design mode.
+        if (IsHandleCreated || _forcedLayout || (DesignMode && (_textBox != null)))
         {
-            // If any of the vertical edges are anchored then we might need to ignore the call
-            if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
-            {
-                // If auto sizing the control and not in multiline mode then override the height
-                // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
-                // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
-                if (_autoSize && !Multiline)
-                {
-                    Height = PreferredHeight;
-                }
-                else if (_cachedHeight > -1)
-                {
-                    Height = _cachedHeight;
-                }
-            }
+            Rectangle fillRect = _layoutFill.FillRect;
+            //  for centering the inner text field vertically
+            var y = Height / 2 - _textBox.Height / 2;
+
+            _textBox.SetBounds(fillRect.X, y, fillRect.Width, fillRect.Height);
+        }
+    }
+
+    /// <summary>
+    /// Raises the MouseEnter event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnMouseEnter(EventArgs e)
+    {
+        _mouseOver = true;
+        PerformNeedPaint(true);
+        _textBox.Invalidate();
+        base.OnMouseEnter(e);
+    }
+
+    /// <summary>
+    /// Raises the MouseLeave event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnMouseLeave(EventArgs e)
+    {
+        _mouseOver = false;
+        PerformNeedPaint(true);
+        _textBox.Invalidate();
+        base.OnMouseLeave(e);
+    }
+
+    /// <summary>
+    /// Performs the work of setting the specified bounds of this control.
+    /// </summary>
+    /// <param name="x">The new Left property value of the control.</param>
+    /// <param name="y">The new Top property value of the control.</param>
+    /// <param name="width">The new Width property value of the control.</param>
+    /// <param name="height">The new Height property value of the control.</param>
+    /// <param name="specified">A bitwise combination of the BoundsSpecified values.</param>
+    protected override void SetBoundsCore(int x, int y,
+        int width, int height,
+        BoundsSpecified specified)
+    {
+        // Do we need to prevent the height from being altered?
+        if (_autoSize && !Multiline)
+        {
+            CacheDimensionIfSpecified(specified, BoundsSpecified.Height, height, ref _cachedHeight);
+
+            // Override the actual height used to the fixed height for single line
+            height = PreferredHeight;
+        }
+        else
+        {
+            _cachedHeight = height;
         }
 
-        private void OnTextBoxAcceptsTabChanged(object sender, EventArgs e) => OnAcceptsTabChanged(e);
+        base.SetBoundsCore(x, y, width, height, specified);
+    }
 
-        private void OnTextBoxTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+    /// <summary>
+    /// Gets the default size of the control.
+    /// </summary>
+    protected override Size DefaultSize => new Size(100, PreferredHeight);
 
-        private void OnTextBoxTextAlignChanged(object sender, EventArgs e) => OnTextAlignChanged(e);
-
-        private void OnTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
-
-        private void OnTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
-
-        private void OnTextBoxMultilineChanged(object sender, EventArgs e) => OnMultilineChanged(e);
-
-        private void OnTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
-
-        private void OnTextBoxGotFocus(object sender, EventArgs e)
+    /// <summary>
+    /// Processes a notification from palette storage of a paint and optional layout required.
+    /// </summary>
+    /// <param name="sender">Source of notification.</param>
+    /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
+    protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+    {
+        if (IsHandleCreated && !e.NeedLayout)
         {
+            _textBox.Invalidate();
+        }
+        else
+        {
+            ForceControlLayout();
+        }
+
+        if (!IsDisposed && !Disposing)
+        {
+            // Update the back/fore/font from the palette settings
             UpdateStateAndPalettes();
-            PerformNeedPaint(true);
-            OnGotFocus(e);
-        }
+            IPaletteTriple triple = GetTripleState();
+            PaletteState state = _drawDockerOuter.State;
+            _textBox.BackColor = triple.PaletteBack.GetBackColor1(state);
+            _textBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
 
-        private void OnTextBoxLostFocus(object sender, EventArgs e)
-        {
-            UpdateStateAndPalettes();
-            PerformNeedPaint(true);
-            OnLostFocus(e);
-        }
-
-        private void OnTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
-
-        private void OnTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
-
-        private void OnTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
-
-        private void OnTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
-
-        private void OnTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
-
-        private void OnTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
-
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
-        {
-            if (!IsDisposed && !Disposing)
+            // Only set the font if the text box has been created
+            Font? font = triple.PaletteContent.GetContentShortTextFont(state);
+            if ((_textBox.Handle != IntPtr.Zero) && !_textBox.Font.Equals(font))
             {
-                // Do not show tooltips when the form we are in does not have focus
-                Form? topForm = FindForm();
-                if (topForm is { ContainsFocus: false })
-                {
-                    return;
-                }
-
-                // Never show tooltips at design time
-                if (!DesignMode)
-                {
-                    IContentValues? sourceContent = null;
-                    var toolTipStyle = LabelStyle.ToolTip;
-
-                    var shadow = true;
-
-                    // Find the button spec associated with the tooltip request
-                    ButtonSpec? buttonSpec = _buttonManager?.ButtonSpecFromView(e.Target);
-
-                    // If the tooltip is for a button spec
-                    if (buttonSpec != null)
-                    {
-                        // Are we allowed to show page related tooltips
-                        if (AllowButtonSpecToolTips)
-                        {
-                            // Create a helper object to provide tooltip values
-                            if (Redirector != null)
-                            {
-                                var buttonSpecMapping = new ButtonSpecToContent(Redirector, buttonSpec);
-
-                                // Is there actually anything to show for the tooltip
-                                if (buttonSpecMapping.HasContent)
-                                {
-                                    sourceContent = buttonSpecMapping;
-                                    toolTipStyle = buttonSpec.ToolTipStyle;
-                                    shadow = buttonSpec.ToolTipShadow;
-                                }
-                            }
-                        }
-                    }
-
-                    if (sourceContent != null)
-                    {
-                        // Remove any currently showing tooltip
-                        if (_visualPopupToolTip != null)
-                        {
-                            _visualPopupToolTip.Dispose();
-
-                            if (AllowButtonSpecToolTipPriority)
-                            {
-                                visualBasePopupToolTip.Dispose();
-                            }
-                        }
-
-                        // Create the actual tooltip popup object
-                        _visualPopupToolTip = new VisualPopupToolTip(Redirector,
-                                                                     sourceContent,
-                                                                     Renderer,
-                                                                     PaletteBackStyle.ControlToolTip,
-                                                                     PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
-                                                                     shadow);
-
-                        _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
-                        _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
-                    }
-                }
+                _textBox.Font = font!;
             }
         }
 
-        // Remove any currently showing tooltip
-        private void OnCancelToolTip(object sender, EventArgs e) => _visualPopupToolTip?.Dispose();
+        base.OnNeedPaint(sender, e);
+    }
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+    /// <summary>
+    /// Raises the PaddingChanged event.
+    /// </summary>
+    /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
+    protected override void OnPaddingChanged(EventArgs e)
+    {
+        base.OnPaddingChanged(e);
+
+        // Add adjust actual height to match new setting
+        AdjustHeight(false);
+    }
+
+    /// <summary>
+    /// Raises the Paint event.
+    /// </summary>
+    /// <param name="e">A PaintEventArgs containing the event data.</param>
+    protected override void OnPaint(PaintEventArgs? e) => base.OnPaint(e);
+
+    /// <summary>
+    /// Raises the TabStop event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnTabStopChanged(EventArgs e)
+    {
+        TextBox.TabStop = TabStop;
+        base.OnTabStopChanged(e);
+    }
+
+    /// <summary>
+    /// Raises the CausesValidationChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnCausesValidationChanged(EventArgs e)
+    {
+        TextBox.CausesValidation = CausesValidation;
+        base.OnCausesValidationChanged(e);
+    }
+
+    /// <summary>
+    /// Process Windows-based messages.
+    /// </summary>
+    /// <param name="m">A Windows-based message.</param>
+    protected override void WndProc(ref Message m)
+    {
+        switch (m.Msg)
         {
-            // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
-            popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
-
-            // Not showing a popup page any more
-            _visualPopupToolTip = null;
-        }
-
-        private void OnTextBoxMouseChange(object sender, EventArgs e)
-        {
-            // Change in tracking state?
-            if (_textBox.MouseOver != _trackingMouseEnter)
-            {
-                _trackingMouseEnter = _textBox.MouseOver;
-
-                // Raise appropriate event
-                if (_trackingMouseEnter)
+            case PI.WM_.NCHITTEST:
+                if (InTransparentDesignMode)
                 {
-                    OnTrackMouseEnter(EventArgs.Empty);
-                    OnMouseEnter(e);
+                    m.Result = (IntPtr)PI.HT.TRANSPARENT;
                 }
                 else
                 {
-                    OnTrackMouseLeave(EventArgs.Empty);
-                    OnMouseLeave(e);
+                    base.WndProc(ref m);
+                }
+
+                break;
+            case PI.WM_.LBUTTONDOWN:
+                base.WndProc(ref m);
+                break;
+            default:
+                base.WndProc(ref m);
+                break;
+        }
+    }
+
+    #endregion
+
+    #region Internal
+    internal bool InTransparentDesignMode => InRibbonDesignMode;
+
+    #endregion
+
+    #region Implementation
+
+    private void UpdateStateAndPalettes()
+    {
+        // Get the correct palette settings to use
+        IPaletteTriple tripleState = GetTripleState();
+        _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
+
+        // Update enabled state
+        _drawDockerOuter.Enabled = Enabled;
+
+        // Find the new state of the main view element
+        PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
+
+        _drawDockerOuter.ElementState = state;
+    }
+
+    internal IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
+
+    private int PreferredHeight
+    {
+        get
+        {
+            // Get the preferred size of the entire control
+            Size preferredSize = GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+
+            // We only need to the height
+            return preferredSize.Height;
+        }
+    }
+
+    private void AdjustHeight(bool ignoreAnchored)
+    {
+        // If any of the vertical edges are anchored then we might need to ignore the call
+        if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
+        {
+            // If auto sizing the control and not in multiline mode then override the height
+            // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
+            // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
+            if (_autoSize && !Multiline)
+            {
+                Height = PreferredHeight;
+            }
+            else if (_cachedHeight > -1)
+            {
+                Height = _cachedHeight;
+            }
+        }
+    }
+
+    private void OnTextBoxAcceptsTabChanged(object? sender, EventArgs e) => OnAcceptsTabChanged(e);
+
+    private void OnTextBoxTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
+
+    private void OnTextBoxTextAlignChanged(object? sender, EventArgs e) => OnTextAlignChanged(e);
+
+    private void OnTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
+
+    private void OnTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
+
+    private void OnTextBoxMultilineChanged(object? sender, EventArgs e) => OnMultilineChanged(e);
+
+    private void OnTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
+
+    private void OnTextBoxGotFocus(object? sender, EventArgs e)
+    {
+        UpdateStateAndPalettes();
+        PerformNeedPaint(true);
+        OnGotFocus(e);
+    }
+
+    private void OnTextBoxLostFocus(object? sender, EventArgs e)
+    {
+        UpdateStateAndPalettes();
+        PerformNeedPaint(true);
+        OnLostFocus(e);
+    }
+
+    private void OnTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
+
+    private void OnTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
+
+    private void OnTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
+
+    private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+
+    private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
+
+    private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
+
+    private void OnShowToolTip(object? sender, ToolTipEventArgs e)
+    {
+        if (!IsDisposed && !Disposing)
+        {
+            // Do not show tooltips when the form we are in does not have focus
+            Form? topForm = FindForm();
+            if (topForm is { ContainsFocus: false })
+            {
+                return;
+            }
+
+            // Never show tooltips at design time
+            if (!DesignMode)
+            {
+                IContentValues? sourceContent = null;
+                var toolTipStyle = LabelStyle.ToolTip;
+
+                var shadow = true;
+
+                // Find the button spec associated with the tooltip request
+                ButtonSpec? buttonSpec = _buttonManager?.ButtonSpecFromView(e.Target);
+
+                // If the tooltip is for a button spec
+                if (buttonSpec != null)
+                {
+                    // Are we allowed to show page related tooltips
+                    if (AllowButtonSpecToolTips)
+                    {
+                        // Create a helper object to provide tooltip values
+                        if (Redirector != null)
+                        {
+                            var buttonSpecMapping = new ButtonSpecToContent(Redirector, buttonSpec);
+
+                            // Is there actually anything to show for the tooltip
+                            if (buttonSpecMapping.HasContent)
+                            {
+                                sourceContent = buttonSpecMapping;
+                                toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
+                            }
+                        }
+                    }
+                }
+
+                if (sourceContent != null)
+                {
+                    // Remove any currently showing tooltip
+                    if (_visualPopupToolTip != null)
+                    {
+                        _visualPopupToolTip.Dispose();
+
+                        if (AllowButtonSpecToolTipPriority)
+                        {
+                            _visualBasePopupToolTip?.Dispose();
+                        }
+                    }
+
+                    // Create the actual tooltip popup object
+                    _visualPopupToolTip = new VisualPopupToolTip(Redirector!,
+                        sourceContent,
+                        Renderer,
+                        PaletteBackStyle.ControlToolTip,
+                        PaletteBorderStyle.ControlToolTip,
+                        CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                        shadow);
+
+                    _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
+                    _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
                 }
             }
         }
+    }
 
-        private void OnEditorButtonClicked(object sender, EventArgs e) => new MultilineStringEditor1(this).ShowEditor();
+    // Remove any currently showing tooltip
+    private void OnCancelToolTip(object? sender, EventArgs e) => _visualPopupToolTip?.Dispose();
 
-        private void OnMouseDoubleClick(object sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+    private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
+    {
+        // Unhook events from the specific instance that generated event
+        var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
+        popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
-        private void OnDoubleClick(object sender, EventArgs e) => base.OnDoubleClick(e);
+        // Not showing a popup page any more
+        _visualPopupToolTip = null;
+    }
 
-        private void OnTextBoxClick(object sender, EventArgs e) =>
-            // ReSharper disable RedundantBaseQualifier
-            base.OnClick(e);
-        // ReSharper restore RedundantBaseQualifier
-
-        private void SetCornerRoundingRadius(float? radius)
+    private void OnTextBoxMouseChange(object? sender, EventArgs e)
+    {
+        // Change in tracking state?
+        if (_textBox.MouseOver != _trackingMouseEnter)
         {
-            _cornerRoundingRadius = radius ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
+            _trackingMouseEnter = _textBox.MouseOver;
 
-            StateCommon.Border.Rounding = _cornerRoundingRadius;
-        }
-
-        private void SetIsInAlphaNumericMode(KryptonTextBox owner)
-        {
-            // TODO: Return to this...
-        }
-
-        private void ToggleEllipsisButtonVisibility(bool visible)
-        {
-            // Setup button
-            var bsaEllipsisButton = new ButtonSpecAny();
-
-            bsaEllipsisButton.Text = @"&...";
-
-            if (visible)
+            // Raise appropriate event
+            if (_trackingMouseEnter)
             {
-                ButtonSpecs.Add(bsaEllipsisButton);
-
-                bsaEllipsisButton.Visible = true;
+                OnTrackMouseEnter(EventArgs.Empty);
+                OnMouseEnter(e);
             }
             else
             {
-                bsaEllipsisButton.Visible = false;
-
-                ButtonSpecs.Remove(bsaEllipsisButton);
+                OnTrackMouseLeave(EventArgs.Empty);
+                OnMouseLeave(e);
             }
         }
-
-        #endregion
     }
+
+    private void OnEditorButtonClicked(object? sender, EventArgs e) => new MultilineStringEditor1(this).ShowEditor();
+
+    private void OnMouseDoubleClick(object? sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+
+    private void OnDoubleClick(object? sender, EventArgs e) => base.OnDoubleClick(e);
+
+    private void OnTextBoxClick(object? sender, EventArgs e) =>
+        // ReSharper disable RedundantBaseQualifier
+        base.OnClick(e);
+    // ReSharper restore RedundantBaseQualifier
+
+    //private void SetIsInAlphaNumericMode(KryptonTextBox owner)
+    //{
+    //    // TODO: Return to this...
+    //}
+
+    private void ToggleEllipsisButtonVisibility(bool visible)
+    {
+        // Setup button
+        var bsaEllipsisButton = new ButtonSpecAny();
+
+        bsaEllipsisButton.Text = @"&...";
+
+        if (visible)
+        {
+            ButtonSpecs.Add(bsaEllipsisButton);
+
+            bsaEllipsisButton.Visible = true;
+        }
+        else
+        {
+            bsaEllipsisButton.Visible = false;
+
+            ButtonSpecs.Remove(bsaEllipsisButton);
+        }
+    }
+
+    #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -5,122 +5,232 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
 
-namespace Krypton.Toolkit
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Initialize a new instance of the PaletteCueHintText class.
+/// </summary>
+public class PaletteCueHintText : PaletteInputControlContentStates
 {
+    #region Identity
+    internal PaletteRelativeAlign _shortTextV;
+    private PaletteTextHint _contentTextHint;
+
     /// <summary>
     /// Initialize a new instance of the PaletteCueHintText class.
     /// </summary>
-    public class PaletteCueHintText : PaletteInputControlContentStates
+    public PaletteCueHintText(PaletteRedirect redirect,
+        NeedPaintHandler needPaint)
+        : base(new PaletteContentInheritRedirect(redirect, PaletteContentStyle.InputControlStandalone), needPaint)
     {
-        #region Identity
-        internal PaletteRelativeAlign _shortTextV;
-        private PaletteTextHint _contentTextHint;
+        _shortTextV = PaletteRelativeAlign.Center;
+        _contentTextHint = PaletteTextHint.AntiAlias;
+    }
 
-        /// <summary>
-        /// Initialize a new instance of the PaletteCueHintText class.
-        /// </summary>
-        public PaletteCueHintText(PaletteRedirect? redirect,
-            NeedPaintHandler needPaint)
-            : base(new PaletteContentInheritRedirect(redirect, PaletteContentStyle.InputControlStandalone), needPaint)
+    #endregion
+
+    /// <summary>
+    /// Set a watermark/prompt message for the user.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Set a watermark/prompt message for the user.")]
+    [RefreshProperties(RefreshProperties.All)]
+    public string CueHintText { get; set; }
+
+    private bool ShouldSerializeCueHintText() => !string.IsNullOrWhiteSpace(CueHintText);
+
+    /// <summary>
+    /// Resets the Image property to its default value.
+    /// </summary>
+    private void ResetCueHintText() => CueHintText = string.Empty;
+
+    #region Hint
+    /// <summary>
+    /// Gets the text rendering hint for the text.
+    /// </summary>
+    [KryptonPersist(false)]
+    [Category(@"Visuals")]
+    [Description(@"Text rendering hint for the content text. (No `Inherit`)")]
+    [DefaultValue(PaletteTextHint.AntiAlias)]
+    [RefreshProperties(RefreshProperties.All)]
+    public virtual PaletteTextHint Hint
+    {
+        get => _contentTextHint;
+
+        set
         {
-            _shortTextV = PaletteRelativeAlign.Center;
-            _contentTextHint = PaletteTextHint.AntiAlias;
-        }
-
-        #endregion
-
-        /// <summary>
-        /// Set a watermark/prompt message for the user.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Set a watermark/prompt message for the user.")]
-        [RefreshProperties(RefreshProperties.All)]
-        public string CueHintText { get; set; }
-
-        private bool ShouldSerializeCueHintText() => !string.IsNullOrWhiteSpace(CueHintText);
-
-        /// <summary>
-        /// Resets the Image property to its default value.
-        /// </summary>
-        private void ResetCueHintText() => CueHintText = string.Empty;
-
-        #region Hint
-        /// <summary>
-        /// Gets the text rendering hint for the text.
-        /// </summary>
-        [KryptonPersist(false)]
-        [Category(@"Visuals")]
-        [Description(@"Text rendering hint for the content text. (No `Inherit`)")]
-        [DefaultValue(PaletteTextHint.AntiAlias)]
-        [RefreshProperties(RefreshProperties.All)]
-        public virtual PaletteTextHint Hint
-        {
-            get => _contentTextHint;
-
-            set
+            if (_contentTextHint != value)
             {
-                if (_contentTextHint != value)
-                {
-                    _contentTextHint = value == PaletteTextHint.Inherit ? PaletteTextHint.AntiAlias : value;
-                    PerformNeedPaint(true);
-                }
+                _contentTextHint = value == PaletteTextHint.Inherit ? PaletteTextHint.AntiAlias : value;
+                PerformNeedPaint(true);
             }
         }
+    }
 
-        private bool ShouldSerializeHint() => _contentTextHint != PaletteTextHint.AntiAlias;
+    private bool ShouldSerializeHint() => _contentTextHint != PaletteTextHint.AntiAlias;
 
-        /// <summary>
-        /// Resets the Image property to its default value.
-        /// </summary>
-        private void ResetHint() => _contentTextHint = PaletteTextHint.AntiAlias;
+    /// <summary>
+    /// Resets the Image property to its default value.
+    /// </summary>
+    private void ResetHint() => _contentTextHint = PaletteTextHint.AntiAlias;
 
-        #endregion
+    #endregion
 
-        /// <inheritdoc/>
-        public override bool IsDefault => base.IsDefault
-             && string.IsNullOrWhiteSpace(CueHintText)
-             && (_shortTextV == PaletteRelativeAlign.Center)
-             && !ShouldSerializeHint();
+    /// <inheritdoc/>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public override bool IsDefault => base.IsDefault
+                                      && string.IsNullOrWhiteSpace(CueHintText)
+                                      && (_shortTextV == PaletteRelativeAlign.Center)
+                                      && !ShouldSerializeHint();
 
-        /// <summary>
-        /// Gets the actual content draw value.
-        /// </summary>
-        /// <param name="state">Palette value should be applicable to this state.</param>
-        /// <returns>InheritBool value.</returns>
-        public new InheritBool GetContentDraw(PaletteState state) => string.IsNullOrWhiteSpace(CueHintText) ? InheritBool.True : InheritBool.False;
+    /// <summary>
+    /// Gets the actual content draw value.
+    /// </summary>
+    /// <param name="state">Palette value should be applicable to this state.</param>
+    /// <returns>InheritBool value.</returns>
+    public new InheritBool GetContentDraw(PaletteState state) => string.IsNullOrWhiteSpace(CueHintText) ? InheritBool.True : InheritBool.False;
 
-        /// <summary>
-        /// Gets the font for the short text by generating a new font instance.
-        /// </summary>
-        /// <param name="state">Palette value should be applicable to this state.</param>
-        /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state)
+    /// <summary>
+    /// Gets the font for the short text by generating a new font instance.
+    /// </summary>
+    /// <param name="state">Palette value should be applicable to this state.</param>
+    /// <returns>Font value.</returns>
+    public override Font GetContentShortTextNewFont(PaletteState state)
+    {
+        if (Font != null)
         {
-            if (Font != null)
-            {
-                return new Font(Font, Font.Style);
-            }
-            var font = Inherit.GetContentShortTextFont(state);
-            return new Font(font, FontStyle.Italic);
+            return new Font(Font, Font.Style);
+        }
+        var font = Inherit.GetContentShortTextFont(state);
+        return new Font(font!, FontStyle.Italic);
+    }
+
+    /// <summary>
+    /// Gets the first color for the short text.
+    /// </summary>
+    /// <param name="state">Palette value should be applicable to this state.</param>
+    /// <returns>Color value.</returns>
+    public new Color GetContentShortTextColor1(PaletteState state) => !Color1.IsEmpty ? Color1 : ControlPaint.Light(Inherit.GetContentShortTextColor1(state));
+
+    internal void PerformPaint(VisualControlBase textBox, Graphics? g, PI.RECT rect, SolidBrush backBrush)
+    {
+        Rectangle layoutRectangle = Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+        // Now actually call the function!
+        PerformPaint(textBox, g, layoutRectangle, backBrush);
+    }
+
+    internal void PerformPaint(VisualControlBase textBox, Graphics? g, Rectangle layoutRectangle, SolidBrush backBrush)
+    {
+        if (g == null)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Gets the first color for the short text.
-        /// </summary>
-        /// <param name="state">Palette value should be applicable to this state.</param>
-        /// <returns>Color value.</returns>
-        public new Color GetContentShortTextColor1(PaletteState state) => !Color1.IsEmpty ? Color1 : ControlPaint.Light(Inherit.GetContentShortTextColor1(state));
+        // Fill client first. Do not apply GraphicsHint before this: HighQuality smoothing can leave edge pixels
+        // that look like top/left "lines" (GDI+ DrawString + cue colour). Issue #3382.
+        g.FillRectangle(backBrush, layoutRectangle);
 
-        internal void PerformPaint(VisualControlBase textBox, Graphics? g, PI.RECT rect, SolidBrush backBrush)
+        var padding = GetBorderContentPadding(null, PaletteState.Normal);
+        if (!padding.Equals(CommonHelper.InheritPadding))
         {
-            using var old = new GraphicsHint(g, PaletteGraphicsHint.HighQuality);
-            using var old1 = new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(_contentTextHint));
-            // Define the string formatting requirements
+            layoutRectangle.X += padding.Left;
+            layoutRectangle.Y += padding.Top;
+            layoutRectangle.Width -= padding.Left + padding.Right;
+            layoutRectangle.Height -= padding.Top + padding.Bottom;
+        }
+
+        if (layoutRectangle.Width <= 0 || layoutRectangle.Height <= 0)
+        {
+            return;
+        }
+
+        using var font = GetContentShortTextNewFont(PaletteState.Normal);
+        var foreColor = GetContentShortTextColor1(PaletteState.Normal);
+        var drawText = string.IsNullOrEmpty(CueHintText) ? textBox.Text : CueHintText;
+
+        if (ShouldUseGdiPlusMultilineCue(textBox))
+        {
+            DrawCueHintMultiline(textBox, g, drawText, font, foreColor, layoutRectangle);
+        }
+        else
+        {
+            TextFormatFlags tf = BuildCueTextRendererFormatFlags(textBox);
+            TextRenderer.DrawText(g, drawText, font, layoutRectangle, foreColor, tf);
+        }
+    }
+
+    private static bool ShouldUseGdiPlusMultilineCue(VisualControlBase textBox)
+    {
+        if (textBox is KryptonRichTextBox)
+        {
+            return true;
+        }
+
+        return textBox is KryptonTextBox multilineTextBox && multilineTextBox.Multiline;
+    }
+
+    private TextFormatFlags BuildCueTextRendererFormatFlags(VisualControlBase textBox)
+    {
+        TextFormatFlags tf = TextFormatFlags.NoPrefix
+            | TextFormatFlags.SingleLine
+            | TextFormatFlags.EndEllipsis
+            | TextFormatFlags.NoPadding;
+
+        bool rtl = textBox.RightToLeft == RightToLeft.Yes;
+        if (rtl)
+        {
+            tf |= TextFormatFlags.RightToLeft;
+        }
+
+        PaletteRelativeAlign hAlign = GetContentShortTextH(PaletteState.Normal);
+        if (rtl)
+        {
+            tf |= hAlign switch
+            {
+                PaletteRelativeAlign.Near => TextFormatFlags.Right,
+                PaletteRelativeAlign.Far => TextFormatFlags.Left,
+                PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                _ => TextFormatFlags.Right
+            };
+        }
+        else
+        {
+            tf |= hAlign switch
+            {
+                PaletteRelativeAlign.Near => TextFormatFlags.Left,
+                PaletteRelativeAlign.Far => TextFormatFlags.Right,
+                PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                _ => TextFormatFlags.Left
+            };
+        }
+
+        PaletteRelativeAlign vAlign = GetContentShortTextV(PaletteState.Normal);
+        tf |= vAlign switch
+        {
+            PaletteRelativeAlign.Near => TextFormatFlags.Top,
+            PaletteRelativeAlign.Far => TextFormatFlags.Bottom,
+            _ => TextFormatFlags.VerticalCenter
+        };
+
+        return tf;
+    }
+
+    private void DrawCueHintMultiline(VisualControlBase textBox,
+        Graphics g,
+        string drawText,
+        Font font,
+        Color foreColor,
+        Rectangle layoutRectangle)
+    {
+        using (new GraphicsHint(g, PaletteGraphicsHint.HighQuality))
+        using (new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(_contentTextHint)))
+        {
             var stringFormat = new StringFormat
             {
                 Trimming = StringTrimming.None,
@@ -137,75 +247,55 @@ namespace Krypton.Toolkit
                 PaletteRelativeAlign.Center => StringAlignment.Center,
                 _ => StringAlignment.Near
             };
-            // This is most applicable to the multi-line controls
             stringFormat.LineAlignment = GetContentShortTextV(PaletteState.Normal) switch
             {
                 PaletteRelativeAlign.Near => StringAlignment.Near,
-                //PaletteRelativeAlign.Center => StringAlignment.Center,
                 PaletteRelativeAlign.Far => StringAlignment.Far,
                 _ => StringAlignment.Center
             };
-
-            // Use the correct prefix setting
             stringFormat.HotkeyPrefix = HotkeyPrefix.None;
 
-            Rectangle layoutRectangle = Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
-
-            // Draw entire client area in the background color
-            g.FillRectangle(backBrush, layoutRectangle);
-
-            var padding = GetContentPadding(PaletteState.Normal);
-            if (!padding.Equals(CommonHelper.InheritPadding))
-            {
-                layoutRectangle.X += padding.Left;
-                layoutRectangle.Y += padding.Top;
-                layoutRectangle.Width -= padding.Left + padding.Right;
-                layoutRectangle.Height -= padding.Top + padding.Bottom;
-            }
-
-            using Font font = GetContentShortTextNewFont(PaletteState.Normal);
-            using var foreBrush = new SolidBrush(GetContentShortTextColor1(PaletteState.Normal));
-            var drawText = string.IsNullOrEmpty(CueHintText) ? textBox.Text : CueHintText;
+            using var foreBrush = new SolidBrush(foreColor);
             g.DrawString(drawText, font, foreBrush, layoutRectangle, stringFormat);
         }
+    }
 
-        #region TextV
-        /// <summary>
-        /// Gets and sets the horizontal Content text alignment for the text.
-        /// </summary>
-        [KryptonPersist(false)]
-        [Category(@"Visuals")]
-        [Description(@"Relative Vertical Content text alignment")]
-        [RefreshProperties(RefreshProperties.All)]
-        [DefaultValue(PaletteRelativeAlign.Center)]
-        public PaletteRelativeAlign TextV
+    #region TextV
+    /// <summary>
+    /// Gets and sets the horizontal Content text alignment for the text.
+    /// </summary>
+    [KryptonPersist(false)]
+    [Category(@"Visuals")]
+    [Description(@"Relative Vertical Content text alignment")]
+    [RefreshProperties(RefreshProperties.All)]
+    [DefaultValue(PaletteRelativeAlign.Center)]
+    public PaletteRelativeAlign TextV
+    {
+        get => _shortTextV;
+
+        set
         {
-            get => _shortTextV;
-
-            set
+            if (value != _shortTextV)
             {
-                if (value != _shortTextV)
-                {
-                    _shortTextV = value;
-                    PerformNeedPaint();
-                }
+                _shortTextV = value;
+                PerformNeedPaint();
             }
         }
-
-        private bool ShouldSerializeTextV() => _shortTextV != PaletteRelativeAlign.Center;
-
-        private void ResetTextV() => _shortTextV = PaletteRelativeAlign.Center;
-
-        /// <summary>
-        /// Gets the actual content short text vertical alignment value.
-        /// </summary>
-        /// <param name="state">Palette value should be applicable to this state.</param>
-        /// <returns>RelativeAlignment value.</returns>
-        public override PaletteRelativeAlign GetContentShortTextV(PaletteState state) => _shortTextV != PaletteRelativeAlign.Inherit ? _shortTextH : Inherit.GetContentShortTextV(state);
-
-        // Use the base class
-        //protected virtual Padding GetContentPadding(PaletteState state) => !_padding.Equals(CommonHelper.InheritPadding) ? _padding : Inherit.GetContentPadding(state);
-
-        #endregion
     }
+
+    private bool ShouldSerializeTextV() => _shortTextV != PaletteRelativeAlign.Center;
+
+    private void ResetTextV() => _shortTextV = PaletteRelativeAlign.Center;
+
+    /// <summary>
+    /// Gets the actual content short text vertical alignment value.
+    /// </summary>
+    /// <param name="state">Palette value should be applicable to this state.</param>
+    /// <returns>RelativeAlignment value.</returns>
+    public override PaletteRelativeAlign GetContentShortTextV(PaletteState state) => _shortTextV != PaletteRelativeAlign.Inherit ? _shortTextV : Inherit.GetContentShortTextV(state);
+
+    // Use the base class
+    //protected virtual Padding GetContentPadding(PaletteState state) => !_padding.Equals(CommonHelper.InheritPadding) ? _padding : Inherit.GetContentPadding(state);
+
+    #endregion
 }


### PR DESCRIPTION
# Fix: CueHint artefacts on `KryptonTextBox` (Issue #3382)

## Summary

Fixes incorrect cue-hint vertical alignment, removes GDI+ text-fringe “lines” (often L-shaped, matching cue colour), and adds a TestForm demo. Reported in [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382).

## Problem

When showing a **CueHint** on `KryptonTextBox` (empty value, enabled), users could see:

- Faint **top** and/or **left** streaks that looked like borders (often the same colour as the cue text).
- **Vertical alignment** that followed **horizontal** (`TextH`) by mistake, so with `TextH = Near` the cue was pinned to the **top** instead of respecting **`TextV`** (e.g. **Center**).

Symptoms often worsened when the cue **font differed** from the control content font; they could disappear after focus/typing when native edit painting took over.

## Root cause

1. **`PaletteCueHintText.GetContentShortTextV`** returned **`_shortTextH`** instead of **`_shortTextV`**, so vertical layout used horizontal alignment for the non-inherit path.
2. **GDI+ `DrawString`** plus **`GraphicsHint`** / smoothing applied around the full paint path left anti-aliased edge pixels that read as thin **top/left** lines, especially with `DarkGray` cue colour.
3. **`BeginPaint`** could leave a **clip** that did not cover the full client area; background fill did not always clear prior pixels at the edges.

## Solution

| Area | Change |
|------|--------|
| `PaletteCueHintText` | Return **`_shortTextV`** from **`GetContentShortTextV`** when not `Inherit`. | | `PaletteCueHintText.PerformPaint` | Fill background **first** without high-quality smoothing on that step; use **`TextRenderer.DrawText`** for **single-line** cue (typical `KryptonTextBox`, `KryptonComboBox`); keep **GDI+ `DrawString`** for **multiline** `KryptonTextBox` and `KryptonRichTextBox` only. | | `KryptonTextBox` (internal `TextBox`) | **`Graphics.ResetClip()`** after **`FromHdc`** in the custom **`WM_PAINT`** path so cue painting can clear the full client. | | `KryptonRichTextBox` | Same **`ResetClip()`** before cue **`PerformPaint`**. | | TestForm | **`Bug3382CueHintLinesDemo`** (with **`.Designer.cs`**) plus **Start Screen** entry for manual verification. |

## How to test

1. Run TestForm and open **“Bug 3382 CueHint line artefacts”**.
2. Confirm single-line boxes: **no** faint top/left streaks; Cyrillic cue **vertically centred** with **`TextH = Near`** and default **`TextV`**.
3. Resize/unfocus/repaint and compare **mixed cue/content fonts** vs **matched fonts** rows.
4. Spot-check **KryptonComboBox** cue and **multiline** `KryptonTextBox` cue if applicable.

## Related

- Closes / Fixes [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382)

## Checklist

- [x] Toolkit builds (e.g. `net472`).
- [ ] Visual verification on Windows (designer + runtime) for single-line cue.
- [ ] No regression called out for multiline / `KryptonRichTextBox` cue (still uses GDI+ path).