### PR TITLE
* White inner border artifacts appear on `KryptonButton` when hoverin…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Resolved [#3342](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3342), `KryptonTextBox`, text flickers when resizing the control (multiline active)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs
@@ -307,24 +307,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Border rounding.</returns>
-        public override float GetBorderRounding(PaletteState state)
-        {
-            if (Apply)
-            {
-                var ret = _primary.GetBorderRounding(Override ? OverrideState : state);
-
-                if (ret == -1)
-                {
-                    ret = _backup.GetBorderRounding(state);
-                }
-
-                return ret;
-            }
-            else
-            {
-                return _backup.GetBorderRounding(state);
-            }
-        }
+        public override float GetBorderRounding(PaletteState state) =>
+            MergeBorderRoundingForFocusOverride(state);
 
         /// <summary>
         /// Gets a border image.
@@ -392,6 +376,79 @@ namespace Krypton.Toolkit
                 return _backup.GetBorderImageAlign(state);
             }
         }
+
+        #endregion
+
+        #region Implementation
+
+        /// <summary>
+        /// When focus chrome is merged over StateTracking/StatePressed, corner rounding must come from
+        /// the state triple first so hover/press border geometry matches the fill path (GitHub #3383).
+        /// </summary>
+        private static bool PreferBackupBorderRoundingForFocusMerge(PaletteState state)
+        {
+            switch (state)
+            {
+                case PaletteState.Tracking:
+                case PaletteState.Pressed:
+                case PaletteState.CheckedTracking:
+                case PaletteState.CheckedPressed:
+                case PaletteState.ContextTracking:
+                case PaletteState.ContextPressed:
+                case PaletteState.ContextCheckedTracking:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private float MergeBorderRoundingForFocusOverride(PaletteState state)
+        {
+            if (!Apply)
+            {
+                return _backup.GetBorderRounding(state);
+            }
+
+            if (!Override)
+            {
+                var ret = _primary.GetBorderRounding(state);
+                if (ret == -1f)
+                {
+                    ret = _backup.GetBorderRounding(state);
+                }
+
+                return ret;
+            }
+
+            if (OverrideState == PaletteState.FocusOverride &&
+                PreferBackupBorderRoundingForFocusMerge(state))
+            {
+                var ret = _backup.GetBorderRounding(state);
+                if (ret != -1f)
+                {
+                    return ret;
+                }
+
+                ret = _primary.GetBorderRounding(OverrideState);
+                if (ret != -1f)
+                {
+                    return ret;
+                }
+
+                return _primary.GetBorderRounding(state);
+            }
+
+            {
+                var ret = _primary.GetBorderRounding(OverrideState);
+                if (ret == -1f)
+                {
+                    ret = _backup.GetBorderRounding(state);
+                }
+
+                return ret;
+            }
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2026. All rights reserved. 
  *  
  */
 #endregion
@@ -437,7 +437,7 @@ namespace Krypton.Toolkit
 
                 return _primary.GetBorderRounding(state);
             }
-
+            else
             {
                 var ret = _primary.GetBorderRounding(OverrideState);
                 if (ret == -1f)


### PR DESCRIPTION
…g (`StateTracking` rounding issue) (V85 LTS)

# Fix #3383: KryptonButton hover corner artifacts (`StateTracking` rounding vs focus merge)

## Summary

Fixes rounding geometry when `PaletteBorderInheritOverride` merges **`OverrideFocus`** over **`StateTracking`** / **`StatePressed`** (buttons with keyboard focus). **Corner rounding** for hot/pressed interaction states now comes from the **state triple first**, so background fill paths and border stroke stay aligned—eliminating inner light “fracture” lines on hover.

Fixes [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383).

## Problem

With rounded `KryptonButton`s, **`OverrideFocus.Border.Rounding`** could win over **`StateTracking.Border.Rounding`** whenever focus overrides were applied (`OnGotFocus`), because `PaletteBorderInheritOverride.GetBorderRounding` consulted the primary palette using **`PaletteState.FocusOverride`** before the backup (`StateTracking`). Combined with different hover border width, fill and stroke could disagree and show **white/light inner edges** despite explicit `StateTracking` rounding.

## Solution

In [`PaletteBorderInheritOverride.cs`](Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs), `GetBorderRounding` delegates to **`MergeBorderRoundingForFocusOverride`**:

- When **`Apply`** and **`Override`** are set and **`OverrideState`** is **`PaletteState.FocusOverride`**, and the active element state is an **interaction state** (`Tracking`, `Pressed`, checked/context tracking/pressed variants), resolve rounding from **`_backup`** (state triple) first, then fall back to **`_primary`**.
- **`GetBorderWidth`** behavior is **unchanged** so focus-specific thicker borders from `OverrideFocus` remain possible when widths are inherited on the interaction triple.

## TestForm

- Added **`Bug3383KryptonButtonStateTrackingRoundingDemo`**: side-by-side **repro** (mismatched `StateTracking` rounding + thick hover border vs `OverrideFocus` pill rounding) and **control** (matched rounding).
- Wired in **`StartScreen`** and **`TestForm.csproj`**.
- Instructions: Tab to focus the left button, then hover—corners should stay consistent without inner gap artifacts.

## Manual verification

1. Run TestForm (`dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj" -c Debug`).
2. Open **“Bug 3383 KryptonButton hover rounding vs OverrideFocus”**.
3. Focus left button → hover repeatedly; confirm no inner white corner lines vs pre-fix behavior.
4. Spot-check **`KryptonColorButton`**, **context-menu check buttons**, **command-link** variants (same `PaletteTripleOverride` pattern)—focus + hover should behave consistently.

## Files touched

| Area | Path |
|------|------|
| Core fix | `Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritOverride.cs` |

## Risk / breaking changes

- **Low**: Only affects border **rounding** resolution for the **FocusOverride** merge path in **interaction** palette states; other override kinds (e.g. calendar `BoldedOverride`) keep the previous primary-first rounding order.
- Apps that relied on **`OverrideFocus.Border.Rounding`** overriding **`StateTracking`** geometry while focused **and** hovered may now see **StateTracking** rounding when it is explicitly set on the state triple (intended for #3383).