### PR TITLE
* `ComboBox` with *Any* `UserControl`

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,11 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3443](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3443), `KryptonComboBoxUserControl` - a ComboBox-style control whose drop-down hosts any `UserControl` (or any `Control`). Drop content can opt into the new `IKryptonDropDownUserControl` contract for sizing, lifecycle, and value commit/cancel signalling. Also adds `KryptonDropDownCommitEventArgs` / `KryptonDropDownOpeningEventArgs` and an internal `VisualKryptonDropDownPopup` that supports an optional bottom-right resize grip.
+  * Auto-complete pipeline: optional `IKryptonDropDownFilterable` contract plus `AutoOpenOnType` / `MinFilterLength` properties on the host. When enabled, typing in the editor opens the popup without stealing focus and forwards text to `ApplyFilter`; Up/Down arrows route to `NavigateSelection`, Enter routes to `CommitSelection`, mirroring native ComboBox auto-complete UX.
+  * Designer integration: `KryptonComboBoxUserControlDesigner` + smart-tag action list (`DropDownAlign`, `DropDownWidth/Height`, `DropDownResizable`, `ReadOnlyEditor`, `InputControlStyle`, `PaletteMode`) and a `KryptonDropContentEditor` UITypeEditor that lets designers pick `DropContent` from a drop-down of available `Control`s on the same form **or instantiate a brand-new `UserControl`-derived type** discovered via `ITypeDiscoveryService` (the new component is sited on the host so it appears in `Designer.cs` code-gen).
+  * `TestForm` demo (`KryptonComboBoxUserControlDemo`) covers four scenarios: tree-picker, multi-column grid-picker, plain (non-contract) `UserControl`, and a filter-as-you-type city picker.
+  * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Utilities` assembly.
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Implemented [#3405](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3405), Add Badge Support for `KryptonNavigator` (Notification Indicator)
 * Resolved [#3343](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3343), Strange behavior of `KryptonRichTextBox` when editing text

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -63,6 +63,12 @@
 		<!-- Ensure multi-target outputs don't overwrite each other -->
 		<OutputPath>$(MSBuildThisFileDirectory)..\..\Bin\$(Configuration)\$(TargetFramework)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<!-- AppendTargetFrameworkToOutputPath=false skips SDK append for intermediate output; obj must stay per-TFM or
+		     inner builds collide (CS2012 / CS1705).
+		     Set IntermediateOutputPath in this .props (before Microsoft.Common evaluates TargetRefPath). Defining it
+		     only in Directory.Build.targets ran too late, leaving TargetRefPath at obj\Config\ref\… while the compiler
+		     wrote refint under obj\Config\<tfm>\ → MSB3883 / DirectoryNotFoundException in CopyRefAssembly. -->
+		<IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 	</PropertyGroup>
 
 	<Choose>

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -10,6 +10,13 @@
 		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
 	</PropertyGroup>
 
+	<!-- Outer cross-targeting build: default BuildInParallel=true dispatches inner TFMs concurrently. With custom
+	     OutputPath/IntermediateOutputPath, concurrent inner builds can still mis-resolve or overwrite outputs in
+	     practice (CS1705: referenced assembly built for a higher TFM). Serialize inner TFMs per project. -->
+	<PropertyGroup Condition="'$(TargetFrameworks)' != '' And '$(TargetFramework)' == ''">
+		<BuildInParallel>false</BuildInParallel>
+	</PropertyGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)NetFramework.SystemResourcesExtensions.BindingRedirects.props"
 	        Condition="Exists('$(MSBuildThisFileDirectory)NetFramework.SystemResourcesExtensions.BindingRedirects.props')" />
 

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Controls Toolkit/KryptonComboBoxUserControl.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Controls Toolkit/KryptonComboBoxUserControl.cs
@@ -1,0 +1,617 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Provides a ComboBox-style input control whose drop-down portion hosts an arbitrary
+/// <see cref="Control"/> (typically a developer-supplied <see cref="UserControl"/>).
+/// Implements feature request
+/// <a href="https://github.com/Krypton-Suite/Standard-Toolkit/issues/3443">#3443</a>.
+/// </summary>
+/// <remarks>
+/// The control derives from <see cref="KryptonTextBox"/> and adds a drop button on its right
+/// edge. When the user clicks the button (or presses F4 / Alt+Down) the supplied
+/// <see cref="DropContent"/> is shown as a Krypton-styled popup anchored to the editor.
+/// Drop content can implement <see cref="IKryptonDropDownUserControl"/> to participate in
+/// sizing, lifecycle callbacks and value commit/cancel signalling.
+/// </remarks>
+[ToolboxItem(true)]
+[ToolboxBitmap(typeof(KryptonComboBox), "ToolboxBitmaps.KryptonComboBox.bmp")]
+[DefaultEvent(nameof(ValueCommitted))]
+[DefaultProperty(nameof(Text))]
+[DefaultBindingProperty(nameof(Text))]
+[Designer(typeof(KryptonComboBoxUserControlDesigner))]
+[DesignerCategory(@"code")]
+[Description(@"A ComboBox-style control whose drop-down hosts any UserControl.")]
+public class KryptonComboBoxUserControl : KryptonTextBox
+{
+    #region Static Fields
+
+    /// <summary>Default popup width used when no preferred size is supplied.</summary>
+    private const int DefaultDropDownWidth = 200;
+    /// <summary>Default popup height used when no preferred size is supplied.</summary>
+    private const int DefaultDropDownHeight = 200;
+
+    #endregion
+
+    #region Instance Fields
+
+    private readonly ButtonSpecAny _dropButton;
+    private VisualKryptonDropDownPopup? _popup;
+    private Control? _dropContent;
+    private object? _selectedValue;
+    private LeftRightAlignment _dropDownAlign = LeftRightAlignment.Left;
+    private int _dropDownWidth = DefaultDropDownWidth;
+    private int _dropDownHeight = DefaultDropDownHeight;
+    private Size _minDropDownSize;
+    private Size _maxDropDownSize;
+    private bool _dropDownResizable;
+    private bool _readOnlyEditor;
+    private bool _autoOpenOnType;
+    private int _minFilterLength = 1;
+    private bool _suspendAutoOpen;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Occurs when the drop-down is about to be shown. Set <c>Cancel</c> to suppress the popup.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Occurs when the drop-down is about to be shown.")]
+    public event EventHandler<KryptonDropDownOpeningEventArgs>? DropDownOpening;
+
+    /// <summary>
+    /// Occurs after the drop-down has been shown.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Occurs after the drop-down has been shown.")]
+    public event EventHandler? DropDownOpened;
+
+    /// <summary>
+    /// Occurs when the drop-down has closed (either by commit, cancel, or click outside).
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Occurs when the drop-down has closed.")]
+    public event EventHandler? DropDownClosed;
+
+    /// <summary>
+    /// Occurs when the drop-down content commits a value.
+    /// </summary>
+    [Category(@"Action")]
+    [Description(@"Occurs when the drop-down content commits a value.")]
+    public event EventHandler<KryptonDropDownCommitEventArgs>? ValueCommitted;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="KryptonComboBoxUserControl"/> class.
+    /// </summary>
+    public KryptonComboBoxUserControl()
+    {
+        // Disable native auto-complete by default; consumers can opt in via the inherited properties
+        base.AutoCompleteMode = AutoCompleteMode.None;
+        base.AutoCompleteSource = AutoCompleteSource.None;
+
+        AllowButtonSpecToolTips = true;
+
+        _dropButton = new ButtonSpecAny
+        {
+            Type = PaletteButtonSpecStyle.DropDown,
+            Style = PaletteButtonStyle.ButtonSpec,
+            Edge = PaletteRelativeEdgeAlign.Far
+        };
+        _dropButton.Click += OnDropButtonClick;
+        ButtonSpecs.Add(_dropButton);
+
+        KeyDown += OnEditorKeyDown;
+        TextChanged += OnEditorTextChanged;
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            KeyDown -= OnEditorKeyDown;
+            TextChanged -= OnEditorTextChanged;
+            _dropButton.Click -= OnDropButtonClick;
+
+            CloseDropDown();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region Public Properties
+
+    /// <summary>
+    /// Gets or sets the control to display in the drop-down portion. May be any
+    /// <see cref="Control"/>; controls implementing <see cref="IKryptonDropDownUserControl"/>
+    /// participate in sizing, lifecycle and commit/cancel signalling.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"The control to display in the drop-down portion.")]
+    [DefaultValue(null)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [Editor(typeof(KryptonDropContentEditor), typeof(System.Drawing.Design.UITypeEditor))]
+    public Control? DropContent
+    {
+        get => _dropContent;
+        set
+        {
+            if (_dropContent == value)
+            {
+                return;
+            }
+
+            // Closing while the popup is open is the cleanest behaviour
+            if (IsDroppedDown)
+            {
+                CloseDropDown();
+            }
+
+            _dropContent = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the horizontal alignment of the drop-down relative to the editor.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Horizontal alignment of the drop-down relative to the editor.")]
+    [DefaultValue(LeftRightAlignment.Left)]
+    public LeftRightAlignment DropDownAlign
+    {
+        get => _dropDownAlign;
+        set => _dropDownAlign = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the desired width of the drop-down popup. Ignored when the
+    /// <see cref="DropContent"/> implements <see cref="IKryptonDropDownUserControl"/> and
+    /// returns a non-empty preferred size.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Desired width of the drop-down popup.")]
+    [DefaultValue(DefaultDropDownWidth)]
+    public int DropDownWidth
+    {
+        get => _dropDownWidth;
+        set => _dropDownWidth = Math.Max(1, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the desired height of the drop-down popup. Ignored when the
+    /// <see cref="DropContent"/> implements <see cref="IKryptonDropDownUserControl"/> and
+    /// returns a non-empty preferred size.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Desired height of the drop-down popup.")]
+    [DefaultValue(DefaultDropDownHeight)]
+    public int DropDownHeight
+    {
+        get => _dropDownHeight;
+        set => _dropDownHeight = Math.Max(1, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum size of the drop-down popup.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Minimum size of the drop-down popup. Use Size.Empty to disable.")]
+    public Size MinDropDownSize
+    {
+        get => _minDropDownSize;
+        set => _minDropDownSize = value;
+    }
+
+    private bool ShouldSerializeMinDropDownSize() => !_minDropDownSize.IsEmpty;
+    private void ResetMinDropDownSize() => _minDropDownSize = Size.Empty;
+
+    /// <summary>
+    /// Gets or sets the maximum size of the drop-down popup.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Maximum size of the drop-down popup. Use Size.Empty to disable.")]
+    public Size MaxDropDownSize
+    {
+        get => _maxDropDownSize;
+        set => _maxDropDownSize = value;
+    }
+
+    private bool ShouldSerializeMaxDropDownSize() => !_maxDropDownSize.IsEmpty;
+    private void ResetMaxDropDownSize() => _maxDropDownSize = Size.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user can resize the drop-down popup at runtime.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Whether the user can resize the drop-down popup at runtime.")]
+    [DefaultValue(false)]
+    public bool DropDownResizable
+    {
+        get => _dropDownResizable;
+        set => _dropDownResizable = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the editor is read-only (mimicking
+    /// <c>ComboBoxStyle.DropDownList</c> on the standard <see cref="KryptonComboBox"/>).
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"When true the editor cannot be typed into; selection happens through the drop-down only.")]
+    [DefaultValue(false)]
+    public bool ReadOnlyEditor
+    {
+        get => _readOnlyEditor;
+        set
+        {
+            _readOnlyEditor = value;
+            ReadOnly = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the drop-down should automatically open as the
+    /// user types in the editor (filter-as-you-type). The host opens the popup without stealing
+    /// focus and forwards typed text to the drop content via
+    /// <see cref="IKryptonDropDownFilterable.ApplyFilter"/>.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"When true, typing in the editor automatically opens the drop-down and forwards the text to a filterable drop content.")]
+    [DefaultValue(false)]
+    public bool AutoOpenOnType
+    {
+        get => _autoOpenOnType;
+        set => _autoOpenOnType = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the minimum number of characters that must be typed before
+    /// <see cref="AutoOpenOnType"/> opens the drop-down.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Minimum number of characters before AutoOpenOnType triggers the drop-down.")]
+    [DefaultValue(1)]
+    public int MinFilterLength
+    {
+        get => _minFilterLength;
+        set => _minFilterLength = Math.Max(0, value);
+    }
+
+    /// <summary>
+    /// Gets the value most recently committed by the drop-down content.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public object? SelectedValue => _selectedValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the drop-down is currently shown.
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public bool IsDroppedDown => _popup is { IsHandleCreated: true, IsDisposed: false };
+
+    /// <summary>
+    /// Gets access to the drop button specification, allowing further customisation
+    /// (e.g. a custom image or tooltip).
+    /// </summary>
+    [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public ButtonSpecAny DropButton => _dropButton;
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Opens the drop-down. Has no effect when no <see cref="DropContent"/> is assigned or when
+    /// the drop-down is already open.
+    /// </summary>
+    public void ShowDropDown() => ShowDropDown(retainEditorFocus: false);
+
+    /// <summary>
+    /// Opens the drop-down. Has no effect when no <see cref="DropContent"/> is assigned or when
+    /// the drop-down is already open.
+    /// </summary>
+    /// <param name="retainEditorFocus">
+    /// When <see langword="true"/> focus is forced back to the editor after the popup is shown
+    /// (useful for filter-as-you-type scenarios where the user needs to continue typing).
+    /// </param>
+    public void ShowDropDown(bool retainEditorFocus)
+    {
+        if (_dropContent == null || IsDroppedDown || DesignMode || !IsHandleCreated)
+        {
+            return;
+        }
+
+        var openingArgs = new KryptonDropDownOpeningEventArgs(_dropContent);
+        OnDropDownOpening(openingArgs);
+        if (openingArgs.Cancel)
+        {
+            return;
+        }
+
+        Size popupSize = ResolvePopupSize();
+
+        IRenderer? renderer = null;
+        try
+        {
+            renderer = KryptonManager.CurrentGlobalPalette.GetRenderer();
+        }
+        catch
+        {
+            // Fall back to default renderer if palette cannot supply one
+        }
+
+        _popup = new VisualKryptonDropDownPopup(this, _dropContent, renderer,
+            _dropDownResizable, _minDropDownSize, _maxDropDownSize);
+        _popup.Disposed += OnPopupDisposed;
+        _popup.ValueCommitted += OnPopupValueCommitted;
+
+        Rectangle anchor = RectangleToScreen(ClientRectangle);
+        _popup.ShowAnchored(anchor, popupSize, _dropDownAlign);
+
+        OnDropDownOpened(EventArgs.Empty);
+
+        if (retainEditorFocus)
+        {
+            // Pull focus back to the editor after the contract's OnDropDownOpened may have moved it
+            BeginInvoke(new Action(() =>
+            {
+                if (!IsDisposed && CanFocus && !Focused)
+                {
+                    Focus();
+                    SelectionStart = Text.Length;
+                    SelectionLength = 0;
+                }
+            }));
+        }
+    }
+
+    /// <summary>
+    /// Closes the drop-down if it is currently shown.
+    /// </summary>
+    public void CloseDropDown()
+    {
+        if (_popup == null)
+        {
+            return;
+        }
+
+        if (_popup is { IsDisposed: false, IsHandleCreated: true })
+        {
+            VisualPopupManager.Singleton.EndPopupTracking(_popup);
+        }
+
+        _popup = null;
+    }
+
+    #endregion
+
+    #region Protected Overrides
+
+    /// <summary>
+    /// Raises the <see cref="DropDownOpening"/> event.
+    /// </summary>
+    /// <param name="e">A <see cref="KryptonDropDownOpeningEventArgs"/> that contains the event data.</param>
+    protected virtual void OnDropDownOpening(KryptonDropDownOpeningEventArgs e) => DropDownOpening?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the <see cref="DropDownOpened"/> event.
+    /// </summary>
+    /// <param name="e">An <see cref="EventArgs"/> that contains the event data.</param>
+    protected virtual void OnDropDownOpened(EventArgs e) => DropDownOpened?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the <see cref="DropDownClosed"/> event.
+    /// </summary>
+    /// <param name="e">An <see cref="EventArgs"/> that contains the event data.</param>
+    protected virtual void OnDropDownClosed(EventArgs e) => DropDownClosed?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the <see cref="ValueCommitted"/> event.
+    /// </summary>
+    /// <param name="e">A <see cref="KryptonDropDownCommitEventArgs"/> that contains the event data.</param>
+    protected virtual void OnValueCommitted(KryptonDropDownCommitEventArgs e) => ValueCommitted?.Invoke(this, e);
+
+    #endregion
+
+    #region Implementation
+
+    private Size ResolvePopupSize()
+    {
+        Size proposed = new Size(_dropDownWidth, _dropDownHeight);
+
+        if (_dropContent is IKryptonDropDownUserControl contract)
+        {
+            Size preferred = contract.GetPreferredDropSize(proposed);
+            if (!preferred.IsEmpty)
+            {
+                proposed = preferred;
+            }
+        }
+
+        // Width should be at least the editor width so the popup never appears narrower than its anchor
+        if (proposed.Width < Width)
+        {
+            proposed = new Size(Width, proposed.Height);
+        }
+
+        return proposed;
+    }
+
+    private void OnDropButtonClick(object? sender, EventArgs e)
+    {
+        if (IsDroppedDown)
+        {
+            CloseDropDown();
+        }
+        else
+        {
+            ShowDropDown();
+        }
+    }
+
+    private void OnEditorKeyDown(object? sender, KeyEventArgs e)
+    {
+        // F4 toggles, Alt+Down opens, Alt+Up closes - matches WinForms ComboBox conventions
+        if (e.KeyCode == Keys.F4 && !e.Alt && !e.Control && !e.Shift)
+        {
+            if (IsDroppedDown)
+            {
+                CloseDropDown();
+            }
+            else
+            {
+                ShowDropDown();
+            }
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        if (e.Alt && e.KeyCode == Keys.Down)
+        {
+            if (!IsDroppedDown)
+            {
+                ShowDropDown();
+            }
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        if (e.Alt && e.KeyCode == Keys.Up)
+        {
+            if (IsDroppedDown)
+            {
+                CloseDropDown();
+            }
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        if (e.KeyCode == Keys.Escape && IsDroppedDown)
+        {
+            CloseDropDown();
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        // Forward Up/Down/Enter to a filterable drop content while the popup is open and the
+        // editor still has focus (filter-as-you-type pattern).
+        if (IsDroppedDown && _dropContent is IKryptonDropDownFilterable filterable)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Down:
+                    filterable.NavigateSelection(1);
+                    e.Handled = true;
+                    e.SuppressKeyPress = true;
+                    return;
+                case Keys.Up:
+                    filterable.NavigateSelection(-1);
+                    e.Handled = true;
+                    e.SuppressKeyPress = true;
+                    return;
+                case Keys.Enter:
+                    if (filterable.CommitSelection())
+                    {
+                        e.Handled = true;
+                        e.SuppressKeyPress = true;
+                    }
+                    return;
+            }
+        }
+    }
+
+    private void OnEditorTextChanged(object? sender, EventArgs e)
+    {
+        if (!_autoOpenOnType || _suspendAutoOpen || DesignMode)
+        {
+            return;
+        }
+
+        if (Text.Length < _minFilterLength)
+        {
+            // Below the threshold, close the popup if it was opened by us
+            if (IsDroppedDown)
+            {
+                CloseDropDown();
+            }
+            return;
+        }
+
+        if (!IsDroppedDown)
+        {
+            ShowDropDown(retainEditorFocus: true);
+        }
+
+        if (_dropContent is IKryptonDropDownFilterable filterable)
+        {
+            bool anyMatch = filterable.ApplyFilter(Text);
+            if (!anyMatch && IsDroppedDown)
+            {
+                CloseDropDown();
+            }
+        }
+    }
+
+    private void OnPopupValueCommitted(object? sender, KryptonDropDownCommitEventArgs e)
+    {
+        _selectedValue = e.Value;
+
+        if (e.DisplayText != null)
+        {
+            // Suppress auto-open-on-type while we programmatically push the committed text into
+            // the editor, otherwise the popup would immediately try to reopen with the new text.
+            _suspendAutoOpen = true;
+            try
+            {
+                Text = e.DisplayText;
+                SelectionStart = Text.Length;
+                SelectionLength = 0;
+            }
+            finally
+            {
+                _suspendAutoOpen = false;
+            }
+        }
+
+        OnValueCommitted(e);
+    }
+
+    private void OnPopupDisposed(object? sender, EventArgs e)
+    {
+        if (_popup != null)
+        {
+            _popup.Disposed -= OnPopupDisposed;
+            _popup.ValueCommitted -= OnPopupValueCommitted;
+            _popup = null;
+        }
+
+        OnDropDownClosed(EventArgs.Empty);
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Controls Visuals/VisualKryptonDropDownPopup.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Controls Visuals/VisualKryptonDropDownPopup.cs
@@ -1,0 +1,302 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// VisualPopup subclass that hosts an arbitrary <see cref="Control"/> (typically a developer-supplied
+/// <see cref="UserControl"/>) as the drop-down portion of a <see cref="KryptonComboBoxUserControl"/>.
+/// </summary>
+internal sealed class VisualKryptonDropDownPopup : VisualPopup
+{
+    #region Constants
+
+    /// <summary>Side length of the bottom-right resize grip, in pixels.</summary>
+    private const int GripSize = 12;
+
+    #endregion
+
+    #region Instance Fields
+
+    private readonly KryptonComboBoxUserControl _owner;
+    private readonly Control _dropContent;
+    private readonly IKryptonDropDownUserControl? _contractContent;
+    private readonly bool _resizable;
+    private readonly Size _minDropSize;
+    private readonly Size _maxDropSize;
+    private bool _closedNotified;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>Raised when the drop-down content commits a value.</summary>
+    public event EventHandler<KryptonDropDownCommitEventArgs>? ValueCommitted;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="VisualKryptonDropDownPopup"/> class.
+    /// </summary>
+    /// <param name="owner">The owning combo box.</param>
+    /// <param name="dropContent">The user-supplied control to host.</param>
+    /// <param name="renderer">The renderer to use for the popup chrome.</param>
+    /// <param name="resizable">Whether the popup should expose a bottom-right resize grip.</param>
+    /// <param name="minDropSize">Minimum allowed popup size when resizing. Use <see cref="Size.Empty"/> to skip.</param>
+    /// <param name="maxDropSize">Maximum allowed popup size when resizing. Use <see cref="Size.Empty"/> to skip.</param>
+    public VisualKryptonDropDownPopup(KryptonComboBoxUserControl owner,
+                                      Control dropContent,
+                                      IRenderer? renderer,
+                                      bool resizable,
+                                      Size minDropSize,
+                                      Size maxDropSize)
+        : base(new ViewManager(), renderer, true)
+    {
+        _owner = owner;
+        _dropContent = dropContent;
+        _contractContent = dropContent as IKryptonDropDownUserControl;
+        _resizable = resizable;
+        _minDropSize = minDropSize;
+        _maxDropSize = maxDropSize;
+
+        _dropContent.Dock = DockStyle.Fill;
+
+        // Build a docker view so the popup paints a Krypton border around the hosted control
+        var layoutFill = new ViewLayoutFill(_dropContent);
+        var layoutDocker = new ViewLayoutDocker
+        {
+            { layoutFill, ViewDockStyle.Fill }
+        };
+
+        ViewManager!.Control = this;
+        ViewManager!.AlignControl = this;
+        ViewManager!.Root = layoutDocker;
+
+        Controls.Add(_dropContent);
+
+        if (_contractContent != null)
+        {
+            _contractContent.CommitValue += OnContentCommitValue;
+            _contractContent.RequestClose += OnContentRequestClose;
+        }
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Detach (do not dispose) the user-supplied control so the host can reuse it
+            if (Controls.Contains(_dropContent))
+            {
+                Controls.Remove(_dropContent);
+                _dropContent.Dock = DockStyle.None;
+            }
+
+            if (_contractContent != null)
+            {
+                _contractContent.CommitValue -= OnContentCommitValue;
+                _contractContent.RequestClose -= OnContentRequestClose;
+            }
+
+            // Always notify the contract content that the drop-down has closed, even when the
+            // popup was dismissed by the popup manager (e.g. click outside the popup).
+            if (!_closedNotified)
+            {
+                _closedNotified = true;
+                _contractContent?.OnDropDownClosed(_owner);
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #endregion
+
+    #region Public
+
+    /// <summary>
+    /// Show the popup anchored to the supplied screen rectangle (typically the parent control's
+    /// screen rectangle). The popup positions itself below the rectangle when there is room,
+    /// otherwise above. Horizontal alignment honours <paramref name="alignment"/>.
+    /// </summary>
+    /// <param name="anchorScreenRect">Screen rectangle of the parent control.</param>
+    /// <param name="popupSize">Desired popup size.</param>
+    /// <param name="alignment">Left or right alignment relative to <paramref name="anchorScreenRect"/>.</param>
+    public void ShowAnchored(Rectangle anchorScreenRect, Size popupSize, LeftRightAlignment alignment)
+    {
+        // Notify the contract content (if any) that we are about to open
+        _contractContent?.OnDropDownOpening(_owner);
+
+        // Clamp size to the requested min/max
+        if (!_minDropSize.IsEmpty)
+        {
+            popupSize = new Size(Math.Max(popupSize.Width, _minDropSize.Width),
+                                 Math.Max(popupSize.Height, _minDropSize.Height));
+        }
+        if (!_maxDropSize.IsEmpty)
+        {
+            popupSize = new Size(Math.Min(popupSize.Width, _maxDropSize.Width),
+                                 Math.Min(popupSize.Height, _maxDropSize.Height));
+        }
+
+        Screen screen = Screen.FromRectangle(anchorScreenRect);
+        Rectangle work = screen.WorkingArea;
+
+        int x = alignment == LeftRightAlignment.Right
+            ? anchorScreenRect.Right - popupSize.Width
+            : anchorScreenRect.Left;
+
+        // Keep horizontally on screen
+        if (x + popupSize.Width > work.Right)
+        {
+            x = work.Right - popupSize.Width;
+        }
+        if (x < work.Left)
+        {
+            x = work.Left;
+        }
+
+        // Prefer below the anchor; if not enough room, flip above
+        int y = anchorScreenRect.Bottom;
+        if (y + popupSize.Height > work.Bottom)
+        {
+            int aboveY = anchorScreenRect.Top - popupSize.Height;
+            if (aboveY >= work.Top)
+            {
+                y = aboveY;
+            }
+            else
+            {
+                // Not enough room either way; clamp downward and trim height
+                y = work.Bottom - popupSize.Height;
+                if (y < work.Top)
+                {
+                    y = work.Top;
+                    popupSize = new Size(popupSize.Width, work.Bottom - work.Top);
+                }
+            }
+        }
+
+        Show(new Rectangle(x, y, popupSize.Width, popupSize.Height));
+
+        _contractContent?.OnDropDownOpened(_owner);
+    }
+
+    #endregion
+
+    #region Protected Overrides
+
+    /// <summary>
+    /// Allow drop-down content to receive focus (e.g. a tree, grid or list inside the popup).
+    /// </summary>
+    public override bool AllowBecomeActiveWhenCurrent => true;
+
+    /// <summary>
+    /// Allow content controls inside the popup to handle their own keyboard input.
+    /// </summary>
+    public override bool KeyboardInert => true;
+
+    /// <summary>
+    /// Mouse-down inside the resize grip must keep the popup alive.
+    /// </summary>
+    public override bool DoesCurrentMouseDownEndAllTracking(Message m, Point pt)
+    {
+        if (_resizable && IsInResizeGrip(pt))
+        {
+            return false;
+        }
+
+        return base.DoesCurrentMouseDownEndAllTracking(m, pt);
+    }
+
+    /// <summary>
+    /// Process Windows-based messages.
+    /// </summary>
+    /// <param name="m">A Windows-based message.</param>
+    protected override void WndProc(ref Message m)
+    {
+        if (_resizable && m.Msg == PI.WM_.NCHITTEST)
+        {
+            // Convert lParam (screen point) to client and check the grip area
+            int lParam = (int)m.LParam;
+            var screenPt = new Point((short)PI.LOWORD(lParam), (short)PI.HIWORD(lParam));
+            Point clientPt = PointToClient(screenPt);
+
+            if (IsInResizeGrip(clientPt))
+            {
+                m.Result = (IntPtr)PI.HT.BOTTOMRIGHT;
+                return;
+            }
+        }
+
+        base.WndProc(ref m);
+    }
+
+    /// <summary>
+    /// Paint the resize grip in the bottom-right corner when resizing is enabled.
+    /// </summary>
+    /// <param name="e">A PaintEventArgs that contains the event data.</param>
+    protected override void OnPaint(PaintEventArgs? e)
+    {
+        base.OnPaint(e);
+
+        if (_resizable && e != null)
+        {
+            ControlPaint.DrawSizeGrip(e.Graphics, BackColor,
+                Width - GripSize - 1, Height - GripSize - 1, GripSize, GripSize);
+        }
+    }
+
+    #endregion
+
+    #region Implementation
+
+    private bool IsInResizeGrip(Point clientPt) =>
+        clientPt.X >= Width - GripSize && clientPt.Y >= Height - GripSize;
+
+    private void OnContentCommitValue(object? sender, KryptonDropDownCommitEventArgs e)
+    {
+        ValueCommitted?.Invoke(this, e);
+
+        if (!e.KeepOpen)
+        {
+            CloseInternal();
+        }
+    }
+
+    private void OnContentRequestClose(object? sender, EventArgs e) => CloseInternal();
+
+    private void CloseInternal()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        bool cancel = false;
+        _contractContent?.OnDropDownClosing(_owner, ref cancel);
+        if (cancel)
+        {
+            return;
+        }
+
+        if (IsHandleCreated)
+        {
+            VisualPopupManager.Singleton.EndPopupTracking(this);
+        }
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Action Lists/KryptonComboBoxUserControlActionList.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Action Lists/KryptonComboBoxUserControlActionList.cs
@@ -1,0 +1,177 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Smart-tag action list for <see cref="KryptonComboBoxUserControl"/>.
+/// </summary>
+internal class KryptonComboBoxUserControlActionList : DesignerActionList
+{
+    #region Instance Fields
+
+    private readonly KryptonComboBoxUserControl _control;
+    private readonly IComponentChangeService? _service;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="KryptonComboBoxUserControlActionList"/> class.
+    /// </summary>
+    /// <param name="owner">Designer that owns this action list instance.</param>
+    public KryptonComboBoxUserControlActionList(KryptonComboBoxUserControlDesigner owner)
+        : base(owner.Component)
+    {
+        _control = (owner.Component as KryptonComboBoxUserControl)!;
+        _service = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+    }
+
+    #endregion
+
+    #region Smart-Tag Properties
+
+    /// <summary>Gets or sets the horizontal alignment of the drop-down.</summary>
+    public LeftRightAlignment DropDownAlign
+    {
+        get => _control.DropDownAlign;
+        set
+        {
+            if (_control.DropDownAlign != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.DropDownAlign, value);
+                _control.DropDownAlign = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets the desired width of the drop-down popup.</summary>
+    public int DropDownWidth
+    {
+        get => _control.DropDownWidth;
+        set
+        {
+            if (_control.DropDownWidth != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.DropDownWidth, value);
+                _control.DropDownWidth = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets the desired height of the drop-down popup.</summary>
+    public int DropDownHeight
+    {
+        get => _control.DropDownHeight;
+        set
+        {
+            if (_control.DropDownHeight != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.DropDownHeight, value);
+                _control.DropDownHeight = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets a value indicating whether the user can resize the drop-down.</summary>
+    public bool DropDownResizable
+    {
+        get => _control.DropDownResizable;
+        set
+        {
+            if (_control.DropDownResizable != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.DropDownResizable, value);
+                _control.DropDownResizable = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets a value indicating whether the editor is read-only.</summary>
+    public bool ReadOnlyEditor
+    {
+        get => _control.ReadOnlyEditor;
+        set
+        {
+            if (_control.ReadOnlyEditor != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.ReadOnlyEditor, value);
+                _control.ReadOnlyEditor = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets the input control style.</summary>
+    public InputControlStyle InputControlStyle
+    {
+        get => _control.InputControlStyle;
+        set
+        {
+            if (_control.InputControlStyle != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.InputControlStyle, value);
+                _control.InputControlStyle = value;
+            }
+        }
+    }
+
+    /// <summary>Gets or sets the palette mode.</summary>
+    public PaletteMode PaletteMode
+    {
+        get => _control.PaletteMode;
+        set
+        {
+            if (_control.PaletteMode != value)
+            {
+                _service?.OnComponentChanged(_control, null, _control.PaletteMode, value);
+                _control.PaletteMode = value;
+            }
+        }
+    }
+
+    #endregion
+
+    #region Public Override
+
+    /// <summary>
+    /// Returns the collection of <see cref="DesignerActionItem"/> objects contained in the list.
+    /// </summary>
+    public override DesignerActionItemCollection GetSortedActionItems()
+    {
+        DesignerActionItemCollection actions = new DesignerActionItemCollection();
+
+        if (_control != null)
+        {
+            actions.Add(new DesignerActionHeaderItem("DropDown"));
+            actions.Add(new DesignerActionPropertyItem(nameof(DropDownAlign), "Alignment", "DropDown",
+                "Horizontal alignment of the drop-down relative to the editor."));
+            actions.Add(new DesignerActionPropertyItem(nameof(DropDownWidth), "Width", "DropDown",
+                "Initial width of the drop-down popup."));
+            actions.Add(new DesignerActionPropertyItem(nameof(DropDownHeight), "Height", "DropDown",
+                "Initial height of the drop-down popup."));
+            actions.Add(new DesignerActionPropertyItem(nameof(DropDownResizable), "Resizable", "DropDown",
+                "Whether the user can resize the drop-down popup at runtime."));
+
+            actions.Add(new DesignerActionHeaderItem("Behavior"));
+            actions.Add(new DesignerActionPropertyItem(nameof(ReadOnlyEditor), "ReadOnly editor", "Behavior",
+                "When true the editor cannot be typed into; selection happens through the drop-down only."));
+
+            actions.Add(new DesignerActionHeaderItem("Visuals"));
+            actions.Add(new DesignerActionPropertyItem(nameof(InputControlStyle), "Style", "Visuals",
+                "Input control style applied to the editor."));
+            actions.Add(new DesignerActionPropertyItem(nameof(PaletteMode), "Palette", "Visuals",
+                "Palette applied to drawing."));
+        }
+
+        return actions;
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Designers/KryptonComboBoxUserControlDesigner.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Designers/KryptonComboBoxUserControlDesigner.cs
@@ -1,0 +1,84 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Designer for <see cref="KryptonComboBoxUserControl"/>. Exposes the action list and ensures the
+/// drop button collection participates in selection / copy operations.
+/// </summary>
+internal class KryptonComboBoxUserControlDesigner : ControlDesigner
+{
+    #region Instance Fields
+
+    private KryptonComboBoxUserControl? _comboUserControl;
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="KryptonComboBoxUserControlDesigner"/> class.
+    /// </summary>
+    public KryptonComboBoxUserControlDesigner()
+    {
+        AutoResizeHandles = true;
+    }
+
+    #endregion
+
+    #region Public Overrides
+
+    /// <summary>
+    /// Initializes the designer with the specified component.
+    /// </summary>
+    /// <param name="component">The IComponent to associate the designer with.</param>
+    public override void Initialize(IComponent component)
+    {
+        base.Initialize(component);
+
+        _comboUserControl = component as KryptonComboBoxUserControl;
+    }
+
+    /// <summary>
+    /// Gets the collection of components associated with the component managed by the designer.
+    /// Includes the inherited <c>ButtonSpecs</c> so they participate in select/copy/cut/paste.
+    /// </summary>
+    public override ICollection AssociatedComponents =>
+        _comboUserControl?.ButtonSpecs ?? base.AssociatedComponents;
+
+    /// <summary>
+    /// Gets the selection rules that indicate the movement capabilities of a component.
+    /// </summary>
+    public override SelectionRules SelectionRules
+    {
+        get
+        {
+            // Allow horizontal resize but lock the height (matches KryptonTextBox / KryptonComboBox)
+            SelectionRules rules = base.SelectionRules;
+            rules &= ~(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);
+            return rules;
+        }
+    }
+
+    /// <summary>
+    /// Gets the design-time action lists supported by the component associated with the designer.
+    /// </summary>
+    public override DesignerActionListCollection ActionLists
+    {
+        get
+        {
+            DesignerActionListCollection actions = new DesignerActionListCollection();
+            actions.Add(new KryptonComboBoxUserControlActionList(this));
+            return actions;
+        }
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Editors/KryptonDropContentEditor.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/Designers/Editors/KryptonDropContentEditor.cs
@@ -1,0 +1,338 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+using System.ComponentModel.Design;
+using System.Drawing.Design;
+using System.Windows.Forms.Design;
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Drop-down <see cref="UITypeEditor"/> used by <see cref="KryptonComboBoxUserControl.DropContent"/>
+/// to let designers (a) pick an existing <see cref="UserControl"/> / <see cref="Control"/> from
+/// the same form, or (b) instantiate a brand-new <see cref="UserControl"/>-derived type
+/// discovered via <see cref="ITypeDiscoveryService"/>. Newly-created components are sited on
+/// the designer host so they participate in code-gen / serialization.
+/// </summary>
+internal class KryptonDropContentEditor : UITypeEditor
+{
+    #region Constants
+
+    private const string NoneEntry = "(none)";
+    private const string ExistingHeader = "─── Existing controls ───";
+    private const string NewHeader = "─── New instance ───";
+
+    #endregion
+
+    #region UITypeEditor overrides
+
+    /// <inheritdoc />
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) =>
+        UITypeEditorEditStyle.DropDown;
+
+    /// <inheritdoc />
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
+    {
+        if (provider == null || context == null)
+        {
+            return value;
+        }
+
+        if (provider.GetService(typeof(IWindowsFormsEditorService)) is not IWindowsFormsEditorService editorService
+            || provider.GetService(typeof(IDesignerHost)) is not IDesignerHost host)
+        {
+            return value;
+        }
+
+        Control? owner = context.Instance as Control;
+
+        var listBox = new ListBox
+        {
+            BorderStyle = BorderStyle.None,
+            IntegralHeight = false
+        };
+
+        // 1) "(none)" entry
+        listBox.Items.Add(NoneEntry);
+
+        // 2) Existing controls section
+        var existing = new List<Control>();
+        foreach (IComponent component in host.Container.Components)
+        {
+            if (component is Control candidate
+                && !ReferenceEquals(candidate, owner)
+                && IsValidDropContent(candidate))
+            {
+                existing.Add(candidate);
+            }
+        }
+        existing.Sort((a, b) => string.Compare(GetDisplayName(a), GetDisplayName(b), StringComparison.OrdinalIgnoreCase));
+
+        if (existing.Count > 0)
+        {
+            listBox.Items.Add(ExistingHeader);
+            foreach (Control c in existing)
+            {
+                listBox.Items.Add(c);
+            }
+        }
+
+        // 3) "New instance" section: UserControl-derived types
+        Type[] discovered = DiscoverUserControlTypes(provider);
+        if (discovered.Length > 0)
+        {
+            listBox.Items.Add(NewHeader);
+            foreach (Type t in discovered)
+            {
+                listBox.Items.Add(t);
+            }
+        }
+
+        // Preselect the current value if it is one of the existing controls
+        if (value is Control current)
+        {
+            int idx = listBox.Items.IndexOf(current);
+            if (idx >= 0)
+            {
+                listBox.SelectedIndex = idx;
+            }
+        }
+        else
+        {
+            listBox.SelectedIndex = 0;
+        }
+
+        // Format items for display
+        listBox.Format += (_, e) =>
+        {
+            switch (e.ListItem)
+            {
+                case string s:
+                    e.Value = s;
+                    break;
+                case Type t:
+                    e.Value = $"[New] {t.Name} ({t.Namespace ?? "<global>"})";
+                    break;
+                case Component c when c.Site != null && !string.IsNullOrEmpty(c.Site.Name):
+                    e.Value = $"{c.Site.Name} ({c.GetType().Name})";
+                    break;
+                default:
+                    e.Value = e.ListItem?.GetType().Name ?? string.Empty;
+                    break;
+            }
+        };
+
+        // Auto-size the height to fit (cap at 12 visible rows)
+        int itemHeight = listBox.ItemHeight > 0 ? listBox.ItemHeight : 16;
+        int rows = Math.Min(Math.Max(listBox.Items.Count, 1), 12);
+        listBox.Height = (rows * itemHeight) + 4;
+        listBox.Width = 320;
+
+        bool selectionCommitted = false;
+
+        listBox.MouseUp += (_, _) =>
+        {
+            if (CanCommitItem(listBox.SelectedItem))
+            {
+                selectionCommitted = true;
+                editorService.CloseDropDown();
+            }
+        };
+        listBox.KeyDown += (_, e) =>
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Enter:
+                    if (CanCommitItem(listBox.SelectedItem))
+                    {
+                        selectionCommitted = true;
+                        editorService.CloseDropDown();
+                    }
+                    e.Handled = true;
+                    break;
+                case Keys.Escape:
+                    editorService.CloseDropDown();
+                    e.Handled = true;
+                    break;
+                case Keys.Down:
+                    listBox.SelectedIndex = NextSelectableIndex(listBox, listBox.SelectedIndex, +1);
+                    e.Handled = true;
+                    break;
+                case Keys.Up:
+                    listBox.SelectedIndex = NextSelectableIndex(listBox, listBox.SelectedIndex, -1);
+                    e.Handled = true;
+                    break;
+            }
+        };
+
+        editorService.DropDownControl(listBox);
+
+        if (!selectionCommitted)
+        {
+            return value;
+        }
+
+        return ResolveCommittedValue(listBox.SelectedItem, host, value);
+    }
+
+    #endregion
+
+    #region Implementation
+
+    /// <summary>Decide whether <paramref name="item"/> can be selected as a final value.</summary>
+    private static bool CanCommitItem(object? item) =>
+        item is null
+        || (item is string s && s == NoneEntry)
+        || item is Control
+        || item is Type;
+
+    /// <summary>Resolve the picked item to a <see cref="Control"/> instance (or <see langword="null"/>).</summary>
+    private static object? ResolveCommittedValue(object? selected, IDesignerHost host, object? fallback)
+    {
+        switch (selected)
+        {
+            case null:
+                return fallback;
+            case string s when s == NoneEntry:
+                return null;
+            case Control c:
+                return c;
+            case Type t:
+                // CreateComponent sites the new component on the host so it appears in
+                // Designer.cs code-gen and the property grid's component picker. The new
+                // control is not auto-added to any visual parent &#8211; that is intentional,
+                // since drop-down content typically should not also live on the form.
+                IComponent component = host.CreateComponent(t);
+                return component as Control;
+            default:
+                return fallback;
+        }
+    }
+
+    /// <summary>Skip header rows when navigating with the keyboard.</summary>
+    private static int NextSelectableIndex(ListBox listBox, int current, int step)
+    {
+        int count = listBox.Items.Count;
+        if (count == 0)
+        {
+            return -1;
+        }
+
+        int idx = current;
+        for (int i = 0; i < count; i++)
+        {
+            idx += step;
+            if (idx < 0)
+            {
+                idx = count - 1;
+            }
+            else if (idx >= count)
+            {
+                idx = 0;
+            }
+
+            if (CanCommitItem(listBox.Items[idx]))
+            {
+                return idx;
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>Use the component's site name where available for sorting.</summary>
+    private static string GetDisplayName(Component c) =>
+        c.Site != null && !string.IsNullOrEmpty(c.Site.Name) ? c.Site.Name : c.GetType().Name;
+
+    /// <summary>
+    /// Returns whether <paramref name="candidate"/> is suitable for hosting in the popup.
+    /// </summary>
+    private static bool IsValidDropContent(Control candidate)
+    {
+        if (candidate is Form)
+        {
+            return false;
+        }
+
+        if (candidate is KryptonTextBox)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Enumerate <see cref="UserControl"/>-derived types that have a public parameterless
+    /// constructor and are not abstract, sorted by namespace then by simple name.
+    /// </summary>
+    private static Type[] DiscoverUserControlTypes(IServiceProvider provider)
+    {
+        if (provider.GetService(typeof(ITypeDiscoveryService)) is not ITypeDiscoveryService discovery)
+        {
+            return Array.Empty<Type>();
+        }
+
+        ICollection raw;
+        try
+        {
+            // excludeGlobalTypes = true => limit to project + directly referenced assemblies,
+            // which excludes framework/system types.
+            raw = discovery.GetTypes(typeof(UserControl), excludeGlobalTypes: true);
+        }
+        catch
+        {
+            return Array.Empty<Type>();
+        }
+
+        var results = new List<Type>();
+        foreach (object o in raw)
+        {
+            if (o is Type t && IsCreatableUserControlType(t))
+            {
+                results.Add(t);
+            }
+        }
+
+        results.Sort((a, b) =>
+        {
+            int ns = string.Compare(a.Namespace ?? string.Empty, b.Namespace ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            return ns != 0 ? ns : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+        });
+
+        return results.ToArray();
+    }
+
+    /// <summary>
+    /// Filters out abstract types, generic-type-definitions, types without a public
+    /// parameterless constructor, and the <see cref="UserControl"/> base type itself.
+    /// </summary>
+    private static bool IsCreatableUserControlType(Type t)
+    {
+        if (t == typeof(UserControl))
+        {
+            return false;
+        }
+
+        if (!typeof(UserControl).IsAssignableFrom(t))
+        {
+            return false;
+        }
+
+        if (t.IsAbstract || t.IsGenericTypeDefinition || !t.IsClass)
+        {
+            return false;
+        }
+
+        // Public, parameterless constructor required for designer instantiation
+        return t.GetConstructor(Type.EmptyTypes) != null;
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/EventArgs/KryptonDropDownCommitEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/EventArgs/KryptonDropDownCommitEventArgs.cs
@@ -1,0 +1,44 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Provides data for the <see cref="KryptonComboBoxUserControl.ValueCommitted"/> event and the
+/// <see cref="IKryptonDropDownUserControl.CommitValue"/> event raised by the drop-down content.
+/// </summary>
+public class KryptonDropDownCommitEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KryptonDropDownCommitEventArgs"/> class.
+    /// </summary>
+    /// <param name="value">The picked value (any object). Pass <see langword="null"/> to clear the host's value.</param>
+    /// <param name="displayText">The text to write into the host's editor. Pass <see langword="null"/> to leave the editor unchanged.</param>
+    public KryptonDropDownCommitEventArgs(object? value, string? displayText)
+    {
+        Value = value;
+        DisplayText = displayText;
+    }
+
+    /// <summary>
+    /// Gets the picked value. May be <see langword="null"/>.
+    /// </summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// Gets the display text to push into the host's editor. May be <see langword="null"/>.
+    /// </summary>
+    public string? DisplayText { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the drop-down should remain open after the value
+    /// is committed. Default is <see langword="false"/> &#8211; the popup closes immediately.
+    /// </summary>
+    public bool KeepOpen { get; set; }
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/EventArgs/KryptonDropDownOpeningEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/EventArgs/KryptonDropDownOpeningEventArgs.cs
@@ -1,0 +1,32 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Provides data for the <see cref="KryptonComboBoxUserControl.DropDownOpening"/> event,
+/// allowing subscribers to suppress the drop-down before it appears.
+/// </summary>
+public class KryptonDropDownOpeningEventArgs : CancelEventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KryptonDropDownOpeningEventArgs"/> class.
+    /// </summary>
+    /// <param name="dropContent">The user control that is about to be shown.</param>
+    public KryptonDropDownOpeningEventArgs(Control? dropContent)
+    {
+        DropContent = dropContent;
+    }
+
+    /// <summary>
+    /// Gets the user control that is about to be shown. May be <see langword="null"/> when no
+    /// drop-down content has been assigned.
+    /// </summary>
+    public Control? DropContent { get; }
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/General/IKryptonDropDownFilterable.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/General/IKryptonDropDownFilterable.cs
@@ -1,0 +1,49 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Optional contract a drop-down content control can implement to participate in the host's
+/// "filter-as-you-type" auto-complete pipeline.
+/// </summary>
+/// <remarks>
+/// When <see cref="KryptonComboBoxUserControl.AutoOpenOnType"/> is <see langword="true"/> and the
+/// user types in the editor, the host will automatically open the drop-down (without stealing
+/// focus from the editor) and forward the current text to <see cref="ApplyFilter"/>. While the
+/// popup is open, Up/Down arrow keys are forwarded to <see cref="NavigateSelection"/> and
+/// Enter is forwarded to <see cref="CommitSelection"/>, mimicking the auto-complete UX of a
+/// native ComboBox.
+/// </remarks>
+public interface IKryptonDropDownFilterable
+{
+    /// <summary>
+    /// Update the drop-down content based on the current editor text.
+    /// </summary>
+    /// <param name="text">The current text in the editor.</param>
+    /// <returns>
+    /// <see langword="true"/> when at least one item matches the filter, <see langword="false"/>
+    /// when no items match. The host may close the popup when this returns <see langword="false"/>.
+    /// </returns>
+    bool ApplyFilter(string text);
+
+    /// <summary>
+    /// Move the selection within the drop-down content.
+    /// </summary>
+    /// <param name="direction">+1 for "next" (Down arrow), -1 for "previous" (Up arrow).</param>
+    void NavigateSelection(int direction);
+
+    /// <summary>
+    /// Commit the currently selected item in the drop-down. The implementation is expected to
+    /// raise <see cref="IKryptonDropDownUserControl.CommitValue"/> when there is a valid
+    /// selection to commit.
+    /// </summary>
+    /// <returns><see langword="true"/> if a value was committed; otherwise <see langword="false"/>.</returns>
+    bool CommitSelection();
+}

--- a/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/General/IKryptonDropDownUserControl.cs
+++ b/Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/General/IKryptonDropDownUserControl.cs
@@ -1,0 +1,68 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Utilities;
+
+/// <summary>
+/// Optional contract a developer-supplied <see cref="UserControl"/> can implement so that the
+/// hosting <see cref="KryptonComboBoxUserControl"/> can drive sizing, life-cycle events and value
+/// commit/cancel signalling. Implementing the interface is not required &#8211; a control hosted by
+/// <see cref="KryptonComboBoxUserControl"/> that does not implement it will simply be displayed at
+/// the size requested via <c>DropDownWidth</c> / <c>DropDownHeight</c>.
+/// </summary>
+public interface IKryptonDropDownUserControl
+{
+    /// <summary>
+    /// Gives the drop-down content a chance to declare its preferred initial size before the
+    /// popup is shown. Return <see cref="Size.Empty"/> to fall back to the host's
+    /// <c>DropDownWidth</c> / <c>DropDownHeight</c> values.
+    /// </summary>
+    /// <param name="proposedSize">Size proposed by the host (typically the host's preferred size).</param>
+    /// <returns>The preferred size for the popup, or <see cref="Size.Empty"/> to use defaults.</returns>
+    Size GetPreferredDropSize(Size proposedSize);
+
+    /// <summary>
+    /// Called immediately before the drop-down is shown. Allows the content to refresh data,
+    /// preselect items, etc.
+    /// </summary>
+    /// <param name="owner">The hosting <see cref="KryptonComboBoxUserControl"/>.</param>
+    void OnDropDownOpening(object owner);
+
+    /// <summary>
+    /// Called once the drop-down has been shown.
+    /// </summary>
+    /// <param name="owner">The hosting <see cref="KryptonComboBoxUserControl"/>.</param>
+    void OnDropDownOpened(object owner);
+
+    /// <summary>
+    /// Called when the drop-down is about to close. Implementations can suppress closing by
+    /// setting <paramref name="cancel"/> to <see langword="true"/>.
+    /// </summary>
+    /// <param name="owner">The hosting <see cref="KryptonComboBoxUserControl"/>.</param>
+    /// <param name="cancel">Set to <see langword="true"/> to keep the drop-down open.</param>
+    void OnDropDownClosing(object owner, ref bool cancel);
+
+    /// <summary>
+    /// Called once the drop-down has been hidden.
+    /// </summary>
+    /// <param name="owner">The hosting <see cref="KryptonComboBoxUserControl"/>.</param>
+    void OnDropDownClosed(object owner);
+
+    /// <summary>
+    /// Raised by the drop-down content when the user picks a value. The host listens to this
+    /// event to update its <c>Text</c> / <c>SelectedValue</c> and (optionally) close the popup.
+    /// </summary>
+    event EventHandler<KryptonDropDownCommitEventArgs> CommitValue;
+
+    /// <summary>
+    /// Raised by the drop-down content when it wants the popup to close without committing
+    /// (for example when the user presses Escape inside the user control).
+    /// </summary>
+    event EventHandler RequestClose;
+}

--- a/Source/Krypton Components/TestForm/KryptonComboBoxUserControlDemo.cs
+++ b/Source/Krypton Components/TestForm/KryptonComboBoxUserControlDemo.cs
@@ -1,0 +1,415 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+using Krypton.Toolkit;
+using Krypton.Utilities;
+
+namespace TestForm;
+
+/// <summary>
+/// Demonstrates <see cref="KryptonComboBoxUserControl"/> &#8211; a ComboBox-style control whose
+/// drop-down hosts any <see cref="UserControl"/>. Implements feature request #3443.
+/// </summary>
+public sealed class KryptonComboBoxUserControlDemo : KryptonForm
+{
+    private readonly KryptonComboBoxUserControl _treePickerCombo;
+    private readonly KryptonComboBoxUserControl _gridPickerCombo;
+    private readonly KryptonComboBoxUserControl _plainCombo;
+    private readonly KryptonComboBoxUserControl _filterCombo;
+    private readonly KryptonLabel _statusLabel;
+
+    public KryptonComboBoxUserControlDemo()
+    {
+        Text = @"KryptonComboBoxUserControl Demo (Issue #3443)";
+        StartPosition = FormStartPosition.CenterScreen;
+        ClientSize = new Size(720, 410);
+        Padding = new Padding(12);
+
+        var tlp = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            RowCount = 5,
+            ColumnStyles = { new ColumnStyle(SizeType.Absolute, 220), new ColumnStyle(SizeType.Percent, 100) },
+        };
+        tlp.RowStyles.Add(new RowStyle(SizeType.Absolute, 50));
+        tlp.RowStyles.Add(new RowStyle(SizeType.Absolute, 50));
+        tlp.RowStyles.Add(new RowStyle(SizeType.Absolute, 50));
+        tlp.RowStyles.Add(new RowStyle(SizeType.Absolute, 50));
+        tlp.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+
+        // 1) Tree-picker drop-down (implements IKryptonDropDownUserControl)
+        tlp.Controls.Add(new KryptonLabel { Text = @"Tree picker:" }, 0, 0);
+        _treePickerCombo = new KryptonComboBoxUserControl
+        {
+            Width = 320,
+            DropContent = new TreePickerControl(),
+            DropDownResizable = true,
+            DropDownWidth = 280,
+            DropDownHeight = 240
+        };
+        _treePickerCombo.ValueCommitted += OnValueCommitted;
+        tlp.Controls.Add(_treePickerCombo, 1, 0);
+
+        // 2) Grid-picker drop-down (also implements the contract; multi-column data)
+        tlp.Controls.Add(new KryptonLabel { Text = @"Grid picker:" }, 0, 1);
+        _gridPickerCombo = new KryptonComboBoxUserControl
+        {
+            Width = 320,
+            ReadOnlyEditor = true,
+            DropContent = new GridPickerControl(),
+            DropDownResizable = true,
+            DropDownWidth = 380,
+            DropDownHeight = 220,
+            DropDownAlign = LeftRightAlignment.Right
+        };
+        _gridPickerCombo.ValueCommitted += OnValueCommitted;
+        tlp.Controls.Add(_gridPickerCombo, 1, 1);
+
+        // 3) Plain UserControl drop-down (no contract; demonstrates the fallback path)
+        tlp.Controls.Add(new KryptonLabel { Text = @"Plain control:" }, 0, 2);
+        _plainCombo = new KryptonComboBoxUserControl
+        {
+            Width = 320,
+            DropContent = BuildPlainColorPalette(),
+            DropDownWidth = 240,
+            DropDownHeight = 160
+        };
+        _plainCombo.ValueCommitted += OnValueCommitted;
+        tlp.Controls.Add(_plainCombo, 1, 2);
+
+        // 4) Filter-as-you-type city picker (implements both contracts; AutoOpenOnType)
+        tlp.Controls.Add(new KryptonLabel { Text = @"Filter-as-you-type:" }, 0, 3);
+        _filterCombo = new KryptonComboBoxUserControl
+        {
+            Width = 320,
+            DropContent = new CityFilterControl(),
+            AutoOpenOnType = true,
+            MinFilterLength = 1,
+            DropDownWidth = 280,
+            DropDownHeight = 200
+        };
+        _filterCombo.CueHint.CueHintText = @"Start typing a city name…";
+        _filterCombo.ValueCommitted += OnValueCommitted;
+        tlp.Controls.Add(_filterCombo, 1, 3);
+
+        // Status label
+        _statusLabel = new KryptonLabel
+        {
+            Text = @"Pick a value. Try F4 / Alt+Down to open. The bottom combo opens automatically as you type and Up/Down/Enter navigate the list.",
+            Dock = DockStyle.Top
+        };
+        var statusHost = new KryptonPanel { Dock = DockStyle.Fill, Padding = new Padding(0, 12, 0, 0) };
+        statusHost.Controls.Add(_statusLabel);
+        tlp.Controls.Add(statusHost, 0, 4);
+        tlp.SetColumnSpan(statusHost, 2);
+
+        Controls.Add(tlp);
+    }
+
+    private void OnValueCommitted(object? sender, KryptonDropDownCommitEventArgs e)
+    {
+        var which = ReferenceEquals(sender, _treePickerCombo) ? "Tree"
+                  : ReferenceEquals(sender, _gridPickerCombo) ? "Grid"
+                  : ReferenceEquals(sender, _filterCombo) ? "Filter"
+                  : "Plain";
+        _statusLabel.Text = $@"[{which}] DisplayText='{e.DisplayText}', Value='{e.Value}'";
+    }
+
+    private static UserControl BuildPlainColorPalette()
+    {
+        // A user control without IKryptonDropDownUserControl - the popup just shows it
+        var panel = new UserControl { BackColor = Color.WhiteSmoke };
+        var flow = new FlowLayoutPanel { Dock = DockStyle.Fill, Padding = new Padding(6) };
+        Color[] colors = { Color.Tomato, Color.Goldenrod, Color.MediumSeaGreen, Color.SteelBlue, Color.MediumOrchid, Color.SlateGray };
+        foreach (var c in colors)
+        {
+            var btn = new KryptonButton
+            {
+                Width = 80,
+                Height = 28,
+                Margin = new Padding(4)
+            };
+            btn.Values.Text = c.Name;
+            btn.StateCommon.Back.Color1 = c;
+            btn.StateCommon.Back.Color2 = c;
+            flow.Controls.Add(btn);
+        }
+        panel.Controls.Add(flow);
+        return panel;
+    }
+
+    #region Tree picker drop-down
+
+    private sealed class TreePickerControl : UserControl, IKryptonDropDownUserControl
+    {
+        private readonly KryptonTreeView _tree;
+
+        public TreePickerControl()
+        {
+            _tree = new KryptonTreeView { Dock = DockStyle.Fill };
+            _tree.Nodes.Add(BuildNode("Continents",
+                BuildNode("Europe", BuildNode("United Kingdom"), BuildNode("Germany"), BuildNode("France")),
+                BuildNode("North America", BuildNode("USA"), BuildNode("Canada"), BuildNode("Mexico")),
+                BuildNode("Asia", BuildNode("Japan"), BuildNode("South Korea"), BuildNode("India"))));
+            foreach (TreeNode root in _tree.Nodes)
+            {
+                root.Expand();
+                foreach (TreeNode child in root.Nodes)
+                {
+                    child.Expand();
+                }
+            }
+            _tree.NodeMouseDoubleClick += OnNodeDoubleClick;
+            _tree.KeyDown += OnTreeKeyDown;
+            Controls.Add(_tree);
+        }
+
+        public Size GetPreferredDropSize(Size proposedSize) => new Size(260, 240);
+
+        public void OnDropDownOpening(object owner) { }
+
+        public void OnDropDownOpened(object owner) => _tree.Focus();
+
+        public void OnDropDownClosing(object owner, ref bool cancel) { }
+
+        public void OnDropDownClosed(object owner) { }
+
+        public event EventHandler<KryptonDropDownCommitEventArgs>? CommitValue;
+        public event EventHandler? RequestClose;
+
+        private static TreeNode BuildNode(string text, params TreeNode[] children)
+        {
+            var node = new TreeNode(text);
+            node.Nodes.AddRange(children);
+            return node;
+        }
+
+        private void OnNodeDoubleClick(object? sender, TreeNodeMouseClickEventArgs e)
+        {
+            if (e.Node != null && e.Node.Nodes.Count == 0)
+            {
+                CommitValue?.Invoke(this, new KryptonDropDownCommitEventArgs(e.Node.FullPath, e.Node.Text));
+            }
+        }
+
+        private void OnTreeKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && _tree.SelectedNode is { Nodes.Count: 0 } selected)
+            {
+                CommitValue?.Invoke(this, new KryptonDropDownCommitEventArgs(selected.FullPath, selected.Text));
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
+            else if (e.KeyCode == Keys.Escape)
+            {
+                RequestClose?.Invoke(this, EventArgs.Empty);
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
+        }
+    }
+
+    #endregion
+
+    #region Grid picker drop-down
+
+    private sealed class GridPickerControl : UserControl, IKryptonDropDownUserControl
+    {
+        private readonly KryptonDataGridView _grid;
+
+        public GridPickerControl()
+        {
+            _grid = new KryptonDataGridView
+            {
+                Dock = DockStyle.Fill,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                ReadOnly = true,
+                RowHeadersVisible = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            _grid.Columns.Add("Code", "Code");
+            _grid.Columns.Add("Name", "Name");
+            _grid.Columns.Add("Currency", "Currency");
+            _grid.Rows.Add("UK", "United Kingdom", "GBP");
+            _grid.Rows.Add("US", "United States", "USD");
+            _grid.Rows.Add("DE", "Germany", "EUR");
+            _grid.Rows.Add("FR", "France", "EUR");
+            _grid.Rows.Add("JP", "Japan", "JPY");
+            _grid.Rows.Add("AU", "Australia", "AUD");
+            _grid.Columns[0].Width = 60;
+            _grid.CellDoubleClick += OnGridCellDoubleClick;
+            _grid.KeyDown += OnGridKeyDown;
+            Controls.Add(_grid);
+        }
+
+        public Size GetPreferredDropSize(Size proposedSize) => new Size(360, 200);
+
+        public void OnDropDownOpening(object owner) { }
+
+        public void OnDropDownOpened(object owner) => _grid.Focus();
+
+        public void OnDropDownClosing(object owner, ref bool cancel) { }
+
+        public void OnDropDownClosed(object owner) { }
+
+        public event EventHandler<KryptonDropDownCommitEventArgs>? CommitValue;
+        public event EventHandler? RequestClose;
+
+        private void OnGridCellDoubleClick(object? sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0)
+            {
+                return;
+            }
+            CommitFromRow(_grid.Rows[e.RowIndex]);
+        }
+
+        private void OnGridKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && _grid.CurrentRow != null)
+            {
+                CommitFromRow(_grid.CurrentRow);
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
+            else if (e.KeyCode == Keys.Escape)
+            {
+                RequestClose?.Invoke(this, EventArgs.Empty);
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
+        }
+
+        private void CommitFromRow(DataGridViewRow row)
+        {
+            var code = row.Cells[0].Value?.ToString() ?? string.Empty;
+            var name = row.Cells[1].Value?.ToString() ?? string.Empty;
+            var currency = row.Cells[2].Value?.ToString() ?? string.Empty;
+            CommitValue?.Invoke(this, new KryptonDropDownCommitEventArgs(
+                value: new { Code = code, Name = name, Currency = currency },
+                displayText: $"{name} ({currency})"));
+        }
+    }
+
+    #endregion
+
+    #region Filter-as-you-type drop-down
+
+    private sealed class CityFilterControl : UserControl, IKryptonDropDownUserControl, IKryptonDropDownFilterable
+    {
+        private static readonly string[] AllCities =
+        {
+            "Amsterdam", "Athens", "Auckland", "Bangkok", "Barcelona", "Beijing", "Berlin",
+            "Brisbane", "Brussels", "Budapest", "Buenos Aires", "Cairo", "Cape Town", "Chicago",
+            "Copenhagen", "Dubai", "Dublin", "Edinburgh", "Florence", "Geneva", "Helsinki",
+            "Hong Kong", "Honolulu", "Istanbul", "Jakarta", "Johannesburg", "Kuala Lumpur",
+            "Lisbon", "London", "Los Angeles", "Madrid", "Manila", "Melbourne", "Mexico City",
+            "Milan", "Montreal", "Moscow", "Mumbai", "Nairobi", "Naples", "New York", "Oslo",
+            "Paris", "Prague", "Rio de Janeiro", "Rome", "San Francisco", "Santiago", "Sao Paulo",
+            "Seoul", "Shanghai", "Singapore", "Stockholm", "Sydney", "Taipei", "Tokyo", "Toronto",
+            "Vancouver", "Venice", "Vienna", "Warsaw", "Wellington", "Zurich"
+        };
+
+        private readonly KryptonListBox _list;
+
+        public CityFilterControl()
+        {
+            _list = new KryptonListBox { Dock = DockStyle.Fill };
+            _list.DoubleClick += OnListDoubleClick;
+            Controls.Add(_list);
+            ApplyFilter(string.Empty);
+        }
+
+        public Size GetPreferredDropSize(Size proposedSize) => new Size(260, 220);
+
+        public void OnDropDownOpening(object owner) { }
+
+        public void OnDropDownOpened(object owner)
+        {
+            // Don't steal focus - the host wants the editor to keep focus while the user types
+        }
+
+        public void OnDropDownClosing(object owner, ref bool cancel) { }
+
+        public void OnDropDownClosed(object owner) { }
+
+        public event EventHandler<KryptonDropDownCommitEventArgs>? CommitValue;
+#pragma warning disable CS0067 // Event is part of the IKryptonDropDownUserControl contract; this scenario doesn't request close from inside
+        public event EventHandler? RequestClose;
+#pragma warning restore CS0067
+
+        public bool ApplyFilter(string text)
+        {
+            _list.BeginUpdate();
+            try
+            {
+                _list.Items.Clear();
+                IEnumerable<string> matches = string.IsNullOrEmpty(text)
+                    ? AllCities
+                    : AllCities.Where(c => c.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0);
+
+                foreach (string city in matches)
+                {
+                    _list.Items.Add(city);
+                }
+
+                if (_list.Items.Count > 0)
+                {
+                    _list.SelectedIndex = 0;
+                }
+            }
+            finally
+            {
+                _list.EndUpdate();
+            }
+
+            return _list.Items.Count > 0;
+        }
+
+        public void NavigateSelection(int direction)
+        {
+            if (_list.Items.Count == 0)
+            {
+                return;
+            }
+
+            int idx = _list.SelectedIndex + direction;
+            if (idx < 0)
+            {
+                idx = _list.Items.Count - 1;
+            }
+            else if (idx >= _list.Items.Count)
+            {
+                idx = 0;
+            }
+
+            _list.SelectedIndex = idx;
+            _list.TopIndex = Math.Max(0, idx - 4);
+        }
+
+        public bool CommitSelection()
+        {
+            if (_list.SelectedItem is string city)
+            {
+                CommitValue?.Invoke(this, new KryptonDropDownCommitEventArgs(city, city));
+                return true;
+            }
+
+            return false;
+        }
+
+        private void OnListDoubleClick(object? sender, EventArgs e) => CommitSelection();
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -63,6 +63,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<ButtonTextTrackingExample>("Button Text Tracking", "Demonstrates alternate text color for tracking (hover) state on KryptonButton, KryptonCheckButton, KryptonColorButton and other controls (Issue #1326). Improves readability in dark themes.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<KryptonColorButtonDemo>("KryptonColorButton Custom Colours", "Comprehensive demo of KryptonColorButton custom colours (Issue #776): CustomColors, MaxCustomColors, and visibility. Only 10 colours, or custom + theme + standard, or cap display count.");
+        CreateButton<KryptonComboBoxUserControlDemo>("KryptonComboBoxUserControl", "Demo for Issue #3443: a ComboBox-style control whose drop-down hosts any UserControl. Shows tree-picker, grid-picker and a plain (non-contract) UserControl scenario.");
         CreateButton<BorderlessFormDemo>("Borderless Form Demo", "Demo for Issue #2922: Borderless KryptonForm without system title bar flicker on startup. Form should appear directly in borderless state.");
         CreateButton<Bug2914Test>("Bug 2914 Test", "Tests the fix for 2914.");
         CreateButton<Bug2984SeparatorTest>("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.");


### PR DESCRIPTION
# `KryptonComboBoxUserControl` — ComboBox-style host for *any* `UserControl`

Closes [#3443](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3443)

## Summary

Adds a brand-new `KryptonComboBoxUserControl` to the `Krypton.Utilities` assembly. The control behaves like a normal Krypton ComboBox — a single-line editor with a drop button on the right edge — but its drop-down portion can host **any** `Control` you assign to the new `DropContent` property (typically a developer-supplied `UserControl`, `KryptonTreeView`, `KryptonDataGridView`, custom picker panel, etc.).

The drop content is optional in the truest sense: a plain `UserControl` "just works" and is hosted at the size requested via `DropDownWidth` / `DropDownHeight`. Content that wants tighter integration can opt into the new `IKryptonDropDownUserControl` contract for lifecycle callbacks, auto-sizing, and commit/cancel signalling, or into the new `IKryptonDropDownFilterable` contract for filter-as-you-type auto-completion.

## Why a new control instead of extending `KryptonComboBox`?

`KryptonComboBox` wraps a native Win32 `COMBOBOX` for its list portion — swapping that out for an arbitrary managed `Control` would either fight the underlying handle or change well-understood semantics. A clean, dedicated control derived from `KryptonTextBox` keeps the editor experience identical to the rest of the Krypton input controls and gives the new feature its own property and event surface without breaking existing consumers.

## New types

All types live in the `Krypton.Utilities` namespace under `Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/`.

| Type | Kind | Purpose |
| --- | --- | --- |
| `KryptonComboBoxUserControl` | `KryptonTextBox`-derived control | The public control. | | `IKryptonDropDownUserControl` | Public interface | Optional contract on drop content for sizing, lifecycle, commit/cancel. | | `IKryptonDropDownFilterable` | Public interface | Optional contract on drop content for filter-as-you-type auto-completion. | | `KryptonDropDownCommitEventArgs` | Public `EventArgs` | Carries `Value`, `DisplayText`, `KeepOpen` from drop content to host. | | `KryptonDropDownOpeningEventArgs` | Public `CancelEventArgs` | Cancellable event raised before the popup appears. | | `VisualKryptonDropDownPopup` | `internal sealed` `VisualPopup` | Hosts the drop content, handles anchoring, resizing and dismissal. | | `KryptonComboBoxUserControlDesigner` | `internal` `ControlDesigner` | Adds smart-tag actions, constrains resize to horizontal only, exposes `ButtonSpecs` for select/copy/cut/paste. | | `KryptonComboBoxUserControlActionList` | `internal` `DesignerActionList` | Smart-tag verbs surface alignment, sizing, resizable flag, read-only editor flag, style and palette. | | `KryptonDropContentEditor` | `internal` `UITypeEditor` | Property-grid drop-down for `DropContent`: pick an existing `Control` on the same form **or** instantiate a `UserControl`-derived type discovered via `ITypeDiscoveryService`. |

## API surface (key bits)

### Properties

| Property | Type | Default | Description |
| --- | --- | --- | --- |
| `DropContent` | `Control?` | `null` | The control shown in the popup. | | `DropDownAlign` | `LeftRightAlignment` | `Left` | Horizontal alignment of the popup relative to the editor. | | `DropDownWidth` / `DropDownHeight` | `int` | `200` / `200` | Initial popup size; ignored when `DropContent` returns a non-empty preferred size. | | `MinDropDownSize` / `MaxDropDownSize` | `Size` | `Size.Empty` | Optional resize clamps. | | `DropDownResizable` | `bool` | `false` | Shows a bottom-right resize grip and routes `WM_NCHITTEST` to `HT.BOTTOMRIGHT` so the popup is OS-resizable without dismissing. | | `ReadOnlyEditor` | `bool` | `false` | Mimics `ComboBoxStyle.DropDownList` — the editor is read-only and selection happens through the drop-down only. | | `AutoOpenOnType` | `bool` | `false` | Opens the popup automatically as the user types and forwards text to a filterable drop content. | | `MinFilterLength` | `int` | `1` | Number of characters required before `AutoOpenOnType` triggers. | | `SelectedValue` | `object?` | — | Last value committed by the drop content. | | `IsDroppedDown` | `bool` | — | Whether the popup is currently visible. | | `DropButton` | `ButtonSpecAny` | — | Access to the drop button spec for customisation (image, tooltip, etc.). |

### Events

| Event | Args | Notes |
| --- | --- | --- |
| `DropDownOpening` | `KryptonDropDownOpeningEventArgs` | Cancellable; lets subscribers veto the popup. | | `DropDownOpened` | `EventArgs` | After the popup is shown. | | `DropDownClosed` | `EventArgs` | After the popup is hidden (commit, cancel, or click-outside). | | `ValueCommitted` | `KryptonDropDownCommitEventArgs` | The drop content has committed a value. Default event of the control. |

### Methods

- `ShowDropDown()` / `ShowDropDown(bool retainEditorFocus)` — open programmatically.
- `CloseDropDown()` — close programmatically.

### Keyboard conventions (matches WinForms `ComboBox`)

- **F4** — toggles the drop-down.
- **Alt+Down** — opens.
- **Alt+Up** / **Escape** — closes.
- **Up / Down / Enter** — forwarded to `IKryptonDropDownFilterable` when the popup is open and the editor still has focus (filter-as-you-type pattern).

## How sizing works

1. Host proposes `(DropDownWidth, DropDownHeight)`.
2. If the drop content implements `IKryptonDropDownUserControl`, `GetPreferredDropSize(proposedSize)` may return a different size (return `Size.Empty` to fall back to the host's values).
3. The popup clamps against `MinDropDownSize` and `MaxDropDownSize`.
4. Width is never narrower than the editor itself.
5. The popup prefers to appear *below* the editor; when there isn't enough working-area room it flips *above*; when neither fits, it clamps to the work area and trims height.

## Designer experience

- `[Designer(typeof(KryptonComboBoxUserControlDesigner))]` — surfaces smart tags and locks the design-time selection rules to **horizontal resize only** (matches `KryptonTextBox` / `KryptonComboBox`).
- Smart-tag verbs: alignment, width, height, resizable, read-only editor, input control style, palette mode.
- `[Editor(typeof(KryptonDropContentEditor), typeof(UITypeEditor))]` on `DropContent` — opens a list that shows:
  - `(none)`
  - `─── Existing controls ───` followed by every `Control` already on the same designer host (excluding `Form` and `KryptonTextBox`-derived editors).
  - `─── New instance ───` followed by every `UserControl`-derived type with a public parameterless constructor discovered via `ITypeDiscoveryService` (`excludeGlobalTypes: true`, so framework types are filtered out).
- When the designer picks a `[New] …` row the editor calls `IDesignerHost.CreateComponent(type)`, so the new component is sited on the host and emitted into `Designer.cs` code-gen. The new control is not auto-added to any visual parent — drop-down content typically should not also live on the form surface.

## Build coverage

- Builds for **all** supported TFMs of `Krypton.Utilities`: `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net11.0-windows`.
- `0 Warning(s) / 0 Error(s)` across the full solution build.
- Language version `preview` with nullable reference types enabled — no new `#nullable` warnings introduced.

## TestForm demo

`Source/Krypton Components/TestForm/KryptonComboBoxUserControlDemo.cs` ships four scenarios that double as smoke tests:

1. **Tree picker** — a `KryptonTreeView` inside a `UserControl` that implements `IKryptonDropDownUserControl`. Demonstrates resizable popups, double-click / Enter commit, and Escape cancel.
2. **Grid picker** — a `KryptonDataGridView` with multi-column data, right-aligned drop-down, and a read-only editor.
3. **Plain `UserControl`** — a flow-laid-out colour palette that does *not* implement the contract; proves the fallback path.
4. **Filter-as-you-type city picker** — a `KryptonListBox` inside a `UserControl` that implements both `IKryptonDropDownUserControl` and `IKryptonDropDownFilterable`. Demonstrates `AutoOpenOnType` plus Up/Down/Enter routing while the editor keeps focus.

The demo is wired into `StartScreen` so it shows up in the standard TestForm launcher.

## Files changed

- **New** (all under `Source/Krypton Components/Krypton.Utilities/Components/KryptonComboBoxUserControl/`):
  - `Controls Toolkit/KryptonComboBoxUserControl.cs`
  - `Controls Visuals/VisualKryptonDropDownPopup.cs`
  - `General/IKryptonDropDownUserControl.cs`
  - `General/IKryptonDropDownFilterable.cs`
  - `EventArgs/KryptonDropDownCommitEventArgs.cs`
  - `EventArgs/KryptonDropDownOpeningEventArgs.cs`
  - `Designers/Designers/KryptonComboBoxUserControlDesigner.cs`
  - `Designers/Action Lists/KryptonComboBoxUserControlActionList.cs`
  - `Designers/Editors/KryptonDropContentEditor.cs`
- **New**: `Source/Krypton Components/TestForm/KryptonComboBoxUserControlDemo.cs`
- **Modified**: `Source/Krypton Components/TestForm/StartScreen.cs` — adds a launcher button for the new demo.
- **Modified**: `Documents/Changelog/Changelog.md` — new entry under the **2026-11-xx — Build 2611 (V110 Nightly)** section.

## Test plan

Build:

- [x] `dotnet build "Source/Krypton Components/Krypton.Utilities/Krypton.Utilities.csproj" -c Debug -f net472`
- [x] `dotnet build "Source/Krypton Components/Krypton.Utilities/Krypton.Utilities.csproj" -c Debug -f net8.0-windows`
- [x] Full solution build with `0 Warning(s) / 0 Error(s)`.

Manual / TestForm verification (steps for the reviewer):

1. Launch `TestForm`, click **KryptonComboBoxUserControl Demo**.
2. **Tree picker** — open with the drop button, press **F4** and **Alt+Down**, resize the popup from the bottom-right corner, double-click a leaf and verify the editor text and status label update.
3. **Grid picker** — verify the popup right-aligns to the editor, that the editor is read-only, and that **Enter** commits the current row.
4. **Plain colour panel** — verify the popup appears at the requested dimensions and dismisses on click-outside.
5. **Filter-as-you-type** — type "lon"; the popup opens automatically, the list narrows to matches, **Down/Up** navigate selection, **Enter** commits, and the editor retains focus throughout.
6. **Escape** — closes the popup without committing.
7. **Designer smoke test**:
   - Drop `KryptonComboBoxUserControl` on a form; verify the smart-tag panel exposes the documented verbs.
   - Open the **DropContent** property in the property grid; verify the dropdown lists `(none)`, existing controls, **and** the `[New] TypeName (Namespace)` rows for every `UserControl`-derived type in the project. Picking a `[New]` row creates a sited component that appears in `Designer.cs`.

## Breaking changes

None. Pure addition under `Krypton.Utilities`. No public API on existing controls was changed.

## Packaging note

The new control ships in the `Krypton.Utilities` assembly, so consumers need the `Krypton.Standard.Toolkit` NuGet package (which packs all sub-assemblies) — this is noted in the changelog entry.

- Optional collection-editor-style designer dialog for `DropContent` that lets designers paste in a fully-built `UserControl` defined in another file. The smart-tag + `KryptonDropContentEditor` shipped here cover both "pick existing" and "instantiate a new type"; a richer dialog would be polish on top.

<img width="662" height="257" alt="image" src="https://github.com/user-attachments/assets/3a3fbd2b-e9eb-4015-aed0-e14c87c03f12" />
