### PR TITLE
* Fix `Krypton.Standard.Toolkit` pack output layout; add NuGet push s…

### DIFF
--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -247,9 +247,16 @@ jobs:
 
           $packages = Get-ChildItem "Artefacts/Packages/Canary/*.nupkg" -ErrorAction SilentlyContinue
           $publishedAny = $false
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
 
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing Canary LTS package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -268,9 +275,14 @@ jobs:
             Write-Output "No NuGet packages found to push"
           }
 
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -264,9 +264,16 @@ jobs:
           )
           $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
 
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -285,9 +292,14 @@ jobs:
             Write-Output "No NuGet packages found to push"
           }
 
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -306,9 +306,16 @@ jobs:
           )
           $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
 
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -328,9 +335,14 @@ jobs:
             Write-Output "No NuGet packages found to push"
           }
 
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,9 +221,16 @@ jobs:
           )
           $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
-          
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
+
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -242,10 +249,15 @@ jobs:
           } else {
             Write-Output "No NuGet packages found to push"
           }
-          
+
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         # Kill switch check
@@ -541,9 +553,16 @@ jobs:
           )
           $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
-          
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
+
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -562,10 +581,15 @@ jobs:
           } else {
             Write-Output "No NuGet packages found to push"
           }
-          
+
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         # Kill switch check
@@ -880,9 +904,16 @@ jobs:
           )
           $packages = @(Get-ChildItem -Path $packageCandidates -ErrorAction SilentlyContinue | Sort-Object FullName -Unique)
           $publishedAny = $false
-          
+          $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/StandardToolkitNupkgGuard.ps1')
+          $standardToolkitNupkgSizeGateFailed = $false
+
           if ($packages) {
             foreach ($package in $packages) {
+              if (-not (Test-StandardToolkitNupkgPushAllowed -Package $package)) {
+                $standardToolkitNupkgSizeGateFailed = $true
+                continue
+              }
               Write-Output "Pushing package: $($package.Name)"
               try {
                 $output = dotnet nuget push "$($package.FullName)" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate 2>&1 | Out-String
@@ -901,10 +932,15 @@ jobs:
           } else {
             Write-Output "No NuGet packages found to push"
           }
-          
+
+          if ($standardToolkitNupkgSizeGateFailed) {
+            exit 1
+          }
+
           echo "packages_published=$publishedAny" >> $env:GITHUB_OUTPUT
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          STANDARD_TOOLKIT_MIN_NUPKG_MB: ${{ vars.STANDARD_TOOLKIT_MIN_NUPKG_MB }}
 
       - name: Get Version
         # Kill switch check

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -53,7 +53,7 @@
 * Resolved [#3381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3381), Vertical text centering on a rounded-corner `KryptonButton`
 * Implemented [#3380](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3380), `KryptonToolTip` - A user control/component wrapper around the existing KToolTips
 * Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents
-* Resolved [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377), `Krypton.Standard.Toolkit` NuGet package does not contain all binaries
+* Resolved [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377), `Krypton.Standard.Toolkit` NuGet package does not contain all binaries (pack path fixes from [#3404](https://github.com/Krypton-Suite/Standard-Toolkit/pull/3404) plus `OutDir` aligned with shared `OutputPath` in `Directory.Build.targets` so builds with `UseArtifactsOutput=true` write DLLs where pack collects them)
 * Resolved [#3164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3164), Font properties with no explicit value were not correctly serialized/deserialized in exported XML
 * Resolved [#3183](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3183), Small square rendered next to Close button on KryptonForm when using a custom theme
 * Implemented [#908](https://github.com/Krypton-Suite/Standard-Toolkit/issues/908), Create new items via 'New Item/Project'

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -14,21 +14,21 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Clean" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Restore" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" />
 	</Target>
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
@@ -50,10 +50,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Pack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -28,7 +28,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)" Targets="Build" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/Scripts/CI/StandardToolkitNupkgGuard.ps1
+++ b/Scripts/CI/StandardToolkitNupkgGuard.ps1
@@ -1,0 +1,49 @@
+# Shared guard for workflows that publish Krypton.Standard.Toolkit aggregate packages (.nupkg only).
+# Dot-source this script, then call Test-StandardToolkitNupkgPushAllowed before dotnet nuget push.
+#
+# Minimum size (default 10 MiB):
+#   - GitHub Actions: set repository variable STANDARD_TOOLKIT_MIN_NUPKG_MB (integer megabytes).
+#     Workflows pass it as env STANDARD_TOOLKIT_MIN_NUPKG_MB.
+#   - Optional env STANDARD_TOOLKIT_MIN_NUPKG_BYTES overrides when set to a positive integer (bytes).
+
+function Get-StandardToolkitMinNupkgBytes {
+    $bytesRaw = $env:STANDARD_TOOLKIT_MIN_NUPKG_BYTES
+    if (-not [string]::IsNullOrWhiteSpace($bytesRaw)) {
+        $b = [long]0
+        if ([long]::TryParse($bytesRaw.Trim(), [ref]$b) -and $b -gt 0) {
+            return $b
+        }
+    }
+
+    $mbRaw = $env:STANDARD_TOOLKIT_MIN_NUPKG_MB
+    if (-not [string]::IsNullOrWhiteSpace($mbRaw)) {
+        $m = [long]0
+        if ([long]::TryParse($mbRaw.Trim(), [ref]$m) -and $m -gt 0) {
+            return $m * [long](1024 * 1024)
+        }
+    }
+
+    return [long](10 * 1024 * 1024)
+}
+
+function Test-StandardToolkitNupkgPushAllowed {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$Package
+    )
+
+    $minBytes = Get-StandardToolkitMinNupkgBytes
+
+    if (-not $Package.Name.StartsWith('Krypton.Standard.Toolkit.', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
+    if ($Package.Length -ge $minBytes) {
+        return $true
+    }
+
+    $mb = [math]::Round($Package.Length / (1024 * 1024), 2)
+    $minMb = [math]::Round($minBytes / (1024 * 1024), 2)
+    Write-Host "::error::Refusing NuGet push: Krypton.Standard.Toolkit aggregate package '$($Package.Name)' is $mb MiB (minimum $minMb MiB). Package appears incomplete."
+    return $false
+}

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -61,7 +61,7 @@
 
 	<PropertyGroup Condition="'$(TargetFramework)' != '' And !$([System.String]::Copy('$(TargetFramework)').Contains(';'))">
 		<!-- Ensure multi-target outputs don't overwrite each other -->
-		<OutputPath>$(MSBuildThisFileDirectory)..\..\Bin\$(Configuration)\$(TargetFramework)\</OutputPath>
+		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -10,6 +10,8 @@
 		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
 		<!-- Keep OutDir in sync: props set OutputPath before this; SDK freezes OutDir unless updated with OutputPath. -->
 		<OutDir>$(OutputPath)</OutDir>
+		<!-- Shared per-TFM output folder across projects; avoid project-to-project copy/clean churn in the same directory. -->
+		<UseCommonOutputDirectory>true</UseCommonOutputDirectory>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)NetFramework.SystemResourcesExtensions.BindingRedirects.props"

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -8,6 +8,8 @@
 	     inner multi-target build overwrite Krypton.Toolkit.dll (etc.), so net472 then references net10+ (CS1705). -->
 	<PropertyGroup Condition="'$(TargetFramework)' != ''">
 		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
+		<!-- Keep OutDir in sync: props set OutputPath before this; SDK freezes OutDir unless updated with OutputPath. -->
+		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)NetFramework.SystemResourcesExtensions.BindingRedirects.props"


### PR DESCRIPTION
…ize guard

# Fix `Krypton.Standard.Toolkit` pack output layout; add NuGet push size guard and docs

## Summary

- Aligns **`OutDir`** with the shared **`OutputPath`** in **`Source/Krypton Components/Directory.Build.targets`** so builds with **`/p:UseArtifactsOutput=true`** (GitHub Actions and local) write assemblies to **`$(KryptonBuildOutputRoot)<Configuration>/<TFM>/`**, where **`Krypton.Standard.Toolkit`** packing already looks. This addresses incomplete aggregate packages (empty **`lib`**, ~1–2 MiB **`.nupkg`**) that could still occur after [#3404](https://github.com/Krypton-Suite/Standard-Toolkit/pull/3404) path priority alone.
- Adds **`Scripts/CI/StandardToolkitNupkgGuard.ps1`** and wires it into all workflows that **`dotnet nuget push`** to nuget.org: refuse to push **`Krypton.Standard.Toolkit*.nupkg`** below a minimum size (default **10 MiB** unless overridden).
- Exposes **`STANDARD_TOOLKIT_MIN_NUPKG_MB`** as an optional GitHub Actions **repository variable** on those push steps.
- Updates Contributing documentation (**`NuGetPackaging.md`**, **`GitHubActionsWorkflows.md`**, **`DirectoryBuildConfiguration.md`**) and the Changelog entry for [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377) as applicable.

Fixes [#3377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3377).

## Problem

1. **`OutputPath`** was overridden late to **`artifacts/bin/<Configuration>/<TFM>/`**, but **`OutDir`** stayed tied to the earlier **`Bin/...`** value from **`Directory.Build.props`**. Compilers emitted to **`Bin`**, while **`AddReferencedAssembliesToPackage`** preferred **`$(KryptonBuildOutputRoot)...`**, so **`Exists`** failed and **`lib`** was empty.
2. CI had no automated gate to stop publishing a broken tiny aggregate package.

## Solution

1. **`Directory.Build.targets`**: set **`<OutDir>$(OutputPath)</OutDir>`** alongside **`OutputPath`** when **`$(TargetFramework)`** is set.
2. **`StandardToolkitNupkgGuard.ps1`**: **`Test-StandardToolkitNupkgPushAllowed`**; resolve minimum from **`STANDARD_TOOLKIT_MIN_NUPKG_MB`** (env, from **`vars.STANDARD_TOOLKIT_MIN_NUPKG_MB`**) or optional **`STANDARD_TOOLKIT_MIN_NUPKG_BYTES`**; default **10 MiB**.
3. **Workflows** (`release.yml`, `canary.yml`, `nightly.yml`, `canary-lts-release.yml`): dot-source guard before push; set **`standardToolkitNupkgSizeGateFailed`** and **`exit 1`** if any aggregate package is skipped for size after other pushes in the loop.
4. **Docs**: aggregate package section, CI guard section, corrected **`Directory.Build.targets`** excerpt and **`OutDir`** rationale.

## Files changed (reference)

| Area | Paths |
|------|--------|
| Build | `Source/Krypton Components/Directory.Build.targets` | | CI guard | `Scripts/CI/StandardToolkitNupkgGuard.ps1` | | Workflows | `.github/workflows/release.yml`, `canary.yml`, `nightly.yml`, `canary-lts-release.yml` | | Docs | `Documents/Developer/Contributing/Build System/NuGetPackaging.md`, `DirectoryBuildConfiguration.md`, `Documents/Developer/Contributing/GitHubActionsWorkflows.md` | | Changelog | `Documents/Changelog/Changelog.md` (if not already updated on branch) |

## How to verify

1. Local (artifacts layout): `dotnet msbuild "Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj" /t:Pack /p:Configuration=Release /p:TFMs=all /p:UseArtifactsOutput=true` Inspect **`.nupkg`**: **`lib/<tfm>/`** should list module DLLs; size should be in the tens of MB for multi-TFM, not ~1–2 MB.
2. Confirm compile output lines point at **`artifacts/bin/Release/<tfm>/`** (not only **`Bin/...`** when **`UseArtifactsOutput=true`**).
3. Optional: set **`vars.STANDARD_TOOLKIT_MIN_NUPKG_MB`** in a fork to a high value and confirm push step fails on an intentionally small **`Krypton.Standard.Toolkit`** package.

## Maintainer checklist

- [ ] Repo variable **`STANDARD_TOOLKIT_MIN_NUPKG_MB`** set if you want something other than the script default (**10** MiB); otherwise omit.
- [ ] After merge, confirm next release/canary/nightly push produces a normally sized **`Krypton.Standard.Toolkit`** package on NuGet.

## Breaking changes

None expected. Output layout under **`UseArtifactsOutput=true`** now matches **`KryptonBuildOutputRoot`** consistently; **`UseArtifactsOutput=false`** remains **`Bin/...`** for both **`OutputPath`** and **`OutDir`**.