### PR TITLE
* Fix: KryptonManager `TypeInitializationException` on .NET Framework

### DIFF
--- a/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
+++ b/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
@@ -377,12 +377,10 @@
 		<Optimize>True</Optimize>
 	</PropertyGroup>
 
-	<!-- .NET Framework apps: auto binding redirects fix System.Resources.Extensions 4.0.0.0 vs 4.0.1.0 load failures. -->
+	<!-- .NET Framework: binding redirects + buildTransitive import for System.Resources.Extensions. -->
 	<ItemGroup>
-		<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props"
-				Pack="true"
-				PackagePath="build\$(PackageId).props"
-				Visible="false" />
+		<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props" Link="NetFxSreRedirects.props" Pack="true" PackagePath="build\$(PackageId).props" Visible="false" />
+		<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props" Link="NetFxSreRedirectsTransitive.props" Pack="true" PackagePath="buildTransitive\$(PackageId).props" Visible="false" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -41,6 +41,11 @@ public sealed class KryptonManager : Component
     private static float _cachedDpiX = 0f;
     private static float _cachedDpiY = 0f;
 
+#if NETFRAMEWORK
+    // Must run before any other static field that touches embedded resources (e.g. KryptonImageStorage / KryptonManager.Strings).
+    private static readonly int _resourceAssemblyResolveHook = KryptonNetFxResourceAssemblyResolve.Register();
+#endif
+
     // Initialize the default modes
 
     // Initialize instances to match the default modes

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonNetFxResourceAssemblyResolve.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonNetFxResourceAssemblyResolve.cs
@@ -1,0 +1,71 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+#if NETFRAMEWORK
+using System.IO;
+using System.Reflection;
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Ensures <see cref="System.Resources.Extensions"/> loads from the same directory as this assembly on .NET Framework.
+/// Preserialized .resx can request an older assembly identity than the NuGet DLL (e.g. 4.0.0.0 vs 9.0.0.0), which
+/// otherwise surfaces as <see cref="TypeInitializationException"/> during <see cref="KryptonManager"/> static init
+/// when binding redirects are missing or incomplete (see GitHub #3330).
+/// </summary>
+internal static class KryptonNetFxResourceAssemblyResolve
+{
+    private static bool _registered;
+
+    /// <summary>Registers <see cref="AppDomain.AssemblyResolve"/> once; returns 0 for use as a static field initializer.</summary>
+    internal static int Register()
+    {
+        if (_registered)
+        {
+            return 0;
+        }
+
+        _registered = true;
+        AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+        return 0;
+    }
+
+    private static Assembly? OnAssemblyResolve(object? sender, ResolveEventArgs args)
+    {
+        var requested = args.Name;
+        if (string.IsNullOrEmpty(requested)
+            || !requested.StartsWith("System.Resources.Extensions,", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var toolkitAssembly = typeof(KryptonNetFxResourceAssemblyResolve).Assembly;
+        var dir = Path.GetDirectoryName(toolkitAssembly.Location);
+        if (string.IsNullOrEmpty(dir))
+        {
+            return null;
+        }
+
+        var path = Path.Combine(dir, "System.Resources.Extensions.dll");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+#endif

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -923,9 +923,10 @@
 	<Optimize>True</Optimize>
   </PropertyGroup>
 
-  <!-- .NET Framework apps: auto binding redirects fix System.Resources.Extensions 4.0.0.0 vs 4.0.1.0 load failures. -->
+  <!-- .NET Framework: binding redirects + buildTransitive import for System.Resources.Extensions; toolkit also uses AssemblyResolve on net4x. -->
   <ItemGroup>
-	<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props" Pack="true" PackagePath="build\$(PackageId).props" Visible="false" />
+	<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props" Link="NetFxSreRedirects.props" Pack="true" PackagePath="build\$(PackageId).props" Visible="false" />
+	<None Include="..\NetFramework.SystemResourcesExtensions.BindingRedirects.props" Link="NetFxSreRedirectsTransitive.props" Pack="true" PackagePath="buildTransitive\$(PackageId).props" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
@@ -1,13 +1,15 @@
 <Project>
 	<!--
-	  Krypton net4x builds use preserialized .resx; at runtime the loader may request
-	  System.Resources.Extensions, Version=4.0.0.0 while the NuGet assembly is 4.0.1.0, causing
-	  FileLoadException (0x80131040) during resource initialization (e.g. KryptonManager / image storage).
+	  Krypton net4x builds use preserialized .resx; at runtime the loader may request an older
+	  System.Resources.Extensions identity (e.g. 4.0.0.0) than the NuGet assembly (9.0.0.0 for package 9.0.10),
+	  causing FileLoadException (0x80131040) during resource initialization (e.g. KryptonManager / image storage).
 
 	  Auto-generate redirects alone is not always enough: ResolveAssemblyReference may not emit a
 	  suggested redirect when the conflict is only visible through Krypton's compiled references.
-	  This file is packed as build/$(PackageId).props for Krypton.Toolkit and Krypton.Standard.Toolkit,
-	  and is imported from Directory.Build.targets so project-reference apps (e.g. TestForm) get the same fix.
+	  This file is packed as build/ and buildTransitive/ $(PackageId).props for Krypton.Toolkit and
+	  Krypton.Standard.Toolkit, and is imported from Directory.Build.targets so project-reference apps
+	  (e.g. TestForm) get the same fix. Krypton.Toolkit also registers AssemblyResolve on .NET Framework
+	  (KryptonNetFxResourceAssemblyResolve) so apps run without relying solely on app.config redirects.
 	-->
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -24,7 +26,7 @@
 			<SuggestedBindingRedirects Remove="@(_KryptonSreSuggestedRemove)" />
 			<_KryptonSreSuggestedRemove Remove="@(_KryptonSreSuggestedRemove)" />
 			<SuggestedBindingRedirects Include="System.Resources.Extensions, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-				<MaxVersion>4.0.1.0</MaxVersion>
+				<MaxVersion>9.0.0.0</MaxVersion>
 			</SuggestedBindingRedirects>
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
# Fix: KryptonManager `TypeInitializationException` on .NET Framework (#3330)

## Summary

Resolves startup crashes on **.NET Framework** where `System.TypeInitializationException` is reported for `Krypton.Toolkit.KryptonManager`, typically caused by a **`FileLoadException`** when loading **`System.Resources.Extensions`** (requested assembly identity does not match the deployed DLL).

**Related:** [Issue #3330](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3330)

## Problem

- Krypton **net4x** builds use **preserialized** `.resx` resources, which depend on **`System.Resources.Extensions`** at runtime.
- The loader may request an **older** assembly version than the **NuGet 9.x** DLL shipped with the toolkit, so fusion fails unless **binding redirects** are present and correct.
- Not all consuming apps inherit redirects reliably (e.g. certain restore / `app.config` setups), which surfaces as failure during **`KryptonManager`** static initialization (before any form is shown).

## Solution

1. **`.NET Framework` assembly resolve hook** Introduces `KryptonNetFxResourceAssemblyResolve`, which registers **`AppDomain.AssemblyResolve`** once and, for `System.Resources.Extensions`, loads the DLL from the **same directory as `Krypton.Toolkit.dll`** via `Assembly.LoadFrom`, so the correct file is used even when the requested version string does not match.

2. **Early registration** A **`KryptonManager`** static field initializer runs **before** other static fields that touch embedded resources (e.g. `Strings` / `Images`), so the hook is active before resource types initialize.

3. **Binding redirect metadata** Updates **`NetFramework.SystemResourcesExtensions.BindingRedirects.props`** so the injected suggested redirect’s **`MaxVersion`** aligns with **System.Resources.Extensions 9.0.10** (assembly identity **9.0.0.0**), not the legacy **4.0.1.0** cap.

4. **NuGet packaging** Packs the same props into **`build\$(PackageId).props`** and **`buildTransitive\$(PackageId).props`** for **Krypton.Toolkit** and **Krypton.Standard.Toolkit**, so more SDK-style apps pick up **`AutoGenerateBindingRedirects`** for .NET Framework.

## Files touched (conceptual)

| Area | Change |
|------|--------|
| `Krypton.Toolkit` | New `KryptonNetFxResourceAssemblyResolve.cs`; `KryptonManager` static hook | | `NetFramework.SystemResourcesExtensions.BindingRedirects.props` | Comment + `MaxVersion` **9.0.0.0** | | `Krypton.Toolkit 2022.csproj` / `Krypton.Standard.Toolkit.csproj` | Duplicate pack entries for `build` + `buildTransitive` |

## Testing

- `dotnet build` **Krypton.Toolkit** for **`net472`** and **`net8.0-windows`** (Debug) succeeds.
- Manual: new **.NET Framework 4.8** WinForms app referencing Krypton, **`KryptonManager`** on main form, run without custom `app.config` redirects — should start when **`System.Resources.Extensions.dll`** is copied next to **`Krypton.Toolkit.dll`** (as with a normal NuGet / build output layout).

## Breaking changes

None intended. Behavior on **.NET (Core)** is unchanged (`#if NETFRAMEWORK`).

## Checklist

- [x] Targets root cause for #3330 on net4x (`System.Resources.Extensions` load failure during static init).
- [ ] Changelog entry added under the correct version (if required by repo process).