### PR TITLE
* Unable to add child controls into `KryptonHeaderGroup` (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3451](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3451), Unable to add child controls into `KryptonHeaderGroup` at design time (`ReadOnly controls collection`). `DisplayRectangle` now reports the view fill rect, group container designers call `PerformLayout` after `EnableDesignMode`, and `KryptonGroupPanelDesigner.CanBeParentedTo` checks the parent component type correctly. Same `DisplayRectangle` improvement applied to `KryptonGroup` and `KryptonGroupBox`.
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365), `KryptonLinkLabel` 'Autosize' Not Shrinking

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -288,7 +288,14 @@ public class KryptonGroup : VisualControlContainment
             // Ensure that the layout is calculated in order to know the remaining display space
             ForceViewLayout();
 
-            // The inside panel is the client rectangle size
+            // The fill rect from view layout is authoritative; Panel bounds are applied in OnLayout
+            // and can be stale when the designer queries DisplayRectangle before WinForms layout runs.
+            Rectangle fillRect = _layoutFill.FillRect;
+            if (!fillRect.IsEmpty)
+            {
+                return fillRect;
+            }
+
             return new Rectangle(Panel.Location, Panel.Size);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -557,7 +557,14 @@ public class KryptonGroupBox : VisualControlContainment
             // Ensure that the layout is calculated in order to know the remaining display space
             ForceViewLayout();
 
-            // The inside panel is the client rectangle size
+            // The fill rect from view layout is authoritative; Panel bounds are applied in OnLayout
+            // and can be stale when the designer queries DisplayRectangle before WinForms layout runs.
+            Rectangle fillRect = _layoutFill.FillRect;
+            if (!fillRect.IsEmpty)
+            {
+                return fillRect;
+            }
+
             return new Rectangle(Panel.Location, Panel.Size);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -732,7 +732,14 @@ public class KryptonHeaderGroup : VisualControlContainment
             // Ensure that the layout is calculated in order to know the remaining display space
             ForceViewLayout();
 
-            // The inside panel is the client rectangle size
+            // The fill rect from view layout is authoritative; Panel bounds are applied in OnLayout
+            // and can be stale when the designer queries DisplayRectangle before WinForms layout runs.
+            Rectangle fillRect = _layoutFill.FillRect;
+            if (!fillRect.IsEmpty)
+            {
+                return fillRect;
+            }
+
             return new Rectangle(Panel.Location, Panel.Size);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupBoxDesigner.cs
@@ -10,6 +10,8 @@
  */
 #endregion
 
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.ListView;
+
 namespace Krypton.Toolkit;
 
 internal class KryptonGroupBoxDesigner : ParentControlDesigner
@@ -46,6 +48,9 @@ internal class KryptonGroupBoxDesigner : ParentControlDesigner
         if (_groupBox != null)
         {
             EnableDesignMode(_groupBox.Panel, nameof(Panel));
+
+            // Ensure the panel has valid bounds before the designer queries DisplayRectangle for drop targets
+            _groupBox.PerformLayout();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupDesigner.cs
@@ -44,6 +44,9 @@ internal class KryptonGroupDesigner : ParentControlDesigner
         if (_group != null)
         {
             EnableDesignMode(_group.Panel, nameof(Panel));
+
+            // Ensure the panel has valid bounds before the designer queries DisplayRectangle for drop targets
+            _group.PerformLayout();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupPanelDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupPanelDesigner.cs
@@ -56,7 +56,7 @@ internal class KryptonGroupPanelDesigner : KryptonPanelDesigner,
     /// <returns>true if the control managed by the specified designer can parent the control managed by this designer; otherwise, false.</returns>
     public override bool CanBeParentedTo(IDesigner parentDesigner) =>
         // We should only ever exist inside a Krypton group container
-        (parentDesigner is KryptonGroup or KryptonHeaderGroup);
+        parentDesigner.Component is KryptonGroup or KryptonGroupBox or KryptonHeaderGroup;
 
     /// <summary>
     /// Gets the selection rules that indicate the movement capabilities of a component.

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderGroupDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderGroupDesigner.cs
@@ -82,6 +82,9 @@ internal class KryptonHeaderGroupDesigner : ParentControlDesigner
         if (_headerGroup != null)
         {
             EnableDesignMode(_headerGroup.Panel, nameof(Panel));
+
+            // Ensure the panel has valid bounds before the designer queries DisplayRectangle for drop targets
+            _headerGroup.PerformLayout();
         }
     }
 


### PR DESCRIPTION
# Fix design-time child parenting for KryptonHeaderGroup (and related group containers)

Closes [#3451](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3451)

## Summary

Fixes a WinForms designer failure when adding child controls to `KryptonHeaderGroup` (and improves the same design-time path for `KryptonGroup` and `KryptonGroupBox`). The designer no longer attempts to add controls to the read-only outer `Controls` collection, which previously threw `NotSupportedException: ReadOnly controls collection`.

## Problem

`KryptonHeaderGroup`, `KryptonGroup`, and `KryptonGroupBox` host user content on an internal `Panel` (`KryptonGroupPanel`). The outer control uses `KryptonReadOnlyControls`, so direct `Controls.Add` on the container is not supported.

At design time, dropping or reparenting a control onto `KryptonHeaderGroup` could target the outer container instead of `Panel` when:

1. **`DisplayRectangle` was stale** — it returned `Panel.Location` / `Panel.Size`, which are only updated in `OnLayout`, so the designer could see an empty or wrong drop zone before layout ran.
2. **Panel bounds were not ready** — the designer queried drop targets before `PerformLayout` established the internal panel geometry.
3. **`KryptonGroupPanelDesigner.CanBeParentedTo` was incorrect** — it tested `parentDesigner is KryptonGroup` (the designer instance) instead of `parentDesigner.Component is KryptonGroup` (the control).

Reported symptoms ([#3451](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3451)):

- Toolbox drop onto `KryptonHeaderGroup` shows an error dialog.
- Dragging an existing control into the header group snaps it back to its previous parent.

## Solution

| Area | Change |
|------|--------|
| **Runtime** | `DisplayRectangle` on `KryptonHeaderGroup`, `KryptonGroup`, and `KryptonGroupBox` now returns `_layoutFill.FillRect` after `ForceViewLayout()`, falling back to panel bounds only when the fill rect is empty. | | **Designers** | `KryptonHeaderGroupDesigner`, `KryptonGroupDesigner`, and `KryptonGroupBoxDesigner` call `PerformLayout()` after `EnableDesignMode(Panel, …)` so panel bounds exist before the designer queries drop targets. | | **Panel designer** | `KryptonGroupPanelDesigner.CanBeParentedTo` now checks `parentDesigner.Component is KryptonGroup or KryptonGroupBox or KryptonHeaderGroup`. | 

Child controls must still be parented to `*.Panel` (e.g. `khgMain.Panel.Controls.Add(...)`). Generated designer code in the repo already follows this pattern.

## Files changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs`
- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs`
- `Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderGroupDesigner.cs`
- `Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupDesigner.cs`
- `Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupBoxDesigner.cs`
- `Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupPanelDesigner.cs`
- `Documents/Changelog/Changelog.md`

## Test plan

- [ ] Build `Krypton.Toolkit` and `TestForm` (Debug, at least `net48`).
- [ ] Open **TestForm → Bug 3451 HeaderGroup panel parenting** at runtime; confirm existing panel children are visible.
- [ ] Open `Bug3451KryptonHeaderGroupPanelDemo` in the **WinForms Designer**.
- [ ] Drag a `KryptonButton` from the toolbox into the **content area** of `KryptonHeaderGroup` (below the primary header, not on the header caption).
- [ ] Confirm no `ReadOnly controls collection` error and that designer code uses `khgDemo.Panel.Controls.Add(...)`.
- [ ] Repeat toolbox drop for `KryptonGroup` and `KryptonGroupBox` content areas.
- [ ] Drag an existing form control into the header group content area; confirm it stays parented under `Panel`.
- [ ] Verify a freshly dropped `KryptonHeaderGroup` on a form (default size) accepts a child in the panel region after the fix.

## Notes

- Drops directly onto the **header caption/chrome** may still be rejected; only the internal `Panel` is a valid child host. Users should drop into the content region below the header(s), consistent with `KryptonGroupBox` behavior.
- No breaking API or binary changes.
- Milestone: Version 105 (LTS) / V110 per issue labels.