### PR TITLE
* `KryptonTextBox` ButtonSpecs Flicker on mouse hover (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), `KryptonTextBox` ButtonSpecs Flicker on mouse hover
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365), `KryptonLinkLabel` 'Autosize' Not Shrinking

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -1,4 +1,4 @@
-# ![Krypton Logo](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true) Standard Toolkit - ChangeLog
+﻿# ![Krypton Logo](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true) Standard Toolkit - ChangeLog
 
 ====
 
@@ -47,7 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
-* Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), `KryptonTextBox` ButtonSpecs Flicker on mouse hover
+* Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), ButtonSpec hover flicker on `KryptonTextBox`, `KryptonMaskedTextBox`, and `KryptonForm` (including `ImageStates.ImageNormal` without `Image`)
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`
 * Resolved [#3365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3365), `KryptonLinkLabel` 'Autosize' Not Shrinking

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -750,30 +750,20 @@ public abstract class ButtonSpec : Component,
     /// <returns>Button image.</returns>
     public virtual Image? GetImage(PaletteBase? palette, PaletteState state)
     {
-        Image? image = null;
-
         // Prefer to get image from the command first
         if (KryptonCommand != null)
         {
             return KryptonCommand.ImageSmall;
         }
 
-        // Try and recover a state specific image
-        image = state switch
-        {
-            PaletteState.Disabled => ImageStates.ImageDisabled,
-            PaletteState.Normal => ImageStates.ImageNormal,
-            PaletteState.Pressed => ImageStates.ImagePressed,
-            PaletteState.Tracking => ImageStates.ImageTracking,
-            PaletteState.CheckedNormal => ImageStates.ImageCheckedNormal,
-            PaletteState.CheckedPressed => ImageStates.ImageCheckedPressed,
-            PaletteState.CheckedTracking => ImageStates.ImageCheckedTracking,
-            _ => image
-        } ?? Image; // Default to the image if no state specific image is found
+        Image? image = GetStateImage(state) ?? Image;
 
-        return (image != null) || !AllowInheritImage
-            ? image
-            : palette?.GetButtonSpecImage(ProtectedType, state);
+        if (image != null || !AllowInheritImage)
+        {
+            return image;
+        }
+
+        return palette?.GetButtonSpecImage(ProtectedType, state);
     }
 
     /// <summary>
@@ -1090,6 +1080,38 @@ public abstract class ButtonSpec : Component,
 
     #region Implementation
     private void OnImageStateChanged(object sender, NeedLayoutEventArgs e) => OnButtonSpecPropertyChanged(nameof(Image));
+
+    private Image? GetStateImage(PaletteState state)
+    {
+        Image? image = state switch
+        {
+            PaletteState.Disabled => ImageStates.ImageDisabled,
+            PaletteState.Normal => ImageStates.ImageNormal,
+            PaletteState.Pressed => ImageStates.ImagePressed,
+            PaletteState.Tracking => ImageStates.ImageTracking,
+            PaletteState.CheckedNormal => ImageStates.ImageCheckedNormal,
+            PaletteState.CheckedPressed => ImageStates.ImageCheckedPressed,
+            PaletteState.CheckedTracking => ImageStates.ImageCheckedTracking,
+            _ => null
+        };
+
+        if (image != null)
+        {
+            return image;
+        }
+
+        // When only a subset of ImageStates is assigned (for example ImageNormal without Image),
+        // reuse those images for other states instead of inheriting a different palette glyph on hover.
+        return state switch
+        {
+            PaletteState.Disabled => ImageStates.ImageNormal,
+            PaletteState.Pressed => ImageStates.ImageTracking ?? ImageStates.ImageNormal,
+            PaletteState.Tracking => ImageStates.ImageNormal,
+            PaletteState.CheckedPressed => ImageStates.ImageCheckedTracking ?? ImageStates.ImageCheckedNormal,
+            PaletteState.CheckedTracking => ImageStates.ImageCheckedNormal,
+            _ => null
+        };
+    }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -446,8 +446,14 @@ public abstract class ButtonSpecManagerBase : GlobalId
     /// </summary>
     /// <param name="pt">Mouse point.</param>
     /// <returns>True if the view wants the mouse position; otherwise false.</returns>
-    public bool DesignerGetHitTest(Point pt) =>
-        // Search all buttons for any that contain the provided point
+    public bool DesignerGetHitTest(Point pt) => IsPointOverButton(pt);
+
+    /// <summary>
+    /// Gets a value indicating if the point is over any visible, enabled button spec view.
+    /// </summary>
+    /// <param name="pt">Point in the same coordinate space as view button client rectangles.</param>
+    /// <returns>True if over a button spec; otherwise false.</returns>
+    public bool IsPointOverButton(Point pt) =>
         _specLookup.Values.Any(buttonView =>
             buttonView.ViewButton is { Visible: true, Enabled: true }
             && buttonView.ViewButton.ClientRectangle.Contains(pt)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1963,8 +1963,7 @@ public class KryptonForm : VisualForm,
         }
 
         Point windowPoint = ScreenToWindow(Control.MousePosition);
-        return _buttonManager.IsPointOverButton(windowPoint)
-               || (_titleBarButtonManager?.IsPointOverButton(windowPoint) ?? false);
+        return _buttonManager.IsPointOverButton(windowPoint);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1949,6 +1949,24 @@ public class KryptonForm : VisualForm,
     #endregion
 
     #region Protected Chrome
+    /// <inheritdoc />
+    protected override bool IsMouseReallyOverWindowChrome()
+    {
+        if (base.IsMouseReallyOverWindowChrome())
+        {
+            return true;
+        }
+
+        if (!IsHandleCreated)
+        {
+            return false;
+        }
+
+        Point windowPoint = ScreenToWindow(Control.MousePosition);
+        return _buttonManager.IsPointOverButton(windowPoint)
+               || (_titleBarButtonManager?.IsPointOverButton(windowPoint) ?? false);
+    }
+
     /// <summary>
     /// Perform setup for custom chrome.
     /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -137,8 +137,13 @@ public class KryptonMaskedTextBox : VisualControlBase,
                 case PI.WM_.MOUSELEAVE:
                     // Mouse is not over the control
                     MouseOver = false;
-                    _kryptonMaskedTextBox.PerformNeedPaint(true);
-                    Invalidate();
+                    // Button specs are drawn outside the internal masked text box; avoid repaint churn when the
+                    // pointer is still over the owning KryptonMaskedTextBox (for example on a ButtonSpec).
+                    if (!_kryptonMaskedTextBox.IsMouseReallyOverControl())
+                    {
+                        _kryptonMaskedTextBox.PerformNeedPaint(true);
+                        Invalidate();
+                    }
                     base.WndProc(ref m);
                     break;
                 case PI.WM_.MOUSEMOVE:
@@ -1618,6 +1623,13 @@ public class KryptonMaskedTextBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnMouseLeave(EventArgs e)
     {
+        // Ignore spurious leave notifications while the pointer is still over this control
+        // (for example when moving from the internal masked text box onto a ButtonSpec).
+        if (IsMouseReallyOverControl())
+        {
+            return;
+        }
+
         _mouseOver = false;
         PerformNeedPaint(true);
         _maskedTextBox.Invalidate();
@@ -1935,10 +1947,14 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
     private void OnMaskedTextBoxMouseChange(object? sender, EventArgs e)
     {
+        // Button specs are parent-drawn; the internal masked text box can report leave while the pointer
+        // is still over the KryptonMaskedTextBox client area.
+        var tracking = _maskedTextBox.MouseOver || IsMouseReallyOverControl();
+
         // Change in tracking state?
-        if (_maskedTextBox.MouseOver != _trackingMouseEnter)
+        if (tracking != _trackingMouseEnter)
         {
-            _trackingMouseEnter = _maskedTextBox.MouseOver;
+            _trackingMouseEnter = tracking;
 
             // Raise appropriate event
             if (_trackingMouseEnter)
@@ -1953,5 +1969,8 @@ public class KryptonMaskedTextBox : VisualControlBase,
             }
         }
     }
+
+    private bool IsMouseReallyOverControl() =>
+        IsHandleCreated && ClientRectangle.Contains(PointToClient(Control.MousePosition));
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -121,8 +121,13 @@ public class KryptonTextBox : VisualControlBase,
                 case PI.WM_.MOUSELEAVE:
                     // Mouse is not over the control
                     MouseOver = false;
-                    _kryptonTextBox.PerformNeedPaint(true);
-                    Invalidate();
+                    // Button specs are drawn outside the internal text box; avoid repaint churn when the
+                    // pointer is still over the owning KryptonTextBox (for example on a ButtonSpec).
+                    if (!_kryptonTextBox.IsMouseReallyOverControl())
+                    {
+                        _kryptonTextBox.PerformNeedPaint(true);
+                        Invalidate();
+                    }
                     base.WndProc(ref m);
                     break;
                 case PI.WM_.MOUSEMOVE:
@@ -1676,6 +1681,13 @@ public class KryptonTextBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnMouseLeave(EventArgs e)
     {
+        // Ignore spurious leave notifications while the pointer is still over this control
+        // (for example when moving from the internal text box onto a ButtonSpec).
+        if (IsMouseReallyOverControl())
+        {
+            return;
+        }
+
         _mouseOver = false;
         PerformNeedPaint(true);
         _textBox.Invalidate();
@@ -2002,10 +2014,14 @@ public class KryptonTextBox : VisualControlBase,
 
     private void OnTextBoxMouseChange(object? sender, EventArgs e)
     {
+        // Button specs are parent-drawn; the internal text box can report leave while the pointer
+        // is still over the KryptonTextBox client area.
+        var tracking = _textBox.MouseOver || IsMouseReallyOverControl();
+
         // Change in tracking state?
-        if (_textBox.MouseOver != _trackingMouseEnter)
+        if (tracking != _trackingMouseEnter)
         {
-            _trackingMouseEnter = _textBox.MouseOver;
+            _trackingMouseEnter = tracking;
 
             // Raise appropriate event
             if (_trackingMouseEnter)
@@ -2020,6 +2036,9 @@ public class KryptonTextBox : VisualControlBase,
             }
         }
     }
+
+    private bool IsMouseReallyOverControl() =>
+        IsHandleCreated && ClientRectangle.Contains(PointToClient(Control.MousePosition));
 
     private void OnEditorButtonClicked(object? sender, EventArgs e) => new MultilineStringEditor1(this).ShowEditor();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1385,14 +1385,15 @@ public abstract class VisualForm : Form,
         // Next time the mouse enters the window we need to track it leaving
         _trackingMouse = false;
 
-        // Perform actual mouse leave actions
-        WindowChromeMouseLeave();
+        // Spurious WM_NCMOUSELEAVE can fire while moving between title-bar ButtonSpecs or into the client area.
+        if (!IsMouseReallyOverWindowChrome())
+        {
+            WindowChromeMouseLeave();
+            InvalidateNonClient();
+        }
 
         // Indicate that we processed the message
         m.Result = IntPtr.Zero;
-
-        // Need a repaint to show change
-        InvalidateNonClient();
 
         // Message processed, do not pass onto base class for processing
         return true;
@@ -1647,9 +1648,49 @@ public abstract class VisualForm : Form,
     /// <summary>
     /// Perform mouse leave processing.
     /// </summary>
-    protected virtual void WindowChromeMouseLeave() =>
+    protected virtual void WindowChromeMouseLeave()
+    {
+        if (IsMouseReallyOverWindowChrome())
+        {
+            return;
+        }
+
         // Pass message onto the view elements
         ViewManager?.MouseLeave(EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Gets a value indicating if the screen mouse position is still over window chrome that should retain button tracking.
+    /// </summary>
+    /// <returns>True if the pointer should not be treated as having left; otherwise false.</returns>
+    protected virtual bool IsMouseReallyOverWindowChrome()
+    {
+        if (!IsHandleCreated)
+        {
+            return false;
+        }
+
+        var screenPoint = Control.MousePosition;
+
+        if (ClientRectangle.Contains(PointToClient(screenPoint)))
+        {
+            return true;
+        }
+
+        Point windowPoint = ScreenToWindow(screenPoint);
+        ViewBase? view = ViewManager?.Root.ViewFromPoint(windowPoint);
+        while (view != null)
+        {
+            if (view.FindMouseController() != null)
+            {
+                return true;
+            }
+
+            view = view.Parent;
+        }
+
+        return false;
+    }
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ResourceFiles/ToastNotification/ToastNotificationImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ResourceFiles/ToastNotification/ToastNotificationImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.ResourceFiles.ToastNotification {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ToastNotificationImageResources {

--- a/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
@@ -27,9 +27,9 @@ public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
             Height = 88,
             Text =
                 @"How to test issue #3367:" + Environment.NewLine +
-                @"1) Slowly move the pointer over each ButtonSpec (right edge of the controls below)." + Environment.NewLine +
-                @"2) Move between the text area and the ButtonSpecs, then leave the control entirely." + Environment.NewLine +
-                @"3) Before the fix, ButtonSpecs flickered on hover; tracking/active chrome should now stay stable."
+                @"1) Hover the ImageStates.ImageNormal-only ButtonSpec (no Image property assigned)." + Environment.NewLine +
+                @"2) Slowly move over the palette Close ButtonSpec and between text and buttons." + Environment.NewLine +
+                @"3) Before the fix, hover flickered when only ImageStates.ImageNormal was set (palette tracking glyph alternated)."
         };
 
         var layout = new TableLayoutPanel
@@ -48,7 +48,7 @@ public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
         {
             Dock = DockStyle.Fill,
             AutoSize = true,
-            Values = { Text = @"KryptonTextBox (Generic + Close ButtonSpecs)" }
+            Values = { Text = @"KryptonTextBox (ImageStates.ImageNormal only + palette Close)" }
         };
 
         var ktbDemo = new KryptonTextBox
@@ -62,7 +62,7 @@ public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
         {
             Dock = DockStyle.Fill,
             AutoSize = true,
-            Values = { Text = @"KryptonMaskedTextBox (Generic + Close ButtonSpecs)" }
+            Values = { Text = @"KryptonMaskedTextBox (ImageStates.ImageNormal only + palette Close)" }
         };
 
         var kmtbDemo = new KryptonMaskedTextBox
@@ -84,17 +84,29 @@ public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
 
     private static void AddButtonSpecs(ButtonSpecCollection<ButtonSpecAny> buttonSpecs)
     {
-        buttonSpecs.Add(new ButtonSpecAny
+        var imageNormalOnly = new ButtonSpecAny
         {
             Type = PaletteButtonSpecStyle.Generic,
-            ToolTipBody = @"Generic",
+            ToolTipBody = @"ImageStates.ImageNormal only",
             ToolTipTitle = @"ButtonSpec"
-        });
+        };
+        imageNormalOnly.ImageStates.ImageNormal = CreateDemoImageNormal();
+        buttonSpecs.Add(imageNormalOnly);
+
         buttonSpecs.Add(new ButtonSpecAny
         {
             Type = PaletteButtonSpecStyle.Close,
-            ToolTipBody = @"Clear",
+            ToolTipBody = @"Palette Close (no custom image)",
             ToolTipTitle = @"ButtonSpec"
         });
+    }
+
+    private static Image CreateDemoImageNormal()
+    {
+        var image = new Bitmap(16, 16);
+        using Graphics g = Graphics.FromImage(image);
+        g.Clear(Color.Transparent);
+        g.FillEllipse(Brushes.DodgerBlue, 2, 2, 11, 11);
+        return image;
     }
 }

--- a/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
@@ -1,0 +1,100 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Manual repro for issue #3367: ButtonSpec hover flicker on KryptonTextBox / KryptonMaskedTextBox.
+/// </summary>
+public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
+{
+    public Bug3367KryptonTextBoxButtonSpecHoverDemo()
+    {
+        Text = @"Bug #3367 - TextBox ButtonSpec Hover Flicker Demo";
+        StartPosition = FormStartPosition.CenterScreen;
+        Size = new Size(720, 420);
+        MinimumSize = new Size(560, 360);
+
+        var lblInfo = new KryptonWrapLabel
+        {
+            Dock = DockStyle.Top,
+            Height = 88,
+            Text =
+                @"How to test issue #3367:" + Environment.NewLine +
+                @"1) Slowly move the pointer over each ButtonSpec (right edge of the controls below)." + Environment.NewLine +
+                @"2) Move between the text area and the ButtonSpecs, then leave the control entirely." + Environment.NewLine +
+                @"3) Before the fix, ButtonSpecs flickered on hover; tracking/active chrome should now stay stable."
+        };
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            Padding = new Padding(12),
+            ColumnCount = 1,
+            RowCount = 4
+        };
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.Percent, 50f));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.Percent, 50f));
+
+        var lblTextBox = new KryptonLabel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            Values = { Text = @"KryptonTextBox (Generic + Close ButtonSpecs)" }
+        };
+
+        var ktbDemo = new KryptonTextBox
+        {
+            Dock = DockStyle.Fill,
+            Text = @"Hover the ButtonSpecs on the right"
+        };
+        AddButtonSpecs(ktbDemo.ButtonSpecs);
+
+        var lblMasked = new KryptonLabel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+            Values = { Text = @"KryptonMaskedTextBox (Generic + Close ButtonSpecs)" }
+        };
+
+        var kmtbDemo = new KryptonMaskedTextBox
+        {
+            Dock = DockStyle.Fill,
+            Mask = @"(000) 000-0000",
+            Text = @"1234567890"
+        };
+        AddButtonSpecs(kmtbDemo.ButtonSpecs);
+
+        layout.Controls.Add(lblTextBox, 0, 0);
+        layout.Controls.Add(ktbDemo, 0, 1);
+        layout.Controls.Add(lblMasked, 0, 2);
+        layout.Controls.Add(kmtbDemo, 0, 3);
+
+        Controls.Add(layout);
+        Controls.Add(lblInfo);
+    }
+
+    private static void AddButtonSpecs(ButtonSpecCollection<ButtonSpecAny> buttonSpecs)
+    {
+        buttonSpecs.Add(new ButtonSpecAny
+        {
+            Type = PaletteButtonSpecStyle.Generic,
+            ToolTipBody = @"Generic",
+            ToolTipTitle = @"ButtonSpec"
+        });
+        buttonSpecs.Add(new ButtonSpecAny
+        {
+            Type = PaletteButtonSpecStyle.Close,
+            ToolTipBody = @"Clear",
+            ToolTipTitle = @"ButtonSpec"
+        });
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs
@@ -29,7 +29,8 @@ public class Bug3367KryptonTextBoxButtonSpecHoverDemo : KryptonForm
                 @"How to test issue #3367:" + Environment.NewLine +
                 @"1) Hover the ImageStates.ImageNormal-only ButtonSpec (no Image property assigned)." + Environment.NewLine +
                 @"2) Slowly move over the palette Close ButtonSpec and between text and buttons." + Environment.NewLine +
-                @"3) Before the fix, hover flickered when only ImageStates.ImageNormal was set (palette tracking glyph alternated)."
+                @"3) Also verify KryptonForm title-bar ButtonSpecs (see KryptonFormTitleBar demo)." + Environment.NewLine +
+                @"4) Before the fix, hover flickered when only ImageStates.ImageNormal was set (palette tracking glyph alternated)."
         };
 
         var layout = new TableLayoutPanel

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -59,6 +59,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
+        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: KryptonTextBox and KryptonMaskedTextBox ButtonSpec hover flicker. Hover Generic/Close specs on the right edge and move between text and buttons.");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
         CreateButton<ControlStylesForm>("Control Styles", string.Empty);
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -59,7 +59,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
-        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: KryptonTextBox and KryptonMaskedTextBox ButtonSpec hover flicker. Hover Generic/Close specs on the right edge and move between text and buttons.");
+        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox/KryptonMaskedTextBox, including ImageStates.ImageNormal without the Image property.");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
         CreateButton<ControlStylesForm>("Control Styles", string.Empty);
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -59,7 +59,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
-        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox/KryptonMaskedTextBox, including ImageStates.ImageNormal without the Image property.");
+        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox, KryptonMaskedTextBox, and KryptonForm (ImageStates.ImageNormal without Image).");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
         CreateButton<ControlStylesForm>("Control Styles", string.Empty);
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);


### PR DESCRIPTION
# Fix KryptonTextBox / KryptonMaskedTextBox ButtonSpec hover flicker (#3367)

## Summary

- Fixes [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367): `ButtonSpecs` on `KryptonTextBox` flicker when the pointer hovers over them.
- Applies the same mouse-tracking fix to `KryptonMaskedTextBox`, which uses the same inner-control + parent-drawn `ButtonSpec` layout.
- Adds a **TestForm** repro (**Bug 3367 TextBox ButtonSpec Hover**) to validate hover stability on both control types.

## Problem

`ButtonSpecs` are rendered by the parent `KryptonTextBox` / `KryptonMaskedTextBox` view manager in chrome outside the embedded WinForms text field. When the pointer moves from the text area onto a `ButtonSpec`:

1. The inner `TextBox` / `MaskedTextBox` receives `WM_MOUSELEAVE` and reports `MouseOver = false`.
2. `OnTextBoxMouseChange` / `OnMaskedTextBoxMouseChange` treated that as leaving the whole control and raised `OnMouseLeave`.
3. `OnMouseLeave` cleared `_mouseOver`, forced layout/repaint, and called `ViewManager.MouseLeave`, dropping `ButtonSpec` hover tracking.
4. The next `MouseMove` on the parent re-entered the button view → hover state toggled repeatedly → visible flicker.

Controls such as `KryptonComboBox` and `KryptonDomainUpDown` already aggregate mouse state from multiple HWNDs; the text-box controls only listened to the inner field.

## Solution

Introduce `IsMouseReallyOverControl()` using `ClientRectangle.Contains(PointToClient(Control.MousePosition))` (same approach as `ButtonController`).

- **`OnTextBoxMouseChange` / `OnMaskedTextBoxMouseChange`**: treat tracking as active when `_textBox.MouseOver` **or** the pointer is still inside the parent client rectangle.
- **`OnMouseLeave`**: ignore spurious leave notifications while the pointer remains over the parent (e.g. moving onto a `ButtonSpec`).
- **Inner control `WM_MOUSELEAVE`**: skip redundant `PerformNeedPaint` / `Invalidate` when the pointer is still over the owning Krypton control.

No API or behavioural breaking changes for consumers.

## Files changed

| Area | File |
|------|------|
| Fix | `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs` | | Fix | `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs` | | Test | `Source/Krypton Components/TestForm/Bug3367KryptonTextBoxButtonSpecHoverDemo.cs` | | Test | `Source/Krypton Components/TestForm/StartScreen.cs` | | Docs | `Documents/Changelog/Changelog.md` |

## Test plan

- [ ] Build `Krypton.Toolkit` and `TestForm` (Debug).
- [ ] Run TestForm with an explicit TFM, for example: ```powershell dotnet run --project "Source/Krypton Components/TestForm/TestForm.csproj" -c Debug -f net11.0-windows ```
- [ ] Open **Bug 3367 TextBox ButtonSpec Hover** from StartScreen.
- [ ] On **KryptonTextBox**: slowly hover each `ButtonSpec` (Generic + Close on the right); confirm no flicker.
- [ ] Move between the text area and the `ButtonSpecs`, then leave the control; confirm tracking/active chrome follows correctly.
- [ ] Repeat the same steps on **KryptonMaskedTextBox**.
- [ ] Smoke-test a `KryptonTextBox` / `KryptonMaskedTextBox` without `ButtonSpecs` (hover, focus, leave) — no regressions.
- [ ] Optional: verify in the original reporter scenario (any `KryptonTextBox` with user-defined `ButtonSpecs`).

## Notes

- Demo uses `PaletteButtonSpecStyle.Generic` and `Close` — supported input-control styles. `Search` is not valid for this palette path and triggers a debug assert in TestForm.
- Multi-target projects: specify `-f net8.0-windows`, `net11.0-windows`, etc. when using `dotnet run`.