### PR TITLE
* `KryptonTreeView` items flicker when selected/clicked

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
 	<PropertyGroup>
+		<!-- Solution/CLI graph builds can evaluate child projects before Configuration is set; default
+		     avoids wrong TargetFrameworks (Otherwise omits net472) and Bin\<tfm>\ output paths. -->
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+		<Platform Condition="'$(Platform)' == ''">Any CPU</Platform>
 		<UseArtifactsOutput Condition="'$(UseArtifactsOutput)' == ''">false</UseArtifactsOutput>
 		<KryptonLegacyBinRoot>$(MSBuildThisFileDirectory)Bin\</KryptonLegacyBinRoot>
 		<KryptonLegacyPackageRoot>$(KryptonLegacyBinRoot)Packages\</KryptonLegacyPackageRoot>

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection/check updates; no per-node background repaint)
 * Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), ButtonSpec hover flicker on `KryptonTextBox`, `KryptonMaskedTextBox`, and `KryptonForm` (including `ImageStates.ImageNormal` without `Image`)
 * Implemented [#3447](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3447), Add missing toolbox bitmap images
 * Implemented [#3455](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3455), **[Breaking Change]** Rename `Krypton.Utilities` to `Krypton.Toolkit.Utilities` (project folder, `Krypton.Toolkit.Utilities.csproj`, assembly name, root namespace, and all types). Aligns naming with `Krypton.Navigator.Utilities`. Update `using` directives, fully qualified type names, `ProjectReference` paths, and any tooling or CI paths that pointed at `Krypton.Utilities`. The aggregate `Krypton.Standard.Toolkit` package now ships `Krypton.Toolkit.Utilities.dll` instead of `Krypton.Utilities.dll`.

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -12,6 +12,9 @@
 	</ItemGroup>
 
 	<!-- Target Framework Selection: Determines which .NET versions to build for based on configuration -->
+	<PropertyGroup>
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+	</PropertyGroup>
 	<Choose>
 		<!-- Nightly, Canary, and Debug configurations build for all target frameworks -->
 		<When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -59,7 +59,7 @@ public class KryptonTreeView : VisualControlBase,
         /// <param name="kryptonTreeView">Reference to owning control.</param>
         public InternalTreeView(KryptonTreeView kryptonTreeView)
         {
-            SetStyle(ControlStyles.ResizeRedraw, true);
+            SetStyle(ControlStyles.ResizeRedraw | ControlStyles.OptimizedDoubleBuffer, true);
 
             _kryptonTreeView = kryptonTreeView;
 
@@ -148,9 +148,20 @@ public class KryptonTreeView : VisualControlBase,
 
         #region Protected
         /// <summary>
-        /// Raises the Layout event.
+        /// Initializes extended TreeView styles when the handle is created.
         /// </summary>
-        /// <param name="levent">A LayoutEventArgs containing the event data.</param>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            // comctl32 double-buffering for owner-draw notifications.
+            _ = PI.SendMessage(Handle, PI.TVM_.TVM_SETEXTENDEDSTYLE, (IntPtr)PI.TVS_EX_DOUBLEBUFFER,
+                (IntPtr)PI.TVS_EX_DOUBLEBUFFER);
+
+            _kryptonTreeView.SyncTreeViewBackColor();
+        }
+
         protected override void OnLayout(LayoutEventArgs levent)
         {
             base.OnLayout(levent);
@@ -245,7 +256,6 @@ public class KryptonTreeView : VisualControlBase,
                 {
                     // Must use the screen device context for the bitmap when drawing into the
                     // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
                     var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
 
                     try
@@ -264,14 +274,6 @@ public class KryptonTreeView : VisualControlBase,
                                        _kryptonTreeView.Renderer))
                             {
                                 ViewDrawPanel.Render(context);
-                            }
-
-                            // We can only control the background color by using the built in property and not
-                            // by overriding the drawing directly, therefore we can only provide a single color.
-                            Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                            if (color1 != BackColor)
-                            {
-                                BackColor = color1;
                             }
 
                             // Replace given DC with the screen DC for base window proc drawing
@@ -329,13 +331,14 @@ public class KryptonTreeView : VisualControlBase,
     private readonly FixedContentValue? _contentValues;
     private bool? _fixedActive;
     private ButtonStyle _style;
-    private readonly IntPtr _screenDC;
     private bool _itemHeightDefault;
     private bool _mouseOver;
     private bool _alwaysActive;
     private bool _forcedLayout;
     private bool _trackingMouseEnter;
     private bool _isRecreating; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/777
+    private int _selectUpdateCount;
+    private TreeNode? _pendingMultiSelectToggle;
     private bool _multiSelect;
     private KryptonScrollbarManager? _scrollbarManager;
     private bool? _useKryptonScrollbars;
@@ -666,9 +669,6 @@ public class KryptonTreeView : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add tree view to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_treeView);
     }
@@ -687,10 +687,6 @@ public class KryptonTreeView : VisualControlBase,
             _scrollbarManager = null;
         }
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
     #endregion
 
@@ -1577,11 +1573,6 @@ public class KryptonTreeView : VisualControlBase,
     {
         if (!_isRecreating)
         {
-            if (_multiSelect && e.Node is not null)
-            {
-                e.Node.Checked = !e.Node.Checked;
-            }
-
             AfterSelect?.Invoke(this, e);
         }
     }
@@ -1882,11 +1873,18 @@ public class KryptonTreeView : VisualControlBase,
     /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
     protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
-        if (IsHandleCreated && !e.NeedLayout)
+        if (_selectUpdateCount == 0)
         {
-            _treeView.Invalidate();
+            if (IsHandleCreated && !e.NeedLayout)
+            {
+                _treeView.Invalidate();
+            }
+            else
+            {
+                ForceControlLayout();
+            }
         }
-        else
+        else if (e.NeedLayout)
         {
             ForceControlLayout();
         }
@@ -1894,7 +1892,11 @@ public class KryptonTreeView : VisualControlBase,
         // Update palette to reflect latest state
         UpdateItemHeight();
         UpdateStateAndPalettes();
-        base.OnNeedPaint(sender, e);
+
+        if (_selectUpdateCount == 0)
+        {
+            base.OnNeedPaint(sender, e);
+        }
     }
 
     /// <summary>
@@ -2071,6 +2073,20 @@ public class KryptonTreeView : VisualControlBase,
             _treeView.ViewDrawPanel.ElementState = state;
             _drawDockerOuter.ElementState = state;
             _treeView.Font = StateCommon.Node.Content.ShortText.Font;
+
+            SyncTreeViewBackColor();
+        }
+    }
+
+    private void SyncTreeViewBackColor()
+    {
+        // We can only control the background color by using the built in property and not
+        // by overriding the drawing directly, therefore we can only provide a single color.
+        // Must not assign BackColor during WM_PAINT; doing so triggers a second erase/paint cycle.
+        Color color1 = _treeView.ViewDrawPanel.GetPalette().GetBackColor1(_treeView.ViewDrawPanel.State);
+        if (_treeView.BackColor != color1)
+        {
+            _treeView.BackColor = color1;
         }
     }
 
@@ -2099,6 +2115,9 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewDrawNode(object? sender, DrawTreeNodeEventArgs e)
     {
+        // OwnerDrawAll: skip native item painting (CDRF_SKIPDEFAULT).
+        e.DrawDefault = false;
+
         // We cannot do anything without a valid node
         if (e.Node == null)
         {
@@ -2229,8 +2248,9 @@ public class KryptonTreeView : VisualControlBase,
         // Update the view with the calculated state
         _drawButton.ElementState = buttonState;
 
-        // Grab the raw device context for the graphics instance
-        var hdc = e.Graphics.GetHdc();
+        Graphics g = e.Graphics;
+        var savedClip = g.Clip;
+        g.SetClip(e.Bounds);
 
         try
         {
@@ -2243,213 +2263,185 @@ public class KryptonTreeView : VisualControlBase,
             bounds.X += nodeIndent;
             bounds.Width -= nodeIndent;
 
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            var hBitmap = PI.CreateCompatibleBitmap(hdc, bounds.Right, bounds.Bottom);
-
-            // If we managed to get a compatible bitmap
-            if (hBitmap != IntPtr.Zero)
+            using (var context = new ViewLayoutContext(this, Renderer))
             {
+                context.DisplayRectangle = bounds;
+
+                // If not using full row selection, then layout using only required width
+                Size prefSize = _layoutDocker.GetPreferredSize(context);
+                if (!FullRowSelect)
+                {
+                    if (prefSize.Width < bounds.Width)
+                    {
+                        bounds.Width = prefSize.Width;
+                    }
+                }
+
+                // Always ensure we have enough space for drawing all the elements
+                if (bounds.Width < prefSize.Width)
+                {
+                    bounds.Width = prefSize.Width;
+                }
+
+                context.DisplayRectangle = bounds;
+
+                _layoutDocker.Layout(context);
+            }
+
+            // Row background is painted once in InternalTreeView.WmPaint before DefWndProc/DrawNode.
+
+            // Do we have an indent area for drawing plus/minus/lines?
+            if (indentBounds.X >= 0)
+            {
+                // Do we draw lines between nodes?
+                if (ShowLines
+                    && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                {
+                    // Find center points
+                    var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
+                    var vCenter = indentBounds.Y + (indentBounds.Height / 2);
+                    vCenter -= (vCenter + 1) % 2;
+
+                    // Default to showing full line height
+                    var top = indentBounds.Y;
+                    top -= (top + 1) % 2;
+                    var bottom = indentBounds.Bottom;
+
+                    // If the first root node then do not show top half of line
+                    if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
+                    {
+                        top = vCenter;
+                    }
+
+                    // If the last node in collection then do not show bottom half of line
+                    if (e.Node.NextNode == null)
+                    {
+                        bottom = vCenter;
+                    }
+
+                    // Draw the horizontal and vertical lines
+                    Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+                    using var linePen = new Pen(lineColor);
+                    linePen.DashStyle = DashStyle.Dot;
+                    linePen.DashOffset = indent % 2;
+                    g.DrawLine(linePen, hCenter, top, hCenter, bottom);
+                    g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
+                    hCenter -= indent;
+
+                    // Draw the vertical lines for previous node levels
+                    while (hCenter >= 0)
+                    {
+                        var begin = indentBounds.Y;
+                        begin -= (begin + 1) % 2;
+                        g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
+                        hCenter -= indent;
+                    }
+                }
+
+                // Do we draw any plus/minus images in indent bounds?
+                if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                {
+                    Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
+                    if (drawImage != null)
+                    {
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
+                            indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
+                            drawImage.Width, drawImage.Height));
+                    }
+                }
+            }
+
+            using (var context = new RenderContext(this, g, bounds, Renderer))
+            {
+                _layoutDocker.Render(context);
+            }
+
+            var isSelected = (e.State & TreeNodeStates.Selected) == TreeNodeStates.Selected;
+
+            // Do we draw an image for the node?
+            if (ImageList != null)
+            {
+                Image? drawImage = null;
+                var imageCount = ImageList.Images.Count;
+
                 try
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    PI.SelectObject(_screenDC, hBitmap);
-
-                    // Easier to draw using a graphics instance than a DC!
-                    using Graphics g = Graphics.FromHdc(_screenDC);
-                    using (var context = new ViewLayoutContext(this, Renderer))
+                    if (isSelected)
                     {
-                        context.DisplayRectangle = e.Bounds;
-                        _treeView.ViewDrawPanel.Layout(context);
-                        context.DisplayRectangle = bounds;
-
-                        // If no using full row selection, then layout using only required width
-                        Size prefSize = _layoutDocker.GetPreferredSize(context);
-                        if (!FullRowSelect)
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
                         {
-                            if (prefSize.Width < bounds.Width)
-                            {
-                                bounds.Width = prefSize.Width;
-                            }
+                            drawImage = ImageList.Images[e.Node.SelectedImageKey];
                         }
-
-                        // Always ensure we have enough space for drawing all the elements
-                        if (bounds.Width < prefSize.Width)
+                        else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
                         {
-                            bounds.Width = prefSize.Width;
+                            drawImage = ImageList.Images[e.Node.SelectedImageIndex];
                         }
-
-                        context.DisplayRectangle = bounds;
-
-                        _layoutDocker.Layout(context);
+                        else if (!string.IsNullOrEmpty(SelectedImageKey))
+                        {
+                            drawImage = ImageList.Images[SelectedImageKey];
+                        }
+                        else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[SelectedImageIndex];
+                        }
                     }
-
-                    using (var context = new RenderContext(this, g, e.Bounds, Renderer))
+                    else
                     {
-                        _treeView.ViewDrawPanel.Render(context);
-                    }
-
-                    // Do we have an indent area for drawing plus/minus/lines?
-                    if (indentBounds.X >= 0)
-                    {
-                        // Do we draw lines between nodes?
-                        if (ShowLines
-                            && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.ImageKey))
                         {
-                            // Find center points
-                            var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
-                            var vCenter = indentBounds.Y + (indentBounds.Height / 2);
-                            vCenter -= (vCenter + 1) % 2;
-
-                            // Default to showing full line height
-                            var top = indentBounds.Y;
-                            top -= (top + 1) % 2;
-                            var bottom = indentBounds.Bottom;
-
-                            // If the first root node then do not show top half of line
-                            if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
-                            {
-                                top = vCenter;
-                            }
-
-                            // If the last node in collection then do not show bottom half of line
-                            if (e.Node.NextNode == null)
-                            {
-                                bottom = vCenter;
-                            }
-
-                            // Draw the horizontal and vertical lines
-                            Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
-                            using var linePen = new Pen(lineColor);
-                            linePen.DashStyle = DashStyle.Dot;
-                            linePen.DashOffset = indent % 2;
-                            g.DrawLine(linePen, hCenter, top, hCenter, bottom);
-                            g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
-                            hCenter -= indent;
-
-                            // Draw the vertical lines for previous node levels
-                            while (hCenter >= 0)
-                            {
-                                var begin = indentBounds.Y;
-                                begin -= (begin + 1) % 2;
-                                g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
-                                hCenter -= indent;
-                            }
+                            drawImage = ImageList.Images[e.Node.ImageKey];
                         }
-
-                        // Do we draw any plus/minus images in indent bounds?
-                        if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                        else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
                         {
-                            Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
-                                    indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
-                                    drawImage.Width, drawImage.Height));
-                            }
+                            drawImage = ImageList.Images[e.Node.ImageIndex];
+                        }
+                        else if (!string.IsNullOrEmpty(ImageKey))
+                        {
+                            drawImage = ImageList.Images[ImageKey];
+                        }
+                        else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[ImageIndex];
                         }
                     }
 
-                    using (var context = new RenderContext(this, g, bounds, Renderer))
+                    if (drawImage != null)
                     {
-                        _layoutDocker.Render(context);
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, _layoutImage.ClientRectangle);
                     }
-
-                    // Do we draw an image for the node?
-                    if (ImageList != null)
-                    {
-                        Image? drawImage = null;
-                        var imageCount = ImageList.Images.Count;
-
-                        try
-                        {
-                            if (e.Node.IsSelected)
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageKey];
-                                }
-                                else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageKey];
-                                }
-                                else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageIndex];
-                                }
-                            }
-                            else
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.ImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageKey];
-                                }
-                                else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(ImageKey))
-                                {
-                                    drawImage = ImageList.Images[ImageKey];
-                                }
-                                else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[ImageIndex];
-                                }
-                            }
-
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, _layoutImage.ClientRectangle);
-                            }
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-                    }
-
-                    // Draw a node state image?
-                    if (_layoutImageCenterState.Visible)
-                    {
-                        if (drawStateImage != null)
-                        {
-                            float dpiFactor = g.DpiX / 96F;
-                            drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
-                                drawStateImage.Width * dpiFactor,
-                                drawStateImage.Height * dpiFactor, false)!;
-                            g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
-                        }
-                    }
-
-                    // Now blit from the bitmap from the screen to the real dc
-                    PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
                 }
-                finally
+                catch
                 {
-                    // Delete the temporary bitmap
-                    PI.DeleteObject(hBitmap);
+                    // ignored
+                }
+            }
+
+            // Draw a node state image?
+            if (_layoutImageCenterState.Visible)
+            {
+                if (drawStateImage != null)
+                {
+                    float dpiFactor = g.DpiX / 96F;
+                    drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                        drawStateImage.Width * dpiFactor,
+                        drawStateImage.Height * dpiFactor, false)!;
+                    g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
                 }
             }
         }
         finally
         {
-            // Must reserve the GetHdc() call before
-            e.Graphics.ReleaseHdc();
+            g.Clip = savedClip;
         }
     }
 
@@ -2489,7 +2481,29 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewItemDrag(object? sender, ItemDragEventArgs e) => OnItemDrag(e);
 
-    private void OnTreeViewBeforeSelect(object? sender, TreeViewCancelEventArgs e) => OnBeforeSelect(e);
+    private void OnTreeViewBeforeSelect(object? sender, TreeViewCancelEventArgs e)
+    {
+        if (!_isRecreating)
+        {
+            _selectUpdateCount++;
+            _treeView.BeginUpdate();
+
+            if (_multiSelect && e.Node is not null)
+            {
+                _pendingMultiSelectToggle = e.Node;
+            }
+        }
+
+        OnBeforeSelect(e);
+
+        if (e.Cancel && !_isRecreating)
+        {
+            _pendingMultiSelectToggle = null;
+
+            _selectUpdateCount--;
+            _treeView.EndUpdate();
+        }
+    }
 
     private void OnTreeViewBeforeLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnBeforeLabelEdit(e);
 
@@ -2499,7 +2513,28 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewBeforeCheck(object? sender, TreeViewCancelEventArgs e) => OnBeforeCheck(e);
 
-    private void OnTreeViewAfterSelect(object? sender, TreeViewEventArgs e) => OnAfterSelect(e);
+    private void OnTreeViewAfterSelect(object? sender, TreeViewEventArgs e)
+    {
+        try
+        {
+            if (!_isRecreating && _pendingMultiSelectToggle is not null)
+            {
+                _pendingMultiSelectToggle.Checked = !_pendingMultiSelectToggle.Checked;
+            }
+
+            OnAfterSelect(e);
+        }
+        finally
+        {
+            if (!_isRecreating && _selectUpdateCount > 0)
+            {
+                _selectUpdateCount--;
+                _treeView.EndUpdate();
+            }
+
+            _pendingMultiSelectToggle = null;
+        }
+    }
 
     private void OnTreeViewAfterLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnAfterLabelEdit(e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -657,6 +657,8 @@ internal partial class PI
             TVM_GETISEARCHSTRINGW = 0x1100 + 64,
             TVM_SETITEMHEIGHT = 0x1100 + 27,
             TVM_GETITEMHEIGHT = 0x1100 + 28,
+            TVM_SETEXTENDEDSTYLE = 0x1100 + 44,
+            TVM_GETEXTENDEDSTYLE = 0x1100 + 45,
 
             SETITEMA = 0x110d,
             SETITEM = 0x110d,
@@ -700,6 +702,7 @@ internal partial class PI
     internal const int TVS_EDITLABELS = 0x0008;
 
     internal const int TVS_CHECKBOXES = 0x0100;
+    internal const int TVS_EX_DOUBLEBUFFER = 0x0004;
     //TVS_HASBUTTONS = 0x0001,
     //TVS_HASLINES = 0x0002,
     //TVS_LINESATROOT = 0x0004,


### PR DESCRIPTION
# Fix `KryptonTreeView` selection flicker (#3282)

## Summary

- Fixes [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282): `KryptonTreeView` items visibly flicker when selected or clicked, especially with `OwnerDrawAll`, `MultiSelect`, `CheckBoxes`, and large `ItemHeight` (e.g. TestForm TreeView example).
- Ensures owner-drawn nodes skip native item painting, composites the control in a single off-screen `WM_PAINT` buffer, and batches selection/checkbox updates so deselect/select does not surface as separate on-screen paints.
- Defaults empty MSBuild `Configuration` to `Debug` so solution-wide `dotnet build` resolves correct TFMs and `Bin\Debug\<tfm>\` output paths (fixes local full-solution build failures unrelated to the TreeView runtime bug).

## Problem

`KryptonTreeView` uses an internal `TreeView` with `DrawMode = OwnerDrawAll`. On selection change, users could see a brief flash because:

1. Native TreeView item painting could still run unless `DrawDefault` is cleared (`CDRF_SKIPDEFAULT`).
2. Drawing each row directly to the display during `NM_CUSTOMDRAW` allowed the previously selected and newly selected rows to appear in separate paint steps.
3. Per-node background rendering (`ViewDrawPanel.Render` in `DrawNode`) repainted the row chrome on every item draw during selection changes.
4. `MultiSelect` toggled `Checked` during `BeforeSelect`, which could trigger extra check-state repaints outside a single redraw batch.

## Solution

### `KryptonTreeView` / `InternalTreeView`

| Change | Purpose |
|--------|---------|
| `e.DrawDefault = false` in `OnTreeViewDrawNode` | Skip native selection/focus chrome for `OwnerDrawAll`. | | Restore `InternalTreeView.WmPaint` off-screen bitmap | Paint Krypton background once, call `DefWndProc` (custom draw) into the same DC, then `BitBlt` once to the client area. | | `TVS_EX_DOUBLEBUFFER` via `TVM_SETEXTENDEDSTYLE` | Additional comctl32 buffering for owner-draw notifications. | | Remove per-row `ViewDrawPanel.Render` in `DrawNode` | Row background comes from the composite `WmPaint` pass only. | | `SyncTreeViewBackColor()` from `UpdateStateAndPalettes` | Avoid setting `BackColor` during `WM_PAINT` (extra erase/paint cycle). | | `BeginUpdate` / `EndUpdate` around selection | Suppress intermediate redraws while selection changes. | | `_selectUpdateCount` + `OnNeedPaint` guard | Avoid outer `KryptonTreeView` invalidation during batched selection. | | Defer `MultiSelect` checkbox toggle to `AfterSelect` (before `EndUpdate`) | Apply check + selection in one redraw when `MultiSelect` is enabled. |

### Build (incidental)

- `Directory.Build.props` and `Source/Krypton Components/Directory.Build.props`: default `Configuration` to `Debug` and `Platform` to `Any CPU` when unset, so graph builds do not omit `net472` or emit to `Bin\<tfm>\` instead of `Bin\Debug\<tfm>\`.

## Files changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs`
- `Documents/Changelog/Changelog.md`
- `Directory.Build.props`
- `Source/Krypton Components/Directory.Build.props`

## Test plan

- [ ] Build toolkit and TestForm (Debug): ```cmd dotnet build "Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug dotnet run --project "Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net48 ```
- [ ] **TreeView Example** (`TreeViewExample`): `CheckBoxes = true`, `MultiSelect = true`; click different nodes rapidly — no visible flicker on selection change.
- [ ] Set **`ItemHeight`** to **64** (property grid or code) and repeat; confirm large rows do not flash.
- [ ] **TreeView Test** form: compare `KryptonTreeView` vs standard `TreeView` side by side if useful.
- [ ] Toggle expand/collapse, scroll, keyboard navigation (arrows), and focus in/out — no regression in painting or lines/plus-minus glyphs.
- [ ] With `MultiSelect = true`, confirm clicking a node toggles its checked state without extra flicker.
- [ ] Smoke test on at least one additional TFM if convenient (e.g. `net8.0-windows`).
- [ ] Optional: verify `dotnet build` of the full solution without `-c Debug` still succeeds (Configuration default).

## Breaking changes

None. Behaviour is a visual/rendering fix; public API is unchanged.

## Screenshots / recordings

_GIF or short video of TreeView Example before/after appreciated for PR review._

## Related

- Closes #3282
- Changelog: V110 Nightly section in `Documents/Changelog/Changelog.md`