### PR TITLE
* QR Code Enhancements

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -92,6 +92,8 @@
 * Implemented [#1002](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1002), Implement `ActionLists` for file dialogs, `KryptonOpenFileDialog`, `KryptonSaveFileDialog`, and `KryptonFolderBrowserDialog` to expose common design-time properties.
 * Implemented [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305), QR Code Generation/Viewer
   * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Toolkit.Utilities` assembly.
+  * `KryptonQRCode` optional palette integration for `CenterImage`: `CenterImageUsePaletteColors`, `CenterImagePaletteStyle`, `CenterImageColorMap`, `CenterImageColorTo`, `CenterImageTransparentColor`, and `CenterImageEffect` (empty/inherit values resolve from the active palette; template glyphs using the Krypton transparency key remap to the effective dark module color). `GetCenterImagePalette()` and `QRCodeCenterImagePalette` support `GetBitmap()` / `GenerateBitmap()` export with the same drawing rules.
+  * Added `PaletteImageDrawing` in `Krypton.Toolkit` — shared palette image effect and color-remap drawing used by `KryptonQRCode` and `RenderBase.DrawImageHelper`.
 * Resolved [#3018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3018), `KryptonToast` no longer works properly
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), `KryptonDockingManager.LoadConfigFromArray` throws exception
 * Resolved [#3225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3225), Ribbon large button image-to-text separator not DPI-scaled

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/Controls Toolkit/KryptonQRCode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/Controls Toolkit/KryptonQRCode.cs
@@ -34,6 +34,12 @@ public class KryptonQRCode : KryptonPanel
     private Image? _centerImage;
     private float _centerImageRelativeSize = 0.22f;
     private int _centerImagePaddingModules = 1;
+    private bool _centerImageUsePaletteColors;
+    private PaletteContentStyle _centerImagePaletteStyle = PaletteContentStyle.LabelNormalPanel;
+    private Color _centerImageColorMap = Color.Empty;
+    private Color _centerImageColorTo = Color.Empty;
+    private Color _centerImageTransparentColor = Color.Empty;
+    private PaletteImageEffect _centerImageEffect = PaletteImageEffect.Inherit;
 
     #endregion
 
@@ -188,6 +194,9 @@ public class KryptonQRCode : KryptonPanel
     /// <remarks>
     /// The control does not take ownership; you must dispose the image when finished.
     /// Larger images or higher data density increase scan failures—prefer a higher <see cref="ErrorCorrectionLevel"/> (e.g. H or Q).
+    /// Set <see cref="CenterImageUsePaletteColors"/> to apply palette image effects and color remapping (see
+    /// <see cref="CenterImageColorMap"/>, <see cref="CenterImageColorTo"/>, <see cref="CenterImageTransparentColor"/>,
+    /// and <see cref="CenterImageEffect"/>).
     /// </remarks>
     [Category(@"Appearance")]
     [DefaultValue(null)]
@@ -284,6 +293,192 @@ public class KryptonQRCode : KryptonPanel
         CenterImagePaddingModules = 1;
     }
 
+    /// <summary>
+    /// Gets or sets whether the <see cref="CenterImage"/> is drawn using palette image effect and color-remap rules.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, <see cref="CenterImageEffect"/>, <see cref="CenterImageColorMap"/>,
+    /// <see cref="CenterImageColorTo"/>, and <see cref="CenterImageTransparentColor"/> use
+    /// <see cref="Color.Empty"/> / <see cref="PaletteImageEffect.Inherit"/> to inherit from
+    /// <see cref="CenterImagePaletteStyle"/> on the current palette. Template glyphs that use the
+    /// Krypton transparency key (<see cref="GlobalStaticVariables.TRANSPARENCY_KEY_COLOR"/>) are
+    /// remapped to the effective dark module color when the palette does not specify a map color.
+    /// </remarks>
+    [Category(@"Appearance")]
+    [DefaultValue(false)]
+    [Description(@"Apply palette image effect and color remapping to the center image.")]
+    public bool CenterImageUsePaletteColors
+    {
+        get => _centerImageUsePaletteColors;
+        set
+        {
+            if (_centerImageUsePaletteColors != value)
+            {
+                _centerImageUsePaletteColors = value;
+                Invalidate();
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImageUsePaletteColors() => _centerImageUsePaletteColors;
+
+    private void ResetCenterImageUsePaletteColors()
+    {
+        CenterImageUsePaletteColors = false;
+    }
+
+    /// <summary>
+    /// Gets or sets the palette content style used when resolving inherited center-image colors and effects.
+    /// </summary>
+    [Category(@"Appearance")]
+    [DefaultValue(PaletteContentStyle.LabelNormalPanel)]
+    [Description(@"Palette content style for center image color map, effect, and transparency.")]
+    public PaletteContentStyle CenterImagePaletteStyle
+    {
+        get => _centerImagePaletteStyle;
+        set
+        {
+            if (_centerImagePaletteStyle != value)
+            {
+                _centerImagePaletteStyle = value;
+                if (_centerImageUsePaletteColors)
+                {
+                    Invalidate();
+                }
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImagePaletteStyle() => _centerImagePaletteStyle != PaletteContentStyle.LabelNormalPanel;
+
+    private void ResetCenterImagePaletteStyle()
+    {
+        CenterImagePaletteStyle = PaletteContentStyle.LabelNormalPanel;
+    }
+
+    /// <summary>
+    /// Gets or sets the source color remapped when drawing <see cref="CenterImage"/> with palette colors enabled.
+    /// </summary>
+    /// <remarks><see cref="Color.Empty"/> inherits from the palette (<see cref="CenterImagePaletteStyle"/>).</remarks>
+    [Category(@"Appearance")]
+    [Description(@"Source color to remap in the center image. Empty inherits from the palette.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [DefaultValue(typeof(Color), "")]
+    public Color CenterImageColorMap
+    {
+        get => _centerImageColorMap;
+        set
+        {
+            if (_centerImageColorMap != value)
+            {
+                _centerImageColorMap = value;
+                if (_centerImageUsePaletteColors)
+                {
+                    Invalidate();
+                }
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImageColorMap() => !_centerImageColorMap.IsEmpty;
+
+    private void ResetCenterImageColorMap()
+    {
+        CenterImageColorMap = Color.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the destination color used when remapping <see cref="CenterImageColorMap"/>.
+    /// </summary>
+    /// <remarks><see cref="Color.Empty"/> inherits from the palette, then the effective dark module color.</remarks>
+    [Category(@"Appearance")]
+    [Description(@"Target color for center image remapping. Empty inherits from the palette.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [DefaultValue(typeof(Color), "")]
+    public Color CenterImageColorTo
+    {
+        get => _centerImageColorTo;
+        set
+        {
+            if (_centerImageColorTo != value)
+            {
+                _centerImageColorTo = value;
+                if (_centerImageUsePaletteColors)
+                {
+                    Invalidate();
+                }
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImageColorTo() => !_centerImageColorTo.IsEmpty;
+
+    private void ResetCenterImageColorTo()
+    {
+        CenterImageColorTo = Color.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the color in <see cref="CenterImage"/> that should be drawn transparent.
+    /// </summary>
+    /// <remarks><see cref="Color.Empty"/> inherits from the palette (<see cref="CenterImagePaletteStyle"/>).</remarks>
+    [Category(@"Appearance")]
+    [Description(@"Center image color drawn transparent. Empty inherits from the palette.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [DefaultValue(typeof(Color), "")]
+    public Color CenterImageTransparentColor
+    {
+        get => _centerImageTransparentColor;
+        set
+        {
+            if (_centerImageTransparentColor != value)
+            {
+                _centerImageTransparentColor = value;
+                if (_centerImageUsePaletteColors)
+                {
+                    Invalidate();
+                }
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImageTransparentColor() => !_centerImageTransparentColor.IsEmpty;
+
+    private void ResetCenterImageTransparentColor()
+    {
+        CenterImageTransparentColor = Color.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the palette image effect applied to <see cref="CenterImage"/> when palette drawing is enabled.
+    /// </summary>
+    /// <remarks><see cref="PaletteImageEffect.Inherit"/> uses the palette value for <see cref="CenterImagePaletteStyle"/>.</remarks>
+    [Category(@"Appearance")]
+    [DefaultValue(PaletteImageEffect.Inherit)]
+    [Description(@"Image effect for the center image. Inherit uses the palette content style.")]
+    public PaletteImageEffect CenterImageEffect
+    {
+        get => _centerImageEffect;
+        set
+        {
+            if (_centerImageEffect != value)
+            {
+                _centerImageEffect = value;
+                if (_centerImageUsePaletteColors)
+                {
+                    Invalidate();
+                }
+            }
+        }
+    }
+
+    private bool ShouldSerializeCenterImageEffect() => _centerImageEffect != PaletteImageEffect.Inherit;
+
+    private void ResetCenterImageEffect()
+    {
+        CenterImageEffect = PaletteImageEffect.Inherit;
+    }
+
     #endregion
 
     #region Identity
@@ -301,6 +496,11 @@ public class KryptonQRCode : KryptonPanel
     #region Public Methods
 
     /// <summary>
+    /// Resolves palette image drawing settings for <see cref="CenterImage"/>.
+    /// </summary>
+    public QRCodeCenterImagePalette GetCenterImagePalette() => GetResolvedCenterImagePalette();
+
+    /// <summary>
     /// Generates a bitmap of the current QR code.
     /// </summary>
     /// <returns>A bitmap of the QR code, or null if no content.</returns>
@@ -315,7 +515,8 @@ public class KryptonQRCode : KryptonPanel
             _showBorder,
             _centerImage,
             _centerImageRelativeSize,
-            _centerImagePaddingModules);
+            _centerImagePaddingModules,
+            GetResolvedCenterImagePalette());
     }
 
     /// <summary>
@@ -329,6 +530,7 @@ public class KryptonQRCode : KryptonPanel
     /// <param name="centerImage">Optional centered image; null for none.</param>
     /// <param name="centerImageRelativeSize">Center image area as fraction of symbol side (0.05–0.45).</param>
     /// <param name="centerImagePaddingModules">Padding in modules between cleared area and image.</param>
+    /// <param name="centerImagePalette">Optional resolved palette settings for the center image.</param>
     /// <returns>A bitmap of the QR code.</returns>
     public static Bitmap GenerateBitmap(
         string content,
@@ -338,7 +540,8 @@ public class KryptonQRCode : KryptonPanel
         Color? lightColor = null,
         Image? centerImage = null,
         float centerImageRelativeSize = 0.22f,
-        int centerImagePaddingModules = 1)
+        int centerImagePaddingModules = 1,
+        QRCodeCenterImagePalette centerImagePalette = default)
     {
         bool[,] matrix = QRCodeGeneratorCore.Generate(content, eccLevel);
         return QRCodeBitmapRenderer.Render(
@@ -349,7 +552,8 @@ public class KryptonQRCode : KryptonPanel
             true,
             centerImage,
             centerImageRelativeSize,
-            centerImagePaddingModules);
+            centerImagePaddingModules,
+            centerImagePalette);
     }
 
     /// <summary>
@@ -404,7 +608,8 @@ public class KryptonQRCode : KryptonPanel
             light,
             _centerImage,
             _centerImageRelativeSize,
-            _centerImagePaddingModules);
+            _centerImagePaddingModules,
+            GetResolvedCenterImagePalette());
     }
 
     #endregion
@@ -432,6 +637,48 @@ public class KryptonQRCode : KryptonPanel
         PaletteBack back = Enabled ? StateNormal : StateDisabled;
         PaletteState state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
         return back.GetBackColor1(state);
+    }
+
+    private QRCodeCenterImagePalette GetResolvedCenterImagePalette()
+    {
+        if (!_centerImageUsePaletteColors)
+        {
+            return new QRCodeCenterImagePalette(false);
+        }
+
+        PaletteState state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
+        PaletteBase palette = GetResolvedPalette();
+        PaletteContentStyle style = _centerImagePaletteStyle;
+
+        PaletteImageEffect effect = _centerImageEffect != PaletteImageEffect.Inherit
+            ? _centerImageEffect
+            : palette.GetContentImageEffect(style, state);
+        if (effect == PaletteImageEffect.Inherit)
+        {
+            effect = PaletteImageEffect.Normal;
+        }
+
+        Color colorMap = !_centerImageColorMap.IsEmpty
+            ? _centerImageColorMap
+            : palette.GetContentImageColorMap(style, state);
+        if (colorMap.IsEmpty)
+        {
+            colorMap = GlobalStaticVariables.TRANSPARENCY_KEY_COLOR;
+        }
+
+        Color colorTo = !_centerImageColorTo.IsEmpty
+            ? _centerImageColorTo
+            : palette.GetContentImageColorTo(style, state);
+        if (colorTo.IsEmpty)
+        {
+            colorTo = GetEffectiveDarkModuleColor();
+        }
+
+        Color transparentColor = !_centerImageTransparentColor.IsEmpty
+            ? _centerImageTransparentColor
+            : palette.GetContentImageColorTransparent(style, state);
+
+        return new QRCodeCenterImagePalette(true, effect, colorMap, colorTo, transparentColor);
     }
 
     private void Regenerate()

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeBitmapRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeBitmapRenderer.cs
@@ -26,7 +26,7 @@ internal static class QRCodeBitmapRenderer
     /// <param name="showBorder">Whether to add a quiet zone (4 modules).</param>
     /// <returns>A bitmap of the QR code.</returns>
     public static Bitmap Render(bool[,] matrix, int moduleSize, Color darkColor, Color lightColor, bool showBorder)
-        => Render(matrix, moduleSize, darkColor, lightColor, showBorder, null, 0.22f, 1);
+        => Render(matrix, moduleSize, darkColor, lightColor, showBorder, null, 0.22f, 1, default);
 
     /// <summary>
     /// Renders the QR code matrix to a bitmap, optionally drawing a centered image over the symbol.
@@ -39,7 +39,8 @@ internal static class QRCodeBitmapRenderer
         bool showBorder,
         Image? centerImage,
         float centerImageRelativeSize,
-        int centerImagePaddingModules)
+        int centerImagePaddingModules,
+        QRCodeCenterImagePalette centerImagePalette)
     {
         int border = showBorder ? moduleSize * 4 : 0;
         int size = matrix.GetLength(0);
@@ -61,7 +62,7 @@ internal static class QRCodeBitmapRenderer
                 }
             }
 
-            DrawCenterImageIfAny(g, size, moduleSize, border, border, lightColor, centerImage, centerImageRelativeSize, centerImagePaddingModules);
+            DrawCenterImageIfAny(g, size, moduleSize, border, border, lightColor, centerImage, centerImageRelativeSize, centerImagePaddingModules, centerImagePalette);
         }
 
         return bmp;
@@ -79,7 +80,8 @@ internal static class QRCodeBitmapRenderer
         Color lightColor,
         Image? centerImage,
         float relativeSize,
-        int paddingModules)
+        int paddingModules,
+        QRCodeCenterImagePalette centerImagePalette)
     {
         if (centerImage is null)
         {
@@ -138,7 +140,23 @@ internal static class QRCodeBitmapRenderer
         g.PixelOffsetMode = PixelOffsetMode.Half;
         try
         {
-            g.DrawImage(centerImage, lx, ly, w, h);
+            var destRect = new Rectangle(lx, ly, w, h);
+            if (centerImagePalette.UsePaletteColors)
+            {
+                PaletteImageDrawing.Draw(
+                    g,
+                    centerImage,
+                    destRect,
+                    VisualOrientation.Top,
+                    centerImagePalette.Effect,
+                    centerImagePalette.TransparentColor,
+                    centerImagePalette.ColorMap,
+                    centerImagePalette.ColorTo);
+            }
+            else
+            {
+                g.DrawImage(centerImage, destRect);
+            }
         }
         finally
         {

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeCenterImagePalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeCenterImagePalette.cs
@@ -1,0 +1,56 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Utilities;
+
+/// <summary>
+/// Resolved palette image drawing settings for a QR code center image.
+/// </summary>
+public readonly struct QRCodeCenterImagePalette
+{
+    /// <summary>Initializes a new instance with palette image drawing disabled.</summary>
+    public QRCodeCenterImagePalette(bool usePaletteColors)
+    {
+        UsePaletteColors = usePaletteColors;
+        Effect = PaletteImageEffect.Normal;
+        ColorMap = GlobalStaticVariables.EMPTY_COLOR;
+        ColorTo = GlobalStaticVariables.EMPTY_COLOR;
+        TransparentColor = GlobalStaticVariables.EMPTY_COLOR;
+    }
+
+    /// <summary>Initializes a new instance with resolved palette image values.</summary>
+    public QRCodeCenterImagePalette(
+        bool usePaletteColors,
+        PaletteImageEffect effect,
+        Color colorMap,
+        Color colorTo,
+        Color transparentColor)
+    {
+        UsePaletteColors = usePaletteColors;
+        Effect = effect;
+        ColorMap = colorMap;
+        ColorTo = colorTo;
+        TransparentColor = transparentColor;
+    }
+
+    /// <summary>Gets whether palette image drawing is active.</summary>
+    public bool UsePaletteColors { get; }
+
+    /// <summary>Gets the image effect to apply.</summary>
+    public PaletteImageEffect Effect { get; }
+
+    /// <summary>Gets the source color to remap.</summary>
+    public Color ColorMap { get; }
+
+    /// <summary>Gets the destination color for remapping.</summary>
+    public Color ColorTo { get; }
+
+    /// <summary>Gets the color that should be drawn transparent.</summary>
+    public Color TransparentColor { get; }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/PaletteImageDrawing.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/PaletteImageDrawing.cs
@@ -1,0 +1,219 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Draws images using the same palette image effect and color-remap rules as <see cref="RenderBase"/>.
+/// </summary>
+public static class PaletteImageDrawing
+{
+    #region Static Fields
+
+    private static readonly object _threadLock = new object();
+
+    private static readonly ColorMatrix _matrixGrayScale = new ColorMatrix([
+        [0.3f, 0.3f, 0.3f, 0, 0], [0.59f, 0.59f, 0.59f, 0, 0],
+        [0.11f, 0.11f, 0.11f, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixGrayScaleRed = new ColorMatrix([
+        [1, 0, 0, 0, 0], [0, 0.59f, 0.59f, 0, 0], [0, 0.11f, 0.11f, 0, 0],
+        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixGrayScaleGreen = new ColorMatrix([
+        [0.3f, 0, 0.3f, 0, 0], [0, 1, 0, 0, 0], [0.11f, 0, 0.11f, 0, 0],
+        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixGrayScaleBlue = new ColorMatrix([
+        [0.3f, 0.3f, 0, 0, 0], [0.59f, 0.59f, 0, 0, 0], [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixLight = new ColorMatrix([
+        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0], [0.1f, 0.1f, 0.1f, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixLightLight = new ColorMatrix([
+        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0], [0.2f, 0.2f, 0.2f, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixDark = new ColorMatrix([
+        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0], [-0.1f, -0.1f, -0.1f, 0, 1]
+    ]);
+
+    private static readonly ColorMatrix _matrixDarkDark = new ColorMatrix([
+        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 0], [-0.25f, -0.25f, -0.25f, 0, 1]
+    ]);
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    /// Draws an image with palette image effect and optional color remapping.
+    /// </summary>
+    /// <param name="graphics">Target graphics.</param>
+    /// <param name="image">Image to draw.</param>
+    /// <param name="destRect">Destination rectangle.</param>
+    /// <param name="orientation">Visual orientation.</param>
+    /// <param name="effect">Drawing effect.</param>
+    /// <param name="remapTransparent">Color that should become transparent.</param>
+    /// <param name="remapColor">Image color to remap.</param>
+    /// <param name="remapNew">Replacement color for <paramref name="remapColor"/>.</param>
+    public static void Draw(
+        Graphics graphics,
+        Image image,
+        Rectangle destRect,
+        VisualOrientation orientation,
+        PaletteImageEffect effect,
+        Color remapTransparent,
+        Color remapColor,
+        Color remapNew)
+    {
+        if (graphics == null)
+        {
+            throw new ArgumentNullException(nameof(graphics));
+        }
+
+        if (image == null)
+        {
+            throw new ArgumentNullException(nameof(image));
+        }
+
+        lock (_threadLock)
+        {
+            using var attribs = new ImageAttributes();
+
+            switch (effect)
+            {
+                case PaletteImageEffect.Disabled:
+                    attribs.SetColorMatrix(CommonHelper.MatrixDisabled);
+                    break;
+                case PaletteImageEffect.GrayScale:
+                    attribs.SetColorMatrix(_matrixGrayScale, ColorMatrixFlag.SkipGrays);
+                    break;
+                case PaletteImageEffect.GrayScaleRed:
+                    attribs.SetColorMatrix(_matrixGrayScaleRed, ColorMatrixFlag.SkipGrays);
+                    break;
+                case PaletteImageEffect.GrayScaleGreen:
+                    attribs.SetColorMatrix(_matrixGrayScaleGreen, ColorMatrixFlag.SkipGrays);
+                    break;
+                case PaletteImageEffect.GrayScaleBlue:
+                    attribs.SetColorMatrix(_matrixGrayScaleBlue, ColorMatrixFlag.SkipGrays);
+                    break;
+                case PaletteImageEffect.Light:
+                    attribs.SetColorMatrix(_matrixLight);
+                    break;
+                case PaletteImageEffect.LightLight:
+                    attribs.SetColorMatrix(_matrixLightLight);
+                    break;
+                case PaletteImageEffect.Dark:
+                    attribs.SetColorMatrix(_matrixDark);
+                    break;
+                case PaletteImageEffect.DarkDark:
+                    attribs.SetColorMatrix(_matrixDarkDark);
+                    break;
+                case PaletteImageEffect.Inherit:
+                case PaletteImageEffect.Normal:
+                    break;
+            }
+
+            if ((remapTransparent != GlobalStaticVariables.EMPTY_COLOR) ||
+                ((remapColor != GlobalStaticVariables.EMPTY_COLOR) && (remapNew != GlobalStaticVariables.EMPTY_COLOR)))
+            {
+                var colorMaps = new List<ColorMap>();
+
+                if (remapTransparent != GlobalStaticVariables.EMPTY_COLOR)
+                {
+                    colorMaps.Add(new ColorMap
+                    {
+                        OldColor = remapTransparent,
+                        NewColor = Color.Transparent
+                    });
+                }
+
+                if ((remapColor != GlobalStaticVariables.EMPTY_COLOR) && (remapNew != GlobalStaticVariables.EMPTY_COLOR))
+                {
+                    colorMaps.Add(new ColorMap
+                    {
+                        OldColor = remapColor,
+                        NewColor = remapNew
+                    });
+                }
+
+                attribs.SetRemapTable(colorMaps.ToArray(), ColorAdjustType.Bitmap);
+            }
+
+            var translateX = 0;
+            var translateY = 0;
+            var rotation = 0f;
+            Rectangle drawRect = destRect;
+
+            switch (orientation)
+            {
+                case VisualOrientation.Bottom:
+                    translateX = (drawRect.X * 2) + drawRect.Width;
+                    translateY = (drawRect.Y * 2) + drawRect.Height;
+                    rotation = 180f;
+                    break;
+                case VisualOrientation.Left:
+                    drawRect = drawRect with { Width = drawRect.Height, Height = drawRect.Width };
+                    translateX = drawRect.X - drawRect.Y;
+                    translateY = drawRect.X + drawRect.Y + drawRect.Width;
+                    rotation = -90f;
+                    break;
+                case VisualOrientation.Right:
+                    drawRect = drawRect with { Width = drawRect.Height, Height = drawRect.Width };
+                    translateX = drawRect.X + drawRect.Y + drawRect.Height;
+                    translateY = -(drawRect.X - drawRect.Y);
+                    rotation = 90f;
+                    break;
+            }
+
+            if ((translateX != 0) || (translateY != 0))
+            {
+                graphics.TranslateTransform(translateX, translateY);
+            }
+
+            if (rotation != 0f)
+            {
+                graphics.RotateTransform(rotation);
+            }
+
+            try
+            {
+                graphics.DrawImage(image, drawRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attribs);
+            }
+            catch (ArgumentException)
+            {
+            }
+            finally
+            {
+                if (rotation != 0f)
+                {
+                    graphics.RotateTransform(-rotation);
+                }
+
+                if ((translateX != 0) || (translateY != 0))
+                {
+                    graphics.TranslateTransform(-translateX, -translateY);
+                }
+            }
+        }
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -25,50 +25,6 @@ public abstract class RenderBase : Component,
     IRenderRibbon,
     IRenderGlyph
 {
-    #region Static Fields
-    private static readonly object _threadLock = new object();
-
-    private static readonly ColorMatrix _matrixGrayScale = new ColorMatrix([
-        [0.3f, 0.3f, 0.3f, 0, 0], [0.59f, 0.59f, 0.59f, 0, 0],
-        [0.11f, 0.11f, 0.11f, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixGrayScaleRed = new ColorMatrix([
-        [1, 0, 0, 0, 0], [0, 0.59f, 0.59f, 0, 0], [0, 0.11f, 0.11f, 0, 0],
-        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixGrayScaleGreen = new ColorMatrix([
-        [0.3f, 0, 0.3f, 0, 0], [0, 1, 0, 0, 0], [0.11f, 0, 0.11f, 0, 0],
-        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixGrayScaleBlue = new ColorMatrix([
-        [0.3f, 0.3f, 0, 0, 0], [0.59f, 0.59f, 0, 0, 0], [0, 0, 1, 0, 0],
-        [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixLight = new ColorMatrix([
-        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
-        [0, 0, 0, 1, 0], [0.1f, 0.1f, 0.1f, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixLightLight = new ColorMatrix([
-        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
-        [0, 0, 0, 1, 0], [0.2f, 0.2f, 0.2f, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixDark = new ColorMatrix([
-        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
-        [0, 0, 0, 1, 0], [-0.1f, -0.1f, -0.1f, 0, 1]
-    ]);
-
-    private static readonly ColorMatrix _matrixDarkDark = new ColorMatrix([
-        [1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0],
-        [0, 0, 0, 1, 0], [-0.25f, -0.25f, -0.25f, 0, 1]
-    ]);
-    #endregion
-
     #region IRenderer
     /// <summary>
     /// Gets the standard border renderer.
@@ -936,152 +892,25 @@ public abstract class RenderBase : Component,
     {
         Debug.Assert(context != null);
 
-        // Prevent problems with multiple threads using the same palette images 
-        // by only allowing a single thread to draw the provided image at a time
-        lock (_threadLock)
+        if (context == null)
         {
-            // Validate reference parameter
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            // Use image attributes class to modify image drawing for effects
-            var attribs = new ImageAttributes();
-
-            switch (effect)
-            {
-                case PaletteImageEffect.Disabled:
-                    attribs.SetColorMatrix(CommonHelper.MatrixDisabled);
-                    break;
-                case PaletteImageEffect.GrayScale:
-                    attribs.SetColorMatrix(_matrixGrayScale, ColorMatrixFlag.SkipGrays);
-                    break;
-                case PaletteImageEffect.GrayScaleRed:
-                    attribs.SetColorMatrix(_matrixGrayScaleRed, ColorMatrixFlag.SkipGrays);
-                    break;
-                case PaletteImageEffect.GrayScaleGreen:
-                    attribs.SetColorMatrix(_matrixGrayScaleGreen, ColorMatrixFlag.SkipGrays);
-                    break;
-                case PaletteImageEffect.GrayScaleBlue:
-                    attribs.SetColorMatrix(_matrixGrayScaleBlue, ColorMatrixFlag.SkipGrays);
-                    break;
-                case PaletteImageEffect.Light:
-                    attribs.SetColorMatrix(_matrixLight);
-                    break;
-                case PaletteImageEffect.LightLight:
-                    attribs.SetColorMatrix(_matrixLightLight);
-                    break;
-                case PaletteImageEffect.Dark:
-                    attribs.SetColorMatrix(_matrixDark);
-                    break;
-                case PaletteImageEffect.DarkDark:
-                    attribs.SetColorMatrix(_matrixDarkDark);
-                    break;
-                case PaletteImageEffect.Inherit:                            // Should never happen!
-                    Debug.Assert(false);
-                    DebugTools.NotImplemented(effect.ToString());
-                    break;
-            }
-
-            // Do we need to remap a colors in the bitmap?
-            if ((remapTransparent != GlobalStaticVariables.EMPTY_COLOR) ||
-                ((remapColor != GlobalStaticVariables.EMPTY_COLOR) && (remapNew != GlobalStaticVariables.EMPTY_COLOR)))
-            {
-                var colorMaps = new List<ColorMap>();
-
-                // Create remapping for the transparent color
-                if (remapTransparent != GlobalStaticVariables.EMPTY_COLOR)
-                {
-                    var remap = new ColorMap
-                    {
-                        OldColor = remapTransparent,
-                        NewColor = Color.Transparent
-                    };
-                    colorMaps.Add(remap);
-                }
-
-                // Create remapping from source to target colors
-                if ((remapColor != GlobalStaticVariables.EMPTY_COLOR) && (remapNew != GlobalStaticVariables.EMPTY_COLOR))
-                {
-                    var remap = new ColorMap
-                    {
-                        OldColor = remapColor,
-                        NewColor = remapNew
-                    };
-                    colorMaps.Add(remap);
-                }
-
-                attribs.SetRemapTable(colorMaps.ToArray(), ColorAdjustType.Bitmap);
-            }
-
-            var translateX = 0;
-            var translateY = 0;
-            var rotation = 0f;
-
-            // Perform any transformations needed for orientation
-            switch (orientation)
-            {
-                case VisualOrientation.Bottom:
-                    // Translate to opposite side of origin, so the rotate can 
-                    // then bring it back to original position but mirror image
-                    translateX = (imageRect.X * 2) + imageRect.Width;
-                    translateY = (imageRect.Y * 2) + imageRect.Height;
-                    rotation = 180f;
-                    break;
-                case VisualOrientation.Left:
-                    // Invert the dimensions of the rectangle for drawing upwards
-                    imageRect = imageRect with { Width = imageRect.Height, Height = imageRect.Width };
-
-                    // Translate back from a quarter left turn to the original place 
-                    translateX = imageRect.X - imageRect.Y;
-                    translateY = imageRect.X + imageRect.Y + imageRect.Width;
-                    rotation = -90f;
-                    break;
-                case VisualOrientation.Right:
-                    // Invert the dimensions of the rectangle for drawing upwards
-                    imageRect = imageRect with { Width = imageRect.Height, Height = imageRect.Width };
-
-                    // Translate back from a quarter right turn to the original place 
-                    translateX = imageRect.X + imageRect.Y + imageRect.Height;
-                    translateY = -(imageRect.X - imageRect.Y);
-                    rotation = 90f;
-                    break;
-            }
-
-            // Apply the transforms if we have any to apply
-            if ((translateX != 0) || (translateY != 0))
-            {
-                context.Graphics.TranslateTransform(translateX, translateY);
-            }
-
-            if (rotation != 0f)
-            {
-                context.Graphics.RotateTransform(rotation);
-            }
-
-            try
-            {
-                // Finally, just draw the image and let the transforms do the rest
-                context.Graphics.DrawImage(image!, imageRect, 0, 0, imageRect.Width, imageRect.Height, GraphicsUnit.Pixel, attribs);
-            }
-            catch (ArgumentException)
-            {
-            }
-            finally
-            {
-                if (rotation != 0f)
-                {
-                    context.Graphics.RotateTransform(-rotation);
-                }
-
-                // Remove the applied transforms
-                if ((translateX != 0) | (translateY != 0))
-                {
-                    context.Graphics.TranslateTransform(-translateX, -translateY);
-                }
-            }
+            throw new ArgumentNullException(nameof(context));
         }
+
+        if (image == null)
+        {
+            return;
+        }
+
+        PaletteImageDrawing.Draw(
+            context.Graphics,
+            image,
+            imageRect,
+            orientation,
+            effect,
+            remapTransparent,
+            remapColor,
+            remapNew);
     }
     #endregion
 }

--- a/Source/Krypton Components/TestForm/QRCodeDemo.cs
+++ b/Source/Krypton Components/TestForm/QRCodeDemo.cs
@@ -213,7 +213,8 @@ public partial class QRCodeDemo : KryptonForm
                 _kcbtnLightColor.SelectedColor,
                 centerImage: _kryptonQRCode.CenterImage,
                 centerImageRelativeSize: _kryptonQRCode.CenterImageRelativeSize,
-                centerImagePaddingModules: _kryptonQRCode.CenterImagePaddingModules);
+                centerImagePaddingModules: _kryptonQRCode.CenterImagePaddingModules,
+                centerImagePalette: _kryptonQRCode.GetCenterImagePalette());
 
             Clipboard.SetImage(bmp);
             KryptonMessageBox.Show(this,


### PR DESCRIPTION
# KryptonQRCode: palette-aware center image drawing

## Summary

- Adds optional palette image drawing for `KryptonQRCode.CenterImage`, matching the same effect and color-remap rules used elsewhere in the toolkit (e.g. button and content images).
- Extracts shared drawing logic into `PaletteImageDrawing` (`Krypton.Toolkit`) and routes `RenderBase.DrawImageHelper` through it, reducing duplication and keeping QR export/on-screen rendering consistent.
- Extends [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305) QR Code work in `Krypton.Toolkit.Utilities`; no breaking changes (`CenterImageUsePaletteColors` defaults to `false`).

## Background

`KryptonQRCode` already supports theme-aware **module** colours via `DarkColor` / `LightColor` when left empty (palette label text and panel client background). `CenterImage` was drawn with a plain `Graphics.DrawImage` call, so template glyphs and logos did not follow palette image effects or colour remapping when the global theme changed.

This change closes that gap with an opt-in palette pipeline.

## Changes

### `KryptonQRCode` (`Krypton.Toolkit.Utilities`)

New properties:

| Property | Default | Purpose |
|----------|---------|---------|
| `CenterImageUsePaletteColors` | `false` | Enables palette image drawing for `CenterImage` | | `CenterImagePaletteStyle` | `LabelNormalPanel` | `PaletteContentStyle` used to resolve inherited palette values | | `CenterImageColorMap` | `Empty` | Source remap colour; empty inherits from palette | | `CenterImageColorTo` | `Empty` | Target remap colour; empty inherits from palette, then effective dark module colour | | `CenterImageTransparentColor` | `Empty` | Colour drawn transparent; empty inherits from palette | | `CenterImageEffect` | `Inherit` | Image effect (disabled, grayscale, light/dark, etc.); `Inherit` uses palette |

New API:

- `GetCenterImagePalette()` — returns resolved `QRCodeCenterImagePalette` for the current control state (enabled/disabled, palette, overrides).
- `QRCodeCenterImagePalette` — public struct passed to `GenerateBitmap(..., centerImagePalette: ...)` so static export matches on-control rendering.

**Resolution order** (when `CenterImageUsePaletteColors` is `true`):

1. Property override (non-empty colour / non-`Inherit` effect)
2. Active palette for `CenterImagePaletteStyle`
3. Fallback for template glyphs: `GlobalStaticVariables.TRANSPARENCY_KEY_COLOR` (magenta) → effective dark module colour when the palette does not define map/to colours

**Unchanged behaviour:** full-colour photos and logos remain unaffected unless `CenterImageUsePaletteColors` is set to `true`.

### `QRCodeBitmapRenderer`

- `DrawCenterImageIfAny` and `Render` accept `QRCodeCenterImagePalette` and call `PaletteImageDrawing.Draw` when palette drawing is enabled.

### `PaletteImageDrawing` (`Krypton.Toolkit`)

- New public static helper applying palette image effects (`PaletteImageEffect`) and colour remaps (transparent key, map → to).
- Used by `KryptonQRCode` and `RenderBase.DrawImageHelper` (refactor; behaviour preserved for existing render paths).

### Other

- `Documents/Changelog/Changelog.md` — V110 Nightly entry under [#3305](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3305).
- `TestForm/QRCodeDemo.cs` — static API demo passes `GetCenterImagePalette()` when copying via `GenerateBitmap`.

## Files touched

- `Source/Krypton Components/Krypton.Toolkit/Rendering/PaletteImageDrawing.cs` *(new)*
- `Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs`
- `Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/Controls Toolkit/KryptonQRCode.cs`
- `Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeBitmapRenderer.cs`
- `Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton QR Code/General/QRCodeCenterImagePalette.cs` *(new)*
- `Source/Krypton Components/TestForm/QRCodeDemo.cs`
- `Documents/Changelog/Changelog.md`

## Test plan

- [ ] Build `Krypton.Toolkit` and `Krypton.Toolkit.Utilities` (e.g. `net48` Debug).
- [ ] Run `TestForm` → **QR Code** demo.
- [ ] Generate a QR code with default settings; confirm appearance unchanged (palette center image off by default).
- [ ] Assign a magenta-key template glyph to `CenterImage`; set `CenterImageUsePaletteColors = true`.
- [ ] Switch global palette / theme; confirm center glyph and dark modules track the theme.
- [ ] Disable the control; confirm disabled image effect applies when palette specifies it.
- [ ] Set explicit `CenterImageColorMap` / `CenterImageColorTo`; confirm overrides win over palette.
- [ ] **Save PNG** and **Copy image**; confirm exported bitmap matches on-screen preview.
- [ ] **Static API** button; confirm clipboard image uses the same center-image palette rules via `GetCenterImagePalette()`.
- [ ] Assign a full-colour logo with `CenterImageUsePaletteColors = false`; confirm no unwanted remapping.

## Notes for reviewers

- `PaletteImageDrawing.Draw` uses the full source image dimensions (`0, 0, image.Width, image.Height`) when drawing to a destination rect; this is intentional for correctly scaled center logos in the QR renderer.
- Magenta → dark module fallback only applies when palette drawing is enabled and the palette does not supply map/to colours—appropriate for Krypton template assets, not for arbitrary photographs.

<img width="667" height="255" alt="image" src="https://github.com/user-attachments/assets/fa8be4ef-97aa-4cfb-a638-aa6d6b97a28b" />
