### PR TITLE
* KryptonTreeView items flicker when selected/clicked (V105)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,15 +83,6 @@
 		</Otherwise>
 	</Choose>
 
-	<!-- MSB3822/3823: non-string .resx entries need preserialized resources + this package for the SDK GenerateResource task. -->
-	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
-		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	</PropertyGroup>
-
-	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' AND '$(UseWindowsForms)' == 'true'">
-		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
-	</ItemGroup>
-
 	<PropertyGroup Condition="'$(Configuration)' == 'Nightly'">
 		<DefineConstants>$(DefineConstants);NIGHTLY</DefineConstants>
 	</PropertyGroup>

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection/check updates; no per-node background repaint)
 * Resolved [#3451](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3451), Unable to add child controls into `KryptonHeaderGroup` at design time (`ReadOnly controls collection`). `DisplayRectangle` now reports the view fill rect, group container designers call `PerformLayout` after `EnableDesignMode`, and `KryptonGroupPanelDesigner.CanBeParentedTo` checks the parent component type correctly. Same `DisplayRectangle` improvement applied to `KryptonGroup` and `KryptonGroupBox`.
 * Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), ButtonSpec hover flicker on `KryptonTextBox`, `KryptonMaskedTextBox`, and `KryptonForm` (including `ImageStates.ImageNormal` without `Image`)
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -20,6 +20,15 @@
 		<Version>$(LibraryVersion)</Version>
 	</PropertyGroup>
 
+	<!-- MSB3822/3823: non-string .resx entries need preserialized resources + this package for the SDK GenerateResource task. -->
+	<PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
+		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
+		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+	</ItemGroup>
+
 	<!-- Configure NuGet package output to separate directory for easier management -->
 	<PropertyGroup>
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\Bin\Packages\$(Configuration)\</PackageOutputPath>

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -25,6 +25,7 @@
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\Bin\Packages\$(Configuration)\</PackageOutputPath>
 		<!-- Ensure multi-target outputs don't overwrite each other -->
 		<OutputPath>$(MSBuildThisFileDirectory)..\..\Bin\$(Configuration)\$(TargetFramework)\</OutputPath>
+		<IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2021 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2021 - 2026. All rights reserved.
  */
 #endregion
 
@@ -234,6 +234,9 @@ public class KryptonPropertyGrid : VisualControlBase,
     private bool _alwaysActive;
     private bool _forcedLayout;
     private readonly KryptonContextMenuItem _resetMenuItem;
+    private Font? _normalFont;
+    private Font? _disabledFont;
+    private Font? _activeFont;
 
     /// <summary>Occurs before a key is pressed while the control has focus.</summary>
     [Description(@"Occurs before a key is pressed while the control has focus.")]
@@ -333,6 +336,10 @@ public class KryptonPropertyGrid : VisualControlBase,
         {
             PI.DeleteDC(_screenDC);
         }
+
+        _normalFont?.Dispose();
+        _disabledFont?.Dispose();
+        _activeFont?.Dispose();
     }
     #endregion
 
@@ -634,8 +641,15 @@ public class KryptonPropertyGrid : VisualControlBase,
 
             var normalFont = gridState.PaletteContent?.GetContentShortTextFont(PaletteState.ContextNormal);
             var disabledFont = gridState.PaletteContent?.GetContentShortTextFont(PaletteState.Disabled);
+            List<Font>? oldFonts = null;
+            Font? normalControlFont = UpdateControlFont(ref _normalFont, normalFont, ref oldFonts);
+            Font? disabledControlFont = UpdateControlFont(ref _disabledFont, disabledFont, ref oldFonts);
+            Font? activeControlFont = UpdateControlFont(
+                ref _activeFont,
+                StateActive.PaletteContent?.GetContentShortTextFont(PaletteState.Tracking),
+                ref oldFonts);
 
-            _propertyGrid.Font = (Enabled ? normalFont : disabledFont)!;
+            _propertyGrid.Font = Enabled ? normalControlFont : disabledControlFont;
             _propertyGrid.BackColor =
                 gridState.PaletteBack.GetBackColor1(Enabled ? PaletteState.Normal : PaletteState.Disabled);
 
@@ -646,22 +660,21 @@ public class KryptonPropertyGrid : VisualControlBase,
                 IPaletteTriple triple;
                 if (control.Focused)
                 {
-                    state = PaletteState.FocusOverride;
+                    state = PaletteState.Tracking;
                     triple = StateActive;
-                    control.Font = StateActive.PaletteContent?.GetContentShortTextFont(PaletteState.FocusOverride)!;
+                    control.Font = activeControlFont;
                 }
                 else if (control.Enabled)
                 {
                     state = PaletteState.ContextNormal;
                     triple = StateNormal;
-                    // Note: tobitege commented out to avoid unrecoverable exception in System.Drawing, when toggling theme back and forth
-                    control.Font = normalFont!;
+                    control.Font = normalControlFont;
                 }
                 else
                 {
                     state = PaletteState.Disabled;
                     triple = StateDisabled;
-                    control.Font = disabledFont!;
+                    control.Font = disabledControlFont;
                 }
 
                 control.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
@@ -676,8 +689,60 @@ public class KryptonPropertyGrid : VisualControlBase,
             _propertyGrid.ViewForeColor = ContrastColor(_propertyGrid.ViewBackColor);
             //PI.SendMessage(_propertyGrid.Handle, PI.WM_.SETREDRAW, (IntPtr)PI.BOOL.TRUE, IntPtr.Zero);
             Invalidate();
+
+            if (oldFonts != null)
+            {
+                foreach (Font oldFont in oldFonts)
+                {
+                    oldFont.Dispose();
+                }
+            }
         }
     }
+
+    private static Font? UpdateControlFont(ref Font? controlFont, Font? paletteFont, ref List<Font>? oldFonts)
+    {
+        if (paletteFont == null)
+        {
+            if (controlFont != null)
+            {
+                if (oldFonts == null)
+                {
+                    oldFonts = new List<Font>();
+                }
+
+                oldFonts.Add(controlFont);
+                controlFont = null;
+            }
+
+            return null;
+        }
+
+        if ((controlFont == null) || !SameFont(controlFont, paletteFont))
+        {
+            if (controlFont != null)
+            {
+                if (oldFonts == null)
+                {
+                    oldFonts = new List<Font>();
+                }
+
+                oldFonts.Add(controlFont);
+            }
+
+            controlFont = (Font)paletteFont.Clone();
+        }
+
+        return controlFont;
+    }
+
+    private static bool SameFont(Font font1, Font font2) =>
+        font1.Name == font2.Name &&
+        font1.Size.Equals(font2.Size) &&
+        font1.Style == font2.Style &&
+        font1.Unit == font2.Unit &&
+        font1.GdiCharSet == font2.GdiCharSet &&
+        font1.GdiVerticalFont == font2.GdiVerticalFont;
 
     private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -59,7 +59,7 @@ public class KryptonTreeView : VisualControlBase,
         /// <param name="kryptonTreeView">Reference to owning control.</param>
         public InternalTreeView(KryptonTreeView kryptonTreeView)
         {
-            SetStyle(ControlStyles.ResizeRedraw, true);
+            SetStyle(ControlStyles.ResizeRedraw | ControlStyles.OptimizedDoubleBuffer, true);
 
             _kryptonTreeView = kryptonTreeView;
 
@@ -148,9 +148,19 @@ public class KryptonTreeView : VisualControlBase,
 
         #region Protected
         /// <summary>
-        /// Raises the Layout event.
+        /// Initializes extended TreeView styles when the handle is created.
         /// </summary>
-        /// <param name="levent">A LayoutEventArgs containing the event data.</param>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            _ = PI.SendMessage(Handle, PI.TVM_.TVM_SETEXTENDEDSTYLE, (IntPtr)PI.TVS_EX_DOUBLEBUFFER,
+                (IntPtr)PI.TVS_EX_DOUBLEBUFFER);
+
+            _kryptonTreeView.SyncTreeViewBackColor();
+        }
+
         protected override void OnLayout(LayoutEventArgs levent)
         {
             base.OnLayout(levent);
@@ -266,14 +276,6 @@ public class KryptonTreeView : VisualControlBase,
                                 ViewDrawPanel.Render(context);
                             }
 
-                            // We can only control the background color by using the built in property and not
-                            // by overriding the drawing directly, therefore we can only provide a single color.
-                            Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                            if (color1 != BackColor)
-                            {
-                                BackColor = color1;
-                            }
-
                             // Replace given DC with the screen DC for base window proc drawing
                             IntPtr beforeDC = m.WParam;
                             m.WParam = _screenDC;
@@ -329,13 +331,14 @@ public class KryptonTreeView : VisualControlBase,
     private readonly FixedContentValue? _contentValues;
     private bool? _fixedActive;
     private ButtonStyle _style;
-    private readonly IntPtr _screenDC;
     private bool _itemHeightDefault;
     private bool _mouseOver;
     private bool _alwaysActive;
     private bool _forcedLayout;
     private bool _trackingMouseEnter;
     private bool _isRecreating; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/777
+    private int _selectUpdateCount;
+    private TreeNode? _pendingMultiSelectToggle;
     private bool _multiSelect;
     #endregion
 
@@ -663,9 +666,6 @@ public class KryptonTreeView : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add tree view to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_treeView);
     }
@@ -676,14 +676,8 @@ public class KryptonTreeView : VisualControlBase,
     /// Releases all resources used by the Control.
     /// </summary>
     /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
-    }
+    protected override void Dispose(bool disposing) => base.Dispose(disposing);
+
     #endregion
 
     #region Public
@@ -1537,11 +1531,6 @@ public class KryptonTreeView : VisualControlBase,
     {
         if (!_isRecreating)
         {
-            if (_multiSelect && e.Node is not null)
-            {
-                e.Node.Checked = !e.Node.Checked;
-            }
-
             AfterSelect?.Invoke(this, e);
         }
     }
@@ -1837,11 +1826,18 @@ public class KryptonTreeView : VisualControlBase,
     /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
     protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
-        if (IsHandleCreated && !e.NeedLayout)
+        if (_selectUpdateCount == 0)
         {
-            _treeView.Invalidate();
+            if (IsHandleCreated && !e.NeedLayout)
+            {
+                _treeView.Invalidate();
+            }
+            else
+            {
+                ForceControlLayout();
+            }
         }
-        else
+        else if (e.NeedLayout)
         {
             ForceControlLayout();
         }
@@ -1849,7 +1845,11 @@ public class KryptonTreeView : VisualControlBase,
         // Update palette to reflect latest state
         UpdateItemHeight();
         UpdateStateAndPalettes();
-        base.OnNeedPaint(sender, e);
+
+        if (_selectUpdateCount == 0)
+        {
+            base.OnNeedPaint(sender, e);
+        }
     }
 
     /// <summary>
@@ -2004,6 +2004,20 @@ public class KryptonTreeView : VisualControlBase,
             _treeView.ViewDrawPanel.ElementState = state;
             _drawDockerOuter.ElementState = state;
             _treeView.Font = StateCommon.Node.Content.ShortText.Font;
+
+            SyncTreeViewBackColor();
+        }
+    }
+
+    private void SyncTreeViewBackColor()
+    {
+        // We can only control the background color by using the built in property and not
+        // by overriding the drawing directly, therefore we can only provide a single color.
+        // Must not assign BackColor during WM_PAINT; doing so triggers a second erase/paint cycle.
+        Color color1 = _treeView.ViewDrawPanel.GetPalette().GetBackColor1(_treeView.ViewDrawPanel.State);
+        if (_treeView.BackColor != color1)
+        {
+            _treeView.BackColor = color1;
         }
     }
 
@@ -2032,6 +2046,9 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewDrawNode(object? sender, DrawTreeNodeEventArgs e)
     {
+        // OwnerDrawAll: skip native item painting (CDRF_SKIPDEFAULT).
+        e.DrawDefault = false;
+
         // We cannot do anything without a valid node
         if (e.Node == null)
         {
@@ -2162,8 +2179,9 @@ public class KryptonTreeView : VisualControlBase,
         // Update the view with the calculated state
         _drawButton.ElementState = buttonState;
 
-        // Grab the raw device context for the graphics instance
-        var hdc = e.Graphics.GetHdc();
+        Graphics g = e.Graphics;
+        var savedClip = g.Clip;
+        g.SetClip(e.Bounds);
 
         try
         {
@@ -2176,213 +2194,185 @@ public class KryptonTreeView : VisualControlBase,
             bounds.X += nodeIndent;
             bounds.Width -= nodeIndent;
 
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            var hBitmap = PI.CreateCompatibleBitmap(hdc, bounds.Right, bounds.Bottom);
-
-            // If we managed to get a compatible bitmap
-            if (hBitmap != IntPtr.Zero)
+            using (var context = new ViewLayoutContext(this, Renderer))
             {
+                context.DisplayRectangle = bounds;
+
+                // If not using full row selection, then layout using only required width
+                Size prefSize = _layoutDocker.GetPreferredSize(context);
+                if (!FullRowSelect)
+                {
+                    if (prefSize.Width < bounds.Width)
+                    {
+                        bounds.Width = prefSize.Width;
+                    }
+                }
+
+                // Always ensure we have enough space for drawing all the elements
+                if (bounds.Width < prefSize.Width)
+                {
+                    bounds.Width = prefSize.Width;
+                }
+
+                context.DisplayRectangle = bounds;
+
+                _layoutDocker.Layout(context);
+            }
+
+            // Row background is painted once in InternalTreeView.WmPaint before DefWndProc/DrawNode.
+
+            // Do we have an indent area for drawing plus/minus/lines?
+            if (indentBounds.X >= 0)
+            {
+                // Do we draw lines between nodes?
+                if (ShowLines
+                    && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                {
+                    // Find center points
+                    var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
+                    var vCenter = indentBounds.Y + (indentBounds.Height / 2);
+                    vCenter -= (vCenter + 1) % 2;
+
+                    // Default to showing full line height
+                    var top = indentBounds.Y;
+                    top -= (top + 1) % 2;
+                    var bottom = indentBounds.Bottom;
+
+                    // If the first root node then do not show top half of line
+                    if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
+                    {
+                        top = vCenter;
+                    }
+
+                    // If the last node in collection then do not show bottom half of line
+                    if (e.Node.NextNode == null)
+                    {
+                        bottom = vCenter;
+                    }
+
+                    // Draw the horizontal and vertical lines
+                    Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+                    using var linePen = new Pen(lineColor);
+                    linePen.DashStyle = DashStyle.Dot;
+                    linePen.DashOffset = indent % 2;
+                    g.DrawLine(linePen, hCenter, top, hCenter, bottom);
+                    g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
+                    hCenter -= indent;
+
+                    // Draw the vertical lines for previous node levels
+                    while (hCenter >= 0)
+                    {
+                        var begin = indentBounds.Y;
+                        begin -= (begin + 1) % 2;
+                        g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
+                        hCenter -= indent;
+                    }
+                }
+
+                // Do we draw any plus/minus images in indent bounds?
+                if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                {
+                    Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
+                    if (drawImage != null)
+                    {
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
+                            indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
+                            drawImage.Width, drawImage.Height));
+                    }
+                }
+            }
+
+            using (var context = new RenderContext(this, g, bounds, Renderer))
+            {
+                _layoutDocker.Render(context);
+            }
+
+            var isSelected = (e.State & TreeNodeStates.Selected) == TreeNodeStates.Selected;
+
+            // Do we draw an image for the node?
+            if (ImageList != null)
+            {
+                Image? drawImage = null;
+                var imageCount = ImageList.Images.Count;
+
                 try
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    PI.SelectObject(_screenDC, hBitmap);
-
-                    // Easier to draw using a graphics instance than a DC!
-                    using Graphics g = Graphics.FromHdc(_screenDC);
-                    using (var context = new ViewLayoutContext(this, Renderer))
+                    if (isSelected)
                     {
-                        context.DisplayRectangle = e.Bounds;
-                        _treeView.ViewDrawPanel.Layout(context);
-                        context.DisplayRectangle = bounds;
-
-                        // If no using full row selection, then layout using only required width
-                        Size prefSize = _layoutDocker.GetPreferredSize(context);
-                        if (!FullRowSelect)
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
                         {
-                            if (prefSize.Width < bounds.Width)
-                            {
-                                bounds.Width = prefSize.Width;
-                            }
+                            drawImage = ImageList.Images[e.Node.SelectedImageKey];
                         }
-
-                        // Always ensure we have enough space for drawing all the elements
-                        if (bounds.Width < prefSize.Width)
+                        else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
                         {
-                            bounds.Width = prefSize.Width;
+                            drawImage = ImageList.Images[e.Node.SelectedImageIndex];
                         }
-
-                        context.DisplayRectangle = bounds;
-
-                        _layoutDocker.Layout(context);
+                        else if (!string.IsNullOrEmpty(SelectedImageKey))
+                        {
+                            drawImage = ImageList.Images[SelectedImageKey];
+                        }
+                        else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[SelectedImageIndex];
+                        }
                     }
-
-                    using (var context = new RenderContext(this, g, e.Bounds, Renderer))
+                    else
                     {
-                        _treeView.ViewDrawPanel.Render(context);
-                    }
-
-                    // Do we have an indent area for drawing plus/minus/lines?
-                    if (indentBounds.X >= 0)
-                    {
-                        // Do we draw lines between nodes?
-                        if (ShowLines
-                            && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.ImageKey))
                         {
-                            // Find center points
-                            var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
-                            var vCenter = indentBounds.Y + (indentBounds.Height / 2);
-                            vCenter -= (vCenter + 1) % 2;
-
-                            // Default to showing full line height
-                            var top = indentBounds.Y;
-                            top -= (top + 1) % 2;
-                            var bottom = indentBounds.Bottom;
-
-                            // If the first root node then do not show top half of line
-                            if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
-                            {
-                                top = vCenter;
-                            }
-
-                            // If the last node in collection then do not show bottom half of line
-                            if (e.Node.NextNode == null)
-                            {
-                                bottom = vCenter;
-                            }
-
-                            // Draw the horizontal and vertical lines
-                            Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
-                            using var linePen = new Pen(lineColor);
-                            linePen.DashStyle = DashStyle.Dot;
-                            linePen.DashOffset = indent % 2;
-                            g.DrawLine(linePen, hCenter, top, hCenter, bottom);
-                            g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
-                            hCenter -= indent;
-
-                            // Draw the vertical lines for previous node levels
-                            while (hCenter >= 0)
-                            {
-                                var begin = indentBounds.Y;
-                                begin -= (begin + 1) % 2;
-                                g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
-                                hCenter -= indent;
-                            }
+                            drawImage = ImageList.Images[e.Node.ImageKey];
                         }
-
-                        // Do we draw any plus/minus images in indent bounds?
-                        if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                        else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
                         {
-                            Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
-                                    indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
-                                    drawImage.Width, drawImage.Height));
-                            }
+                            drawImage = ImageList.Images[e.Node.ImageIndex];
+                        }
+                        else if (!string.IsNullOrEmpty(ImageKey))
+                        {
+                            drawImage = ImageList.Images[ImageKey];
+                        }
+                        else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[ImageIndex];
                         }
                     }
 
-                    using (var context = new RenderContext(this, g, bounds, Renderer))
+                    if (drawImage != null)
                     {
-                        _layoutDocker.Render(context);
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, _layoutImage.ClientRectangle);
                     }
-
-                    // Do we draw an image for the node?
-                    if (ImageList != null)
-                    {
-                        Image? drawImage = null;
-                        var imageCount = ImageList.Images.Count;
-
-                        try
-                        {
-                            if (e.Node.IsSelected)
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageKey];
-                                }
-                                else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageKey];
-                                }
-                                else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageIndex];
-                                }
-                            }
-                            else
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.ImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageKey];
-                                }
-                                else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(ImageKey))
-                                {
-                                    drawImage = ImageList.Images[ImageKey];
-                                }
-                                else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[ImageIndex];
-                                }
-                            }
-
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, _layoutImage.ClientRectangle);
-                            }
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-                    }
-
-                    // Draw a node state image?
-                    if (_layoutImageCenterState.Visible)
-                    {
-                        if (drawStateImage != null)
-                        {
-                            float dpiFactor = g.DpiX / 96F;
-                            drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
-                                drawStateImage.Width * dpiFactor,
-                                drawStateImage.Height * dpiFactor, false)!;
-                            g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
-                        }
-                    }
-
-                    // Now blit from the bitmap from the screen to the real dc
-                    PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
                 }
-                finally
+                catch
                 {
-                    // Delete the temporary bitmap
-                    PI.DeleteObject(hBitmap);
+                    // ignored
+                }
+            }
+
+            // Draw a node state image?
+            if (_layoutImageCenterState.Visible)
+            {
+                if (drawStateImage != null)
+                {
+                    float dpiFactor = g.DpiX / 96F;
+                    drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                        drawStateImage.Width * dpiFactor,
+                        drawStateImage.Height * dpiFactor, false)!;
+                    g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
                 }
             }
         }
         finally
         {
-            // Must reserve the GetHdc() call before
-            e.Graphics.ReleaseHdc();
+            g.Clip = savedClip;
         }
     }
 
@@ -2422,7 +2412,29 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewItemDrag(object? sender, ItemDragEventArgs e) => OnItemDrag(e);
 
-    private void OnTreeViewBeforeSelect(object? sender, TreeViewCancelEventArgs e) => OnBeforeSelect(e);
+    private void OnTreeViewBeforeSelect(object? sender, TreeViewCancelEventArgs e)
+    {
+        if (!_isRecreating)
+        {
+            _selectUpdateCount++;
+            _treeView.BeginUpdate();
+
+            if (_multiSelect && e.Node is not null)
+            {
+                _pendingMultiSelectToggle = e.Node;
+            }
+        }
+
+        OnBeforeSelect(e);
+
+        if (e.Cancel && !_isRecreating)
+        {
+            _pendingMultiSelectToggle = null;
+
+            _selectUpdateCount--;
+            _treeView.EndUpdate();
+        }
+    }
 
     private void OnTreeViewBeforeLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnBeforeLabelEdit(e);
 
@@ -2432,7 +2444,28 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeViewBeforeCheck(object? sender, TreeViewCancelEventArgs e) => OnBeforeCheck(e);
 
-    private void OnTreeViewAfterSelect(object? sender, TreeViewEventArgs e) => OnAfterSelect(e);
+    private void OnTreeViewAfterSelect(object? sender, TreeViewEventArgs e)
+    {
+        try
+        {
+            if (!_isRecreating && _pendingMultiSelectToggle is not null)
+            {
+                _pendingMultiSelectToggle.Checked = !_pendingMultiSelectToggle.Checked;
+            }
+
+            OnAfterSelect(e);
+        }
+        finally
+        {
+            if (!_isRecreating && _selectUpdateCount > 0)
+            {
+                _selectUpdateCount--;
+                _treeView.EndUpdate();
+            }
+
+            _pendingMultiSelectToggle = null;
+        }
+    }
 
     private void OnTreeViewAfterLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnAfterLabelEdit(e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -657,6 +657,8 @@ internal partial class PI
             TVM_GETISEARCHSTRINGW = 0x1100 + 64,
             TVM_SETITEMHEIGHT = 0x1100 + 27,
             TVM_GETITEMHEIGHT = 0x1100 + 28,
+            TVM_SETEXTENDEDSTYLE = 0x1100 + 44,
+            TVM_GETEXTENDEDSTYLE = 0x1100 + 45,
 
             SETITEMA = 0x110d,
             SETITEM = 0x110d,
@@ -700,6 +702,7 @@ internal partial class PI
     internal const int TVS_EDITLABELS = 0x0008;
 
     internal const int TVS_CHECKBOXES = 0x0100;
+    internal const int TVS_EX_DOUBLEBUFFER = 0x0004;
     //TVS_HASBUTTONS = 0x0001,
     //TVS_HASLINES = 0x0002,
     //TVS_LINESATROOT = 0x0004,


### PR DESCRIPTION
# Fix `KryptonTreeView` selection flicker (#3282)

## Summary

- Fixes [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282): `KryptonTreeView` items visibly flicker when selected or clicked, especially with `OwnerDrawAll`, `MultiSelect`, `CheckBoxes`, and large `ItemHeight` (e.g. TestForm TreeView example).
- Ensures owner-drawn nodes skip native item painting, composites the control in a single off-screen `WM_PAINT` buffer, and batches selection/checkbox updates so deselect/select does not surface as separate on-screen paints.
- Defaults empty MSBuild `Configuration` to `Debug` so solution-wide `dotnet build` resolves correct `Bin\Debug\<tfm>\` output paths.

## Problem

`KryptonTreeView` uses an internal `TreeView` with `DrawMode = OwnerDrawAll`. On selection change, users could see a brief flash because:

1. Native TreeView item painting could still run unless `DrawDefault` is cleared (`CDRF_SKIPDEFAULT`).
2. Per-node off-screen `BitBlt` in `DrawNode` caused rows to update in separate steps during selection changes.
3. Per-node `ViewDrawPanel.Render` repainted row chrome on every item draw.
4. `BackColor` was assigned during `WM_PAINT`, triggering an extra erase/paint cycle.
5. `MultiSelect` toggled `Checked` during `OnAfterSelect` outside a single redraw batch.

## Solution

| Change | Purpose |
|--------|---------|
| `e.DrawDefault = false` in `OnTreeViewDrawNode` | Skip native selection/focus chrome for `OwnerDrawAll`. | | `InternalTreeView.WmPaint` off-screen bitmap | Paint Krypton background once, `DefWndProc` (custom draw) into same DC, single `BitBlt`. | | `TVS_EX_DOUBLEBUFFER` via `TVM_SETEXTENDEDSTYLE` | comctl32 buffering for owner-draw notifications. | | Draw directly on `e.Graphics` in `DrawNode` (no per-node bitmap) | Avoid tearing between old/new selection rows. | | Remove per-row `ViewDrawPanel.Render` in `DrawNode` | Background from composite `WmPaint` only. | | `SyncTreeViewBackColor()` from `UpdateStateAndPalettes` | Avoid `BackColor` changes during `WM_PAINT`. | | `BeginUpdate` / `EndUpdate` + `OnNeedPaint` guard | Batch selection redraws. | | Defer `MultiSelect` checkbox toggle to `AfterSelect` (before `EndUpdate`) | One redraw for check + selection. |

## Files changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs`
- `Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs`
- `Documents/Changelog/Changelog.md`
- `Directory.Build.props`
- `Source/Krypton Components/Directory.Build.props`

## Test plan

- [ ] Build toolkit and TestForm (Debug): ```cmd dotnet build "Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug dotnet run --project "Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net48 ```
- [ ] **TreeView Example**: `CheckBoxes = true`, `MultiSelect = true`; click different nodes rapidly — no flicker.
- [ ] Set **`ItemHeight`** to **64** and repeat.
- [ ] **TreeView Test** form: compare `KryptonTreeView` vs standard `TreeView` if useful.
- [ ] Expand/collapse, scroll, keyboard navigation, focus in/out — no painting regressions.
- [ ] With `MultiSelect = true`, confirm click toggles checked state without extra flicker.

## Breaking changes

None.

## Related

- Closes #3282

<img width="693" height="254" alt="image" src="https://github.com/user-attachments/assets/26b123f5-9a9f-4733-96e8-124ee1463608" />
