### PR TITLE
3502-V110-fix-webview2-ci-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1168,7 +1168,12 @@ jobs:
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         shell: pwsh
         run: |
-          if (-not (Test-Path "WebView2SDK")) { mkdir WebView2SDK }
+          $root = $env:GITHUB_WORKSPACE
+          if (-not $root) { $root = (Get-Location).Path }
+          $utilProj = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj"
+          $libDir = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2"
+          if (-not (Test-Path $utilProj)) { Write-Error "Project not found: $utilProj"; exit 1 }
+          if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force }
           $packageId = "Microsoft.Web.WebView2"
           # Prerelease WebView2 for alpha NuGet ordering; dotnet restore still requires an SDK that supports net11.0-windows (see Pin SDK step).
           Write-Host "Using prerelease=true for WebView2 SDK lookup (alpha build)"
@@ -1194,17 +1199,18 @@ jobs:
           }
           if (-not $latestVersion) { $latestVersion = "1.0.3595.46" }
           Write-Host "Using WebView2 SDK version (preview): $latestVersion"
-          dotnet add "Source/Krypton Components/Krypton.Toolkit.Utilities/Krypton.Toolkit.Utilities.csproj" package Microsoft.Web.WebView2 --version $latestVersion
-          dotnet restore "Source/Krypton Components/Krypton.Toolkit.Utilities/Krypton.Toolkit.Utilities.csproj"
-          $nugetBasePath = "$env:USERPROFILE\.nuget\packages\microsoft.web.webview2\$latestVersion"
-          $coreDll = Get-ChildItem -Path $nugetBasePath -Recurse -Name "Microsoft.Web.WebView2.Core.dll" | Select-Object -First 1
-          Copy-Item (Join-Path $nugetBasePath $coreDll) "WebView2SDK\"
-          $winFormsDll = Get-ChildItem -Path $nugetBasePath -Recurse -Name "Microsoft.Web.WebView2.WinForms.dll" | Select-Object -First 1
-          Copy-Item (Join-Path $nugetBasePath $winFormsDll) "WebView2SDK\"
-          $loaderDll = Get-ChildItem -Path $nugetBasePath -Recurse -Name "WebView2Loader.dll" | Select-Object -First 1
-          Copy-Item (Join-Path $nugetBasePath $loaderDll) "WebView2SDK\"
-          # Note: We keep the PackageReference in the project file - file-based refs will take precedence when DLLs exist,
-          # and PackageReference serves as a fallback for builds where SDK files aren't available
+          dotnet add "$utilProj" package $packageId --version $latestVersion
+          dotnet restore "$utilProj"
+          $nugetBase = Join-Path $env:USERPROFILE ".nuget\packages\microsoft.web.webview2\$latestVersion"
+          @("Microsoft.Web.WebView2.Core.dll","Microsoft.Web.WebView2.WinForms.dll","WebView2Loader.dll") | ForEach-Object {
+            $f = Get-ChildItem -Path $nugetBase -Recurse -Name $_ -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($f) { Copy-Item (Join-Path $nugetBase $f) $libDir -Force; Write-Host "Copied $_" }
+          }
+          [xml]$proj = Get-Content $utilProj
+          $nodes = $proj.SelectNodes("//PackageReference[@Include='$packageId']")
+          foreach ($node in $nodes) { $node.ParentNode.RemoveChild($node) | Out-Null }
+          $proj.Save($utilProj)
+          Write-Host "Removed temporary WebView2 PackageReference entries"
 
       - name: Restore
         # Kill switch check


### PR DESCRIPTION
Fixes #3502.

The alpha release workflow was adding the latest prerelease Microsoft.Web.WebView2 package to Krypton.Toolkit.Utilities and leaving that temporary PackageReference in place before restoring the full solution. TestForm could still fall back to its older WebView2 package reference, so NuGet saw the same package through two paths at different versions and failed restore with NU1605.

This changes the alpha WebView2 setup to copy the downloaded SDK DLLs into the bundled Lib\WebView2 location used by the projects, then removes the temporary WebView2 PackageReference before the solution restore. That keeps the dynamic prerelease dependency out of the restore graph while preserving the intended alpha SDK staging behavior.
