### PR TITLE
* KryptonTreeView items flicker when selected/clicked (V85)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
+	<PropertyGroup>
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+		<Platform Condition="'$(Platform)' == ''">Any CPU</Platform>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<PropertyGroup>

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection updates; no per-node background repaint)
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents
 * Resolved [#3382](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3382), Lines when using `CueHint` for `KryptonTextBox`

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -20,6 +20,10 @@
 		<Version>$(LibraryVersion)</Version>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<ItemGroup>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1,100 +1,1693 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
  *  
  */
 #endregion
 
-namespace Krypton.Toolkit;
-
-/// <summary>
-/// Provide a RichTextBox with Krypton styling applied.
-/// </summary>
-[ToolboxItem(true)]
-[ToolboxBitmap(typeof(KryptonRichTextBox), "ToolboxBitmaps.KryptonRichTextBox.bmp")]
-[DefaultEvent(nameof(TextChanged))]
-[DefaultProperty(nameof(Text))]
-[DefaultBindingProperty(nameof(Text))]
-[Designer(typeof(KryptonRichTextBoxDesigner))]
-[DesignerCategory(@"code")]
-[Description(@"Enables the user to enter text, and provides multi-line editing and password character masking.")]
-public class KryptonRichTextBox : VisualControlBase,
-    IContainedInputControl
+namespace Krypton.Toolkit
 {
-    #region Classes
-    private class InternalRichTextBox : RichTextBox
+    /// <summary>
+    /// Provide a RichTextBox with Krypton styling applied.
+    /// </summary>
+    [ToolboxItem(true)]
+    [ToolboxBitmap(typeof(KryptonRichTextBox), "ToolboxBitmaps.KryptonRichTextBox.bmp")]
+    [DefaultEvent(nameof(TextChanged))]
+    [DefaultProperty(nameof(Text))]
+    [DefaultBindingProperty(nameof(Text))]
+    [Designer(typeof(KryptonRichTextBoxDesigner))]
+    [DesignerCategory(@"code")]
+    [Description(@"Enables the user to enter text, and provides multi-line editing and password character masking.")]
+    public class KryptonRichTextBox : VisualControlBase,
+                                      IContainedInputControl
     {
-        #region Static Fields
+        #region Classes
+        private class InternalRichTextBox : RichTextBox
+        {
+            #region Static Fields
 
-        private const double AN_INCH = 14.4;
+            private const double AN_INCH = 14.4;
 
+            #endregion
+
+            #region Instance Fields
+            private readonly KryptonRichTextBox _kryptonRichTextBox;
+            private bool _mouseOver;
+            #endregion
+
+            #region Events
+            /// <summary>
+            /// Occurs when the mouse enters the InternalComboBox.
+            /// </summary>
+            public event EventHandler? TrackMouseEnter;
+
+            /// <summary>
+            /// Occurs when the mouse leaves the InternalComboBox.
+            /// </summary>
+            public event EventHandler? TrackMouseLeave;
+            #endregion
+
+            #region Identity
+            /// <summary>
+            /// Initialize a new instance of the InternalTextBox class.
+            /// </summary>
+            /// <param name="kryptonRichTextBox">Reference to owning control.</param>
+            public InternalRichTextBox(KryptonRichTextBox kryptonRichTextBox)
+            {
+                _kryptonRichTextBox = kryptonRichTextBox;
+
+                // Remove from view until size for the first time by the Krypton control
+                Size = Size.Empty;
+
+                // We provide the border manually
+                BorderStyle = BorderStyle.None;
+            }
+            #endregion
+
+            #region Public
+            /// <summary>
+            /// Gets and sets if the mouse is currently over the combo box.
+            /// </summary>
+            public bool MouseOver
+            {
+                get => _mouseOver;
+
+                set
+                {
+                    // Only interested in changes
+                    if (_mouseOver != value)
+                    {
+                        _mouseOver = value;
+
+                        // Generate appropriate change event
+                        if (_mouseOver)
+                        {
+                            OnTrackMouseEnter(EventArgs.Empty);
+                        }
+                        else
+                        {
+                            OnTrackMouseLeave(EventArgs.Empty);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Print the specified range of characters.
+            /// </summary>
+            /// <param name="charFrom">Start character.</param>
+            /// <param name="charTo">End character.</param>
+            /// <param name="gr">Graphics instance to use.</param>
+            /// <param name="bounds">Drawing bounds.</param>
+            /// <returns>Pointer to returned result.</returns>
+            public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds)
+            {
+                //Calculate the area to render and print
+                PI.RECT rectToPrint;
+                rectToPrint.top = 0;
+                rectToPrint.bottom = (int)(bounds.Height * AN_INCH);
+                rectToPrint.left = 0;
+                rectToPrint.right = (int)(bounds.Width * AN_INCH);
+
+                //Calculate the size of the page
+                PI.RECT rectPage;
+                rectPage.top = 0;
+                rectPage.bottom = (int)(gr.ClipBounds.Height * AN_INCH);
+                rectPage.left = 0;
+                rectPage.right = (int)(gr.ClipBounds.Right * AN_INCH);
+
+                var hdc = gr.GetHdc();
+
+                PI.FORMATRANGE fmtRange;
+                fmtRange.chrg.cpMax = charTo;
+                fmtRange.chrg.cpMin = charFrom;
+                fmtRange.hdc = hdc;
+                fmtRange.hdcTarget = hdc;
+                fmtRange.rc = rectToPrint;
+                fmtRange.rcPage = rectPage;
+
+                var wparam = new IntPtr(1);
+
+                //Get the pointer to the FORMATRANGE structure in memory
+                var lparam = Marshal.AllocCoTaskMem(Marshal.SizeOf(fmtRange));
+                Marshal.StructureToPtr(fmtRange, lparam, false);
+
+                //Send the rendered data for printing 
+                var res = (IntPtr)PI.SendMessage(Handle, PI.EM_FORMATRANGE, wparam, lparam);
+
+                //Free the block of memory allocated
+                Marshal.FreeCoTaskMem(lparam);
+
+                //Release the device context handle obtained by a previous call
+                gr.ReleaseHdc(hdc);
+
+                //Return last + 1 character printer
+                return (int)res.ToInt64();
+            }
+            #endregion
+
+            #region Protected
+            protected override void OnEnabledChanged(EventArgs e)
+            {
+                // Do not forward, to allow the correct Background for disabled state
+                // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/722
+            }
+
+            /// <summary>
+            /// Process Windows-based messages.
+            /// </summary>
+            /// <param name="m">A Windows-based message.</param>
+            protected override void WndProc(ref Message m)
+            {
+                switch (m.Msg)
+                {
+                    case PI.WM_.NCHITTEST:
+                        if (_kryptonRichTextBox.InTransparentDesignMode)
+                        {
+                            m.Result = (IntPtr)PI.HT.TRANSPARENT;
+                        }
+                        else
+                        {
+                            base.WndProc(ref m);
+                        }
+
+                        break;
+                    case PI.WM_.MOUSELEAVE:
+                        // Mouse is not over the control
+                        MouseOver = false;
+                        _kryptonRichTextBox.PerformNeedPaint(true);
+                        Invalidate();
+                        base.WndProc(ref m);
+                        break;
+                    case PI.WM_.MOUSEMOVE:
+                        // Mouse is over the control
+                        if (!MouseOver)
+                        {
+                            MouseOver = true;
+                            _kryptonRichTextBox.PerformNeedPaint(true);
+                            Invalidate();
+                        }
+                        base.WndProc(ref m);
+                        break;
+                    case PI.WM_.CONTEXTMENU:
+                        // Only interested in overriding the behavior when we have a krypton context menu...
+                        if (_kryptonRichTextBox.KryptonContextMenu != null)
+                        {
+                            // Extract the screen mouse position (if might not actually be provided)
+                            var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
+
+                            // If keyboard activated, the menu position is centered
+                            if (((int)(long)m.LParam) == -1)
+                            {
+                                mousePt = PointToScreen(new Point(Width / 2, Height / 2));
+                            }
+
+                            // Show the context menu
+                            _kryptonRichTextBox.KryptonContextMenu.Show(_kryptonRichTextBox, mousePt);
+
+                            // We eat the message!
+                            return;
+                        }
+                        base.WndProc(ref m);
+                        break;
+                    case PI.WM_.PAINT:
+                        if (!string.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
+                            && (_kryptonRichTextBox.TextLength == 0)
+                        )
+                        {
+                            var ps = new PI.PAINTSTRUCT();
+                            // Do we need to BeginPaint or just take the given HDC?
+                            var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+                            using (Graphics g = Graphics.FromHdc(hdc))
+                            {
+                                // BeginPaint can restrict the clip to the update region; cue rendering needs a solid full-client
+                                // fill to avoid edge artefacts (issue #3382).
+                                g.ResetClip();
+
+                                // Grab the client area of the control
+                                PI.GetClientRect(Handle, out PI.RECT rect);
+
+                                PaletteState state = _kryptonRichTextBox.Enabled
+                                    ? _kryptonRichTextBox.IsActive
+                                        ? PaletteState.Tracking
+                                        : PaletteState.Normal
+                                    : PaletteState.Disabled;
+                                var states = _kryptonRichTextBox.GetTripleState();
+
+                                // Drawn entire client area in the background color
+                                using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
+                                // Go perform the drawing of the CueHint
+                                _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, rect, backBrush);
+                            }
+
+                            // Do we need to match the original BeginPaint?
+                            if (m.WParam == IntPtr.Zero)
+                            {
+                                PI.EndPaint(Handle, ref ps);
+                            }
+                        }
+                        base.WndProc(ref m);
+                        break;
+                    default:
+                        base.WndProc(ref m);
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Raises the TrackMouseEnter event.
+            /// </summary>
+            /// <param name="e">An EventArgs containing the event data.</param>
+            protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
+
+            /// <summary>
+            /// Raises the TrackMouseLeave event.
+            /// </summary>
+            /// <param name="e">An EventArgs containing the event data.</param>
+            protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
+
+            /// <summary>
+            /// Raises the OnMouseMove event.
+            /// </summary>
+            /// <param name="e">An EventArgs containing the event data.</param>
+            protected override void OnMouseMove(MouseEventArgs e)
+            {
+                base.OnMouseMove(e);
+
+                _kryptonRichTextBox.OnMouseMove(e);
+            }
+            #endregion
+        }
+        #endregion
+
+        #region Type Definitions
+        /// <summary>
+        /// Collection for managing ButtonSpecAny instances.
+        /// </summary>
+        public class RichTextBoxButtonSpecCollection : ButtonSpecCollection<ButtonSpecAny>
+        {
+            #region Identity
+            /// <summary>
+            /// Initialize a new instance of the RichTextBoxButtonSpecCollection class.
+            /// </summary>
+            /// <param name="owner">Reference to owning object.</param>
+            public RichTextBoxButtonSpecCollection(KryptonRichTextBox owner)
+                : base(owner)
+            {
+            }
+            #endregion
+        }
         #endregion
 
         #region Instance Fields
-        private readonly KryptonRichTextBox _kryptonRichTextBox;
+
+        private VisualPopupToolTip? _visualPopupToolTip;
+        private readonly ButtonSpecManagerLayout _buttonManager;
+        private readonly ViewLayoutDocker _drawDockerInner;
+        private readonly ViewDrawDocker _drawDockerOuter;
+        private readonly ViewLayoutFill _layoutFill;
+        private readonly InternalRichTextBox _richTextBox;
+        private InputControlStyle _inputControlStyle;
+        private bool? _fixedActive;
+        private bool _forcedLayout;
+        private bool _autoSize;
         private bool _mouseOver;
+        private bool _alwaysActive;
+        private bool _trackingMouseEnter;
+        private bool _firstPaint;
+        private float _cornerRoundingRadius;
+
         #endregion
 
         #region Events
         /// <summary>
-        /// Occurs when the mouse enters the InternalComboBox.
+        /// Occurs when the value of the AcceptsTab property changes.
         /// </summary>
+        [Description(@"Occurs when the value of the AcceptsTab property changes.")]
+        [Category(@"Property Changed")]
+        public event EventHandler? AcceptsTabChanged;
+
+        /// <summary>
+        /// Occurs when the value of the HideSelection property changes.
+        /// </summary>
+        [Description(@"Occurs when the value of the HideSelection property changes.")]
+        [Category(@"Property Changed")]
+        public event EventHandler? HideSelectionChanged;
+
+        /// <summary>
+        /// Occurs when the value of the Modified property changes.
+        /// </summary>
+        [Description(@"Occurs when the value of the Modified property changes.")]
+        [Category(@"Property Changed")]
+        public event EventHandler? ModifiedChanged;
+
+        /// <summary>
+        /// Occurs when the value of the Multiline property changes.
+        /// </summary>
+        [Description(@"Occurs when the value of the Multiline property changes.")]
+        [Category(@"Property Changed")]
+        public event EventHandler? MultilineChanged;
+
+        /// <summary>
+        /// Occurs when the value of the ReadOnly property changes.
+        /// </summary>
+        [Description(@"Occurs when the value of the ReadOnly property changes.")]
+        [Category(@"Property Changed")]
+        public event EventHandler? ReadOnlyChanged;
+
+        /// <summary>
+        /// Occurs when the current selection has changed.
+        /// </summary>
+        [Description(@"Occurs when the current selection has changed.")]
+        [Category(@"Behavior")]
+        public event EventHandler? SelectionChanged;
+
+        /// <summary>
+        /// Occurs when the user takes an action that would change a protected range of text.
+        /// </summary>
+        [Description(@"Occurs when the user takes an action that would change a protected range of text.")]
+        [Category(@"Behavior")]
+        public event EventHandler? Protected;
+
+        /// <summary>
+        /// Occurs when a hyperlink in the text is clicked.
+        /// </summary>
+        [Description(@"Occurs when a hyperlink in the text is clicked.")]
+        [Category(@"Behavior")]
+        public event LinkClickedEventHandler? LinkClicked;
+
+        /// <summary>
+        /// Occurs when the horizontal scroll bar is clicked.
+        /// </summary>
+        [Description(@"Occurs when the horizontal scroll bar is clicked.")]
+        [Category(@"Behavior")]
+        public event EventHandler? HScroll;
+
+        /// <summary>
+        /// Occurs when the vertical scroll bar is clicked.
+        /// </summary>
+        [Description(@"Occurs when the vertical scroll bar is clicked.")]
+        [Category(@"Behavior")]
+        public event EventHandler? VScroll;
+
+        /// <summary>
+        /// Occurs when the mouse enters the control.
+        /// </summary>
+        [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+        [Category(@"Mouse")]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseEnter;
 
         /// <summary>
-        /// Occurs when the mouse leaves the InternalComboBox.
+        /// Occurs when the mouse leaves the control.
         /// </summary>
+        [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
+        [Category(@"Mouse")]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler? TrackMouseLeave;
+
+        /// <summary>
+        /// Occurs when the value of the BackColor property changes.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler? BackColorChanged;
+
+        /// <summary>
+        /// Occurs when the value of the BackgroundImage property changes.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler? BackgroundImageChanged;
+
+        /// <summary>
+        /// Occurs when the value of the BackgroundImageLayout property changes.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler? BackgroundImageLayoutChanged;
+
+        /// <summary>
+        /// Occurs when the value of the ForeColor property changes.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler? ForeColorChanged;
         #endregion
 
         #region Identity
         /// <summary>
-        /// Initialize a new instance of the InternalTextBox class.
+        /// Initialize a new instance of the KryptonRichTextBox class.
         /// </summary>
-        /// <param name="kryptonRichTextBox">Reference to owning control.</param>
-        public InternalRichTextBox(KryptonRichTextBox kryptonRichTextBox)
+        public KryptonRichTextBox()
         {
-            _kryptonRichTextBox = kryptonRichTextBox;
+            // Contains another control and needs marking as such for validation to work
+            SetStyle(ControlStyles.ContainerControl, true);
 
-            // Remove from view until size for the first time by the Krypton control
-            Size = Size.Empty;
+            // Cannot select this control, only the child TextBox
+            SetStyle(ControlStyles.Selectable, false);
 
-            // We provide the border manually
-            BorderStyle = BorderStyle.None;
+            // Defaults
+            _autoSize = false;
+            _alwaysActive = true;
+            AllowButtonSpecToolTips = false;
+            AllowButtonSpecToolTipPriority = false;
+            _firstPaint = true;
+            _inputControlStyle = InputControlStyle.Standalone;
+
+            // Create storage properties
+            ButtonSpecs = new RichTextBoxButtonSpecCollection(this);
+
+            // Create the palette storage
+            StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
+            StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+            StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+            StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+            CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
+
+            // Create the internal text box used for containing content
+            _richTextBox = new InternalRichTextBox(this);
+            _richTextBox.TrackMouseEnter += OnRichTextBoxMouseChange;
+            _richTextBox.TrackMouseLeave += OnRichTextBoxMouseChange;
+            _richTextBox.AcceptsTabChanged += OnRichTextBoxAcceptsTabChanged;
+            _richTextBox.TextChanged += OnRichTextBoxTextChanged;
+            _richTextBox.HideSelectionChanged += OnRichTextBoxHideSelectionChanged;
+            _richTextBox.ModifiedChanged += OnRichTextBoxModifiedChanged;
+            _richTextBox.MultilineChanged += OnRichTextBoxMultilineChanged;
+            _richTextBox.ReadOnlyChanged += OnRichTextBoxReadOnlyChanged;
+            _richTextBox.GotFocus += OnRichTextBoxGotFocus;
+            _richTextBox.LostFocus += OnRichTextBoxLostFocus;
+            _richTextBox.KeyDown += OnRichTextBoxKeyDown;
+            _richTextBox.KeyUp += OnRichTextBoxKeyUp;
+            _richTextBox.KeyPress += OnRichTextBoxKeyPress;
+            _richTextBox.PreviewKeyDown += OnRichTextBoxPreviewKeyDown;
+            _richTextBox.LinkClicked += OnRichTextBoxLinkClicked;
+            _richTextBox.Protected += OnRichTextBoxProtected;
+            _richTextBox.SelectionChanged += OnRichTextBoxSelectionChanged;
+            _richTextBox.HScroll += OnRichTextBoxHScroll;
+            _richTextBox.VScroll += OnRichTextBoxVScroll;
+            _richTextBox.Validating += OnRichTextBoxValidating;
+            _richTextBox.Validated += OnRichTextBoxValidated;
+
+            // Create the element that fills the remainder space and remembers fill rectangle
+            _layoutFill = new ViewLayoutFill(_richTextBox);
+
+            // Create inner view for placing inside the drawing docker
+            _drawDockerInner = new ViewLayoutDocker
+            {
+                { _layoutFill, ViewDockStyle.Fill }
+            };
+
+            // Create view for the control border and background
+            _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
+            {
+                { _drawDockerInner, ViewDockStyle.Fill }
+            };
+
+            // Create the view manager instance
+            ViewManager = new ViewManager(this, _drawDockerOuter);
+
+            // Create button specification collection manager
+            _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
+                                                         new[] { _drawDockerInner },
+                                                         new IPaletteMetric[] { StateCommon },
+                                                         new[] { PaletteMetricInt.HeaderButtonEdgeInsetInputControl },
+                                                         new[] { PaletteMetricPadding.HeaderButtonPaddingInputControl },
+                                                         CreateToolStripRenderer,
+                                                         NeedPaintDelegate);
+
+            // Create the manager for handling tooltips
+            ToolTipManager = new ToolTipManager(ToolTipValues);
+            ToolTipManager.ShowToolTip += OnShowToolTip;
+            ToolTipManager.CancelToolTip += OnCancelToolTip;
+            _buttonManager.ToolTipManager = ToolTipManager;
+
+            // Add text box to the controls collection
+            ((KryptonReadOnlyControls)Controls).AddInternal(_richTextBox);
+
+            // Update the back/fore/font from the palette settings
+            UpdateStateAndPalettes();
+            _richTextBox.BackColor = StateActive.PaletteBack.GetBackColor1(PaletteState.Tracking);
+            _richTextBox.ForeColor = StateActive.PaletteContent.GetContentShortTextColor1(PaletteState.Tracking);
+
+            // Only set the font if the rich text box has been created
+            if (_richTextBox.Handle != IntPtr.Zero)
+            {
+                _richTextBox.Font = StateActive.PaletteContent.GetContentShortTextFont(PaletteState.Tracking);
+            }
+
+            _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
+        }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Remove any showing tooltip
+                OnCancelToolTip(this, EventArgs.Empty);
+
+                // Remember to pull down the manager instance
+                _buttonManager.Destruct();
+            }
+
+            base.Dispose(disposing);
         }
         #endregion
 
         #region Public
+
+        /// <summary>Gets or sets the corner rounding radius.</summary>
+        /// <value>The corner rounding radius.</value>
+        [Category(@"Visuals"), DefaultValue(GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE), Description(@"Defines the corner roundness on the current window (-1 is the default look).")]
+        public float CornerRoundingRadius
+        {
+            get => _cornerRoundingRadius;
+            set => SetCornerRoundingRadius(value);
+        }
+
+        [Category(@"Visuals")]
+        [Description(@"Set a watermark/prompt message for the user.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteCueHintText CueHint { get; }
+
+        private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
+
         /// <summary>
-        /// Gets and sets if the mouse is currently over the combo box.
+        /// Gets and sets if the control is in the tab chain.
+        /// </summary>
+        public new bool TabStop
+        {
+            get => _richTextBox.TabStop;
+            set => _richTextBox.TabStop = value;
+        }
+
+        /// <summary>
+        /// Gets and sets if the control is in the ribbon design mode.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool MouseOver
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
+        public bool InRibbonDesignMode { get; set; }
+
+        /// <summary>
+        /// Gets access to the contained RichTextBox instance.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Browsable(false)]
+        public RichTextBox? RichTextBox => _richTextBox;
+
+        /// <summary>
+        /// Gets access to the contained input control.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Browsable(false)]
+        public Control ContainedControl => RichTextBox;
+
+        /// <summary>
+        /// Gets a value indicating whether the control has input focus.
+        /// </summary>
+        [Browsable(false)]
+        public override bool Focused => RichTextBox.Focused;
+
+        /// <summary>
+        /// Gets or sets the ability to drag/drop onto the control.
+        /// </summary>
+        [Browsable(false)]
+        public override bool AllowDrop
         {
-            get => _mouseOver;
+            get => base.AllowDrop;
+            set => base.AllowDrop = value;
+        }
+
+        /// <summary>
+        /// Gets and sets a value indicating if the control is automatically sized.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [DefaultValue(false)]
+        public override bool AutoSize
+        {
+            get => _autoSize;
+            set => _autoSize = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the background color for the control.
+        /// </summary>
+        [Browsable(false)]
+        [Bindable(false)]
+        public override Color BackColor
+        {
+            get => base.BackColor;
+            set => base.BackColor = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the font of the text Displayed by the control.
+        /// </summary>
+        [Browsable(false)]
+        [Bindable(false)]
+        [AmbientValue(null)]
+        [AllowNull]
+        public override Font Font
+        {
+            get => base.Font;
+            set => base.Font = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the foreground color for the control.
+        /// </summary>
+        [Browsable(false)]
+        [Bindable(false)]
+        public override Color ForeColor
+        {
+            get => base.ForeColor;
+            set => base.ForeColor = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the internal padding space.
+        /// </summary>
+        [Browsable(false)]
+        [Localizable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new Padding Padding
+        {
+            get => base.Padding;
+            set => base.Padding = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the text associated associated with the control.
+        /// </summary>
+        [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+        [AllowNull]
+        public override string Text
+        {
+            get => _richTextBox.Text;
+            set => _richTextBox.Text = value;
+        }
+
+        private bool ShouldSerializeText() =>
+            // Must always persist the text value if even when it is the default. Otherwise when
+            // you first move over the control which has been given RTF it resets the fonts.
+            true;
+
+        /// <summary>
+        /// Gets the length of text in the control.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int TextLength => _richTextBox.TextLength;
+
+        /// <summary>
+        /// Gets and sets the associated context menu strip.
+        /// </summary>
+        public override ContextMenuStrip? ContextMenuStrip
+        {
+            get => base.ContextMenuStrip;
 
             set
             {
-                // Only interested in changes
-                if (_mouseOver != value)
-                {
-                    _mouseOver = value;
+                base.ContextMenuStrip = value;
+                _richTextBox.ContextMenuStrip = value;
+            }
+        }
 
-                    // Generate appropriate change event
-                    if (_mouseOver)
-                    {
-                        OnTrackMouseEnter(EventArgs.Empty);
-                    }
-                    else
-                    {
-                        OnTrackMouseLeave(EventArgs.Empty);
-                    }
+        /// <summary>
+        /// Gets and sets if the control can redo a previously undo operation.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool CanRedo => _richTextBox.CanRedo;
+
+        /// <summary>
+        /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool CanUndo => _richTextBox.CanUndo;
+
+        /// <summary>
+        /// Gets a value indicating whether the contents have changed since last last.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool Modified => _richTextBox.Modified;
+
+        /// <summary>
+        /// Gets and sets the language option.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextBoxLanguageOptions LanguageOption
+        {
+            get => _richTextBox.LanguageOption;
+            set => _richTextBox.LanguageOption = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the name of the action to be redone.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string RedoActionName => _richTextBox.RedoActionName;
+
+        /// <summary>
+        /// Gets and sets the name of the action to be undone.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string UndoActionName => _richTextBox.UndoActionName;
+
+        /// <summary>
+        /// Gets and sets if keyboard shortcuts are enabled.
+        /// </summary>
+        [Browsable(false)]
+        [DefaultValue(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool RichTextShortcutsEnabled
+        {
+            get => _richTextBox.RichTextShortcutsEnabled;
+            set => _richTextBox.RichTextShortcutsEnabled = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the text in rich text format.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [RefreshProperties(RefreshProperties.All)]
+        public string Rtf
+        {
+            get => _richTextBox.Rtf;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.Rtf = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the selection portion of the rich text format.
+        /// </summary>
+        [Browsable(false)]
+        [DefaultValue("")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string SelectedRtf
+        {
+            get => _richTextBox.SelectedRtf;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectedRtf = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the selected text within the control.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string SelectedText
+        {
+            get => _richTextBox.SelectedText;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectedText = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the alignment of the selection.
+        /// </summary>
+        [Browsable(false)]
+        [DefaultValue(HorizontalAlignment.Left)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public HorizontalAlignment SelectionAlignment
+        {
+            get => _richTextBox.SelectionAlignment;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionAlignment = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the background color of the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Color SelectionBackColor
+        {
+            get => _richTextBox.SelectionBackColor;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionBackColor = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the bullet indentation of the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool SelectionBullet
+        {
+            get => _richTextBox.SelectionBullet;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionBullet = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the character offset of the selection.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionCharOffset
+        {
+            get => _richTextBox.SelectionCharOffset;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionCharOffset = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the text color of the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Color SelectionColor
+        {
+            get => _richTextBox.SelectionColor;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionColor = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the text font for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Font SelectionFont
+        {
+            get => _richTextBox.SelectionFont;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionFont = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the hanging indent for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionHangingIndent
+        {
+            get => _richTextBox.SelectionHangingIndent;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionHangingIndent = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the indent for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionIndent
+        {
+            get => _richTextBox.SelectionIndent;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionIndent = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the selection length for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionLength
+        {
+            get => _richTextBox.SelectionLength;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionLength = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the protected setting for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionProtected
+        {
+            get => _richTextBox.SelectionLength;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionLength = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the right indent for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionRightIndent
+        {
+            get => _richTextBox.SelectionRightIndent;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionRightIndent = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the starting point of text selected in the control.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int SelectionStart
+        {
+            get => _richTextBox.SelectionStart;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionStart = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the tab settings for the selected area.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int[] SelectionTabs
+        {
+            get => _richTextBox.SelectionTabs;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionTabs = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the type of selection.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextBoxSelectionTypes SelectionType => _richTextBox.SelectionType;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.
+        /// </summary>
+        [Category(@"Appearance")]
+        [Description(@"Defines if mnemonic characters generate click events for button specs.")]
+        [DefaultValue(true)]
+        public bool UseMnemonic
+        {
+            get => _buttonManager.UseMnemonic;
+
+            set
+            {
+                if (_buttonManager.UseMnemonic != value)
+                {
+                    _buttonManager.UseMnemonic = value;
+                    PerformNeedPaint(true);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
+        [DefaultValue(true)]
+        public bool AlwaysActive
+        {
+            get => _alwaysActive;
+
+            set
+            {
+                if (_alwaysActive != value)
+                {
+                    _alwaysActive = value;
+                    PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the lines of text in a multiline edit, as an array of String values.
+        /// </summary>
+        [Category(@"Appearance")]
+        [Description(@"The lines of text in a multiline edit, as an array of String values.")]
+        [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [MergableProperty(false)]
+        [Localizable(true)]
+        public string[] Lines
+        {
+            get => _richTextBox.Lines;
+            set => _richTextBox.Lines = value;
+        }
+
+        /// <summary>
+        /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
+        /// </summary>
+        [Category(@"Appearance")]
+        [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
+        [DefaultValue(RichTextBoxScrollBars.Both)]
+        [Localizable(true)]
+        public RichTextBoxScrollBars ScrollBars
+        {
+            get => _richTextBox.ScrollBars;
+            set => _richTextBox.ScrollBars = value;
+        }
+
+        /// <summary>
+        /// Indicates if lines are automatically word-wrapped for multiline edit controls.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
+        [DefaultValue(true)]
+        [Localizable(true)]
+        public bool WordWrap
+        {
+            get => _richTextBox.WordWrap;
+            set => _richTextBox.WordWrap = value;
+        }
+
+        /// <summary>
+        /// Defines the right margin dimensions.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Defines the right margin dimensions.")]
+        [DefaultValue(0)]
+        [Localizable(true)]
+        public int RightMargin
+        {
+            get => _richTextBox.RightMargin;
+            set => _richTextBox.RightMargin = value;
+        }
+
+        /// <summary>
+        /// Turns on/off the selection margin.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Turns on/off the selection margin.")]
+        [DefaultValue(false)]
+        public bool ShowSelectionMargin
+        {
+            get => _richTextBox.ShowSelectionMargin;
+            set => _richTextBox.ShowSelectionMargin = value;
+        }
+
+        /// <summary>
+        /// Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.")]
+        [DefaultValue(1.0f)]
+        [Localizable(true)]
+        public float ZoomFactor
+        {
+            get => _richTextBox.ZoomFactor;
+            set => _richTextBox.ZoomFactor = value;
+        }
+
+        /// <summary>
+        /// Gets and sets whether the text in the control can span more than one line.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Control whether the text in the control can span more than one line.")]
+        [RefreshProperties(RefreshProperties.All)]
+        [DefaultValue(true)]
+        [Localizable(true)]
+        public bool Multiline
+        {
+            get => _richTextBox.Multiline;
+            set => _richTextBox.Multiline = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
+        [DefaultValue(false)]
+        public bool AcceptsTab
+        {
+            get => _richTextBox.AcceptsTab;
+            set => _richTextBox.AcceptsTab = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
+        [DefaultValue(true)]
+        public bool HideSelection
+        {
+            get => _richTextBox.HideSelection;
+            set => _richTextBox.HideSelection = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of characters that can be entered into the edit control.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
+        [DefaultValue(0x7fffffff)]
+        [Localizable(true)]
+        public int MaxLength
+        {
+            get => _richTextBox.MaxLength;
+            set => _richTextBox.MaxLength = value;
+        }
+
+        /// <summary>
+        /// Turns on/off automatic word selection.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Turns on/off automatic word selection.")]
+        [DefaultValue(false)]
+        public bool AutoWordSelection
+        {
+            get => _richTextBox.AutoWordSelection;
+            set => _richTextBox.AutoWordSelection = value;
+        }
+
+        /// <summary>
+        /// Defines the indent for bullets in the control.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Defines the indent for bullets in the control.")]
+        [DefaultValue(0)]
+        [Localizable(true)]
+        public int BulletIndent
+        {
+            get => _richTextBox.BulletIndent;
+            set => _richTextBox.BulletIndent = value;
+        }
+
+        /// <summary>
+        /// Indicates whether URLs are automatically formatted as links.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether URLs are automatically formatted as links.")]
+        [DefaultValue(true)]
+        public bool DetectUrls
+        {
+            get => _richTextBox.DetectUrls;
+            set => _richTextBox.DetectUrls = value;
+        }
+
+        /// <summary>
+        /// Enable drag/drop of text, pictures and other data.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Enable drag/drop of text, pictures and other data.")]
+        [DefaultValue(false)]
+        public bool EnableAutoDragDrop
+        {
+            get => _richTextBox.EnableAutoDragDrop;
+            set => _richTextBox.EnableAutoDragDrop = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Controls whether the text in the edit control can be changed or not.")]
+        [RefreshProperties(RefreshProperties.Repaint)]
+        [DefaultValue(false)]
+        public bool ReadOnly
+        {
+            get => _richTextBox.ReadOnly;
+            set => _richTextBox.ReadOnly = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
+        /// </summary>
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
+        [DefaultValue(true)]
+        public bool ShortcutsEnabled
+        {
+            get => _richTextBox.ShortcutsEnabled;
+            set => _richTextBox.ShortcutsEnabled = value;
+        }
+
+        /// <summary>
+        /// Gets and sets the input control style.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Input control style.")]
+        public InputControlStyle InputControlStyle
+        {
+            get => _inputControlStyle;
+
+            set
+            {
+                if (_inputControlStyle != value)
+                {
+                    _inputControlStyle = value;
+                    StateCommon.SetStyles(value);
+                    PerformNeedPaint(true);
+                }
+            }
+        }
+
+        private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
+
+        private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
+
+        /// <summary>
+        /// Gets and sets a value indicating if tooltips should be Displayed for button specs.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Should tooltips be Displayed for button specs.")]
+        [DefaultValue(false)]
+        public bool AllowButtonSpecToolTips { get; set; }
+
+        /// <summary>
+        /// Gets and sets a value indicating if button spec tooltips should remove the parent tooltip.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Should button spec tooltips should remove the parent tooltip")]
+        [DefaultValue(false)]
+        public bool AllowButtonSpecToolTipPriority { get; set; }
+
+        /// <summary>
+        /// Gets the collection of button specifications.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Collection of button specifications.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public RichTextBoxButtonSpecCollection ButtonSpecs { get; }
+
+        /// <summary>
+        /// Gets access to the common textbox appearance entries that other states can override.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common textbox appearance that other states can override.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleRedirect StateCommon { get; }
+
+        private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
+
+        /// <summary>
+        /// Gets access to the disabled textbox appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled textbox appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateDisabled { get; }
+
+        private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
+
+        /// <summary>
+        /// Gets access to the normal textbox appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal textbox appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateNormal { get; }
+
+        private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
+
+        /// <summary>
+        /// Gets access to the active textbox appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining active textbox appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateActive { get; }
+
+        private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
+
+        /// <summary>
+        /// Appends text to the current text of a rich text box.
+        /// </summary>
+        /// <param name="text">The text to append to the current contents of the text box.</param>
+        public void AppendText(string text) => _richTextBox.AppendText(text);
+
+        /// <summary>
+        /// Clears all text from the text box control.
+        /// </summary>
+        public void Clear() => _richTextBox.Clear();
+
+        /// <summary>
+        /// Clears information about the most recent operation from the undo buffer of the rich text box. 
+        /// </summary>
+        public void ClearUndo() => _richTextBox.ClearUndo();
+
+        /// <summary>
+        /// Copies the current selection in the text box to the Clipboard.
+        /// </summary>
+        public void Copy() => _richTextBox.Copy();
+
+        /// <summary>
+        /// Moves the current selection in the text box to the Clipboard.
+        /// </summary>
+        public void Cut() => _richTextBox.Cut();
+
+        /// <summary>
+        /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
+        /// </summary>
+        public void DeselectAll() => _richTextBox.DeselectAll();
+
+        /// <summary>
+        /// Determines whether you can paste information from the Clipboard in the specified data format.
+        /// </summary>
+        /// <param name="clipFormat">One of the System.Windows.Forms.DataFormats.Format values.</param>
+        /// <returns>true if you can paste data from the Clipboard in the specified data format; otherwise, false.</returns>
+        public bool CanPaste(DataFormats.Format clipFormat) => _richTextBox.CanPaste(clipFormat);
+
+        /// <summary>
+        /// Searches the text in a RichTextBox control for a string.
+        /// </summary>
+        /// <param name="str">The text to locate in the control.</param>
+        /// <returns>The location within the control where the search text was found or -1 if the search string is not found or an empty search string is specified in the str parameter.</returns>
+        public int Find(string str) => _richTextBox.Find(str);
+
+        /// <summary>
+        /// Searches the text of a RichTextBox control for the first instance of a character from a list of characters.
+        /// </summary>
+        /// <param name="characterSet">The array of characters to search for.</param>
+        /// <returns>The location within the control where the search characters were found or -1 if the search characters are not found or an empty search character set is specified in the char parameter.</returns>
+        public int Find(char[] characterSet) => _richTextBox.Find(characterSet);
+
+        /// <summary>
+        /// Searches the text of a RichTextBox control, at a specific starting point, for the first instance of a character from a list of characters.
+        /// </summary>
+        /// <param name="characterSet">The array of characters to search for.</param>
+        /// <param name="start">The location within the control's text at which to begin searching.</param>
+        /// <returns>The location within the control where the search characters are found.</returns>
+        public int Find(char[] characterSet, int start) => _richTextBox.Find(characterSet, start);
+
+        /// <summary>
+        /// Searches the text in a RichTextBox control for a string with specific options applied to the search.
+        /// </summary>
+        /// <param name="str">The text to locate in the control.</param>
+        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+        /// <returns>The location within the control where the search text was found.</returns>
+        public int Find(string str, RichTextBoxFinds options) => _richTextBox.Find(str, options);
+
+        /// <summary>
+        /// Searches a range of text in a RichTextBox control for the first instance of a character from a list of characters.
+        /// </summary>
+        /// <param name="characterSet">The array of characters to search for.</param>
+        /// <param name="start">The location within the control's text at which to begin searching.</param>
+        /// <param name="end">The location within the control's text at which to end searching.</param>
+        /// <returns>The location within the control where the search characters are found.</returns>
+        public int Find(char[] characterSet, int start, int end) => _richTextBox.Find(characterSet, start, end);
+
+        /// <summary>
+        /// Searches the text in a RichTextBox control for a string at a specific location within the control and with specific options applied to the search.
+        /// </summary>
+        /// <param name="str">The text to locate in the control.</param>
+        /// <param name="start">The location within the control's text at which to begin searching.</param>
+        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+        /// <returns>The location within the control where the search text was found.</returns>
+        public int Find(string str, int start, RichTextBoxFinds options) => _richTextBox.Find(str, start, options);
+
+        /// <summary>
+        /// Searches the text in a RichTextBox control for a string within a range of text within the control and with specific options applied to the search.
+        /// </summary>
+        /// <param name="str">The text to locate in the control.</param>
+        /// <param name="start">The location within the control's text at which to begin searching.</param>
+        /// <param name="end">The location within the control's text at which to end searching. This value must be equal to negative one (-1) or greater than or equal to the start parameter.</param>
+        /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
+        /// <returns></returns>
+        public int Find(string str, int start, int end, RichTextBoxFinds options) => _richTextBox.Find(str, start, end, options);
+
+        /// <summary>
+        /// Retrieves the character that is closest to the specified location within the control.
+        /// </summary>
+        /// <param name="pt">The location from which to seek the nearest character.</param>
+        /// <returns>The character at the specified location.</returns>
+        public int GetCharFromPosition(Point pt) => _richTextBox.GetCharFromPosition(pt);
+
+        /// <summary>
+        /// Retrieves the index of the character nearest to the specified location.
+        /// </summary>
+        /// <param name="pt">The location to search.</param>
+        /// <returns>The zero-based character index at the specified location.</returns>
+        public int GetCharIndexFromPosition(Point pt) => _richTextBox.GetCharIndexFromPosition(pt);
+
+        /// <summary>
+        /// Retrieves the index of the first character of a given line.
+        /// </summary>
+        /// <param name="lineNumber">The line for which to get the index of its first character.</param>
+        /// <returns>The zero-based character index in the specified line.</returns>
+        public int GetFirstCharIndexFromLine(int lineNumber) => _richTextBox.GetFirstCharIndexFromLine(lineNumber);
+
+        /// <summary>
+        /// Retrieves the index of the first character of the current line.
+        /// </summary>
+        /// <returns>The zero-based character index in the current line.</returns>
+        public int GetFirstCharIndexOfCurrentLine() => _richTextBox.GetFirstCharIndexOfCurrentLine();
+
+        /// <summary>
+        /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
+        /// </summary>
+        /// <param name="index">The character index position to search.</param>
+        /// <returns>The zero-based line number in which the character index is located.</returns>
+        public int GetLineFromCharIndex(int index) => _richTextBox.GetLineFromCharIndex(index);
+
+        /// <summary>
+        /// Retrieves the location within the control at the specified character index.
+        /// </summary>
+        /// <param name="index">The index of the character for which to retrieve the location.</param>
+        /// <returns>The location of the specified character.</returns>
+        public Point GetPositionFromCharIndex(int index) => _richTextBox.GetPositionFromCharIndex(index);
+
+        /// <summary>
+        /// Loads a rich text format (RTF) or standard ASCII text file into the RichTextBox control.
+        /// </summary>
+        /// <param name="path">The name and location of the file to load into the control.</param>
+        public void LoadFile(string path) => _richTextBox.LoadFile(path);
+
+        /// <summary>
+        /// Loads the contents of an existing data stream into the RichTextBox control.
+        /// </summary>
+        /// <param name="data">A stream of data to load into the RichTextBox control.</param>
+        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+        public void LoadFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(data, fileType);
+
+        /// <summary>
+        /// Loads a specific type of file into the RichTextBox control.
+        /// </summary>
+        /// <param name="path">The name and location of the file to load into the control.</param>
+        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+        public void LoadFile(string path, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(path, fileType);
+
+        /// <summary>
+        /// Replaces the current selection in the text box with the contents of the Clipboard.
+        /// </summary>
+        public void Paste() => _richTextBox.Paste();
+
+        /// <summary>
+        /// Undoes the last edit operation in the text box.
+        /// </summary>
+        public void Undo() => _richTextBox.Undo();
+
+        /// <summary>
+        /// Pastes the contents of the Clipboard in the specified Clipboard format.
+        /// </summary>
+        /// <param name="clipFormat">The Clipboard format in which the data should be obtained from the Clipboard.</param>
+        public void Paste(DataFormats.Format clipFormat) => _richTextBox.Paste(clipFormat);
+
+        /// <summary>
+        /// Reapplies the last operation that was undone in the control.
+        /// </summary>
+        public void Redo() => _richTextBox.Redo();
+
+        /// <summary>
+        /// Saves the contents of the RichTextBox to a rich text format (RTF) file.
+        /// </summary>
+        /// <param name="path">The name and location of the file to save.</param>
+        public void SaveFile(string path) => _richTextBox.SaveFile(path);
+
+        /// <summary>
+        /// Saves the contents of a RichTextBox control to an open data stream.
+        /// </summary>
+        /// <param name="data">The data stream that contains the file to save to.</param>
+        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+        public void SaveFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(data, fileType);
+
+        /// <summary>
+        /// Saves the contents of the KryptonRichTextBox to a specific type of file.
+        /// </summary>
+        /// <param name="path">The name and location of the file to save.</param>
+        /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
+        public void SaveFile(string path, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(path, fileType);
+
+        /// <summary>
+        /// Scrolls the contents of the control to the current caret position.
+        /// </summary>
+        public void ScrollToCaret() => _richTextBox.ScrollToCaret();
+
+        /// <summary>
+        /// Selects a range of text in the control.
+        /// </summary>
+        /// <param name="start">The position of the first character in the current text selection within the text box.</param>
+        /// <param name="length">The number of characters to select.</param>
+        public void Select(int start, int length) => _richTextBox.Select(start, length);
+
+        /// <summary>
+        /// Selects all text in the control.
+        /// </summary>
+        public void SelectAll() => _richTextBox.SelectAll();
+
+        /// <summary>
+        /// Sets the fixed state of the control.
+        /// </summary>
+        /// <param name="active">Should the control be fixed as active.</param>
+        public void SetFixedState(bool active) => _fixedActive = active;
+
+        /// <summary>
+        /// Gets access to the ToolTipManager used for displaying tool tips.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ToolTipManager ToolTipManager { get; }
+
+        /// <summary>
+        /// Gets a value indicating if the input control is active.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsActive =>
+            _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
+
+        /// <summary>
+        /// Sets input focus to the control.
+        /// </summary>
+        /// <returns>true if the input focus request was successful; otherwise, false.</returns>
+        public new bool Focus() => RichTextBox != null && RichTextBox.Focus();
+
+        /// <summary>
+        /// Activates the control.
+        /// </summary>
+        public new void Select() => RichTextBox?.Select();
+
+        /// <summary>
+        /// Get the preferred size of the control based on a proposed size.
+        /// </summary>
+        /// <param name="proposedSize">Starting size proposed by the caller.</param>
+        /// <returns>Calculated preferred size.</returns>
+        public override Size GetPreferredSize(Size proposedSize)
+        {
+            // Do we have a manager to ask for a preferred size?
+            if (ViewManager != null)
+            {
+                // Ask the view to Perform a layout
+                Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
+
+                // Apply the maximum sizing
+                if (MaximumSize.Width > 0)
+                {
+                    retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
+                }
+
+                if (MaximumSize.Height > 0)
+                {
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
+                }
+
+                // Apply the minimum sizing
+                if (MinimumSize.Width > 0)
+                {
+                    retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
+                }
+
+                if (MinimumSize.Height > 0)
+                {
+                    retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
+                }
+
+                return retSize;
+            }
+            else
+            {
+                // Fall back on default control processing
+                return base.GetPreferredSize(proposedSize);
+            }
+        }
+
+        /// <summary>
+        /// Gets the rectangle that represents the display area of the control.
+        /// </summary>
+        public override Rectangle DisplayRectangle
+        {
+            get
+            {
+                // Ensure that the layout is calculated in order to know the remaining display space
+                ForceViewLayout();
+
+                // The inside text box is the client rectangle size
+                return new Rectangle(_richTextBox.Location, _richTextBox.Size);
             }
         }
 
@@ -106,157 +1699,127 @@ public class KryptonRichTextBox : VisualControlBase,
         /// <param name="gr">Graphics instance to use.</param>
         /// <param name="bounds">Drawing bounds.</param>
         /// <returns>Pointer to returned result.</returns>
-        public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds)
+        public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds) => _richTextBox.Print(charFrom, charTo, gr, bounds);
+
+        /// <summary>
+        /// Override the display padding for the layout fill.
+        /// </summary>
+        /// <param name="padding">Display padding value.</param>
+        public void SetLayoutDisplayPadding(Padding padding) => _layoutFill.DisplayPadding = padding;
+
+        /// <summary>
+        /// Internal design time method.
+        /// </summary>
+        /// <param name="pt">Mouse location.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
+        public bool DesignerGetHitTest(Point pt)
         {
-            //Calculate the area to render and print
-            PI.RECT rectToPrint;
-            rectToPrint.top = 0;
-            rectToPrint.bottom = (int)(bounds.Height * AN_INCH);
-            rectToPrint.left = 0;
-            rectToPrint.right = (int)(bounds.Width * AN_INCH);
+            // Ignore call as view builder is already destructed
+            if (IsDisposed)
+            {
+                return false;
+            }
 
-            //Calculate the size of the page
-            PI.RECT rectPage;
-            rectPage.top = 0;
-            rectPage.bottom = (int)(gr.ClipBounds.Height * AN_INCH);
-            rectPage.left = 0;
-            rectPage.right = (int)(gr.ClipBounds.Right * AN_INCH);
-
-            var hdc = gr.GetHdc();
-
-            PI.FORMATRANGE fmtRange;
-            fmtRange.chrg.cpMax = charTo;
-            fmtRange.chrg.cpMin = charFrom;
-            fmtRange.hdc = hdc;
-            fmtRange.hdcTarget = hdc;
-            fmtRange.rc = rectToPrint;
-            fmtRange.rcPage = rectPage;
-
-            var wParam = new IntPtr(1);
-
-            //Get the pointer to the FORMATRANGE structure in memory
-            var lParam = Marshal.AllocCoTaskMem(Marshal.SizeOf(fmtRange));
-            Marshal.StructureToPtr(fmtRange, lParam, false);
-
-            //Send the rendered data for printing 
-            var res = (IntPtr)PI.SendMessage(Handle, PI.EM_FORMATRANGE, wParam, lParam);
-
-            //Free the block of memory allocated
-            Marshal.FreeCoTaskMem(lParam);
-
-            //Release the device context handle obtained by a previous call
-            gr.ReleaseHdc(hdc);
-
-            //Return last + 1 character printer
-            return (int)res.ToInt64();
-        }
-        #endregion
-
-        #region Protected
-        protected override void OnEnabledChanged(EventArgs e)
-        {
-            // Do not forward, to allow the correct Background for disabled state
-            // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/722
+            // Check if any of the button specs want the point
+            return (_buttonManager != null) && _buttonManager.DesignerGetHitTest(pt);
         }
 
         /// <summary>
-        /// Process Windows-based messages.
+        /// Internal design time method.
         /// </summary>
-        /// <param name="m">A Windows-based message.</param>
-        protected override void WndProc(ref Message m)
+        /// <param name="pt">Mouse location.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
+        public Component DesignerComponentFromPoint(Point pt) =>
+            // Ignore call as view builder is already destructed
+            IsDisposed ? null : ViewManager.ComponentFromPoint(pt);
+
+        // Ask the current view for a decision
+        /// <summary>
+        /// Internal design time method.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
+        public void DesignerMouseLeave() =>
+            // Simulate the mouse leaving the control so that the tracking
+            // element that thinks it has the focus is informed it does not
+            OnMouseLeave(EventArgs.Empty);
+
+        #endregion
+
+        #region Protected
+        /// <summary>
+        /// Force the layout logic to size and position the controls.
+        /// </summary>
+        protected void ForceControlLayout()
         {
-            switch (m.Msg)
-            {
-                case PI.WM_.NCHITTEST:
-                    if (_kryptonRichTextBox.InTransparentDesignMode)
-                    {
-                        m.Result = (IntPtr)PI.HT.TRANSPARENT;
-                    }
-                    else
-                    {
-                        base.WndProc(ref m);
-                    }
-
-                    break;
-                case PI.WM_.MOUSELEAVE:
-                    // Mouse is not over the control
-                    MouseOver = false;
-                    _kryptonRichTextBox.PerformNeedPaint(true);
-                    Invalidate();
-                    base.WndProc(ref m);
-                    break;
-                case PI.WM_.MOUSEMOVE:
-                    // Mouse is over the control
-                    if (!MouseOver)
-                    {
-                        MouseOver = true;
-                        _kryptonRichTextBox.PerformNeedPaint(true);
-                        Invalidate();
-                    }
-                    base.WndProc(ref m);
-                    break;
-                case PI.WM_.CONTEXTMENU:
-                    // Only interested in overriding the behavior when we have a krypton context menu...
-                    if (_kryptonRichTextBox.KryptonContextMenu != null)
-                    {
-                        // Extract the screen mouse position (if might not actually be provided)
-                        var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
-
-                        // If keyboard activated, the menu position is centered
-                        if (((int)(long)m.LParam) == -1)
-                        {
-                            mousePt = PointToScreen(new Point(Width / 2, Height / 2));
-                        }
-
-                        // Show the context menu
-                        _kryptonRichTextBox.KryptonContextMenu.Show(_kryptonRichTextBox, mousePt);
-
-                        // We eat the message!
-                        return;
-                    }
-                    base.WndProc(ref m);
-                    break;
-                case PI.WM_.PAINT:
-                    if (!string.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
-                        && (_kryptonRichTextBox.TextLength == 0)
-                       )
-                    {
-                        var ps = new PI.PAINTSTRUCT();
-                        // Do we need to BeginPaint or just take the given HDC?
-                        IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
-                        using (Graphics g = Graphics.FromHdc(hdc))
-                        {
-                            g.ResetClip();
-
-                            // Grab the client area of the control
-                            PI.GetClientRect(Handle, out PI.RECT rect);
-
-                            PaletteState state = _kryptonRichTextBox.Enabled
-                                ? _kryptonRichTextBox.IsActive
-                                    ? PaletteState.Tracking
-                                    : PaletteState.Normal
-                                : PaletteState.Disabled;
-                            IPaletteTriple states = _kryptonRichTextBox.GetTripleState();
-
-                            // Drawn entire client area in the background color
-                            using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
-                            // Go perform the drawing of the CueHint
-                            _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, rect, backBrush);
-                        }
-
-                        // Do we need to match the original BeginPaint?
-                        if (m.WParam == IntPtr.Zero)
-                        {
-                            PI.EndPaint(Handle, ref ps);
-                        }
-                    }
-                    base.WndProc(ref m);
-                    break;
-                default:
-                    base.WndProc(ref m);
-                    break;
-            }
+            _forcedLayout = true;
+            OnLayout(new LayoutEventArgs(null, null));
+            _forcedLayout = false;
         }
+        #endregion
+
+        #region Protected Virtual
+        /// <summary>
+        /// Raises the AcceptsTabChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the HideSelectionChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the ModifiedChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the MultilineChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the ReadOnlyChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the VScroll event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnVScroll(EventArgs e) => VScroll?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the HScroll event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnHScroll(EventArgs e) => HScroll?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the SelectionChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnSelectionChanged(EventArgs e) => SelectionChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the Protected event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected virtual void OnProtected(EventArgs e) => Protected?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the LinkClicked event.
+        /// </summary>
+        /// <param name="e">A LinkClickedEventArgs that contains the event data.</param>
+        protected virtual void OnLinkClicked(LinkClickedEventArgs e) => LinkClicked?.Invoke(this, e);
 
         /// <summary>
         /// Raises the TrackMouseEnter event.
@@ -269,2434 +1832,468 @@ public class KryptonRichTextBox : VisualControlBase,
         /// </summary>
         /// <param name="e">An EventArgs containing the event data.</param>
         protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
+        #endregion
+
+        #region Protected Overrides
+        /// <summary>
+        /// Creates a new instance of the control collection for the KryptonTextBox.
+        /// </summary>
+        /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
         /// <summary>
-        /// Raises the OnMouseMove event.
+        /// Raises the HandleCreated event.
         /// </summary>
         /// <param name="e">An EventArgs containing the event data.</param>
-        protected override void OnMouseMove(MouseEventArgs e)
+        protected override void OnHandleCreated(EventArgs e)
         {
-            base.OnMouseMove(e);
+            // Let base class do standard stuff
+            base.OnHandleCreated(e);
 
-            _kryptonRichTextBox.OnMouseMove(e);
-        }
-        #endregion
-    }
-    #endregion
+            // Force the font to be set into the text box child control
+            PerformNeedPaint(false);
 
-    #region Instance Fields
-
-    private VisualPopupToolTip? _visualPopupToolTip;
-    private readonly ViewLayoutDocker _drawDockerInner;
-    private readonly ViewDrawDocker _drawDockerOuter;
-    private readonly ViewLayoutFill _layoutFill;
-    private readonly InternalRichTextBox _richTextBox;
-    private InputControlStyle _inputControlStyle;
-    private bool? _fixedActive;
-    private bool _forcedLayout;
-    private bool _autoSize;
-    private bool _mouseOver;
-    private bool _alwaysActive;
-    private bool _trackingMouseEnter;
-    private bool _firstPaint;
-    private string? _originalRtf; // Store original RTF to restore when switching away from dark mode black themes
-
-    #endregion
-
-    #region Events
-    /// <summary>
-    /// Occurs when the value of the AcceptsTab property changes.
-    /// </summary>
-    [Description(@"Occurs when the value of the AcceptsTab property changes.")]
-    [Category(@"Property Changed")]
-    public event EventHandler? AcceptsTabChanged;
-
-    /// <summary>
-    /// Occurs when the value of the HideSelection property changes.
-    /// </summary>
-    [Description(@"Occurs when the value of the HideSelection property changes.")]
-    [Category(@"Property Changed")]
-    public event EventHandler? HideSelectionChanged;
-
-    /// <summary>
-    /// Occurs when the value of the Modified property changes.
-    /// </summary>
-    [Description(@"Occurs when the value of the Modified property changes.")]
-    [Category(@"Property Changed")]
-    public event EventHandler? ModifiedChanged;
-
-    /// <summary>
-    /// Occurs when the value of the Multiline property changes.
-    /// </summary>
-    [Description(@"Occurs when the value of the Multiline property changes.")]
-    [Category(@"Property Changed")]
-    public event EventHandler? MultilineChanged;
-
-    /// <summary>
-    /// Occurs when the value of the ReadOnly property changes.
-    /// </summary>
-    [Description(@"Occurs when the value of the ReadOnly property changes.")]
-    [Category(@"Property Changed")]
-    public event EventHandler? ReadOnlyChanged;
-
-    /// <summary>
-    /// Occurs when the current selection has changed.
-    /// </summary>
-    [Description(@"Occurs when the current selection has changed.")]
-    [Category(@"Behavior")]
-    public event EventHandler? SelectionChanged;
-
-    /// <summary>
-    /// Occurs when the user takes an action that would change a protected range of text.
-    /// </summary>
-    [Description(@"Occurs when the user takes an action that would change a protected range of text.")]
-    [Category(@"Behavior")]
-    public event EventHandler? Protected;
-
-    /// <summary>
-    /// Occurs when a hyperlink in the text is clicked.
-    /// </summary>
-    [Description(@"Occurs when a hyperlink in the text is clicked.")]
-    [Category(@"Behavior")]
-    public event LinkClickedEventHandler? LinkClicked;
-
-    /// <summary>
-    /// Occurs when the horizontal scroll bar is clicked.
-    /// </summary>
-    [Description(@"Occurs when the horizontal scroll bar is clicked.")]
-    [Category(@"Behavior")]
-    public event EventHandler? HScroll;
-
-    /// <summary>
-    /// Occurs when the vertical scroll bar is clicked.
-    /// </summary>
-    [Description(@"Occurs when the vertical scroll bar is clicked.")]
-    [Category(@"Behavior")]
-    public event EventHandler? VScroll;
-
-    /// <summary>
-    /// Occurs when the mouse enters the control.
-    /// </summary>
-    [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
-    [Category(@"Mouse")]
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public event EventHandler? TrackMouseEnter;
-
-    /// <summary>
-    /// Occurs when the mouse leaves the control.
-    /// </summary>
-    [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
-    [Category(@"Mouse")]
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public event EventHandler? TrackMouseLeave;
-
-    /// <summary>
-    /// Occurs when the value of the BackColor property changes.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public new event EventHandler? BackColorChanged;
-
-    /// <summary>
-    /// Occurs when the value of the BackgroundImage property changes.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public new event EventHandler? BackgroundImageChanged;
-
-    /// <summary>
-    /// Occurs when the value of the BackgroundImageLayout property changes.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public new event EventHandler? BackgroundImageLayoutChanged;
-
-    /// <summary>
-    /// Occurs when the value of the ForeColor property changes.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public new event EventHandler? ForeColorChanged;
-    #endregion
-
-    #region Identity
-    /// <summary>
-    /// Initialize a new instance of the KryptonRichTextBox class.
-    /// </summary>
-    public KryptonRichTextBox()
-    {
-        // Contains another control and needs marking as such for validation to work
-        SetStyle(ControlStyles.ContainerControl, true);
-
-        // Cannot select this control, only the child TextBox
-        SetStyle(ControlStyles.Selectable, false);
-
-        // Defaults
-        _autoSize = false;
-        _alwaysActive = true;
-        _firstPaint = true;
-        _inputControlStyle = InputControlStyle.Standalone;
-
-        // Create the palette storage
-        StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.InputControlStandalone, PaletteContentStyle.InputControlStandalone, NeedPaintDelegate);
-        StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-        StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-        StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
-        CueHint = new PaletteCueHintText(Redirector, NeedPaintDelegate);
-
-        // Create the internal text box used for containing content
-        _richTextBox = new InternalRichTextBox(this);
-        _richTextBox.TrackMouseEnter += OnRichTextBoxMouseChange;
-        _richTextBox.TrackMouseLeave += OnRichTextBoxMouseChange;
-        _richTextBox.AcceptsTabChanged += OnRichTextBoxAcceptsTabChanged;
-        _richTextBox.TextChanged += OnRichTextBoxTextChanged;
-        _richTextBox.HideSelectionChanged += OnRichTextBoxHideSelectionChanged;
-        _richTextBox.ModifiedChanged += OnRichTextBoxModifiedChanged;
-        _richTextBox.MultilineChanged += OnRichTextBoxMultilineChanged;
-        _richTextBox.ReadOnlyChanged += OnRichTextBoxReadOnlyChanged;
-        _richTextBox.GotFocus += OnRichTextBoxGotFocus;
-        _richTextBox.LostFocus += OnRichTextBoxLostFocus;
-        _richTextBox.KeyDown += OnRichTextBoxKeyDown;
-        _richTextBox.KeyUp += OnRichTextBoxKeyUp;
-        _richTextBox.KeyPress += OnRichTextBoxKeyPress;
-        _richTextBox.PreviewKeyDown += OnRichTextBoxPreviewKeyDown;
-        _richTextBox.LinkClicked += OnRichTextBoxLinkClicked;
-        _richTextBox.Protected += OnRichTextBoxProtected;
-        _richTextBox.SelectionChanged += OnRichTextBoxSelectionChanged;
-        _richTextBox.HScroll += OnRichTextBoxHScroll;
-        _richTextBox.VScroll += OnRichTextBoxVScroll;
-        _richTextBox.Validating += OnRichTextBoxValidating;
-        _richTextBox.Validated += OnRichTextBoxValidated;
-
-        // Create the element that fills the remainder space and remembers fill rectangle
-        _layoutFill = new ViewLayoutFill(_richTextBox);
-
-        // Create inner view for placing inside the drawing docker
-        _drawDockerInner = new ViewLayoutDocker
-        {
-            { _layoutFill, ViewDockStyle.Fill }
-        };
-
-        // Create view for the control border and background
-        _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
-        {
-            { _drawDockerInner, ViewDockStyle.Fill }
-        };
-
-        // Create the view manager instance
-        ViewManager = new ViewManager(this, _drawDockerOuter);
-
-        // Create the manager for handling tooltips
-        ToolTipManager = new ToolTipManager(ToolTipValues);
-        ToolTipManager.ShowToolTip += OnShowToolTip;
-        ToolTipManager.CancelToolTip += OnCancelToolTip;
-
-        // Add text box to the controls collection
-        ((KryptonReadOnlyControls)Controls).AddInternal(_richTextBox);
-
-        // Update the back/fore/font from the palette settings
-        UpdateStateAndPalettes();
-        _richTextBox.BackColor = StateActive.PaletteBack.GetBackColor1(PaletteState.Tracking);
-        _richTextBox.ForeColor = StateActive.PaletteContent.GetContentShortTextColor1(PaletteState.Tracking);
-
-        // Only set the font if the rich text box has been created
-        if (_richTextBox.Handle != IntPtr.Zero)
-        {
-            _richTextBox.Font = StateActive.PaletteContent.GetContentShortTextFont(PaletteState.Tracking)!;
-        }
-    }
-
-    /// <summary>
-    /// Clean up any resources being used.
-    /// </summary>
-    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            // Remove any showing tooltip
-            OnCancelToolTip(this, EventArgs.Empty);
+            // We need a layout to occur before any painting
+            InvokeLayout();
         }
 
-        base.Dispose(disposing);
-    }
-    #endregion
-
-    #region Public
-    /// <summary>
-    /// 
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Set a watermark/prompt message for the user.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public PaletteCueHintText CueHint { get; }
-
-    private bool ShouldSerializeCueHint() => !CueHint.IsDefault;
-
-    /// <summary>
-    /// Gets and sets if the control is in the tab chain.
-    /// </summary>
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public new bool TabStop
-    {
-        get => _richTextBox.TabStop;
-        set => _richTextBox.TabStop = value;
-    }
-
-    /// <summary>
-    /// Gets and sets if the control is in the ribbon design mode.
-    /// </summary>
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Browsable(false)]
-    public bool InRibbonDesignMode { get; set; }
-
-    /// <summary>
-    /// Gets access to the contained RichTextBox instance.
-    /// </summary>
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [EditorBrowsable(EditorBrowsableState.Always)]
-    [Browsable(false)]
-    public RichTextBox RichTextBox => _richTextBox;
-
-    /// <summary>
-    /// Gets access to the contained input control.
-    /// </summary>
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [EditorBrowsable(EditorBrowsableState.Always)]
-    [Browsable(false)]
-    public Control ContainedControl => RichTextBox;
-
-    /// <summary>
-    /// Gets a value indicating whether the control has input focus.
-    /// </summary>
-    [Browsable(false)]
-    public override bool Focused => RichTextBox.Focused;
-
-    /// <summary>
-    /// Gets or sets the ability to drag/drop onto the control.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-    public override bool AllowDrop
-    {
-        get => base.AllowDrop;
-        set => base.AllowDrop = value;
-    }
-
-    /// <summary>
-    /// Gets and sets a value indicating if the control is automatically sized.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-    [RefreshProperties(RefreshProperties.Repaint)]
-    [DefaultValue(false)]
-    public override bool AutoSize
-    {
-        get => _autoSize;
-        set => _autoSize = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the background color for the control.
-    /// </summary>
-    [Browsable(false)]
-    [Bindable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override Color BackColor
-    {
-        get => base.BackColor;
-        set => base.BackColor = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the font of the text Displayed by the control.
-    /// </summary>
-    [Browsable(false)]
-    [Bindable(false)]
-    [AmbientValue(null)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [AllowNull]
-    public override Font Font
-    {
-        get => base.Font;
-        set => base.Font = value!;
-    }
-
-    /// <summary>
-    /// Gets or sets the foreground color for the control.
-    /// </summary>
-    [Browsable(false)]
-    [Bindable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override Color ForeColor
-    {
-        get => base.ForeColor;
-        set => base.ForeColor = value;
-    }
-
-    /// <summary>
-    /// Gets and sets the internal padding space.
-    /// </summary>
-    [Browsable(false)]
-    [Localizable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public new Padding Padding
-    {
-        get => base.Padding;
-        set => base.Padding = value;
-    }
-
-    /// <summary>
-    /// Gets and sets the text associated with the control.
-    /// </summary>
-    [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
-    [AllowNull]
-    public override string Text
-    {
-        get => _richTextBox.Text;
-        set => _richTextBox.Text = value;
-    }
-
-    private bool ShouldSerializeText() =>
-        // Must always persist the text value if even when it is the default. Otherwise when
-        // you first move over the control which has been given RTF it resets the fonts.
-        true;
-
-    /// <summary>
-    /// Gets the length of text in the control.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int TextLength => _richTextBox.TextLength;
-
-    /// <summary>
-    /// Gets and sets the associated context menu strip.
-    /// </summary>
-    [DefaultValue(null)]
-    public override ContextMenuStrip? ContextMenuStrip
-    {
-        get => base.ContextMenuStrip;
-
-        set
+        /// <summary>
+        /// Raises the EnabledChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnEnabledChanged(EventArgs e)
         {
-            base.ContextMenuStrip = value;
-            _richTextBox.ContextMenuStrip = value;
-        }
-    }
+            // Change in enabled state requires a layout and repaint
+            UpdateStateAndPalettes();
 
-    /// <summary>
-    /// Gets and sets if the control can redo a previously undo operation.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool CanRedo => _richTextBox.CanRedo;
+            // Update view elements
+            _drawDockerInner.Enabled = Enabled;
+            _drawDockerOuter.Enabled = Enabled;
 
-    /// <summary>
-    /// Gets a value indicating whether the user can undo the previous operation in a rich text box control.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool CanUndo => _richTextBox.CanUndo;
-
-    /// <summary>
-    /// Gets a value indicating whether the contents have changed since last.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool Modified => _richTextBox.Modified;
-
-    /// <summary>
-    /// Gets and sets the language option.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public RichTextBoxLanguageOptions LanguageOption
-    {
-        get => _richTextBox.LanguageOption;
-        set => _richTextBox.LanguageOption = value;
-    }
-
-    /// <summary>
-    /// Gets and sets the name of the action to be redone.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public string? RedoActionName => _richTextBox.RedoActionName;
-
-    /// <summary>
-    /// Gets and sets the name of the action to be undone.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public string? UndoActionName => _richTextBox.UndoActionName;
-
-    /// <summary>
-    /// Gets and sets if keyboard shortcuts are enabled.
-    /// </summary>
-    [Browsable(false)]
-    [DefaultValue(true)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool RichTextShortcutsEnabled
-    {
-        get => _richTextBox.RichTextShortcutsEnabled;
-        set => _richTextBox.RichTextShortcutsEnabled = value;
-    }
-
-    /// <summary>
-    /// Gets and sets the text in rich text format.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [RefreshProperties(RefreshProperties.All)]
-    [AllowNull]
-    public string? Rtf
-    {
-        get => _richTextBox.Rtf ?? string.Empty;
-
-        set
-        {
-            // Store original RTF only when it's truly new content (not just restoration)
-            // Compare with current text to detect if content has actually changed
-            if (!string.IsNullOrEmpty(value))
-            {
-                string currentText = _richTextBox.Text;
-                bool isNewContent = _originalRtf == null;
-
-                // If we have stored original, check if this is significantly different
-                // (palette modifications won't change text content, only RTF codes)
-                if (!isNewContent && _originalRtf != null)
-                {
-                    // If RTF is very different in length or structure, it's likely new content
-                    // Small differences are likely just palette-related modifications
-                    if (value != null)
-                    {
-                        int lengthDiff = Math.Abs(value.Length - _originalRtf.Length);
-                        if (lengthDiff > 100) // Significant difference suggests new content
-                        {
-                            isNewContent = true;
-                        }
-                    }
-                }
-
-                if (isNewContent)
-                {
-                    _originalRtf = value;
-                }
-            }
-            else
-            {
-                _originalRtf = null;
-            }
+            // Update state to reflect change in enabled state
+            _buttonManager.RefreshButtons();
 
             PerformNeedPaint(true);
-            _richTextBox.Rtf = value;
-        }
-    }
 
-    /// <summary>
-    /// Gets and sets the selection portion of the rich text format.
-    /// </summary>
-    [Browsable(false)]
-    [DefaultValue("")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public string SelectedRtf
-    {
-        get => _richTextBox.SelectedRtf;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectedRtf = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the selected text within the control.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public string SelectedText
-    {
-        get => _richTextBox.SelectedText;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectedText = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the alignment of the selection.
-    /// </summary>
-    [Browsable(false)]
-    [DefaultValue(HorizontalAlignment.Left)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public HorizontalAlignment SelectionAlignment
-    {
-        get => _richTextBox.SelectionAlignment;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionAlignment = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the background color of the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Color SelectionBackColor
-    {
-        get => _richTextBox.SelectionBackColor;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionBackColor = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the bullet indentation of the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool SelectionBullet
-    {
-        get => _richTextBox.SelectionBullet;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionBullet = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the character offset of the selection.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionCharOffset
-    {
-        get => _richTextBox.SelectionCharOffset;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionCharOffset = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the text color of the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Color SelectionColor
-    {
-        get => _richTextBox.SelectionColor;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionColor = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the text font for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Font SelectionFont
-    {
-        // Tested that: the System.WWindows.Forms.RichTextBox returns RichtTextBox.Font when no text has been selected.
-        // Null forgiving operator removes the warning.
-        get => _richTextBox.SelectionFont!;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionFont = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the hanging indent for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionHangingIndent
-    {
-        get => _richTextBox.SelectionHangingIndent;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionHangingIndent = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the indent for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionIndent
-    {
-        get => _richTextBox.SelectionIndent;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionIndent = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the selection length for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionLength
-    {
-        get => _richTextBox.SelectionLength;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionLength = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the protected setting for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionProtected
-    {
-        get => _richTextBox.SelectionLength;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionLength = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the right indent for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionRightIndent
-    {
-        get => _richTextBox.SelectionRightIndent;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionRightIndent = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the starting point of text selected in the control.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int SelectionStart
-    {
-        get => _richTextBox.SelectionStart;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionStart = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the tab settings for the selected area.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public int[] SelectionTabs
-    {
-        get => _richTextBox.SelectionTabs;
-
-        set
-        {
-            PerformNeedPaint(true);
-            _richTextBox.SelectionTabs = value;
-        }
-    }
-
-    /// <summary>
-    /// Gets and sets the type of selection.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public RichTextBoxSelectionTypes SelectionType => _richTextBox.SelectionType;
-
-    /// <summary>
-    /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
-    [DefaultValue(true)]
-    public bool AlwaysActive
-    {
-        get => _alwaysActive;
-
-        set
-        {
-            if (_alwaysActive != value)
-            {
-                _alwaysActive = value;
-                PerformNeedPaint(true);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Gets or sets the lines of text in a multiline edit, as an array of String values.
-    /// </summary>
-    [Category(@"Appearance")]
-    [Description(@"The lines of text in a multiline edit, as an array of String values.")]
-    [Editor(@"System.Windows.Forms.Design.StringArrayEditor", typeof(UITypeEditor))]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [MergableProperty(false)]
-    [Localizable(true)]
-    public string[] Lines
-    {
-        get => _richTextBox.Lines;
-        set => _richTextBox.Lines = value;
-    }
-
-    /// <summary>
-    /// Gets or sets, for multiline edit controls, which scroll bars will be shown for this control.
-    /// </summary>
-    [Category(@"Appearance")]
-    [Description(@"Indicates, for multiline edit controls, which scroll bars will be shown for this control.")]
-    [DefaultValue(RichTextBoxScrollBars.Both)]
-    [Localizable(true)]
-    public RichTextBoxScrollBars ScrollBars
-    {
-        get => _richTextBox.ScrollBars;
-        set => _richTextBox.ScrollBars = value;
-    }
-
-    /// <summary>
-    /// Indicates if lines are automatically word-wrapped for multiline edit controls.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Indicates if lines are automatically word-wrapped for multiline edit controls.")]
-    [DefaultValue(true)]
-    [Localizable(true)]
-    public bool WordWrap
-    {
-        get => _richTextBox.WordWrap;
-        set => _richTextBox.WordWrap = value;
-    }
-
-    /// <summary>
-    /// Defines the right margin dimensions.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Defines the right margin dimensions.")]
-    [DefaultValue(0)]
-    [Localizable(true)]
-    public int RightMargin
-    {
-        get => _richTextBox.RightMargin;
-        set => _richTextBox.RightMargin = value;
-    }
-
-    /// <summary>
-    /// Turns on/off the selection margin.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Turns on/off the selection margin.")]
-    [DefaultValue(false)]
-    public bool ShowSelectionMargin
-    {
-        get => _richTextBox.ShowSelectionMargin;
-        set => _richTextBox.ShowSelectionMargin = value;
-    }
-
-    /// <summary>
-    /// Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Defines the current scaling factor of the KryptonRichTextBox display; 1.0 is normal viewing.")]
-    [DefaultValue(1.0f)]
-    [Localizable(true)]
-    public float ZoomFactor
-    {
-        get => _richTextBox.ZoomFactor;
-        set => _richTextBox.ZoomFactor = value;
-    }
-
-    /// <summary>
-    /// Gets and sets whether the text in the control can span more than one line.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Control whether the text in the control can span more than one line.")]
-    [RefreshProperties(RefreshProperties.All)]
-    [DefaultValue(true)]
-    [Localizable(true)]
-    public bool Multiline
-    {
-        get => _richTextBox.Multiline;
-        set => _richTextBox.Multiline = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating if tab characters are accepted as input for multiline edit controls.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Indicates if tab characters are accepted as input for multiline edit controls.")]
-    [DefaultValue(false)]
-    public bool AcceptsTab
-    {
-        get => _richTextBox.AcceptsTab;
-        set => _richTextBox.AcceptsTab = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating that the selection should be hidden when the edit control loses focus.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Indicates that the selection should be hidden when the edit control loses focus.")]
-    [DefaultValue(true)]
-    public bool HideSelection
-    {
-        get => _richTextBox.HideSelection;
-        set => _richTextBox.HideSelection = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the maximum number of characters that can be entered into the edit control.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
-    [DefaultValue(0x7fffffff)]
-    [Localizable(true)]
-    public int MaxLength
-    {
-        get => _richTextBox.MaxLength;
-        set => _richTextBox.MaxLength = value;
-    }
-
-    /// <summary>
-    /// Turns on/off automatic word selection.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Turns on/off automatic word selection.")]
-    [DefaultValue(false)]
-    public bool AutoWordSelection
-    {
-        get => _richTextBox.AutoWordSelection;
-        set => _richTextBox.AutoWordSelection = value;
-    }
-
-    /// <summary>
-    /// Defines the indent for bullets in the control.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Defines the indent for bullets in the control.")]
-    [DefaultValue(0)]
-    [Localizable(true)]
-    public int BulletIndent
-    {
-        get => _richTextBox.BulletIndent;
-        set => _richTextBox.BulletIndent = value;
-    }
-
-    /// <summary>
-    /// Indicates whether URLs are automatically formatted as links.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Indicates whether URLs are automatically formatted as links.")]
-    [DefaultValue(true)]
-    public bool DetectUrls
-    {
-        get => _richTextBox.DetectUrls;
-        set => _richTextBox.DetectUrls = value;
-    }
-
-    /// <summary>
-    /// Enable drag/drop of text, pictures and other data.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Enable drag/drop of text, pictures and other data.")]
-    [DefaultValue(false)]
-    public bool EnableAutoDragDrop
-    {
-        get => _richTextBox.EnableAutoDragDrop;
-        set => _richTextBox.EnableAutoDragDrop = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the text in the edit control can be changed or not.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Controls whether the text in the edit control can be changed or not.")]
-    [RefreshProperties(RefreshProperties.Repaint)]
-    [DefaultValue(false)]
-    public bool ReadOnly
-    {
-        get => _richTextBox.ReadOnly;
-        set => _richTextBox.ReadOnly = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether shortcuts defined for the control are enabled.
-    /// </summary>
-    [Category(@"Behavior")]
-    [Description(@"Indicates whether shortcuts defined for the control are enabled.")]
-    [DefaultValue(true)]
-    public bool ShortcutsEnabled
-    {
-        get => _richTextBox.ShortcutsEnabled;
-        set => _richTextBox.ShortcutsEnabled = value;
-    }
-
-    /// <summary>
-    /// Gets and sets the input control style.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Input control style.")]
-    public InputControlStyle InputControlStyle
-    {
-        get => _inputControlStyle;
-
-        set
-        {
-            if (_inputControlStyle != value)
-            {
-                _inputControlStyle = value;
-                StateCommon.SetStyles(value);
-                PerformNeedPaint(true);
-            }
-        }
-    }
-
-    private bool ShouldSerializeInputControlStyle() => InputControlStyle != InputControlStyle.Standalone;
-    private void ResetInputControlStyle() => InputControlStyle = InputControlStyle.Standalone;
-
-    /// <summary>
-    /// Gets access to the common textbox appearance entries that other states can override.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Overrides for defining common textbox appearance that other states can override.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public PaletteInputControlTripleRedirect StateCommon { get; }
-
-    private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
-
-    /// <summary>
-    /// Gets access to the disabled textbox appearance entries.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Overrides for defining disabled textbox appearance.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public PaletteInputControlTripleStates StateDisabled { get; }
-
-    private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
-
-    /// <summary>
-    /// Gets access to the normal textbox appearance entries.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Overrides for defining normal textbox appearance.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public PaletteInputControlTripleStates StateNormal { get; }
-
-    private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
-
-    /// <summary>
-    /// Gets access to the active textbox appearance entries.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Overrides for defining active textbox appearance.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public PaletteInputControlTripleStates StateActive { get; }
-
-    private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
-
-    /// <summary>
-    /// Appends text to the current text of a rich text box.
-    /// </summary>
-    /// <param name="text">The text to append to the current contents of the text box.</param>
-    public void AppendText(string text) => _richTextBox.AppendText(text);
-
-    /// <summary>
-    /// Clears all text from the text box control.
-    /// </summary>
-    public void Clear() => _richTextBox.Clear();
-
-    /// <summary>
-    /// Clears information about the most recent operation from the undo buffer of the rich text box. 
-    /// </summary>
-    public void ClearUndo() => _richTextBox.ClearUndo();
-
-    /// <summary>
-    /// Copies the current selection in the text box to the Clipboard.
-    /// </summary>
-    public void Copy() => _richTextBox.Copy();
-
-    /// <summary>
-    /// Moves the current selection in the text box to the Clipboard.
-    /// </summary>
-    public void Cut() => _richTextBox.Cut();
-
-    /// <summary>
-    /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
-    /// </summary>
-    public void DeselectAll() => _richTextBox.DeselectAll();
-
-    /// <summary>
-    /// Determines whether you can paste information from the Clipboard in the specified data format.
-    /// </summary>
-    /// <param name="clipFormat">One of the System.Windows.Forms.DataFormats.Format values.</param>
-    /// <returns>true if you can paste data from the Clipboard in the specified data format; otherwise, false.</returns>
-    public bool CanPaste(DataFormats.Format clipFormat) => _richTextBox.CanPaste(clipFormat);
-
-    /// <summary>
-    /// Searches the text in a RichTextBox control for a string.
-    /// </summary>
-    /// <param name="str">The text to locate in the control.</param>
-    /// <returns>The location within the control where the search text was found or -1 if the search string is not found or an empty search string is specified in the str parameter.</returns>
-    public int Find(string str) => _richTextBox.Find(str);
-
-    /// <summary>
-    /// Searches the text of a RichTextBox control for the first instance of a character from a list of characters.
-    /// </summary>
-    /// <param name="characterSet">The array of characters to search for.</param>
-    /// <returns>The location within the control where the search characters were found or -1 if the search characters are not found or an empty search character set is specified in the char parameter.</returns>
-    public int Find(char[] characterSet) => _richTextBox.Find(characterSet);
-
-    /// <summary>
-    /// Searches the text of a RichTextBox control, at a specific starting point, for the first instance of a character from a list of characters.
-    /// </summary>
-    /// <param name="characterSet">The array of characters to search for.</param>
-    /// <param name="start">The location within the control's text at which to begin searching.</param>
-    /// <returns>The location within the control where the search characters are found.</returns>
-    public int Find(char[] characterSet, int start) => _richTextBox.Find(characterSet, start);
-
-    /// <summary>
-    /// Searches the text in a RichTextBox control for a string with specific options applied to the search.
-    /// </summary>
-    /// <param name="str">The text to locate in the control.</param>
-    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-    /// <returns>The location within the control where the search text was found.</returns>
-    public int Find(string str, RichTextBoxFinds options) => _richTextBox.Find(str, options);
-
-    /// <summary>
-    /// Searches a range of text in a RichTextBox control for the first instance of a character from a list of characters.
-    /// </summary>
-    /// <param name="characterSet">The array of characters to search for.</param>
-    /// <param name="start">The location within the control's text at which to begin searching.</param>
-    /// <param name="end">The location within the control's text at which to end searching.</param>
-    /// <returns>The location within the control where the search characters are found.</returns>
-    public int Find(char[] characterSet, int start, int end) => _richTextBox.Find(characterSet, start, end);
-
-    /// <summary>
-    /// Searches the text in a RichTextBox control for a string at a specific location within the control and with specific options applied to the search.
-    /// </summary>
-    /// <param name="str">The text to locate in the control.</param>
-    /// <param name="start">The location within the control's text at which to begin searching.</param>
-    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-    /// <returns>The location within the control where the search text was found.</returns>
-    public int Find(string str, int start, RichTextBoxFinds options) => _richTextBox.Find(str, start, options);
-
-    /// <summary>
-    /// Searches the text in a RichTextBox control for a string within a range of text within the control and with specific options applied to the search.
-    /// </summary>
-    /// <param name="str">The text to locate in the control.</param>
-    /// <param name="start">The location within the control's text at which to begin searching.</param>
-    /// <param name="end">The location within the control's text at which to end searching. This value must be equal to negative one (-1) or greater than or equal to the start parameter.</param>
-    /// <param name="options">A bitwise combination of the RichTextBoxFinds values.</param>
-    /// <returns></returns>
-    public int Find(string str, int start, int end, RichTextBoxFinds options) => _richTextBox.Find(str, start, end, options);
-
-    /// <summary>
-    /// Retrieves the character that is closest to the specified location within the control.
-    /// </summary>
-    /// <param name="pt">The location from which to seek the nearest character.</param>
-    /// <returns>The character at the specified location.</returns>
-    public int GetCharFromPosition(Point pt) => _richTextBox.GetCharFromPosition(pt);
-
-    /// <summary>
-    /// Retrieves the index of the character nearest to the specified location.
-    /// </summary>
-    /// <param name="pt">The location to search.</param>
-    /// <returns>The zero-based character index at the specified location.</returns>
-    public int GetCharIndexFromPosition(Point pt) => _richTextBox.GetCharIndexFromPosition(pt);
-
-    /// <summary>
-    /// Retrieves the index of the first character of a given line.
-    /// </summary>
-    /// <param name="lineNumber">The line for which to get the index of its first character.</param>
-    /// <returns>The zero-based character index in the specified line.</returns>
-    public int GetFirstCharIndexFromLine(int lineNumber) => _richTextBox.GetFirstCharIndexFromLine(lineNumber);
-
-    /// <summary>
-    /// Retrieves the index of the first character of the current line.
-    /// </summary>
-    /// <returns>The zero-based character index in the current line.</returns>
-    public int GetFirstCharIndexOfCurrentLine() => _richTextBox.GetFirstCharIndexOfCurrentLine();
-
-    /// <summary>
-    /// Retrieves the line number from the specified character position within the text of the RichTextBox control.
-    /// </summary>
-    /// <param name="index">The character index position to search.</param>
-    /// <returns>The zero-based line number in which the character index is located.</returns>
-    public int GetLineFromCharIndex(int index) => _richTextBox.GetLineFromCharIndex(index);
-
-    /// <summary>
-    /// Retrieves the location within the control at the specified character index.
-    /// </summary>
-    /// <param name="index">The index of the character for which to retrieve the location.</param>
-    /// <returns>The location of the specified character.</returns>
-    public Point GetPositionFromCharIndex(int index) => _richTextBox.GetPositionFromCharIndex(index);
-
-    /// <summary>
-    /// Loads a rich text format (RTF) or standard ASCII text file into the RichTextBox control.
-    /// </summary>
-    /// <param name="path">The name and location of the file to load into the control.</param>
-    public void LoadFile(string path) => _richTextBox.LoadFile(path);
-
-    /// <summary>
-    /// Loads the contents of an existing data stream into the RichTextBox control.
-    /// </summary>
-    /// <param name="data">A stream of data to load into the RichTextBox control.</param>
-    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-    public void LoadFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(data, fileType);
-
-    /// <summary>
-    /// Loads a specific type of file into the RichTextBox control.
-    /// </summary>
-    /// <param name="path">The name and location of the file to load into the control.</param>
-    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-    public void LoadFile(string path, RichTextBoxStreamType fileType) => _richTextBox.LoadFile(path, fileType);
-
-    /// <summary>
-    /// Replaces the current selection in the text box with the contents of the Clipboard.
-    /// </summary>
-    public void Paste() => _richTextBox.Paste();
-
-    /// <summary>
-    /// Undoes the last edit operation in the text box.
-    /// </summary>
-    public void Undo() => _richTextBox.Undo();
-
-    /// <summary>
-    /// Pastes the contents of the Clipboard in the specified Clipboard format.
-    /// </summary>
-    /// <param name="clipFormat">The Clipboard format in which the data should be obtained from the Clipboard.</param>
-    public void Paste(DataFormats.Format clipFormat) => _richTextBox.Paste(clipFormat);
-
-    /// <summary>
-    /// Reapplies the last operation that was undone in the control.
-    /// </summary>
-    public void Redo() => _richTextBox.Redo();
-
-    /// <summary>
-    /// Saves the contents of the RichTextBox to a rich text format (RTF) file.
-    /// </summary>
-    /// <param name="path">The name and location of the file to save.</param>
-    public void SaveFile(string path) => _richTextBox.SaveFile(path);
-
-    /// <summary>
-    /// Saves the contents of a RichTextBox control to an open data stream.
-    /// </summary>
-    /// <param name="data">The data stream that contains the file to save to.</param>
-    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-    public void SaveFile(Stream data, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(data, fileType);
-
-    /// <summary>
-    /// Saves the contents of the KryptonRichTextBox to a specific type of file.
-    /// </summary>
-    /// <param name="path">The name and location of the file to save.</param>
-    /// <param name="fileType">One of the RichTextBoxStreamType values.</param>
-    public void SaveFile(string path, RichTextBoxStreamType fileType) => _richTextBox.SaveFile(path, fileType);
-
-    /// <summary>
-    /// Scrolls the contents of the control to the current caret position.
-    /// </summary>
-    public void ScrollToCaret() => _richTextBox.ScrollToCaret();
-
-    /// <summary>
-    /// Selects a range of text in the control.
-    /// </summary>
-    /// <param name="start">The position of the first character in the current text selection within the text box.</param>
-    /// <param name="length">The number of characters to select.</param>
-    public void Select(int start, int length) => _richTextBox.Select(start, length);
-
-    /// <summary>
-    /// Selects all text in the control.
-    /// </summary>
-    public void SelectAll() => _richTextBox.SelectAll();
-
-    /// <summary>
-    /// Sets the fixed state of the control.
-    /// </summary>
-    /// <param name="active">Should the control be fixed as active.</param>
-    public void SetFixedState(bool active) => _fixedActive = active;
-
-    /// <summary>
-    /// Gets access to the ToolTipManager used for displaying tool tips.
-    /// </summary>
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public ToolTipManager ToolTipManager { get; }
-
-    /// <summary>
-    /// Gets a value indicating if the input control is active.
-    /// </summary>
-    [Browsable(false)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool IsActive =>
-        _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
-
-    /// <summary>
-    /// Sets input focus to the control.
-    /// </summary>
-    /// <returns>true if the input focus request was successful; otherwise, false.</returns>
-    public new bool Focus() => RichTextBox.Focus();
-
-    /// <summary>
-    /// Activates the control.
-    /// </summary>
-    public new void Select() => RichTextBox.Select();
-
-    /// <summary>
-    /// Get the preferred size of the control based on a proposed size.
-    /// </summary>
-    /// <param name="proposedSize">Starting size proposed by the caller.</param>
-    /// <returns>Calculated preferred size.</returns>
-    public override Size GetPreferredSize(Size proposedSize)
-    {
-        // Do we have a manager to ask for a preferred size?
-        if (ViewManager != null)
-        {
-            // Ask the view to Perform a layout
-            Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
-
-            // Apply the maximum sizing
-            if (MaximumSize.Width > 0)
-            {
-                retSize.Width = Math.Min(MaximumSize.Width, retSize.Width);
-            }
-
-            if (MaximumSize.Height > 0)
-            {
-                retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
-            }
-
-            // Apply the minimum sizing
-            if (MinimumSize.Width > 0)
-            {
-                retSize.Width = Math.Max(MinimumSize.Width, retSize.Width);
-            }
-
-            if (MinimumSize.Height > 0)
-            {
-                retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
-            }
-
-            return retSize;
-        }
-        else
-        {
-            // Fall back on default control processing
-            return base.GetPreferredSize(proposedSize);
-        }
-    }
-
-    /// <summary>
-    /// Gets the rectangle that represents the display area of the control.
-    /// </summary>
-    public override Rectangle DisplayRectangle
-    {
-        get
-        {
-            // Ensure that the layout is calculated in order to know the remaining display space
-            ForceViewLayout();
-
-            // The inside text box is the client rectangle size
-            return new Rectangle(_richTextBox.Location, _richTextBox.Size);
-        }
-    }
-
-    /// <summary>
-    /// Print the specified range of characters.
-    /// </summary>
-    /// <param name="charFrom">Start character.</param>
-    /// <param name="charTo">End character.</param>
-    /// <param name="gr">Graphics instance to use.</param>
-    /// <param name="bounds">Drawing bounds.</param>
-    /// <returns>Pointer to returned result.</returns>
-    public int Print(int charFrom, int charTo, Graphics gr, Rectangle bounds) => _richTextBox.Print(charFrom, charTo, gr, bounds);
-
-    /// <summary>
-    /// Override the display padding for the layout fill.
-    /// </summary>
-    /// <param name="padding">Display padding value.</param>
-    public void SetLayoutDisplayPadding(Padding padding) => _layoutFill.DisplayPadding = padding;
-
-    /// <summary>
-    /// Internal design time method.
-    /// </summary>
-    /// <param name="pt">Mouse location.</param>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Browsable(false)]
-    public bool DesignerGetHitTest(Point pt)
-    {
-        // Ignore call as view builder is already destructed
-        return !IsDisposed;
-    }
-
-    /// <summary>
-    /// Internal design time method.
-    /// </summary>
-    /// <param name="pt">Mouse location.</param>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Browsable(false)]
-    public Component? DesignerComponentFromPoint(Point pt) =>
-        // Ignore call as view builder is already destructed
-        IsDisposed ? null : ViewManager?.ComponentFromPoint(pt);
-
-    // Ask the current view for a decision
-    /// <summary>
-    /// Internal design time method.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Browsable(false)]
-    public void DesignerMouseLeave() =>
-        // Simulate the mouse leaving the control so that the tracking
-        // element that thinks it has the focus is informed it does not
-        OnMouseLeave(EventArgs.Empty);
-
-    #endregion
-
-    #region Protected
-    /// <summary>
-    /// Force the layout logic to size and position the controls.
-    /// </summary>
-    protected void ForceControlLayout()
-    {
-        _forcedLayout = true;
-        OnLayout(new LayoutEventArgs(null, null));
-        _forcedLayout = false;
-    }
-    #endregion
-
-    #region Protected Virtual
-    /// <summary>
-    /// Raises the AcceptsTabChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs containing the event data.</param>
-    protected virtual void OnAcceptsTabChanged(EventArgs e) => AcceptsTabChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the HideSelectionChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnHideSelectionChanged(EventArgs e) => HideSelectionChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the ModifiedChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnModifiedChanged(EventArgs e) => ModifiedChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the MultilineChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnMultilineChanged(EventArgs e) => MultilineChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the ReadOnlyChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the VScroll event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnVScroll(EventArgs e) => VScroll?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the HScroll event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnHScroll(EventArgs e) => HScroll?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the SelectionChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnSelectionChanged(EventArgs e) => SelectionChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the Protected event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected virtual void OnProtected(EventArgs e) => Protected?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the LinkClicked event.
-    /// </summary>
-    /// <param name="e">A LinkClickedEventArgs that contains the event data.</param>
-    protected virtual void OnLinkClicked(LinkClickedEventArgs e) => LinkClicked?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the TrackMouseEnter event.
-    /// </summary>
-    /// <param name="e">An EventArgs containing the event data.</param>
-    protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the TrackMouseLeave event.
-    /// </summary>
-    /// <param name="e">An EventArgs containing the event data.</param>
-    protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
-    #endregion
-
-    #region Protected Overrides
-    /// <summary>
-    /// Creates a new instance of the control collection for the KryptonTextBox.
-    /// </summary>
-    /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
-
-    /// <summary>
-    /// Creates the accessibility object for the KryptonRichTextBox control.
-    /// </summary>
-    /// <returns>A new KryptonRichTextBoxAccessibleObject instance for the control.</returns>
-    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonRichTextBoxAccessibleObject(this);
-
-    /// <summary>
-    /// Raises the HandleCreated event.
-    /// </summary>
-    /// <param name="e">An EventArgs containing the event data.</param>
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        // Let base class do standard stuff
-        base.OnHandleCreated(e);
-
-        // Force the font to be set into the text box child control
-        PerformNeedPaint(false);
-
-        // We need a layout to occur before any painting
-        InvokeLayout();
-    }
-
-    /// <summary>
-    /// Raises the EnabledChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnEnabledChanged(EventArgs e)
-    {
-        // Change in enabled state requires a layout and repaint
-        UpdateStateAndPalettes();
-
-        // Update view elements
-        _drawDockerInner.Enabled = Enabled;
-        _drawDockerOuter.Enabled = Enabled;
-
-        PerformNeedPaint(true);
-
-        // Let base class fire standard event
-        base.OnEnabledChanged(e);
-    }
-
-    /// <summary>
-    /// Raises the BackColorChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the BackgroundImageChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the BackgroundImageLayoutChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the ForeColorChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
-
-    /// <summary>
-    /// Raises the Resize event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnResize(EventArgs e)
-    {
-        // Let base class raise events
-        base.OnResize(e);
-
-        // We must have a layout calculation
-        ForceControlLayout();
-    }
-
-    /// <summary>
-    /// Raises the TabStop event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnTabStopChanged(EventArgs e)
-    {
-        RichTextBox.TabStop = TabStop;
-        base.OnTabStopChanged(e);
-    }
-
-    /// <summary>
-    /// Raises the CausesValidationChanged event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnCausesValidationChanged(EventArgs e)
-    {
-        RichTextBox.CausesValidation = CausesValidation;
-        base.OnCausesValidationChanged(e);
-    }
-
-    /// <summary>
-    /// Raises the Layout event.
-    /// </summary>
-    /// <param name="levent">An EventArgs that contains the event data.</param>
-    protected override void OnLayout(LayoutEventArgs levent)
-    {
-        if (!IsDisposed && !Disposing)
-        {
-            // Update with latest content padding for placing around the contained text box control
-            Padding contentPadding = GetTripleState().PaletteContent!.GetBorderContentPadding(null, _drawDockerOuter.State);
-            _layoutFill.DisplayPadding = contentPadding;
+            // Let base class fire standard event
+            base.OnEnabledChanged(e);
         }
 
-        // Let base class calculate fill rectangle
-        base.OnLayout(levent);
+        /// <summary>
+        /// Raises the BackColorChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnBackColorChanged(EventArgs e) => BackColorChanged?.Invoke(this, e);
 
-        if (!IsDisposed && !Disposing)
+        /// <summary>
+        /// Raises the BackgroundImageChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnBackgroundImageChanged(EventArgs e) => BackgroundImageChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the BackgroundImageLayoutChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnBackgroundImageLayoutChanged(EventArgs e) => BackgroundImageLayoutChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the ForeColorChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnForeColorChanged(EventArgs e) => ForeColorChanged?.Invoke(this, e);
+
+        /// <summary>
+        /// Raises the Resize event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnResize(EventArgs e)
         {
-            // Only use layout logic if control is fully initialized or if being forced
-            // to allow a relayout or if in design mode.
-            if (_forcedLayout || DesignMode)
-            {
-                Rectangle fillRect = _layoutFill.FillRect;
-                _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
-            }
-        }
-    }
+            // Let base class raise events
+            base.OnResize(e);
 
-    /// <summary>
-    /// Raises the MouseEnter event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnMouseEnter(EventArgs e)
-    {
-        _mouseOver = true;
-        PerformNeedPaint(true);
-        _richTextBox.Invalidate();
-        base.OnMouseEnter(e);
-    }
-
-    /// <summary>
-    /// Raises the MouseLeave event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnMouseLeave(EventArgs e)
-    {
-        _mouseOver = false;
-        PerformNeedPaint(true);
-        _richTextBox.Invalidate();
-        base.OnMouseLeave(e);
-    }
-
-    /// <summary>
-    /// Raises the GotFocus event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnGotFocus(EventArgs e)
-    {
-        base.OnGotFocus(e);
-        _richTextBox.Focus();
-    }
-
-    /// <summary>
-    /// Gets the default size of the control.
-    /// </summary>
-    protected override Size DefaultSize => new Size(100, 96);
-
-    /// <summary>
-    /// Processes a notification from palette storage of a paint and optional layout required.
-    /// </summary>
-    /// <param name="sender">Source of notification.</param>
-    /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-    protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
-    {
-        if (!e.NeedLayout)
-        {
-            _richTextBox.Invalidate();
-        }
-        else
-        {
+            // We must have a layout calculation
             ForceControlLayout();
         }
 
-        if (!IsDisposed && !Disposing)
+        /// <summary>
+        /// Raises the TabStop event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnTabStopChanged(EventArgs e)
         {
-            // IMPORTANT: Save RTF content BEFORE any property changes that might reset formatting
-            // Setting BackColor, ForeColor, or Font can reset RTF formatting in RichTextBox
-            string? savedRtf = null;
-            bool hasRtfFormatting = false;
+            RichTextBox.TabStop = TabStop;
+            base.OnTabStopChanged(e);
+        }
 
-            if (_richTextBox.Handle != IntPtr.Zero && _richTextBox.TextLength > 0)
+        /// <summary>
+        /// Raises the CausesValidationChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnCausesValidationChanged(EventArgs e)
+        {
+            RichTextBox.CausesValidation = CausesValidation;
+            base.OnCausesValidationChanged(e);
+        }
+
+        /// <summary>
+        /// Raises the Layout event.
+        /// </summary>
+        /// <param name="levent">An EventArgs that contains the event data.</param>
+        protected override void OnLayout(LayoutEventArgs levent)
+        {
+            if (!IsDisposed && !Disposing)
             {
-                savedRtf = _richTextBox.Rtf;
+                // Update with latest content padding for placing around the contained text box control
+                Padding contentPadding = GetTripleState().PaletteContent.GetContentPadding(_drawDockerOuter.State);
+                _layoutFill.DisplayPadding = contentPadding;
+            }
 
-                // Check if the RichTextBox has RTF formatting by examining the Rtf property
-                // If Rtf contains character-level formatting codes, preserve formatting
-                if (!string.IsNullOrEmpty(savedRtf))
+            // Let base class calulcate fill rectangle
+            base.OnLayout(levent);
+
+            if (!IsDisposed && !Disposing)
+            {
+                // Only use layout logic if control is fully initialized or if being forced
+                // to allow a relayout or if in design mode.
+                if (_forcedLayout || (DesignMode && (_richTextBox != null)))
                 {
-                    int rtfLength = savedRtf.Length;
-                    string plainText = _richTextBox.Text;
-                    int plainTextLength = plainText?.Length ?? 0;
-
-                    // Quick length check first (fastest check - O(1))
-                    bool rtfMuchLonger = plainTextLength > 0 && rtfLength > (plainTextLength + 200);
-                    if (rtfMuchLonger)
-                    {
-                        hasRtfFormatting = true;
-                    }
-                    else
-                    {
-                        // Single-pass character scan for maximum efficiency (O(n) worst case, but exits early)
-                        // Look for backslash followed by formatting codes: \b, \i, \ul, \fs, \cf, \highlight, or \f[1-9]
-                        bool foundFormatting = false;
-                        bool foundCustomFont = false;
-                        ReadOnlySpan<char> savedRtfSpan = savedRtf;
-
-                        // Exit early once we find either formatting or custom font (either indicates RTF formatting)
-                        for (int i = 0; i < savedRtfSpan.Length - 1 && !foundFormatting && !foundCustomFont; i++)
-                        {
-                            if (savedRtfSpan[i] == '\\')
-                            {
-                                char nextChar = savedRtfSpan[i + 1];
-
-                                // Check for formatting codes: b, i, u, f, c, h, s
-                                switch (nextChar)
-                                {
-                                    case 'b': // \b (bold)
-                                    case 'i': // \i (italic)
-                                        foundFormatting = true;
-                                        break;
-                                    case 'u': // \ul (underline) - check for 'l' next
-                                        if (i + 2 < savedRtfSpan.Length && savedRtfSpan[i + 2] == 'l')
-                                        {
-                                            foundFormatting = true;
-                                        }
-                                        break;
-                                    case 'f': // \f (font) - check for non-zero digit
-                                        if (i + 2 < savedRtfSpan.Length)
-                                        {
-                                            char fontDigit = savedRtfSpan[i + 2];
-                                            if (char.IsDigit(fontDigit) && fontDigit != '0')
-                                            {
-                                                foundCustomFont = true;
-                                            }
-                                        }
-                                        break;
-                                    case 'c': // \cf (color) - check for 'f' next
-                                        if (i + 2 < savedRtfSpan.Length && savedRtfSpan[i + 2] == 'f')
-                                        {
-                                            foundFormatting = true;
-                                        }
-                                        break;
-                                    case 'h': // \highlight - check character by character to avoid Substring
-                                        if (i + 9 < savedRtfSpan.Length)
-                                        {
-                                            // Check for "highlight" without Substring allocation
-                                            if (savedRtfSpan[i + 2] == 'i' && savedRtfSpan[i + 3] == 'g' &&
-                                                savedRtfSpan[i + 4] == 'h' && savedRtfSpan[i + 5] == 'l' &&
-                                                savedRtfSpan[i + 6] == 'i' && savedRtfSpan[i + 7] == 'g' &&
-                                                savedRtfSpan[i + 8] == 'h' && savedRtfSpan[i + 9] == 't')
-                                            {
-                                                foundFormatting = true;
-                                            }
-                                        }
-                                        break;
-                                    case 's': // \fs (font size) - check for digit after 's'
-                                        if (i + 2 < savedRtfSpan.Length && char.IsDigit(savedRtfSpan[i + 2]))
-                                        {
-                                            foundFormatting = true;
-                                        }
-                                        break;
-                                }
-                            }
-                        }
-
-                        hasRtfFormatting = foundFormatting || foundCustomFont;
-                    }
-                }
-                else if (!string.IsNullOrEmpty(savedRtf))
-                {
-                    // Even if text length is 0, if RTF exists and has structure beyond minimal, preserve it
-                    // This handles edge cases where text might be empty but RTF structure exists
-                    hasRtfFormatting = savedRtf.Length > 50; // Minimal RTF is usually ~30-40 chars
+                    Rectangle fillRect = _layoutFill.FillRect;
+                    _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
                 }
             }
+        }
 
-            // Update the back/fore/font from the palette settings
-            UpdateStateAndPalettes();
-            IPaletteTriple triple = GetTripleState();
-            PaletteState state = _drawDockerOuter.State;
+        /// <summary>
+        /// Raises the MouseEnter event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnMouseEnter(EventArgs e)
+        {
+            _mouseOver = true;
+            PerformNeedPaint(true);
+            _richTextBox.Invalidate();
+            base.OnMouseEnter(e);
+        }
 
-            Color backColor = triple.PaletteBack.GetBackColor1(state);
-            if (_richTextBox.BackColor != backColor)
+        /// <summary>
+        /// Raises the MouseLeave event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            _mouseOver = false;
+            PerformNeedPaint(true);
+            _richTextBox.Invalidate();
+            base.OnMouseLeave(e);
+        }
+
+        /// <summary>
+        /// Raises the GotFocus event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnGotFocus(EventArgs e)
+        {
+            base.OnGotFocus(e);
+            _richTextBox.Focus();
+        }
+
+        /// <summary>
+        /// Gets the default size of the control.
+        /// </summary>
+        protected override Size DefaultSize => new Size(100, 96);
+
+        /// <summary>
+        /// Processes a notification from palette storage of a paint and optional layout required.
+        /// </summary>
+        /// <param name="sender">Source of notification.</param>
+        /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
+        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        {
+            if (!e.NeedLayout)
             {
-                _richTextBox.BackColor = backColor;
+                _richTextBox.Invalidate();
+            }
+            else
+            {
+                ForceControlLayout();
             }
 
-            Color foreColor = triple.PaletteContent!.GetContentShortTextColor1(state);
-            if (_richTextBox.ForeColor != foreColor)
+            if (!IsDisposed && !Disposing)
             {
-                _richTextBox.ForeColor = foreColor;
-            }
+                // Update the back/fore/font from the palette settings
+                UpdateStateAndPalettes();
+                IPaletteTriple triple = GetTripleState();
+                PaletteState state = _drawDockerOuter.State;
 
-            // Only set the font if the rich text box has been created
-            // IMPORTANT: Do not set Font property if RichTextBox has RTF formatting,
-            // as setting Font will reset all RTF formatting. Only set font for plain text.
-            Font? font = triple.PaletteContent.GetContentShortTextFont(state);
-            if ((_richTextBox.Handle != IntPtr.Zero) && font != null && !_richTextBox.Font.Equals(font))
-            {
-                if (!hasRtfFormatting)
+                Color backColor = triple.PaletteBack.GetBackColor1(state);
+                if (_richTextBox.BackColor != backColor)
                 {
-                    // Only set font for plain text to avoid losing RTF formatting
+                    _richTextBox.BackColor = backColor;
+                }
+
+                Color foreColor = triple.PaletteContent.GetContentShortTextColor1(state);
+                if (_richTextBox.ForeColor != foreColor)
+                {
+                    _richTextBox.ForeColor = foreColor;
+                }
+
+                // Only set the font if the rich text box has been created
+                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                if ((_richTextBox.Handle != IntPtr.Zero) && !_richTextBox.Font.Equals(font))
+                {
                     _richTextBox.Font = font;
                 }
             }
 
-            // If we detected RTF formatting, restore it after property changes
-            // This ensures formatting is preserved even if BackColor/ForeColor changes reset it
-            if (hasRtfFormatting && !string.IsNullOrEmpty(savedRtf) && _richTextBox.Handle != IntPtr.Zero)
+            base.OnNeedPaint(sender, e);
+        }
+
+        /// <summary>
+        /// Raises the Paint event.
+        /// </summary>
+        /// <param name="e">A PaintEventArgs containing the event data.</param>
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            if (_firstPaint)
             {
-                // Store original RTF if not already stored or if RTF content has changed
-                // We need to detect if this is a new RTF (different from stored original)
-                // by checking if the text content matches (RTF might be modified but text is same)
-                string currentText = _richTextBox.Text;
-                bool isNewRtf = _originalRtf == null;
+                _firstPaint = false;
+                ForceControlLayout();
+            }
 
-                // If we have stored original, check if text matches to determine if it's the same RTF
-                if (!isNewRtf && _originalRtf != null)
-                {
-                    // Try to get text from original RTF to compare
-                    // If text doesn't match, it's a new RTF
-                    // For simplicity, we'll compare the saved RTF with original
-                    // If they're significantly different, it's likely new content
-                    if (savedRtf != _originalRtf && savedRtf != null && Math.Abs(savedRtf.Length - _originalRtf.Length) > 50)
+            base.OnPaint(e);
+        }
+
+        /// <summary>
+        /// Process Windows-based messages.
+        /// </summary>
+        /// <param name="m">A Windows-based message.</param>
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case PI.WM_.NCHITTEST:
+                    if (InTransparentDesignMode)
                     {
-                        isNewRtf = true;
-                    }
-                }
-
-                if (isNewRtf)
-                {
-                    // Store the original RTF before any modifications
-                    _originalRtf = savedRtf;
-                }
-
-                // Check if we're in a dark mode black theme that requires black text handling
-                PaletteMode currentMode = KryptonManager.CurrentGlobalPaletteMode;
-                bool isDarkModeBlackTheme = currentMode is PaletteMode.Office2007BlackDarkMode or PaletteMode.Office2010BlackDarkMode or PaletteMode.Microsoft365BlackDarkMode;
-
-                string? rtfToRestore;
-
-                if (isDarkModeBlackTheme && _originalRtf != null)
-                {
-                    // In dark mode black themes, check if original RTF contains black text
-                    // If so, replace black color codes with white for visibility
-                    bool hasBlackText = HasBlackTextInRtf(_originalRtf);
-                    if (hasBlackText)
-                    {
-                        // Replace black color codes with white in original RTF
-                        rtfToRestore = RemoveBlackColorCodes(_originalRtf);
+                        m.Result = (IntPtr)PI.HT.TRANSPARENT;
                     }
                     else
                     {
-                        // No black text, use original RTF
-                        rtfToRestore = _originalRtf;
+                        base.WndProc(ref m);
                     }
-                }
-                else
-                {
-                    // Not in dark mode black theme - restore original RTF with all formatting
-                    rtfToRestore = _originalRtf ?? savedRtf;
-                }
 
-                // Check if RTF was modified (lost formatting) and restore it
-                if (_richTextBox != null)
-                {
-                    string? currentRtf = _richTextBox.Rtf;
-                    if (currentRtf != rtfToRestore)
-                    {
-                        // Restore the RTF (either modified for dark mode or original)
-                        _richTextBox.Rtf = rtfToRestore;
-                    }
-                }
-            }
-            else if (!hasRtfFormatting)
-            {
-                // Plain text - clear stored original RTF
-                _originalRtf = null;
-            }
-        }
-
-        base.OnNeedPaint(sender, e);
-    }
-
-    /// <summary>
-    /// Raises the Paint event.
-    /// </summary>
-    /// <param name="e">A PaintEventArgs containing the event data.</param>
-    protected override void OnPaint(PaintEventArgs? e)
-    {
-        if (_firstPaint)
-        {
-            _firstPaint = false;
-            ForceControlLayout();
-        }
-
-        base.OnPaint(e);
-    }
-
-    /// <summary>
-    /// Process Windows-based messages.
-    /// </summary>
-    /// <param name="m">A Windows-based message.</param>
-    protected override void WndProc(ref Message m)
-    {
-        switch (m.Msg)
-        {
-            case PI.WM_.NCHITTEST:
-                if (InTransparentDesignMode)
-                {
-                    m.Result = (IntPtr)PI.HT.TRANSPARENT;
-                }
-                else
-                {
+                    break;
+                default:
                     base.WndProc(ref m);
-                }
-
-                break;
-            default:
-                base.WndProc(ref m);
-                break;
-        }
-    }
-
-    /// <summary>
-    /// Fixes the cursor changing issue.
-    /// </summary>
-    /// <param name="e"></param>
-    protected override void OnCursorChanged(EventArgs e)
-    {
-        base.OnCursorChanged(e);
-
-        _richTextBox.Cursor = Cursor;
-    }
-    #endregion
-
-    #region Internal
-    internal bool InTransparentDesignMode => InRibbonDesignMode;
-
-    #endregion
-
-    #region Implementation
-
-    private void UpdateStateAndPalettes()
-    {
-        // Get the correct palette settings to use
-        IPaletteTriple tripleState = GetTripleState();
-        _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
-
-        // Update enabled state
-        _drawDockerOuter.Enabled = Enabled;
-
-        // Find the new state of the main view element
-        PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
-
-        _drawDockerOuter.ElementState = state;
-    }
-
-    private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
-
-    private void OnRichTextBoxMouseChange(object? sender, EventArgs e)
-    {
-        // Change in tracking state?
-        if (_richTextBox.MouseOver != _trackingMouseEnter)
-        {
-            _trackingMouseEnter = _richTextBox.MouseOver;
-
-            // Raise appropriate event
-            if (_trackingMouseEnter)
-            {
-                OnTrackMouseEnter(EventArgs.Empty);
-                OnMouseEnter(e);
-            }
-            else
-            {
-                OnTrackMouseLeave(EventArgs.Empty);
-                OnMouseLeave(e);
+                    break;
             }
         }
-    }
 
-    private void OnRichTextBoxAcceptsTabChanged(object? sender, EventArgs e) => OnAcceptsTabChanged(e);
-
-    private void OnRichTextBoxTextChanged(object? sender, EventArgs e)
-    {
-        if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
-            && TextLength <= 1)
+        /// <summary>
+        /// Fixes the cursor changing issue.
+        /// </summary>
+        /// <param name="e"></param>
+        protected override void OnCursorChanged(EventArgs e)
         {
-            // Needed to prevent character turds being left behind
-            // Oh, and to get rid of the initial cuetext drawing ;-)
-            _richTextBox.Invalidate();
+            base.OnCursorChanged(e);
+
+            _richTextBox.Cursor = Cursor;
+        }
+        #endregion
+
+        #region Internal
+        internal bool InTransparentDesignMode => InRibbonDesignMode;
+
+        #endregion
+
+        #region Implementation
+
+        private void UpdateStateAndPalettes()
+        {
+            // Get the correct palette settings to use
+            IPaletteTriple tripleState = GetTripleState();
+            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder);
+
+            // Update enabled state
+            _drawDockerOuter.Enabled = Enabled;
+
+            // Find the new state of the main view element
+            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+
+            _drawDockerOuter.ElementState = state;
         }
 
-        OnTextChanged(e);
-    }
+        private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
 
-    private void OnRichTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
-
-    private void OnRichTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
-
-    private void OnRichTextBoxMultilineChanged(object? sender, EventArgs e) => OnMultilineChanged(e);
-
-    private void OnRichTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
-
-    private void OnRichTextBoxGotFocus(object? sender, EventArgs e)
-    {
-        UpdateStateAndPalettes();
-        PerformNeedPaint(true);
-        OnGotFocus(e);
-    }
-
-    private void OnRichTextBoxLostFocus(object? sender, EventArgs e)
-    {
-        UpdateStateAndPalettes();
-        PerformNeedPaint(true);
-        OnLostFocus(e);
-    }
-
-    private void OnRichTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
-
-    private void OnRichTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
-
-    private void OnRichTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
-
-    private void OnRichTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
-
-    private void OnRichTextBoxVScroll(object? sender, EventArgs e) => OnVScroll(e);
-
-    private void OnRichTextBoxHScroll(object? sender, EventArgs e) => OnHScroll(e);
-
-    private void OnRichTextBoxSelectionChanged(object? sender, EventArgs e) => OnSelectionChanged(e);
-
-    private void OnRichTextBoxProtected(object? sender, EventArgs e) => OnProtected(e);
-
-    private void OnRichTextBoxLinkClicked(object? sender, LinkClickedEventArgs e) => OnLinkClicked(e);
-
-    private void OnRichTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
-
-    private void OnRichTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
-
-    private void OnShowToolTip(object? sender, ToolTipEventArgs e)
-    {
-        if (!IsDisposed && !Disposing)
+        private void OnRichTextBoxMouseChange(object sender, EventArgs e)
         {
-            // Do not show tooltips when the form we are in does not have focus
-            Form? topForm = FindForm();
-            if (topForm is { ContainsFocus: false })
+            // Change in tracking state?
+            if (_richTextBox.MouseOver != _trackingMouseEnter)
             {
-                return;
-            }
+                _trackingMouseEnter = _richTextBox.MouseOver;
 
-            // Never show tooltips are design time
-            if (!DesignMode)
-            {
-                IContentValues? sourceContent = null;
-                var toolTipStyle = LabelStyle.ToolTip;
-
-                var shadow = true;
-
-                if (sourceContent != null)
+                // Raise appropriate event
+                if (_trackingMouseEnter)
                 {
-                    // Remove any currently showing tooltip
-                    _visualPopupToolTip?.Dispose();
-
-                    // Create the actual tooltip popup object
-                    _visualPopupToolTip = new VisualPopupToolTip(Redirector,
-                        sourceContent,
-                        Renderer,
-                        PaletteBackStyle.ControlToolTip,
-                        PaletteBorderStyle.ControlToolTip,
-                        CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
-                        shadow);
-
-                    _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
-                    _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
-                }
-            }
-        }
-    }
-
-    private void OnCancelToolTip(object? sender, EventArgs e) =>
-        // Remove any currently showing tooltip
-        _visualPopupToolTip?.Dispose();
-
-    private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
-    {
-        // Unhook events from the specific instance that generated event
-        VisualPopupToolTip popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
-        popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
-
-        // Not showing a popup page anymore
-        _visualPopupToolTip = null;
-    }
-
-    /// <summary>
-    /// Checks if RTF contains black text (color index 0, which is typically black).
-    /// </summary>
-    /// <param name="rtf">The RTF content to check.</param>
-    /// <returns>True if black text is detected, false otherwise.</returns>
-    private static bool HasBlackTextInRtf(ReadOnlySpan<char> rtf)
-    {
-        if (rtf.IsEmpty)
-        {
-            return false;
-        }
-
-        // Check for \cf0 (color index 0, which is typically black in RTF)
-        // This is the most common way black text is specified in RTF
-        // We check for \cf0 followed by space, digit, backslash, or end of string
-        for (int i = 0; i < rtf.Length - 3; i++)
-        {
-            if (rtf[i] == '\\' && rtf[i + 1] == 'c' && rtf[i + 2] == 'f' && rtf[i + 3] == '0')
-            {
-                // Verify it's a complete color code (followed by space, backslash, or end)
-                if (i + 4 >= rtf.Length ||
-                    rtf[i + 4] == ' ' ||
-                    rtf[i + 4] == '\\' ||
-                    rtf[i + 4] == '\r' ||
-                    rtf[i + 4] == '\n' ||
-                    rtf[i + 4] == '\t' ||
-                    !char.IsDigit(rtf[i + 4]))
-                {
-                    return true;
-                }
-
-                i += 3;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Replaces black color codes (\cf0) and default black color with white color in RTF for visibility on dark backgrounds.
-    /// </summary>
-    /// <param name="rtf">The RTF content to modify.</param>
-    /// <returns>RTF with black color codes replaced with white.</returns>
-    private static string RemoveBlackColorCodes(string rtf)
-    {
-        if (string.IsNullOrEmpty(rtf))
-        {
-            return rtf;
-        }
-
-        ReadOnlySpan<char> rtfSpan = rtf;
-
-        // Find or add white color to color table
-        ReadOnlySpan<char> colortblPattern = @"{\colortbl".AsSpan();
-        int colorTableStart = rtfSpan.IndexOf(colortblPattern, StringComparison.Ordinal);
-        int whiteColorIndex = -1;
-        string modifiedRtf = rtf;
-
-        if (colorTableStart >= 0)
-        {
-            // Find the end of color table
-            int braceCount = 0;
-            int colorTableEnd = colorTableStart;
-            bool inColorTable = false;
-
-            for (int i = colorTableStart; i < rtfSpan.Length; i++)
-            {
-                if (rtfSpan[i] == '{')
-                {
-                    braceCount++;
-                    inColorTable = true;
-                }
-                else if (rtfSpan[i] == '}')
-                {
-                    braceCount--;
-                    if (inColorTable && braceCount == 0)
-                    {
-                        colorTableEnd = i;
-                        break;
-                    }
-                }
-            }
-
-            if (colorTableEnd > colorTableStart)
-            {
-                ReadOnlySpan<char> colorTable = rtfSpan.Slice(colorTableStart, colorTableEnd - colorTableStart + 1);
-
-                // Check if white color already exists: \red255\green255\blue255
-                ReadOnlySpan<char> red255Green255Blue255 = @"\red255\green255\blue255".AsSpan();
-                ReadOnlySpan<char> red255Green255Blue255Spaced = @"\red255 \green255 \blue255".AsSpan();
-                bool hasWhite = colorTable.Contains(red255Green255Blue255, StringComparison.Ordinal) ||
-                               colorTable.Contains(red255Green255Blue255Spaced, StringComparison.Ordinal);
-
-                if (hasWhite)
-                {
-                    // Find the index of white color
-                    // Count colors before white (each color ends with ;)
-                    ReadOnlySpan<char> red255 = @"\red255".AsSpan();
-                    int whitePos = colorTable.IndexOf(red255);
-                    if (whitePos > 0)
-                    {
-                        ReadOnlySpan<char> beforeWhite = colorTable.Slice(0, whitePos);
-                        whiteColorIndex = CountColorTableEntries(beforeWhite);
-                    }
+                    OnTrackMouseEnter(EventArgs.Empty);
+                    OnMouseEnter(e);
                 }
                 else
                 {
-                    // White color doesn't exist, add it to color table
-                    // Insert before the closing brace
-                    string whiteColorDef = @";\red255\green255\blue255";
-                    modifiedRtf = rtf.Insert(colorTableEnd, whiteColorDef);
+                    OnTrackMouseLeave(EventArgs.Empty);
+                    OnMouseLeave(e);
+                }
+            }
+        }
 
-                    // Calculate white color index (count existing colors)
-                    whiteColorIndex = CountColorTableEntries(colorTable);
+        private void OnRichTextBoxAcceptsTabChanged(object sender, EventArgs e) => OnAcceptsTabChanged(e);
+
+        private void OnRichTextBoxTextChanged(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
+                && TextLength <= 1)
+            {
+                // Needed to prevent character turds being left behind
+                // Oh, and to get rid of the initial cuetext drawing ;-)
+                _richTextBox.Invalidate();
+            }
+
+            OnTextChanged(e);
+        }
+
+        private void OnRichTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
+
+        private void OnRichTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
+
+        private void OnRichTextBoxMultilineChanged(object sender, EventArgs e) => OnMultilineChanged(e);
+
+        private void OnRichTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
+
+        private void OnRichTextBoxGotFocus(object sender, EventArgs e)
+        {
+            UpdateStateAndPalettes();
+            PerformNeedPaint(true);
+            OnGotFocus(e);
+        }
+
+        private void OnRichTextBoxLostFocus(object sender, EventArgs e)
+        {
+            UpdateStateAndPalettes();
+            PerformNeedPaint(true);
+            OnLostFocus(e);
+        }
+
+        private void OnRichTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+
+        private void OnRichTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+
+        private void OnRichTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+
+        private void OnRichTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+
+        private void OnRichTextBoxVScroll(object sender, EventArgs e) => OnVScroll(e);
+
+        private void OnRichTextBoxHScroll(object sender, EventArgs e) => OnHScroll(e);
+
+        private void OnRichTextBoxSelectionChanged(object sender, EventArgs e) => OnSelectionChanged(e);
+
+        private void OnRichTextBoxProtected(object sender, EventArgs e) => OnProtected(e);
+
+        private void OnRichTextBoxLinkClicked(object sender, LinkClickedEventArgs e) => OnLinkClicked(e);
+
+        private void OnRichTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
+
+        private void OnRichTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+
+        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        {
+            if (!IsDisposed && !Disposing)
+            {
+                // Do not show tooltips when the form we are in does not have focus
+                Form? topForm = FindForm();
+                if (topForm is { ContainsFocus: false })
+                {
+                    return;
                 }
 
-                // IMPORTANT: Replace the default color (index 0, black) with white in the color table
-                // This makes all text without explicit color codes use white instead of black
-                // In RTF, index 0 is the first entry after the opening semicolon
-                // Pattern: {\colortbl ;\red0\green0\blue0;... or {\colortbl ;... (implicit black)
-                int firstSemicolon = colorTable.IndexOf(';');
-                if (firstSemicolon >= 0)
+                // Never show tooltips are design time
+                if (!DesignMode)
                 {
-                    // Find where the first color definition starts (after the semicolon)
-                    int firstColorStart = firstSemicolon + 1;
+                    IContentValues? sourceContent = null;
+                    var toolTipStyle = LabelStyle.ToolTip;
 
-                    // Check if there's an explicit color definition for index 0
-                    // Look for \red, \green, \blue patterns
-                    ReadOnlySpan<char> redPattern = @"\red".AsSpan();
-                    ReadOnlySpan<char> searchSpan = colorTable.Slice(firstColorStart);
-                    int redIndexRelative = searchSpan.IndexOf(redPattern);
-                    int redIndex = redIndexRelative >= 0 ? firstColorStart + redIndexRelative : -1;
-                    int nextSemicolonRelative = searchSpan.IndexOf(';');
-                    int nextSemicolon = nextSemicolonRelative >= 0 ? firstColorStart + nextSemicolonRelative : -1;
-                    int colorEnd = nextSemicolon > 0 ? nextSemicolon : colorTable.Length;
-                    bool hasExplicitFirstColor = redIndex >= 0 && redIndex < colorEnd;
+                    var shadow = true;
 
-                    if (hasExplicitFirstColor)
+                    // Find the button spec associated with the tooltip request
+                    ButtonSpec? buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
+
+                    // If the tooltip is for a button spec
+                    if (buttonSpec != null)
                     {
-                        // Find where the first explicit color ends (next semicolon or closing brace)
-                        ReadOnlySpan<char> searchSpanForEnd = colorTable.Slice(firstColorStart);
-                        int firstColorEndRelative = searchSpanForEnd.IndexOf(';');
-                        int firstColorEnd = firstColorEndRelative >= 0 ? firstColorStart + firstColorEndRelative : -1;
-                        if (firstColorEnd < 0)
+                        // Are we allowed to show page related tooltips
+                        if (AllowButtonSpecToolTips)
                         {
-                            int braceEndRelative = searchSpanForEnd.IndexOf('}');
-                            firstColorEnd = braceEndRelative >= 0 ? firstColorStart + braceEndRelative : -1;
+                            // Create a helper object to provide tooltip values
+                            var buttonSpecMapping = new ButtonSpecToContent(Redirector, buttonSpec);
+
+                            // Is there actually anything to show for the tooltip
+                            if (buttonSpecMapping.HasContent)
+                            {
+                                sourceContent = buttonSpecMapping;
+                                toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
+                            }
+                        }
+                    }
+
+                    if (sourceContent != null)
+                    {
+                        // Remove any currently showing tooltip
+                        _visualPopupToolTip?.Dispose();
+
+                        if (AllowButtonSpecToolTipPriority)
+                        {
+                            visualBasePopupToolTip?.Dispose();
                         }
 
-                        if (firstColorEnd > firstColorStart)
-                        {
-                            // Replace the explicit first color (black) with white
-                            string newColorTable = colorTable.Slice(0, firstColorStart).ToString() +
-                                                  @"\red255\green255\blue255" +
-                                                  colorTable.Slice(firstColorEnd).ToString();
+                        // Create the actual tooltip popup object
+                        _visualPopupToolTip = new VisualPopupToolTip(Redirector,
+                                                                     sourceContent,
+                                                                     Renderer,
+                                                                     PaletteBackStyle.ControlToolTip,
+                                                                     PaletteBorderStyle.ControlToolTip,
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
-                            // Replace the color table in the RTF
-                            modifiedRtf = rtf.Substring(0, colorTableStart) +
-                                         newColorTable +
-                                         rtf.Substring(colorTableEnd + 1);
-
-                            // White is now at index 0
-                            whiteColorIndex = 0;
-                        }
-                    }
-                    else
-                    {
-                        // Index 0 is implicit (no explicit color definition)
-                        // Insert white as the explicit first color
-                        string whiteColorDef = @"\red255\green255\blue255";
-                        string newColorTable = colorTable.Slice(0, firstColorStart).ToString() +
-                                              whiteColorDef +
-                                              colorTable.Slice(firstColorStart).ToString();
-
-                        // Replace the color table in the RTF
-                        modifiedRtf = rtf.Substring(0, colorTableStart) +
-                                     newColorTable +
-                                     rtf.Substring(colorTableEnd + 1);
-
-                        // White is now at index 0
-                        whiteColorIndex = 0;
+                        _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
+                        _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
                     }
                 }
             }
         }
-        else
+
+        private void OnCancelToolTip(object sender, EventArgs e) =>
+            // Remove any currently showing tooltip
+            _visualPopupToolTip?.Dispose();
+
+        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
         {
-            // No color table exists, create one with white as default
-            // Find insertion point after font table
-            ReadOnlySpan<char> newlinePattern = @"}\n".AsSpan();
-            int fontTableEnd = rtfSpan.IndexOf(newlinePattern, StringComparison.Ordinal);
-            if (fontTableEnd < 0)
-            {
-                ReadOnlySpan<char> crlfPattern = @"}\r\n".AsSpan();
-                fontTableEnd = rtfSpan.IndexOf(crlfPattern, StringComparison.Ordinal);
-            }
-            if (fontTableEnd < 0)
-            {
-                fontTableEnd = rtfSpan.IndexOf('}');
-            }
+            // Unhook events from the specific instance that generated event
+            var popupToolTip = (VisualPopupToolTip)sender;
+            popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
-            if (fontTableEnd >= 0)
-            {
-                // Create color table with white as index 0 (default color)
-                string colorTable = @"{\colortbl ;\red255\green255\blue255;}";
-                modifiedRtf = rtf.Insert(fontTableEnd + 1, colorTable);
-                whiteColorIndex = 0; // White is now the default (index 0)
-            }
+            // Not showing a popup page any more
+            _visualPopupToolTip = null;
         }
 
-        // If we couldn't determine white color index, default to removing \cf0
-        if (whiteColorIndex < 0)
+        private void SetCornerRoundingRadius(float? radius)
         {
-            // Fallback: just remove \cf0
-            var result = new System.Text.StringBuilder(modifiedRtf);
-            ReadOnlySpan<char> resultSpan = result.ToString();
-            for (int i = resultSpan.Length - 4; i >= 0; i--)
-            {
-                if (resultSpan[i] == '\\' && resultSpan[i + 1] == 'c' && resultSpan[i + 2] == 'f' && resultSpan[i + 3] == '0')
-                {
-                    if (i + 4 >= resultSpan.Length ||
-                        resultSpan[i + 4] == ' ' ||
-                        resultSpan[i + 4] == '\\' ||
-                        resultSpan[i + 4] == '\r' ||
-                        resultSpan[i + 4] == '\n' ||
-                        resultSpan[i + 4] == '\t' ||
-                        !char.IsDigit(resultSpan[i + 4]))
-                    {
-                        result.Remove(i, 4);
-                        resultSpan = result.ToString();
-                        i -= 3;
-                    }
-                    else
-                    {
-                        i -= 3;
-                    }
-                }
-            }
-            return result.ToString();
+            _cornerRoundingRadius = radius ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
+
+            StateCommon.Border.Rounding = _cornerRoundingRadius;
         }
 
-        // Replace \cf0 with \cf{whiteColorIndex} (which is now 0, but we keep the code for clarity)
-        var finalResult = new System.Text.StringBuilder(modifiedRtf);
-        string replacement = $@"\cf{whiteColorIndex}";
-        ReadOnlySpan<char> finalResultSpan = finalResult.ToString();
-
-        // Scan backwards to avoid index shifting issues
-        for (int i = finalResultSpan.Length - 4; i >= 0; i--)
-        {
-            if (finalResultSpan[i] == '\\' && finalResultSpan[i + 1] == 'c' && finalResultSpan[i + 2] == 'f' && finalResultSpan[i + 3] == '0')
-            {
-                // Verify it's a complete color code
-                if (i + 4 >= finalResultSpan.Length ||
-                    finalResultSpan[i + 4] == ' ' ||
-                    finalResultSpan[i + 4] == '\\' ||
-                    finalResultSpan[i + 4] == '\r' ||
-                    finalResultSpan[i + 4] == '\n' ||
-                    finalResultSpan[i + 4] == '\t' ||
-                    !char.IsDigit(finalResultSpan[i + 4]))
-                {
-                    // Replace \cf0 with white color code
-                    finalResult.Remove(i, 4);
-                    finalResult.Insert(i, replacement);
-                    finalResultSpan = finalResult.ToString();
-                    i -= 3;
-                }
-                else
-                {
-                    i -= 3;
-                }
-            }
-        }
-
-        return finalResult.ToString();
+        #endregion
     }
-
-    /// <summary>
-    /// Counts the number of color entries in a color table string.
-    /// </summary>
-    /// <param name="colorTable">The color table string to count.</param>
-    /// <returns>The number of color entries (semicolons indicate entries).</returns>
-    private static int CountColorTableEntries(ReadOnlySpan<char> colorTable)
-    {
-        if (colorTable.IsEmpty)
-        {
-            return 0;
-        }
-
-#if NET5_0_OR_GREATER
-        // Use Span.Count method available in .NET 5.0 and later
-        int count = MemoryExtensions.Count(colorTable, ';') + 1;
-#else
-        // Fallback for older frameworks without Span.Count
-        int count = 1;
-
-        // Count semicolons to determine number of colors
-        for (int i = 0; i < colorTable.Length; i++)
-        {
-            // Each semicolon indicates a color entry
-            if (colorTable[i] == ';')
-            {
-                // Increment count for each semicolon found
-                count++;
-            }
-        }
-#endif
-
-        // First semicolon is after the opening brace, so subtract 1
-        return count - 1;
-    }
-
-    #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1337,11 +1337,6 @@ public class KryptonTextBox : VisualControlBase,
                 retSize.Height = Math.Max(MinimumSize.Height, retSize.Height);
             }
 
-            if (MinimumControlHeight > 0)
-            {
-                retSize.Height = Math.Max(MinimumControlHeight, retSize.Height);
-            }
-
             return retSize;
         }
         else
@@ -1511,12 +1506,6 @@ public class KryptonTextBox : VisualControlBase,
     protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
     /// <summary>
-    /// Creates the accessibility object for the KryptonTextBox control.
-    /// </summary>
-    /// <returns>A new KryptonTextBoxAccessibleObject instance for the control.</returns>
-    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonTextBoxAccessibleObject(this);
-
-    /// <summary>
     /// Raises the HandleCreated event.
     /// </summary>
     /// <param name="e">An EventArgs containing the event data.</param>
@@ -1635,7 +1624,7 @@ public class KryptonTextBox : VisualControlBase,
             var paletteContent = GetTripleState().PaletteContent;
             if (paletteContent != null)
             {
-                Padding contentPadding = paletteContent.GetBorderContentPadding(null, _drawDockerOuter.State);
+                Padding contentPadding = paletteContent.GetContentPadding(_drawDockerOuter.State);
                 _layoutFill.DisplayPadding = contentPadding;
             }
         }
@@ -1697,7 +1686,18 @@ public class KryptonTextBox : VisualControlBase,
         // Do we need to prevent the height from being altered?
         if (_autoSize && !Multiline)
         {
-            CacheDimensionIfSpecified(specified, BoundsSpecified.Height, height, ref _cachedHeight);
+            switch (Dock)
+            {
+                case DockStyle.Fill:
+                case DockStyle.Left:
+                case DockStyle.Right:
+                    if ((specified & ~BoundsSpecified.Height) == specified)
+                    {
+                        _cachedHeight = height;
+                    }
+
+                    break;
+            }
 
             // Override the actual height used to the fixed height for single line
             height = PreferredHeight;
@@ -1910,9 +1910,9 @@ public class KryptonTextBox : VisualControlBase,
 
     private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-    private void OnTextBoxValidated(object? sender, EventArgs e) => ForwardValidated(e);
+    private void OnTextBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-    private void OnTextBoxValidating(object? sender, CancelEventArgs e) => ForwardValidating(e);
+    private void OnTextBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
     private void OnShowToolTip(object? sender, ToolTipEventArgs e)
     {
@@ -1967,7 +1967,7 @@ public class KryptonTextBox : VisualControlBase,
 
                         if (AllowButtonSpecToolTipPriority)
                         {
-                            _visualBasePopupToolTip?.Dispose();
+                            visualBasePopupToolTip?.Dispose();
                         }
                     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
             /// <param name="kryptonTreeView">Reference to owning control.</param>
             public InternalTreeView(KryptonTreeView kryptonTreeView)
             {
-                SetStyle(ControlStyles.ResizeRedraw, true);
+                SetStyle(ControlStyles.ResizeRedraw | ControlStyles.OptimizedDoubleBuffer, true);
 
                 _kryptonTreeView = kryptonTreeView;
 
@@ -147,9 +147,19 @@ namespace Krypton.Toolkit
 
             #region Protected
             /// <summary>
-            /// Raises the Layout event.
+            /// Initializes extended TreeView styles when the handle is created.
             /// </summary>
-            /// <param name="levent">A LayoutEventArgs containing the event data.</param>
+            /// <param name="e">An EventArgs that contains the event data.</param>
+            protected override void OnHandleCreated(EventArgs e)
+            {
+                base.OnHandleCreated(e);
+
+                _ = PI.SendMessage(Handle, PI.TVM_.TVM_SETEXTENDEDSTYLE, (IntPtr)PI.TVS_EX_DOUBLEBUFFER,
+                    (IntPtr)PI.TVS_EX_DOUBLEBUFFER);
+
+                _kryptonTreeView.SyncTreeViewBackColor();
+            }
+
             protected override void OnLayout(LayoutEventArgs levent)
             {
                 base.OnLayout(levent);
@@ -242,12 +252,10 @@ namespace Krypton.Toolkit
                     // If we managed to get a compatible bitmap
                     if (hBitmap != IntPtr.Zero)
                     {
+                        var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+
                         try
                         {
-                            // Must use the screen device context for the bitmap when drawing into the 
-                            // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                            PI.SelectObject(_screenDC, hBitmap);
-
                             // Easier to draw using a graphics instance than a DC!
                             using (Graphics g = Graphics.FromHdc(_screenDC))
                             {
@@ -264,14 +272,6 @@ namespace Krypton.Toolkit
                                     ViewDrawPanel.Render(context);
                                 }
 
-                                // We can only control the background color by using the built in property and not
-                                // by overriding the drawing directly, therefore we can only provide a single color.
-                                Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                                if (color1 != BackColor)
-                                {
-                                    BackColor = color1;
-                                }
-
                                 // Replace given DC with the screen DC for base window proc drawing
                                 var beforeDC = m.WParam;
                                 m.WParam = _screenDC;
@@ -284,7 +284,7 @@ namespace Krypton.Toolkit
                         }
                         finally
                         {
-                            // Delete the temporary bitmap
+                            PI.SelectObject(_screenDC, oldBitmap);
                             PI.DeleteObject(hBitmap);
                         }
                     }
@@ -324,13 +324,13 @@ namespace Krypton.Toolkit
         private readonly FixedContentValue? _contentValues;
         private bool? _fixedActive;
         private ButtonStyle _style;
-        private readonly IntPtr _screenDC;
         private bool _itemHeightDefault;
         private bool _mouseOver;
         private bool _alwaysActive;
         private bool _forcedLayout;
         private bool _trackingMouseEnter;
         private bool _isRecreating; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/777
+        private int _selectUpdateCount;
         private float _cornerRoundingRadius;
         private float _nodeCornerRoundingRadius;
 
@@ -660,9 +660,6 @@ namespace Krypton.Toolkit
             // Create the view manager instance
             ViewManager = new ViewManager(this, _drawDockerOuter);
 
-            // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
             // Add tree view to the controls collection
             ((KryptonReadOnlyControls)Controls).AddInternal(_treeView);
 
@@ -677,14 +674,8 @@ namespace Krypton.Toolkit
         /// Releases all resources used by the Control. 
         /// </summary>
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
-        }
+        protected override void Dispose(bool disposing) => base.Dispose(disposing);
+
         #endregion
 
         #region Public
@@ -1800,11 +1791,18 @@ namespace Krypton.Toolkit
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
-            if (IsHandleCreated && !e.NeedLayout)
+            if (_selectUpdateCount == 0)
             {
-                _treeView.Invalidate();
+                if (IsHandleCreated && !e.NeedLayout)
+                {
+                    _treeView.Invalidate();
+                }
+                else
+                {
+                    ForceControlLayout();
+                }
             }
-            else
+            else if (e.NeedLayout)
             {
                 ForceControlLayout();
             }
@@ -1812,7 +1810,11 @@ namespace Krypton.Toolkit
             // Update palette to reflect latest state
             UpdateItemHeight();
             UpdateStateAndPalettes();
-            base.OnNeedPaint(sender, e);
+
+            if (_selectUpdateCount == 0)
+            {
+                base.OnNeedPaint(sender, e);
+            }
         }
 
         /// <summary>
@@ -1973,6 +1975,17 @@ namespace Krypton.Toolkit
                 _drawDockerOuter.ElementState = state;
                 _treeView.Font = StateCommon.Node.Content.ShortText.Font;
 
+                SyncTreeViewBackColor();
+            }
+        }
+
+        private void SyncTreeViewBackColor()
+        {
+            // Must not assign BackColor during WM_PAINT; doing so triggers a second erase/paint cycle.
+            Color color1 = _treeView.ViewDrawPanel.GetPalette().GetBackColor1(_treeView.ViewDrawPanel.State);
+            if (_treeView.BackColor != color1)
+            {
+                _treeView.BackColor = color1;
             }
         }
 
@@ -2001,6 +2014,9 @@ namespace Krypton.Toolkit
 
         private void OnTreeViewDrawNode(object sender, DrawTreeNodeEventArgs e)
         {
+            // OwnerDrawAll: skip native item painting (CDRF_SKIPDEFAULT).
+            e.DrawDefault = false;
+
             // We cannot do anything without a valid node
             if (e.Node == null)
             {
@@ -2109,8 +2125,9 @@ namespace Krypton.Toolkit
             // Update the view with the calculated state
             _drawButton.ElementState = buttonState;
 
-            // Grab the raw device context for the graphics instance
-            var hdc = e.Graphics.GetHdc();
+            Graphics g = e.Graphics;
+            var savedClip = g.Clip;
+            g.SetClip(e.Bounds);
 
             try
             {
@@ -2123,213 +2140,185 @@ namespace Krypton.Toolkit
                 bounds.X += nodeIndent;
                 bounds.Width -= nodeIndent;
 
-                // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-                var hBitmap = PI.CreateCompatibleBitmap(hdc, bounds.Right, bounds.Bottom);
-
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                using (var context = new ViewLayoutContext(this, Renderer))
                 {
+                    context.DisplayRectangle = bounds;
+
+                    // If not using full row selection, then layout using only required width
+                    Size prefSize = _layoutDocker.GetPreferredSize(context);
+                    if (!FullRowSelect)
+                    {
+                        if (prefSize.Width < bounds.Width)
+                        {
+                            bounds.Width = prefSize.Width;
+                        }
+                    }
+
+                    // Always ensure we have enough space for drawing all the elements
+                    if (bounds.Width < prefSize.Width)
+                    {
+                        bounds.Width = prefSize.Width;
+                    }
+
+                    context.DisplayRectangle = bounds;
+
+                    _layoutDocker.Layout(context);
+                }
+
+                // Row background is painted once in InternalTreeView.WmPaint before DefWndProc/DrawNode.
+
+                // Do we have a indent area for drawing plus/minus/lines?
+                if (indentBounds.X >= 0)
+                {
+                    // Do we draw lines between nodes?
+                    if (ShowLines
+                        && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                    {
+                        // Find center points
+                        var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
+                        var vCenter = indentBounds.Y + (indentBounds.Height / 2);
+                        vCenter -= (vCenter + 1) % 2;
+
+                        // Default to showing full line height
+                        var top = indentBounds.Y;
+                        top -= (top + 1) % 2;
+                        var bottom = indentBounds.Bottom;
+
+                        // If the first root node then do not show top half of line
+                        if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
+                        {
+                            top = vCenter;
+                        }
+
+                        // If the last node in collection then do not show bottom half of line
+                        if (e.Node.NextNode == null)
+                        {
+                            bottom = vCenter;
+                        }
+
+                        // Draw the horizontal and vertical lines
+                        Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+                        using var linePen = new Pen(lineColor);
+                        linePen.DashStyle = DashStyle.Dot;
+                        linePen.DashOffset = indent % 2;
+                        g.DrawLine(linePen, hCenter, top, hCenter, bottom);
+                        g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
+                        hCenter -= indent;
+
+                        // Draw the vertical lines for previous node levels
+                        while (hCenter >= 0)
+                        {
+                            var begin = indentBounds.Y;
+                            begin -= (begin + 1) % 2;
+                            g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
+                            hCenter -= indent;
+                        }
+                    }
+
+                    // Do we draw any plus/minus images in indent bounds?
+                    if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                    {
+                        Image? drawImage = _redirectImages?.GetTreeViewImage(e.Node.IsExpanded);
+                        if (drawImage != null)
+                        {
+                            float dpiFactor = g.DpiX / 96F;
+                            drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                drawImage.Width * dpiFactor,
+                                drawImage.Height * dpiFactor, false);
+                            g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
+                                indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
+                                drawImage.Width, drawImage.Height));
+                        }
+                    }
+                }
+
+                using (var context = new RenderContext(this, g, bounds, Renderer))
+                {
+                    _layoutDocker.Render(context);
+                }
+
+                var isSelected = (e.State & TreeNodeStates.Selected) == TreeNodeStates.Selected;
+
+                // Do we draw an image for the node?
+                if (ImageList != null)
+                {
+                    Image? drawImage = null;
+                    var imageCount = ImageList.Images.Count;
+
                     try
                     {
-                        // Must use the screen device context for the bitmap when drawing into the 
-                        // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                        PI.SelectObject(_screenDC, hBitmap);
-
-                        // Easier to draw using a graphics instance than a DC!
-                        using Graphics g = Graphics.FromHdc(_screenDC);
-                        using (var context = new ViewLayoutContext(this, Renderer))
+                        if (isSelected)
                         {
-                            context.DisplayRectangle = e.Bounds;
-                            _treeView.ViewDrawPanel.Layout(context);
-                            context.DisplayRectangle = bounds;
-
-                            // If no using full row selection, then layout using only required width
-                            Size prefSize = _layoutDocker.GetPreferredSize(context);
-                            if (!FullRowSelect)
+                            // Check node values before tree level values
+                            if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
                             {
-                                if (prefSize.Width < bounds.Width)
-                                {
-                                    bounds.Width = prefSize.Width;
-                                }
+                                drawImage = ImageList.Images[e.Node.SelectedImageKey];
                             }
-
-                            // Always ensure we have enough space for drawing all the elements
-                            if (bounds.Width < prefSize.Width)
+                            else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
                             {
-                                bounds.Width = prefSize.Width;
+                                drawImage = ImageList.Images[e.Node.SelectedImageIndex];
                             }
-
-                            context.DisplayRectangle = bounds;
-
-                            _layoutDocker.Layout(context);
+                            else if (!string.IsNullOrEmpty(SelectedImageKey))
+                            {
+                                drawImage = ImageList.Images[SelectedImageKey];
+                            }
+                            else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
+                            {
+                                drawImage = ImageList.Images[SelectedImageIndex];
+                            }
                         }
-
-                        using (var context = new RenderContext(this, g, e.Bounds, Renderer))
+                        else
                         {
-                            _treeView.ViewDrawPanel.Render(context);
-                        }
-
-                        // Do we have a indent area for drawing plus/minus/lines?
-                        if (indentBounds.X >= 0)
-                        {
-                            // Do we draw lines between nodes?
-                            if (ShowLines
-                                && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                            // Check node values before tree level values
+                            if (!string.IsNullOrEmpty(e.Node.ImageKey))
                             {
-                                // Find center points
-                                var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
-                                var vCenter = indentBounds.Y + (indentBounds.Height / 2);
-                                vCenter -= (vCenter + 1) % 2;
-
-                                // Default to showing full line height
-                                var top = indentBounds.Y;
-                                top -= (top + 1) % 2;
-                                var bottom = indentBounds.Bottom;
-
-                                // If the first root node then do not show top half of line
-                                if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
-                                {
-                                    top = vCenter;
-                                }
-
-                                // If the last node in collection then do not show bottom half of line
-                                if (e.Node.NextNode == null)
-                                {
-                                    bottom = vCenter;
-                                }
-
-                                // Draw the horizontal and vertical lines
-                                Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
-                                using var linePen = new Pen(lineColor);
-                                linePen.DashStyle = DashStyle.Dot;
-                                linePen.DashOffset = indent % 2;
-                                g.DrawLine(linePen, hCenter, top, hCenter, bottom);
-                                g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
-                                hCenter -= indent;
-
-                                // Draw the vertical lines for previous node levels
-                                while (hCenter >= 0)
-                                {
-                                    var begin = indentBounds.Y;
-                                    begin -= (begin + 1) % 2;
-                                    g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
-                                    hCenter -= indent;
-                                }
+                                drawImage = ImageList.Images[e.Node.ImageKey];
                             }
-
-                            // Do we draw any plus/minus images in indent bounds?
-                            if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                            else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
                             {
-                                Image? drawImage = _redirectImages?.GetTreeViewImage(e.Node.IsExpanded);
-                                if (drawImage != null)
-                                {
-                                    float dpiFactor = g.DpiX / 96F;
-                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                        drawImage.Width * dpiFactor,
-                                        drawImage.Height * dpiFactor, false);
-                                    g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
-                                        indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
-                                        drawImage.Width, drawImage.Height));
-                                }
+                                drawImage = ImageList.Images[e.Node.ImageIndex];
+                            }
+                            else if (!string.IsNullOrEmpty(ImageKey))
+                            {
+                                drawImage = ImageList.Images[ImageKey];
+                            }
+                            else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
+                            {
+                                drawImage = ImageList.Images[ImageIndex];
                             }
                         }
 
-                        using (var context = new RenderContext(this, g, bounds, Renderer))
+                        if (drawImage != null)
                         {
-                            _layoutDocker.Render(context);
+                            float dpiFactor = g.DpiX / 96F;
+                            drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                drawImage.Width * dpiFactor,
+                                drawImage.Height * dpiFactor, false);
+                            g.DrawImage(drawImage, _layoutImage.ClientRectangle);
                         }
-
-                        // Do we draw an image for the node?
-                        if (ImageList != null)
-                        {
-                            Image? drawImage = null;
-                            var imageCount = ImageList.Images.Count;
-
-                            try
-                            {
-                                if (e.Node.IsSelected)
-                                {
-                                    // Check node values before tree level values
-                                    if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
-                                    {
-                                        drawImage = ImageList.Images[e.Node.SelectedImageKey];
-                                    }
-                                    else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
-                                    {
-                                        drawImage = ImageList.Images[e.Node.SelectedImageIndex];
-                                    }
-                                    else if (!string.IsNullOrEmpty(SelectedImageKey))
-                                    {
-                                        drawImage = ImageList.Images[SelectedImageKey];
-                                    }
-                                    else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
-                                    {
-                                        drawImage = ImageList.Images[SelectedImageIndex];
-                                    }
-                                }
-                                else
-                                {
-                                    // Check node values before tree level values
-                                    if (!string.IsNullOrEmpty(e.Node.ImageKey))
-                                    {
-                                        drawImage = ImageList.Images[e.Node.ImageKey];
-                                    }
-                                    else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
-                                    {
-                                        drawImage = ImageList.Images[e.Node.ImageIndex];
-                                    }
-                                    else if (!string.IsNullOrEmpty(ImageKey))
-                                    {
-                                        drawImage = ImageList.Images[ImageKey];
-                                    }
-                                    else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
-                                    {
-                                        drawImage = ImageList.Images[ImageIndex];
-                                    }
-                                }
-
-                                if (drawImage != null)
-                                {
-                                    float dpiFactor = g.DpiX / 96F;
-                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                        drawImage.Width * dpiFactor,
-                                        drawImage.Height * dpiFactor, false);
-                                    g.DrawImage(drawImage, _layoutImage.ClientRectangle);
-                                }
-                            }
-                            catch
-                            {
-                                // ignored
-                            }
-                        }
-
-                        // Draw a node state image?
-                        if (_layoutImageCenterState.Visible)
-                        {
-                            if (drawStateImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
-                                    drawStateImage.Width * dpiFactor,
-                                    drawStateImage.Height * dpiFactor, false);
-                                g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
-                            }
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
                     }
-                    finally
+                    catch
                     {
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        // ignored
+                    }
+                }
+
+                // Draw a node state image?
+                if (_layoutImageCenterState.Visible)
+                {
+                    if (drawStateImage != null)
+                    {
+                        float dpiFactor = g.DpiX / 96F;
+                        drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                            drawStateImage.Width * dpiFactor,
+                            drawStateImage.Height * dpiFactor, false);
+                        g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
                     }
                 }
             }
             finally
             {
-                // Must reserve the GetHdc() call before
-                e.Graphics.ReleaseHdc();
+                g.Clip = savedClip;
             }
         }
 
@@ -2369,7 +2358,22 @@ namespace Krypton.Toolkit
 
         private void OnTreeViewItemDrag(object sender, ItemDragEventArgs e) => OnItemDrag(e);
 
-        private void OnTreeViewBeforeSelect(object sender, TreeViewCancelEventArgs e) => OnBeforeSelect(e);
+        private void OnTreeViewBeforeSelect(object sender, TreeViewCancelEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                _selectUpdateCount++;
+                _treeView.BeginUpdate();
+            }
+
+            OnBeforeSelect(e);
+
+            if (e.Cancel && !_isRecreating)
+            {
+                _selectUpdateCount--;
+                _treeView.EndUpdate();
+            }
+        }
 
         private void OnTreeViewBeforeLabelEdit(object sender, NodeLabelEditEventArgs e) => OnBeforeLabelEdit(e);
 
@@ -2379,7 +2383,21 @@ namespace Krypton.Toolkit
 
         private void OnTreeViewBeforeCheck(object sender, TreeViewCancelEventArgs e) => OnBeforeCheck(e);
 
-        private void OnTreeViewAfterSelect(object sender, TreeViewEventArgs e) => OnAfterSelect(e);
+        private void OnTreeViewAfterSelect(object sender, TreeViewEventArgs e)
+        {
+            try
+            {
+                OnAfterSelect(e);
+            }
+            finally
+            {
+                if (!_isRecreating && _selectUpdateCount > 0)
+                {
+                    _selectUpdateCount--;
+                    _treeView.EndUpdate();
+                }
+            }
+        }
 
         private void OnTreeViewAfterLabelEdit(object sender, NodeLabelEditEventArgs e) => OnAfterLabelEdit(e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -488,6 +488,8 @@ namespace Krypton.Toolkit
                 TVM_GETISEARCHSTRINGW = 0x1100 + 64,
                 TVM_SETITEMHEIGHT = 0x1100 + 27,
                 TVM_GETITEMHEIGHT = 0x1100 + 28,
+                TVM_SETEXTENDEDSTYLE = 0x1100 + 44,
+                TVM_GETEXTENDEDSTYLE = 0x1100 + 45,
 
                 SETITEMA = 0x110d,
                 SETITEM = 0x110d,
@@ -530,6 +532,7 @@ namespace Krypton.Toolkit
         // style
         internal const int TVS_EDITLABELS = 0x0008;
         internal const int TVS_CHECKBOXES = 0x0100;
+        internal const int TVS_EX_DOUBLEBUFFER = 0x0004;
         //TVS_HASBUTTONS = 0x0001,
         //TVS_HASLINES = 0x0002,
         //TVS_LINESATROOT = 0x0004,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -136,7 +136,7 @@ public class PaletteCueHintText : PaletteInputControlContentStates
         // that look like top/left "lines" (GDI+ DrawString + cue colour). Issue #3382.
         g.FillRectangle(backBrush, layoutRectangle);
 
-        var padding = GetBorderContentPadding(null, PaletteState.Normal);
+        var padding = GetContentPadding(PaletteState.Normal);
         if (!padding.Equals(CommonHelper.InheritPadding))
         {
             layoutRectangle.X += padding.Left;


### PR DESCRIPTION
# Fix `KryptonTreeView` selection flicker (#3282)

## Summary

- Fixes [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282): `KryptonTreeView` items visibly flicker when selected or clicked, especially with `OwnerDrawAll`, `CheckBoxes`, and large `ItemHeight` (e.g. TestForm TreeView example).
- Skips native item painting during owner-draw, composites the control in a single off-screen `WM_PAINT` buffer, and batches selection updates so deselect/select does not appear as separate on-screen paints.
- Defaults empty MSBuild `Configuration` to `Debug` so solution-wide `dotnet build` uses `Bin\Debug\<tfm>\` output paths instead of `Bin\<tfm>\`.

## Problem

`KryptonTreeView` hosts an internal `TreeView` with `DrawMode = OwnerDrawAll`. On selection change, users could see a brief flash because:

1. Native TreeView item painting could still run unless `DrawDefault` is cleared (`CDRF_SKIPDEFAULT`).
2. Per-node off-screen `BitBlt` in `DrawNode` let the previously selected and newly selected rows update in separate steps.
3. Per-node `ViewDrawPanel.Render` repainted row chrome on every item draw during selection changes.
4. `BackColor` was assigned during `WM_PAINT`, triggering an extra erase/paint cycle.
5. Outer `OnNeedPaint` could invalidate the tree during a selection change before `EndUpdate`.

## Solution

### `KryptonTreeView` / `InternalTreeView`

| Change | Purpose |
|--------|---------|
| `e.DrawDefault = false` in `OnTreeViewDrawNode` | Skip native selection/focus chrome for `OwnerDrawAll`. | | `InternalTreeView.WmPaint` off-screen bitmap | Paint Krypton background once, call `DefWndProc` (custom draw) into the same DC, then `BitBlt` once to the client area. | | `TVS_EX_DOUBLEBUFFER` via `TVM_SETEXTENDEDSTYLE` | Additional comctl32 buffering for owner-draw notifications. | | Draw directly on `e.Graphics` in `DrawNode` (no per-node bitmap) | Avoid tearing between old/new selection rows. | | Remove per-row `ViewDrawPanel.Render` in `DrawNode` | Row background comes from the composite `WmPaint` pass only. | | `SyncTreeViewBackColor()` from `UpdateStateAndPalettes` | Avoid setting `BackColor` during `WM_PAINT`. | | `BeginUpdate` / `EndUpdate` around selection | Suppress intermediate redraws while selection changes. | | `_selectUpdateCount` + `OnNeedPaint` guard | Avoid outer `KryptonTreeView` invalidation during batched selection. | | Restore GDI bitmap selection in `WmPaint` `finally` | Correct cleanup of off-screen DC state. |

### `PlatformInvoke`

- Added `TVM_SETEXTENDEDSTYLE`, `TVM_GETEXTENDEDSTYLE`, and `TVS_EX_DOUBLEBUFFER`.

### Build (incidental)

- `Directory.Build.props` and `Source/Krypton Components/Directory.Build.props`: default `Configuration` to `Debug` and `Platform` to `Any CPU` when unset.

## Files changed

- `Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs`
- `Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs`
- `Documents/Help/Changelog.md`
- `Directory.Build.props`
- `Source/Krypton Components/Directory.Build.props`

## Test plan

- [ ] Build toolkit and TestForm (Debug): ```cmd dotnet build "Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug dotnet run --project "Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net48 ```
- [ ] Open **TreeView Example** (or equivalent TestForm scenario): enable `CheckBoxes` if applicable; click different nodes rapidly — no visible flicker on selection change.
- [ ] Set **`ItemHeight`** to **64** (property grid or code) and repeat; confirm large rows do not flash.
- [ ] Expand/collapse, scroll, keyboard navigation (arrows), and focus in/out — no regression in painting or lines/plus-minus glyphs.
- [ ] Smoke test on at least one additional TFM if convenient (e.g. `net8.0-windows`).
- [ ] Optional: verify full solution `dotnet build` without `-c Debug` still succeeds (Configuration default).

## Breaking changes

None. Behaviour is a visual/rendering fix; public API is unchanged.

## Related

- Closes #3282
- Changelog: `Documents/Help/Changelog.md` (Build 2606 section)

<img width="662" height="118" alt="image" src="https://github.com/user-attachments/assets/224d8e4d-069a-4f93-b5c6-962e8f4ce689" />
