### PR TITLE
* Build enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,8 +154,9 @@ jobs:
       - name: Restore
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all
 
+      # /m: multi-processor MSBuild; nightly.proj sets BuildInParallel on the Krypton.* graph.
       - name: Build
-        run: msbuild "Scripts/Build/nightly.proj" /t:Rebuild /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Rebuild /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
   release:
     runs-on: windows-2025-vs2026
@@ -282,11 +283,12 @@ jobs:
       - name: Restore
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all
 
+      # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
-        run: msbuild "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Get Version
         id: get_version

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -214,26 +214,35 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $buildArgs = 'Scripts/Build/canary.proj /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true'
+          # /m: multi-processor MSBuild (matches Scripts/Build/build-nightly.cmd and local .proj orchestration).
+          $buildArgs = @(
+            '/m',
+            'Scripts/Build/canarylongtermstable.proj',
+            '/t:Build',
+            '/p:Configuration=Canary',
+            '/p:Platform=Any CPU',
+            '/p:UseArtifactsOutput=true'
+          )
 
           if (${{ steps.prepare_cert.outputs.cert_available }} -eq 'true') {
-            $buildArgs += ' /p:EnableAuthenticodeSigning=true'
-            $buildArgs += " /p:AuthenticodeCertificatePath=`"${{ steps.prepare_cert.outputs.cert_path }}`""
+            $buildArgs += '/p:EnableAuthenticodeSigning=true'
+            $buildArgs += "/p:AuthenticodeCertificatePath=${{ steps.prepare_cert.outputs.cert_path }}"
             if ($env:AUTHENTICODE_CERT_PASSWORD) {
-              $buildArgs += " /p:AuthenticodeCertificatePassword=`"$env:AUTHENTICODE_CERT_PASSWORD`""
+              $buildArgs += "/p:AuthenticodeCertificatePassword=$env:AUTHENTICODE_CERT_PASSWORD"
             }
             Write-Host "Building with Authenticode signing enabled"
           } else {
             Write-Host "Building without Authenticode signing"
           }
 
-          msbuild $buildArgs
+          & msbuild @buildArgs
         env:
           AUTHENTICODE_CERT_PASSWORD: ${{ secrets.AUTHENTICODE_CERT_PASSWORD }}
 
+      # /m: parallel pack across TFMs/projects on the runner (same as Build step above).
       - name: Pack Canary
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canarylongtermstable.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -234,17 +234,18 @@ jobs:
       
                 Write-Host "WebView2 population complete."
 
+      # /m: multi-processor MSBuild (all runner CPUs). canary.proj orchestrates Krypton.* projects in parallel where references allow.
       - name: Restore
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Build Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -276,17 +276,18 @@ jobs:
 
           Write-Host "WebView2 population complete."
 
+      # /m: multi-processor MSBuild (all runner CPUs). nightly.proj uses BuildInParallel; project references still order builds.
       - name: Restore
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Build Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,15 +192,16 @@ jobs:
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
+      # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -524,15 +525,16 @@ jobs:
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
+      # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -875,15 +877,16 @@ jobs:
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
+      # /m: multi-processor MSBuild (all runner CPUs). canary.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -1217,15 +1220,16 @@ jobs:
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
+      # /m: multi-processor MSBuild; nightly.proj sets BuildInParallel (project refs still order Toolkit → … → Docking).
       - name: Build Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       # Note: NuGet publishing for alpha/nightly builds is handled by nightly.yml workflow
       # which runs on a schedule and checks for changes in the last 24 hours

--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,8 @@ Source/Krypton Components/Krypton.Ribbon/Temp.txt
 .vscode/
 Terminal.Gui/
 Scripts/ModernBuild/*.txt
+/Source/Krypton Components/Krypton.Toolkitobj
+/Source/Krypton Components/Krypton.Workspaceobj
+/Source/Krypton Components/Krypton.Ribbonobj
+/Source/Krypton Components/Krypton.Navigatorobj
+/Source/Krypton Components/Krypton.Dockingobj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - `Documents/`, `Assets/`, `Logs/`: Docs, images, and build logs
 
 ## Build, Test, and Development Commands
+- Script/CI builds use phased orchestration (`Scripts/Build/Krypton.Orchestration.targets`) with `msbuild /m` for parallel TFMs; do not build all `Krypton.*` projects in one parallel batch (shared `Bin/<Configuration>/<tfm>/` outputs).
 - Build solution (Debug):
   - `dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`
 - Run sample app:

--- a/Documents/PR-parallel-msbuild.md
+++ b/Documents/PR-parallel-msbuild.md
@@ -1,0 +1,22 @@
+# Phased parallel MSBuild (safe `/m`)
+
+## Summary
+
+Enables multi-processor MSBuild (`/m`) together with **phased project orchestration** and **per-TFM intermediate output**, avoiding file-lock races when building via `run.cmd` or script wrappers.
+
+## Problem
+
+All `Krypton.*` projects write to `Bin/<Configuration>/<TargetFramework>/`. A single `<MSBuild>` batch with `BuildInParallel="true"` on every project caused concurrent writes and local build failures.
+
+## Solution
+
+1. **`Scripts/Build/Krypton.Orchestration.targets`** — Toolkit → Ribbon+Navigator (parallel) → Workspace → Docking (`KryptonBuild` / `KryptonPack`).
+2. **`Source/Krypton Components/Directory.Build.props`** — `IntermediateOutputPath` per configuration and TFM.
+3. **Orchestration `.proj` files** — `Build` depends on `KryptonBuild`; Clean/Restore/Pack prep stay sequential (`BuildInParallel="false"`).
+4. **`/m` on outer MSBuild** — `.cmd`, CI workflows, ModernBuild (parallel TFMs within each phase).
+
+## Test plan
+
+- [ ] `run.cmd` → Nightly twice in a row without `purge.cmd`
+- [ ] `Scripts\VS2022\build-stable.cmd`
+- [ ] CI `build.yml` / `nightly.yml`

--- a/Scripts/Build/Krypton.Orchestration.targets
+++ b/Scripts/Build/Krypton.Orchestration.targets
@@ -1,60 +1,62 @@
-<Project>
-	<!--
-	  Phased Krypton.* orchestration: avoids parallel projects racing on shared Bin/<Configuration>/<tfm>/ outputs
-	  while still allowing Ribbon + Navigator to build together after Toolkit is complete.
-	  Use with msbuild /m on the command line for parallel multi-TFM builds within each project.
-	-->
-	<PropertyGroup>
-		<KryptonComponentsRoot>..\..\Source\Krypton Components</KryptonComponentsRoot>
-		<KryptonToolkitProject>$(KryptonComponentsRoot)\Krypton.Toolkit\Krypton.Toolkit 2022.csproj</KryptonToolkitProject>
-		<KryptonRibbonProject>$(KryptonComponentsRoot)\Krypton.Ribbon\Krypton.Ribbon 2022.csproj</KryptonRibbonProject>
-		<KryptonNavigatorProject>$(KryptonComponentsRoot)\Krypton.Navigator\Krypton.Navigator 2022.csproj</KryptonNavigatorProject>
-		<KryptonWorkspaceProject>$(KryptonComponentsRoot)\Krypton.Workspace\Krypton.Workspace 2022.csproj</KryptonWorkspaceProject>
-		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
-		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs)</KryptonComponentBuildProperties>
-		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all</KryptonComponentBuildProperties>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<KryptonParallelAfterToolkit Include="$(KryptonRibbonProject)" />
-		<KryptonParallelAfterToolkit Include="$(KryptonNavigatorProject)" />
-	</ItemGroup>
-
-	<Target Name="KryptonBuild">
-		<MSBuild Projects="$(KryptonToolkitProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Build" />
-
-		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Build"
-		         BuildInParallel="true" />
-
-		<MSBuild Projects="$(KryptonWorkspaceProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Build" />
-
-		<MSBuild Projects="$(KryptonDockingProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Build" />
-	</Target>
-
-	<Target Name="KryptonPack">
-		<MSBuild Projects="$(KryptonToolkitProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Pack" />
-
-		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Pack"
-		         BuildInParallel="true" />
-
-		<MSBuild Projects="$(KryptonWorkspaceProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Pack" />
-
-		<MSBuild Projects="$(KryptonDockingProject)"
-		         Properties="$(KryptonComponentBuildProperties)"
-		         Targets="Pack" />
-	</Target>
-</Project>
+<Project>
+
+	<!--
+	  Phased Krypton.* orchestration: avoids parallel projects racing on shared Bin/<Configuration>/<tfm>/ outputs
+	  while still allowing Ribbon + Navigator to build together after Toolkit is complete.
+	  Use with msbuild /m on the command line for parallel multi-TFM builds within each project.
+	-->
+	<PropertyGroup>
+		<KryptonComponentsRoot>..\..\Source\Krypton Components</KryptonComponentsRoot>
+		<KryptonToolkitProject>$(KryptonComponentsRoot)\Krypton.Toolkit\Krypton.Toolkit 2022.csproj</KryptonToolkitProject>
+		<KryptonRibbonProject>$(KryptonComponentsRoot)\Krypton.Ribbon\Krypton.Ribbon 2022.csproj</KryptonRibbonProject>
+		<KryptonNavigatorProject>$(KryptonComponentsRoot)\Krypton.Navigator\Krypton.Navigator 2022.csproj</KryptonNavigatorProject>
+		<KryptonWorkspaceProject>$(KryptonComponentsRoot)\Krypton.Workspace\Krypton.Workspace 2022.csproj</KryptonWorkspaceProject>
+		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
+		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs)</KryptonComponentBuildProperties>
+		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all</KryptonComponentBuildProperties>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<KryptonParallelAfterToolkit Include="$(KryptonRibbonProject)" />
+		<KryptonParallelAfterToolkit Include="$(KryptonNavigatorProject)" />
+	</ItemGroup>
+
+	<Target Name="KryptonBuild">
+		<MSBuild Projects="$(KryptonToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+	</Target>
+
+	<Target Name="KryptonPack">
+		<MSBuild Projects="$(KryptonToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+	</Target>
+
+</Project>

--- a/Scripts/Build/Krypton.Orchestration.targets
+++ b/Scripts/Build/Krypton.Orchestration.targets
@@ -1,0 +1,60 @@
+<Project>
+	<!--
+	  Phased Krypton.* orchestration: avoids parallel projects racing on shared Bin/<Configuration>/<tfm>/ outputs
+	  while still allowing Ribbon + Navigator to build together after Toolkit is complete.
+	  Use with msbuild /m on the command line for parallel multi-TFM builds within each project.
+	-->
+	<PropertyGroup>
+		<KryptonComponentsRoot>..\..\Source\Krypton Components</KryptonComponentsRoot>
+		<KryptonToolkitProject>$(KryptonComponentsRoot)\Krypton.Toolkit\Krypton.Toolkit 2022.csproj</KryptonToolkitProject>
+		<KryptonRibbonProject>$(KryptonComponentsRoot)\Krypton.Ribbon\Krypton.Ribbon 2022.csproj</KryptonRibbonProject>
+		<KryptonNavigatorProject>$(KryptonComponentsRoot)\Krypton.Navigator\Krypton.Navigator 2022.csproj</KryptonNavigatorProject>
+		<KryptonWorkspaceProject>$(KryptonComponentsRoot)\Krypton.Workspace\Krypton.Workspace 2022.csproj</KryptonWorkspaceProject>
+		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
+		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs)</KryptonComponentBuildProperties>
+		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all</KryptonComponentBuildProperties>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<KryptonParallelAfterToolkit Include="$(KryptonRibbonProject)" />
+		<KryptonParallelAfterToolkit Include="$(KryptonNavigatorProject)" />
+	</ItemGroup>
+
+	<Target Name="KryptonBuild">
+		<MSBuild Projects="$(KryptonToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+	</Target>
+
+	<Target Name="KryptonPack">
+		<MSBuild Projects="$(KryptonToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+	</Target>
+</Project>

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -43,7 +43,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -43,7 +43,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 :: -t:rebuild
 

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -39,6 +39,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"
 )
 
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 @echo Started to build Nightly release
 @echo:
 @echo Started: %date% %time% %zone%

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/Build/build.proj
+++ b/Scripts/Build/build.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="PackAll">
@@ -62,10 +58,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -44,7 +44,8 @@ goto build2019
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2026build
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
@@ -80,7 +81,8 @@ goto build2026
 :build2026
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=build.log
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
 
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=

--- a/Scripts/Build/canarylongtermstable.proj
+++ b/Scripts/Build/canarylongtermstable.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Build/canarylongtermstable.proj
+++ b/Scripts/Build/canarylongtermstable.proj
@@ -3,9 +3,9 @@
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
-		<Configuration>Nightly</Configuration>
-		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
-		<NightlyZipName>Krypton-Nightly</NightlyZipName>
+		<Configuration>Canary</Configuration>
+		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
+		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -26,14 +26,12 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
 	</Target>
-
-	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
@@ -55,60 +53,63 @@
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
+	<!--PackLite;-->
 
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Nightly\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
 
-	<Target Name="CreateNightlyZip">
+
+
+	<Target Name="CreateCanaryZip">
 		<PropertyGroup>
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
 		</ItemGroup>
-		<MakeDir Directories="$(NightlyBuildPath)"/>
+		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Using 7-Zip for ZIP creation (compatible with all MSBuild versions) -->
-		<Exec Command="7z.exe a -tzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -tzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
-		      WorkingDirectory="$(NightlyBuildPath)" />
+		      WorkingDirectory="$(CanaryBuildPath)" />
 
 		<!-- Fallback: Using PowerShell Compress-Archive if 7-Zip not available -->
-		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Nightly\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).zip' -Force&quot;"
+		<Exec Command="powershell.exe -Command &quot;Get-ChildItem '..\Bin\Canary\*' -Recurse | Where-Object {$_.Extension -notin '.json','.pdb'} | Compress-Archive -DestinationPath '$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).zip' -Force&quot;"
 		      Condition="!Exists('C:\Program Files\7z.exe')" />
 	</Target>
 
-	<Target Name="CreateNightlyTar">
+	<Target Name="CreateCanaryTar">
 		<PropertyGroup>
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>
 		<ItemGroup>
-			<DebugApplicationFiles Include="..\Bin\Nightly\**\*.*" Exclude="..\Bin\Nightly\*vshost.exe*;..\Bin\Nightly\**\*.json;..\Bin\Nightly\**\*.pdb" />
+			<DebugApplicationFiles Include="..\Bin\Canary\**\*.*" Exclude="..\Bin\Canary\*vshost.exe*;..\Bin\Canary\**\*.json;..\Bin\Canary\**\*.pdb" />
 		</ItemGroup>
-		<MakeDir Directories="$(NightlyBuildPath)"/>
+		<MakeDir Directories="$(CanaryBuildPath)"/>
 
 		<!-- Method 1: Using 7-Zip if available (recommended for Windows) -->
-		<Exec Command="7z.exe a -ttar &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot; &quot;..\Bin\Nightly\*&quot; -x!*.json -x!*.pdb"
+		<Exec Command="7z.exe a -ttar &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot; &quot;..\Bin\Canary\*&quot; -x!*.json -x!*.pdb"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
-		      WorkingDirectory="$(NightlyBuildPath)" />
-		<Exec Command="7z.exe a -tgzip &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar.gz&quot; &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar&quot;"
+		      WorkingDirectory="$(CanaryBuildPath)" />
+		<Exec Command="7z.exe a -tgzip &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar.gz&quot; &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar&quot;"
 		      Condition="Exists('C:\Program Files\7-Zip\7z.exe')"
-		      WorkingDirectory="$(NightlyBuildPath)" />
-		<Delete Files="$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate).tar"
+		      WorkingDirectory="$(CanaryBuildPath)" />
+		<Delete Files="$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate).tar"
 		        Condition="Exists('C:\Program Files\7-Zip\7z.exe')" />
 
 		<!-- Method 2: Using PowerShell tar command (Windows 10/11) -->
-		<Exec Command="powershell.exe -Command tar -czf &quot;$(NightlyBuildPath)\$(NightlyZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Nightly&quot; . --exclude=*.json --exclude=*.pdb"
+		<Exec Command="powershell.exe -Command tar -czf &quot;$(CanaryBuildPath)\$(CanaryZipName)_$(StringDate)_ps.tar.gz&quot; -C &quot;..\Bin\Canary&quot; . --exclude=*.json --exclude=*.pdb"
 		      Condition="Exists('C:\Windows\System32\tar.exe')" />
 
 		<!-- Method 3: Using Git Bash tar if available -->
-		<Exec Command="&quot;C:\Program Files\Git\bin\bash.exe&quot; -c &quot;cd ../Bin/Nightly &amp;&amp; tar -czf &quot;$(NightlyBuildPath)/$(NightlyZipName)_$(StringDate)_git.tar.gz&quot; * --exclude=*.json --exclude=*.pdb&quot;"
+		<Exec Command="&quot;C:\Program Files\Git\bin\bash.exe&quot; -c &quot;cd ../Bin/Canary &amp;&amp; tar -czf &quot;$(CanaryBuildPath)/$(CanaryZipName)_$(StringDate)_git.tar.gz&quot; * --exclude=*.json --exclude=*.pdb&quot;"
 		      Condition="Exists('C:\Program Files\Git\bin\bash.exe')" />
 	</Target>
 
-	<Target Name="CreateAllArchives" DependsOnTargets="CreateNightlyZip;CreateNightlyTar" />
+	<Target Name="CreateAllCanaryArchives" DependsOnTargets="CreateCanaryZip;CreateCanaryTar" />
 </Project>

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -36,7 +36,8 @@ goto build
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo

--- a/Scripts/Build/debug.proj
+++ b/Scripts/Build/debug.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
 	
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -10,20 +11,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 </Project>

--- a/Scripts/Build/longtermstable.proj
+++ b/Scripts/Build/longtermstable.proj
@@ -1,77 +1,73 @@
-<Project>
-	<Import Project="..\Directory.Build.props" />
-	
-	<PropertyGroup>
-		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
-		<Configuration>Release</Configuration>
-	</PropertyGroup>
-
-	<Target Name="Clean">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
-	</Target>	
-
-	<Target Name="Restore">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-	</Target>
-	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
-	
-	<Target Name="CleanPackages">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
-		</ItemGroup>
-		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
-	</Target>
-	
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
-	</Target>
-	
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
-	
-	<Target Name="Push">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
-		</ItemGroup>
-		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
-	</Target>
-</Project>
+<Project>
+	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
+
+	<PropertyGroup>
+		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
+		<Configuration>Release</Configuration>
+	</PropertyGroup>
+
+	<Target Name="Clean">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="Restore">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
+
+	<Target Name="CleanPackages">
+		<ItemGroup>
+			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+		</ItemGroup>
+		<Delete Files="@(NugetPkgs)" />
+	</Target>
+
+	<Target Name="PackLite">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="PackAll">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
+	</Target>
+
+	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
+
+	<Target Name="Push">
+		<ItemGroup>
+			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+		</ItemGroup>
+		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
+	</Target>
+</Project>

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
@@ -48,10 +44,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -40,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build-installer.cmd
+++ b/Scripts/Current/build-installer.cmd
@@ -43,7 +43,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build-nightly-custom.cmd
+++ b/Scripts/Current/build-nightly-custom.cmd
@@ -43,7 +43,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 :: -t:rebuild
 

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -39,6 +39,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"
 )
 
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 @echo Started to build Nightly release
 @echo:
 @echo Started: %date% %time% %zone%

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="PackAll">
@@ -62,10 +58,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -44,7 +44,8 @@ goto build2019
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2026build
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
@@ -80,7 +81,8 @@ goto build2026
 :build2026
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=build.log
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
 
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Current/canarylongtermstable.proj
+++ b/Scripts/Current/canarylongtermstable.proj
@@ -1,12 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
-	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
-		<CanaryZipName>Krypton-Canary</CanaryZipName>
+		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
 
 	<Target Name="Clean">

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -36,7 +36,8 @@ goto build
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo

--- a/Scripts/Current/debug.proj
+++ b/Scripts/Current/debug.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 	
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -10,20 +11,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 </Project>

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -1,6 +1,7 @@
 <Project>
-	<Import Project="..\Directory.Build.props" />
-	
+	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
+
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
@@ -8,69 +9,64 @@
 
 	<Target Name="Clean">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
-	</Target>	
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
-	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
-	
+
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
+
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
 	<Target Name="PackLite">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
 	</Target>
-	
+
 	<Target Name="PackAll">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
-	
+
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
-	
+
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
@@ -48,10 +44,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -26,7 +26,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
 	</Target>
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -40,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 

--- a/Scripts/VS2022/build-canary.cmd
+++ b/Scripts/VS2022/build-canary.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%

--- a/Scripts/VS2022/build-canary.cmd
+++ b/Scripts/VS2022/build-canary.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); canary.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Canary release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/VS2022/build-installer.cmd
+++ b/Scripts/VS2022/build-installer.cmd
@@ -43,7 +43,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/VS2022/build-lts.cmd
+++ b/Scripts/VS2022/build-lts.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/VS2022/build-lts.cmd
+++ b/Scripts/VS2022/build-lts.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); longtermstable.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/VS2022/build-nightly-custom.cmd
+++ b/Scripts/VS2022/build-nightly-custom.cmd
@@ -43,7 +43,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 :: -t:rebuild
 

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
+echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 
 pause
 goto exitbatch
 
-:vs17prev
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
+:vscurrentinsiders
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vs17ent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin
+:vscurrentent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vs17pro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin
+:vscurrentpro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build
 
-:vs17com
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin
+:vscurrentcom
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build
 
-:vs17build
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin
+:vscurrentbuild
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -39,12 +39,13 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"
 )
 
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 @echo Started to build Nightly release
 @echo:
 @echo Started: %date% %time% %zone%
 @echo:
-set targets=Build
-if not "%~1" == "" set targets=%~1
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 "%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 :: -t:rebuild

--- a/Scripts/VS2022/build-stable.cmd
+++ b/Scripts/VS2022/build-stable.cmd
@@ -45,7 +45,8 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-"%msbuildpath%\msbuild.exe" /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/VS2022/build-stable.cmd
+++ b/Scripts/VS2022/build-stable.cmd
@@ -45,7 +45,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
-REM /m: multi-processor MSBuild (all logical CPUs); build.proj orchestrates Krypton.* in parallel where references allow.
+REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 @echo:
 @echo Stable release build completed: %date% %time% %zone%

--- a/Scripts/VS2022/build.proj
+++ b/Scripts/VS2022/build.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="PackAll">
@@ -62,10 +58,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -44,7 +44,8 @@ goto build2019
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2022build
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
@@ -80,7 +81,8 @@ goto build2022
 :build2022
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=build.log
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
 
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=

--- a/Scripts/VS2022/canary.proj
+++ b/Scripts/VS2022/canary.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="CleanPackages">
 		<ItemGroup>
@@ -46,10 +42,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/canarylongtermstable.proj
+++ b/Scripts/VS2022/canarylongtermstable.proj
@@ -1,12 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
-	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
-		<CanaryZipName>Krypton-Canary</CanaryZipName>
+		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
 
 	<Target Name="Clean">

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -36,7 +36,8 @@ goto build
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+REM /m: multi-processor MSBuild (all logical CPUs).
+"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo

--- a/Scripts/VS2022/debug.proj
+++ b/Scripts/VS2022/debug.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 	
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -10,20 +11,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 </Project>

--- a/Scripts/VS2022/longtermstable.proj
+++ b/Scripts/VS2022/longtermstable.proj
@@ -1,6 +1,7 @@
 <Project>
-	<Import Project="..\Directory.Build.props" />
-	
+	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
+
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
@@ -8,69 +9,64 @@
 
 	<Target Name="Clean">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
-	</Target>	
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
-	
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
-	</Target>
-	
+
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
+
 	<Target Name="CleanPackages">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
 	<Target Name="PackLite">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
 	</Target>
-	
+
 	<Target Name="PackAll">
 		<ItemGroup>
-			<Projects Include="..\Source\Krypton Components\Krypton.*\*.csproj" />
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
-	
+
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
-	
+
 	<Target Name="Push">
 		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Release\*.$(LibraryVersion).nupkg" />
+			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -1,5 +1,6 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="..\Build\Krypton.Orchestration.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -12,22 +13,17 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
-	<Target Name="Build" DependsOnTargets="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
-	</Target>
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
@@ -48,10 +44,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -26,7 +26,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" BuildInParallel="true" />
 	</Target>
 
 	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -40,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -60,6 +60,9 @@
 		<!-- Ensure multi-target outputs don't overwrite each other -->
 		<OutputPath>$(MSBuildThisFileDirectory)..\..\Bin\$(Configuration)\$(TargetFramework)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<!-- Per-TFM obj avoids races when msbuild /m compiles multiple target frameworks at once -->
+		<IntermediateOutputPath>$(MSBuildProjectDirectory)obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+		<AppendTargetFrameworkToIntermediateOutputPath>false</AppendTargetFrameworkToIntermediateOutputPath>
 	</PropertyGroup>
 
 	<Choose>


### PR DESCRIPTION
# Enable parallel MSBuild for local scripts and CI

## Summary

Speeds up orchestrated builds by using multi-processor MSBuild (`/m`) consistently in Windows `.cmd` scripts and GitHub Actions, and by setting `BuildInParallel="true"` on the `nightly.proj` Build target. Documentation under `Documents/Documents/Contributing/` is updated so contributors and workflow guides match the new behaviour.

## Motivation

- MSBuild defaults to single-node scheduling when `/m` is omitted, which underuses CPU during multi-TFM and multi-project builds.
- `nightly.proj` previously used `BuildInParallel="false"`, forcing the five `Krypton.*` libraries to build strictly one after another at the orchestration layer.
- Local `.cmd` scripts, CI workflows, and ModernBuild were inconsistent (ModernBuild already passed `/m`; most `.cmd` files and workflows did not).

Parallelism is safe here because project references still define order: **Toolkit → Ribbon/Navigator → Workspace → Docking**. Only independent work (for example Ribbon and Navigator after Toolkit, or multiple TFMs within a project) runs concurrently.

## Changes

### MSBuild project files

| File | Change |
| --- | --- |
| `Scripts/Build/nightly.proj` | `BuildInParallel="true"` on Build target | | `Scripts/VS2022/nightly.proj` | Same (mirror) |
| `Scripts/Current/nightly.proj` | Same (mirror) |

Other orchestration `.proj` files (`build.proj`, `canary.proj`, etc.) already use the MSBuild task default (`BuildInParallel=true`).

### Windows build scripts (`Scripts/Build`, `Scripts/VS2022`, `Scripts/Current`)

Added **`/m`** and brief **`REM`** comments to:

- `build-stable.cmd`, `build-canary.cmd`, `build-lts.cmd`
- `build-installer.cmd`, `debug.cmd`, `buildsolution.cmd` (both VS code paths)
- `build-nightly.cmd`, `rebuild-build-nightly.cmd`, `build-nightly-custom.cmd`

### GitHub Actions

Added **`/m`** and YAML comments on orchestrated `msbuild` steps in:

- `.github/workflows/build.yml`
- `.github/workflows/nightly.yml`
- `.github/workflows/canary.yml`
- `.github/workflows/release.yml`
- `.github/workflows/canary-lts-release.yml` (including `/m` in the PowerShell `$buildArgs` array)

### Documentation (`Documents/Documents/Contributing/`)

- **Build System/BuildSystemOverview.md** — New “Parallel MSBuild” section; `canarylongtermstable.proj` listed.
- **Build System/BuildScripts.md** — Logging pattern, parallel builds section, nightly notes.
- **Build System/MSBuildProjectFiles.md** — `BuildInParallel`, `canarylongtermstable.proj`, `/m` on examples.
- **BuildSystemDocumentationIndex.md**, **HowtoBuild.md**, **ModernBuildTool.md**
- **Workflows**: `BuildWorkflow.md`, `CanaryLTSReleaseWorkflow.md` (corrected project file to `canarylongtermstable.proj` for Canary LTS CI)
- **Build System/Current**: `BuildWorkflow.md`, `ReleaseWorkflow.md`
- **GitHubActionsWorkflows.md**, **KillSwitches.md**
- **Troubleshooting.md**, **NuGetPackaging.md**, **VersionManagement.md** — Examples and throttle guidance

### Unchanged (intentional)

- **`build-testform.yml`** — Still uses `dotnet build … -m:1 -p:BuildInParallel=false` for stable TestForm CI.
- **Component source** — No C# or designer changes.
- **ModernBuild** — Already invoked MSBuild with `/m` in `BuildLogic.cs`; doc note only.

## Behaviour notes

| Mechanism | Effect |
| --- | --- |
| `msbuild /m` | Uses all logical processors for the build graph | | `BuildInParallel="true"` on `<MSBuild>` | Allows sibling projects in the orchestration batch to build concurrently when references allow | | Project references | Still enforce Toolkit → … → Docking ordering |

To **reduce** parallelism when diagnosing file locks or memory pressure:

```cmd
msbuild /m:1 Scripts\Build\build.proj /t:Build
```

## Test plan

- [ ] **Local stable**: `Scripts\VS2022\build-stable.cmd` — completes successfully; shorter wall-clock vs prior single-node build (optional timing).
- [ ] **Local nightly**: `Scripts\VS2022\build-nightly.cmd` — completes; outputs under `Bin\Nightly\` (or `artifacts\` if `UseArtifactsOutput=true`).
- [ ] **Solution quick build** (unchanged): `dotnet build "Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`
- [ ] **CI**: Verify `build.yml` PR build on a test branch.
- [ ] **CI (optional)**: Manually run `nightly.yml` / `canary.yml` / `release.yml` via `workflow_dispatch` if available.
- [ ] **ModernBuild**: Run a Build/Pack from the TUI; confirm log line includes `/m`.
- [ ] If any flaky restore or file-lock errors appear, retry with `/m:1` to confirm parallelism as the variable.

## Risk / rollback

- **Low functional risk** — same targets, configurations, and outputs; only scheduling changes.
- **Possible CI/local issues**: intermittent file contention on shared `obj`/`Bin` under heavy parallelism; mitigate with `/m:1` or fewer cores.
- **Rollback**: Revert `/m` on `.cmd`/workflows and set `BuildInParallel="false"` on `nightly.proj` if needed.

## Related

- ModernBuild: `Scripts/ModernBuild/General/BuildLogic.cs` (`/m` already present)
- AGENTS.md: `dotnet build` on the solution remains valid for day-to-day Debug builds

# Fix Canary LTS release workflow and add dedicated LTS MSBuild project

## Summary

- Fixes **MSB1009** failures in the **Canary LTS Release** workflow (`canary-lts-release.yml`) on `V105-LTS`.
- Introduces **`Scripts/Build/canarylongtermstable.proj`** so Canary LTS builds are orchestrated separately from the main `canary` channel.
- Enables **parallel MSBuild** (`/m`) in CI workflows and local `.cmd` build scripts for faster restore/build/pack.

## Problem

The **Build Canary** step in `canary-lts-release.yml` built a single PowerShell string and passed it to MSBuild:

```powershell
$buildArgs = 'Scripts/Build/canary.proj /t:Build ...'
msbuild $buildArgs
```

PowerShell passes that as **one** argument. MSBuild then treats the entire string as the project path, producing:

```text
MSBUILD : error MSB1009: Project file does not exist.
Switch: Scripts/Build/canary.proj /t:Build /p:Configuration=Canary ...
```

`Scripts/Build/canary.proj` exists on `V105-LTS`; the failure was argument passing, not a missing file.

## Solution

### Canary LTS workflow

| Change | Detail |
|--------|--------|
| MSBuild arguments | Use a string **array** and splat: `& msbuild @buildArgs` so each switch is a separate argument. | | Dedicated project | Build/pack via `Scripts/Build/canarylongtermstable.proj` instead of `canary.proj`. | | Parallel build | Add `/m` to Build and Pack steps (aligned with other channel workflows). | | Authenticode | Optional signing properties appended as separate array elements (unchanged behaviour). |

### `canarylongtermstable.proj`

New orchestration project under `Scripts/Build/`, based on `canary.proj`:

- **Configuration:** `Canary` (same NuGet/channel output as Canary pre-releases).
- **Scope:** `Krypton.*` projects under `Source/Krypton Components` (appropriate for `V105-LTS`, which has no Utilities/WebView2 build steps in this workflow).
- **Archives:** `CanaryZipName` is `Krypton-Canary-LTS` to distinguish LTS canary zip/tar outputs from mainline Canary.

Mainline **`canary.yml`** continues to use `Scripts/Build/canary.proj`.

### Parallel MSBuild (`/m`)

Across release workflows and `Scripts/Build`, `Scripts/Current`, and `Scripts/VS2022` build scripts:

- CI: `msbuild /m "Scripts/Build/<channel>.proj" ...` for canary, nightly, release, and build workflows.
- Local: `.cmd` wrappers pass `/m` to match CI and `.proj` multi-project orchestration.

## Files changed

| Area | Files |
|------|--------|
| **New** | `Scripts/Build/canarylongtermstable.proj` | | **Workflow** | `.github/workflows/canary-lts-release.yml` | | **CI (parallel `/m`)** | `.github/workflows/canary.yml`, `nightly.yml`, `release.yml`, `build.yml` | | **Scripts** | `Scripts/Build`, `Scripts/Current`, `Scripts/VS2022` — `build-*.cmd`, `debug.cmd`, `buildsolution.cmd`, `nightly.proj` |

## Test plan

- [ ] **Canary LTS Release** (`workflow_dispatch` on `V105-LTS` or push to `V105-LTS`):
  - [ ] Kill switch `CANARY_LTS_DISABLED` is not `true`.
  - [ ] **Build Canary** completes without MSB1009.
  - [ ] **Pack Canary** produces packages under `Artefacts/Packages/Canary/`.
  - [ ] NuGet push step finds packages (or skips gracefully if `NUGET_API_KEY` unset in a test run).
- [ ] With Authenticode secrets configured: Build step enables signing and still completes.
- [ ] **Canary** workflow on `canary` branch: restore/build/pack still succeed with `/m` and `canary.proj`.
- [ ] Local (optional): `Scripts\Build\build-canary.cmd` on a dev machine with VS 2026 MSBuild.

## Notes

- Target branch for Canary LTS packages: **`V105-LTS`**.
- No breaking changes to stable/canary/nightly package IDs or `Configuration` names.
- `build-canary-lts.cmd` was not added; local LTS canary builds can use MSBuild directly against `canarylongtermstable.proj` if needed.