### PR TITLE
2418-V110-KDGridView title fix

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1709,7 +1709,7 @@ public class KryptonDataGridView : DataGridView
                                 if (!string.IsNullOrEmpty(text))
                                 {
                                     Rectangle constrainedContentBounds = headerContentBounds;
-                                    Rectangle colDisplayRect = GetColumnDisplayRectangle(e.ColumnIndex, false);
+                                    Rectangle colDisplayRect = GetColumnDisplayRectangle(e.ColumnIndex, true);
                                     if (colDisplayRect.Width > 0)
                                     {
                                         // Translate display rect into cell-local coords


### PR DESCRIPTION
Fixes #2681.

The likely cause is in the #2422 header painting change. That change says header text is clipped to the column display rectangle, but the code called GetColumnDisplayRectangle(e.ColumnIndex, false). In DataGridView, false returns the entire column rectangle, while true returns only the visible rectangle.

That means partially visible column headers during horizontal scrolling could still use overflow geometry while the header background and border were painted through the separate offscreen path. This updates the call to request the visible rectangle so the direct TextRenderer.DrawText path clips to the same visible area that the scroll operation exposes.

The existing #2681 scroll invalidation workaround is intentionally left in place. This change addresses the clipping mismatch underneath it, and the workaround can be removed separately after the fast horizontal scrollbar-drag repro is checked visually.