### PR TITLE
* Include `README.md` in NuGet packages

### DIFF
--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -62,22 +62,26 @@
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 
+	<!-- NuGet package readme (https://aka.ms/nuget-include-readme) and license for all pack configurations. -->
+	<ItemGroup>
+		<None Include="..\..\..\Documents\License\License.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Include="..\..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<ItemGroup>
 				<None Include="../../../Assets/PNG/NuGet Package Icons/Krypton Canary.png" Link="Icon.png" Pack="true" PackagePath="" />
-
-				<None Include="..\..\..\Documents\License\License.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
-
-				<None Include="..\..\..\README.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
 			</ItemGroup>
 
 			<PropertyGroup>
@@ -99,18 +103,6 @@
 		<When Condition="'$(Configuration)' == 'Nightly'">
 			<ItemGroup>
 				<None Include="../../../Assets/PNG/NuGet Package Icons/Krypton Nightly.png" Link="Icon.png" Pack="true" PackagePath="" />
-
-				<None Include="..\..\..\Documents\License\License.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
-
-				<None Include="..\..\..\README.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
 			</ItemGroup>
 
 			<PropertyGroup>
@@ -131,18 +123,6 @@
 		<Otherwise>
 			<ItemGroup>
 				<None Include="../../../Assets/PNG/NuGet Package Icons/Krypton Stable.png" Link="Icon.png" Pack="true" PackagePath="" />
-
-				<None Include="..\..\..\Documents\License\License.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
-
-				<None Include="..\..\..\README.md">
-					<Pack>True</Pack>
-					<PackagePath>\</PackagePath>
-				</None>
-
 			</ItemGroup>
 
 			<PropertyGroup>
@@ -156,7 +136,6 @@
 				<Authors>Peter William Wagner &amp; Simon Coghlan &amp; Giduac &amp; Ahmed Abdelhameed &amp; Lesandro &amp; tobitege &amp; Thomas Bolon</Authors>
 				<!--<PackageLicenseFile>License.md</PackageLicenseFile>-->
 				<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-				<PackageReadmeFile>README.md</PackageReadmeFile>
 				<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 				<PackageTags>Krypton ComponentFactory WinForms Themes Controls DataGrid Ribbon Workspace Tabs .NET Toolkit</PackageTags>
 				<PackageReleaseNotes>Get updates here: https://github.com/Krypton-Suite/Standard-Toolkit</PackageReleaseNotes>


### PR DESCRIPTION
# Include `README.md` in NuGet packages

Closes #3514

## Summary

- Declare the repository root `README.md` as the official NuGet package readme for **Release**, **Canary**, and **Nightly** builds by setting `PackageReadmeFile` in `Source/Krypton Components/Directory.Build.props`.
- Hoist shared package content (license + readme) into a single `ItemGroup` so Canary, Nightly, and Release no longer duplicate the same `None` entries three times.
- **Release** already packed `README.md` and had `PackageReadmeFile`; **Canary** and **Nightly** packed the file but omitted `PackageReadmeFile`, which caused workflow warnings such as: ```text warn : Readme missing. Go to https://aka.ms/nuget-include-readme learn How to include a readme file within the package. ```

## Background

NuGet distinguishes between:

1. Including `README.md` as package content (`Pack="true"`), and
2. Registering it as the **package readme** shown on nuget.org (`PackageReadmeFile` → `<readme>README.md</readme>` in the `.nuspec`).

Canary and Nightly only did (1). This change ensures all pack configurations do both, per [Include a readme in your NuGet package](https://aka.ms/nuget-include-readme).

## Changes

| File | Change |
|------|--------|
| `Source/Krypton Components/Directory.Build.props` | Shared `ItemGroup` for `License.md` and `README.md`; shared `PackageReadmeFile`; per-configuration blocks retain icons and metadata only |

Affected packages (via shared props): `Krypton.Toolkit`, `Krypton.Ribbon`, `Krypton.Navigator`, `Krypton.Workspace`, `Krypton.Docking`, and `Krypton.Standard.Toolkit` (and their `.Canary` / `.Nightly` variants).

## Test plan

- [x] Pack `Krypton.Toolkit` with `Configuration=Canary` and confirm the `.nuspec` contains `<readme>README.md</readme>`.
- [ ] Pack with `Configuration=Nightly` and `Configuration=Release` and confirm the same readme metadata.
- [ ] After merge, confirm the next Canary/Nightly/Release workflow push no longer logs `Readme missing`.
- [ ] On nuget.org, verify the package readme tab renders for a newly published package (post-release).

**Local verification (optional):**

```cmd
dotnet msbuild "Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -t:Pack -p:Configuration=Canary -p:TFMs=lite
```

Inspect the generated `.nuspec` under `Bin\Packages\Canary\` (extract the `.nupkg` if needed) and look for `<readme>README.md</readme>` under `<metadata>`.

## Notes

- No workflow or project file changes required; existing `Pack` targets pick up the updated props automatically.
- **LTS branches** (`V85-LTS`, `V105-LTS`): cherry-pick or mirror this props change if those branches maintain a separate `Directory.Build.props` without `PackageReadmeFile` on Canary/Nightly.
- The root `README.md` is used as-is; no separate package-only readme was introduced.

## Breaking changes

None.