### PR TITLE
#3090-V105-LTS Fix ModernBuild: support VS2022/Current script profiles

### DIFF
--- a/Scripts/ModernBuild/General/AppState.cs
+++ b/Scripts/ModernBuild/General/AppState.cs
@@ -45,6 +45,12 @@ public sealed class AppState
     /// </summary>
     public string ProjectFile { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the selected scripts profile (Auto, VS2022, Current).
+    /// Controls which Scripts folder variant is preferred when resolving .proj files.
+    /// </summary>
+    public ScriptProfile ScriptProfile { get; set; } = ScriptProfile.Auto;
+
     #endregion
 
     #region Logging Configuration
@@ -87,6 +93,11 @@ public sealed class AppState
     /// Gets or sets the UTC start time of the current build operation.
     /// </summary>
     public DateTime? StartTimeUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC end time of the most recently completed build operation.
+    /// </summary>
+    public DateTime? EndTimeUtc { get; set; }
     
     /// <summary>
     /// Gets or sets the count of errors encountered during the build.

--- a/Scripts/ModernBuild/General/BuildLogic.cs
+++ b/Scripts/ModernBuild/General/BuildLogic.cs
@@ -16,7 +16,7 @@ internal static class BuildLogic
 {
     /// <summary>
     /// Discovers the root directory of the Krypton repository by searching for build project files.
-    /// Searches upward from the application's base directory to find the Scripts/Project-Files/build.proj file.
+    /// Searches upward from the application's base directory to find known Scripts/*/build.proj layouts.
     /// </summary>
     /// <returns>The full path to the repository root directory.</returns>
     internal static string FindRepoRoot()
@@ -24,8 +24,7 @@ internal static class BuildLogic
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir != null)
         {
-            string probe = Path.Combine(dir.FullName, "Scripts", "Project-Files", "build.proj");
-            if (File.Exists(probe))
+            if (HasKnownBuildProjectLayout(dir.FullName))
             {
                 return dir.FullName;
             }
@@ -36,8 +35,7 @@ internal static class BuildLogic
             var probe = new DirectoryInfo(AppContext.BaseDirectory).Parent?.Parent?.Parent?.Parent;
             if (probe != null)
             {
-                string candidate = Path.Combine(probe.FullName, "Scripts", "Project-Files", "build.proj");
-                if (File.Exists(candidate))
+                if (HasKnownBuildProjectLayout(probe.FullName))
                 {
                     return probe.FullName;
                 }
@@ -48,13 +46,41 @@ internal static class BuildLogic
     }
 
     /// <summary>
-    /// Gets the project file path for the specified build channel.
-    /// Searches in both Scripts and Scripts/Project-Files directories for the appropriate .proj file.
+    /// Determines whether the provided directory appears to be the repository root
+    /// by checking for known build project layouts.
     /// </summary>
-    /// <param name="rootPath">The root path of the repository.</param>
+    /// <param name="rootPath">The directory path to validate as a repository root.</param>
+    /// <returns>True when a known build.proj location exists; otherwise false.</returns>
+    private static bool HasKnownBuildProjectLayout(string rootPath)
+    {
+        string[] candidates =
+        {
+            Path.Combine(rootPath, "Scripts", "build.proj"),
+            Path.Combine(rootPath, "Scripts", "Project-Files", "build.proj"),
+            Path.Combine(rootPath, "Scripts", "Current", "build.proj"),
+            Path.Combine(rootPath, "Scripts", "VS2022", "build.proj"),
+            Path.Combine(rootPath, "Scripts", "Build", "build.proj")
+        };
+
+        foreach (string candidate in candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the project file path for the specified build channel.
+    /// Searches all known script-layout directories for the appropriate .proj file.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
     /// <param name="channel">The build channel (Nightly, Canary, Stable, LTS).</param>
     /// <returns>The path to the project file for the specified channel.</returns>
-    private static string GetProjFileForChannel(string rootPath, ChannelType channel)
+    private static string GetProjFileForChannel(AppState state, ChannelType channel)
     {
         string name = channel switch
         {
@@ -62,17 +88,57 @@ internal static class BuildLogic
             ChannelType.Canary  => "canary.proj",
             _                   => "build.proj"
         };
-        string pfProjectFiles = Path.Combine(rootPath, "Scripts", "Project-Files", name);
-        string pfScripts = Path.Combine(rootPath, "Scripts", name);
-        if (File.Exists(pfScripts))
+        return ResolveProjectFile(state.RootPath, name, state.ScriptProfile, state.MsBuildPath);
+    }
+
+    /// <summary>
+    /// Resolves a script project file name by probing known locations in precedence order.
+    /// </summary>
+    /// <param name="rootPath">The root path of the repository.</param>
+    /// <param name="name">The project file name to locate.</param>
+    /// <param name="scriptProfile">The selected scripts profile (Auto, VS2022, Current).</param>
+    /// <param name="msBuildPath">The currently detected MSBuild executable path.</param>
+    /// <returns>The first existing full path, or the preferred scripts-folder path when none are found.</returns>
+    private static string ResolveProjectFile(string rootPath, string name, ScriptProfile scriptProfile, string msBuildPath)
+    {
+        IReadOnlyList<string> folderOrder = GetScriptResolutionOrder(scriptProfile, msBuildPath);
+        var candidates = new List<string>(folderOrder.Count + 4);
+
+        foreach (string folder in folderOrder)
         {
-            return pfScripts;
+            candidates.Add(Path.Combine(rootPath, "Scripts", folder, name));
         }
-        if (File.Exists(pfProjectFiles))
+
+        candidates.Add(Path.Combine(rootPath, "Scripts", name));
+        candidates.Add(Path.Combine(rootPath, "Scripts", "Project-Files", name));
+
+        foreach (string candidate in candidates)
         {
-            return pfProjectFiles;
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
         }
-        return pfScripts;
+
+        return candidates.Count > 0
+            ? candidates[0]
+            : Path.Combine(rootPath, "Scripts", name);
+    }
+
+    /// <summary>
+    /// Returns the scripts-folder probe order for the selected profile.
+    /// </summary>
+    /// <param name="scriptProfile">The selected scripts profile (Auto, VS2022, Current).</param>
+    /// <param name="msBuildPath">The detected MSBuild executable path.</param>
+    /// <returns>Ordered folder names to probe under Scripts/.</returns>
+    private static IReadOnlyList<string> GetScriptResolutionOrder(ScriptProfile scriptProfile, string msBuildPath)
+    {
+        ScriptProfile effective = GetEffectiveScriptProfile(scriptProfile, msBuildPath);
+        return effective switch
+        {
+            ScriptProfile.VS2022 => new[] { "VS2022", "Current", "Build" },
+            _                    => new[] { "Current", "VS2022", "Build" }
+        };
     }
 
     /// <summary>
@@ -180,6 +246,50 @@ internal static class BuildLogic
     }
 
     /// <summary>
+    /// Gets the next scripts profile in the scripts profile progression cycle.
+    /// </summary>
+    /// <param name="profile">The current scripts profile.</param>
+    /// <returns>The next scripts profile in the cycle (Auto → VS2022 → Current → Auto).</returns>
+    internal static ScriptProfile NextScriptProfile(ScriptProfile profile)
+    {
+        return profile switch
+        {
+            ScriptProfile.Auto    => ScriptProfile.VS2022,
+            ScriptProfile.VS2022  => ScriptProfile.Current,
+            _                     => ScriptProfile.Auto
+        };
+    }
+
+    /// <summary>
+    /// Resolves the effective scripts profile from an explicit or automatic selection.
+    /// </summary>
+    /// <param name="profile">The selected scripts profile.</param>
+    /// <param name="msBuildPath">The detected MSBuild executable path.</param>
+    /// <returns>The effective scripts profile to use for file resolution.</returns>
+    internal static ScriptProfile GetEffectiveScriptProfile(ScriptProfile profile, string msBuildPath)
+    {
+        if (profile != ScriptProfile.Auto)
+        {
+            return profile;
+        }
+
+        if (!string.IsNullOrWhiteSpace(msBuildPath))
+        {
+            if (msBuildPath.IndexOf("\\Microsoft Visual Studio\\2022\\", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return ScriptProfile.VS2022;
+            }
+
+            if (msBuildPath.IndexOf("\\Microsoft Visual Studio\\18\\", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return ScriptProfile.Current;
+            }
+        }
+
+        return ScriptProfile.Current;
+    }
+
+    /// <summary>
     /// Gets the default build configuration for the specified channel.
     /// </summary>
     /// <param name="channel">The build channel type.</param>
@@ -254,6 +364,7 @@ internal static class BuildLogic
         state.NuGetRunPushAfterMsBuild = false;
         state.NuGetRunZipAfterMsBuild = false;
         state.LastCompletedTarget = null;
+        state.EndTimeUtc = null;
         if (state.Action == BuildAction.NuGetTools)
         {
             StartNuGetTools(state);
@@ -268,6 +379,7 @@ internal static class BuildLogic
             state.SummaryReady = false;
             state.ErrorCount = 0;
             state.WarningCount = 0;
+            state.EndTimeUtc = null;
 
             var nugetTargets = new List<string>();
             switch (state.NuGetAction)
@@ -279,7 +391,7 @@ internal static class BuildLogic
                 }
                 case NuGetAction.RebuildPack:
                 {
-                    nugetTargets.Add("Rebuild");
+                    nugetTargets.Add(GetRebuildCompatibleTarget(state));
                     nugetTargets.Add(GetPackTargetForCurrent(state));
                     state.NuGetRunZipAfterMsBuild = state.NuGetCreateZip;
                     break;
@@ -301,7 +413,7 @@ internal static class BuildLogic
                 }
                 case NuGetAction.BuildPackPush:
                 {
-                    nugetTargets.Add("Rebuild");
+                    nugetTargets.Add(GetRebuildCompatibleTarget(state));
                     nugetTargets.Add(GetPackTargetForCurrent(state));
                     state.PendingTargets = new Queue<string>(nugetTargets);
                     // After MSBuild completes, run zip (optional) and then push
@@ -332,9 +444,13 @@ internal static class BuildLogic
         switch (state.Action)
         {
             case BuildAction.Build:
+            {
+                targets.Add("Build");
+                break;
+            }
             case BuildAction.Rebuild:
             {
-                targets.Add("Rebuild");
+                targets.Add(GetRebuildCompatibleTarget(state));
                 break;
             }
             case BuildAction.Pack:
@@ -344,7 +460,7 @@ internal static class BuildLogic
             }
             case BuildAction.BuildPack:
             {
-                targets.Add("Rebuild");
+                targets.Add(GetRebuildCompatibleTarget(state));
                 targets.Add(GetPackTargetForCurrent(state));
                 break;
             }
@@ -377,6 +493,7 @@ internal static class BuildLogic
         finally
         {
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             state.PendingTargets = null;
         }
     }
@@ -393,14 +510,14 @@ internal static class BuildLogic
         if (state.Action == BuildAction.Installer)
         {
             string prefix = "installer";
-            state.ProjectFile = GetInstallerProjFile(state.RootPath);
+            state.ProjectFile = GetInstallerProjFile(state);
             state.TextLogPath = Path.Combine(logs, $"{prefix}-build-summary.log");
             state.BinLogPath = Path.Combine(logs, $"{prefix}-build.binlog");
         }
         else
         {
             string prefix = state.Channel.ToString().ToLowerInvariant();
-            state.ProjectFile = GetProjFileForChannel(state.RootPath, state.Channel);
+            state.ProjectFile = GetProjFileForChannel(state, state.Channel);
             state.TextLogPath = Path.Combine(logs, $"{prefix}-build-summary.log");
             state.BinLogPath = Path.Combine(logs, $"{prefix}-build.binlog");
         }
@@ -541,6 +658,17 @@ internal static class BuildLogic
     }
 
     /// <summary>
+    /// Gets the best available clean-build target for the currently selected channel.
+    /// Nightly project files define a dedicated Rebuild target; other channels use Build.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
+    /// <returns>"Rebuild" for Nightly, otherwise "Build".</returns>
+    private static string GetRebuildCompatibleTarget(AppState state)
+    {
+        return state.Channel == ChannelType.Nightly ? "Rebuild" : "Build";
+    }
+
+    /// <summary>
     /// Starts the next build step in the pending targets queue.
     /// If no more targets are queued, marks the build as complete.
     /// </summary>
@@ -550,6 +678,7 @@ internal static class BuildLogic
         if (state.PendingTargets == null || state.PendingTargets.Count == 0)
         {
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             return;
         }
         string nextTarget = state.PendingTargets.Dequeue();
@@ -569,6 +698,7 @@ internal static class BuildLogic
         {
             state.OnOutput?.Invoke($"Project file not found: {state.ProjectFile}");
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             state.LastExitCode = 1;
             return;
         }
@@ -660,6 +790,7 @@ internal static class BuildLogic
                 catch {}
                 TryLoadSummary(state);
                 state.IsRunning = false;
+                state.EndTimeUtc = DateTime.UtcNow;
                 state.RequestRenderAll?.Invoke();
                 return;
             }
@@ -699,6 +830,7 @@ internal static class BuildLogic
                 // Only load summary once at the end of the full chain
                 TryLoadSummary(state);
                 state.IsRunning = false;
+                state.EndTimeUtc = DateTime.UtcNow;
                 state.RequestRenderAll?.Invoke();
             }
         };
@@ -707,6 +839,7 @@ internal static class BuildLogic
         {
             state.StartTimeUtc = DateTime.UtcNow;
         }
+        state.EndTimeUtc = null;
         state.IsRunning = true;
         state.Process.Start();
         state.Process.BeginOutputReadLine();
@@ -769,6 +902,7 @@ internal static class BuildLogic
         }
         state.IsRunning = true;
         state.StartTimeUtc = DateTime.UtcNow;
+        state.EndTimeUtc = null;
         state.Tail.Clear();
         state.SummaryReady = false;
         state.ErrorCount = 0;
@@ -801,6 +935,7 @@ internal static class BuildLogic
             DelDir("Logs");
             state.LastExitCode = 0;
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             state.SummaryLines = new[] { "Clean completed." };
             state.SummaryReady = true;
             state.OnOutput?.Invoke("Clean complete.");
@@ -866,12 +1001,14 @@ internal static class BuildLogic
         {
             state.LastExitCode = state.Process?.ExitCode ?? -1;
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             state.SummaryLines = new[] { $"NuGet tools exited with code {state.LastExitCode}." };
             state.SummaryReady = true;
         };
 
         state.IsRunning = true;
         state.StartTimeUtc = DateTime.UtcNow;
+        state.EndTimeUtc = null;
         state.Process.Start();
         state.Process.BeginOutputReadLine();
         state.Process.BeginErrorReadLine();
@@ -1086,6 +1223,7 @@ internal static class BuildLogic
         if (state.NuGetPushQueue == null || state.NuGetPushQueue.Count == 0)
         {
             state.IsRunning = false;
+            state.EndTimeUtc = DateTime.UtcNow;
             state.LastExitCode = 0;
             state.SummaryLines = new[] { "NuGet push completed." };
             state.SummaryReady = true;
@@ -1153,6 +1291,7 @@ internal static class BuildLogic
                 state.OnOutput?.Invoke($"[red]nuget.exe exited with code {code} for {Path.GetFileName(pkg)}[/]");
                 state.LastExitCode = code;
                 state.IsRunning = false;
+                state.EndTimeUtc = DateTime.UtcNow;
                 state.SummaryLines = new[] { $"NuGet push failed for {Path.GetFileName(pkg)} (code {code})." };
                 state.SummaryReady = true;
                 state.RequestRenderAll?.Invoke();
@@ -1164,6 +1303,7 @@ internal static class BuildLogic
         {
             state.StartTimeUtc = DateTime.UtcNow;
         }
+        state.EndTimeUtc = null;
         state.IsRunning = true;
         state.Process.Start();
         state.Process.BeginOutputReadLine();
@@ -1273,18 +1413,12 @@ internal static class BuildLogic
 
     /// <summary>
     /// Gets the path to the installer project file.
-    /// Searches in both Scripts and Scripts/Project-Files directories for installer.proj.
+    /// Searches known script-layout directories for installer.proj.
     /// </summary>
-    /// <param name="rootPath">The root path of the repository.</param>
+    /// <param name="state">The current application state.</param>
     /// <returns>The path to the installer project file.</returns>
-    private static string GetInstallerProjFile(string rootPath)
+    private static string GetInstallerProjFile(AppState state)
     {
-        string scripts = Path.Combine(rootPath, "Scripts", "installer.proj");
-        if (File.Exists(scripts))
-        {
-            return scripts;
-        }
-        string projectFiles = Path.Combine(rootPath, "Scripts", "Project-Files", "installer.proj");
-        return projectFiles;
+        return ResolveProjectFile(state.RootPath, "installer.proj", state.ScriptProfile, state.MsBuildPath);
     }
 }

--- a/Scripts/ModernBuild/General/BuildUI.cs
+++ b/Scripts/ModernBuild/General/BuildUI.cs
@@ -17,7 +17,7 @@ public static class BuildUI
     /// <summary>
     /// The fixed width for the tasks area panel in the UI layout.
     /// </summary>
-    private static readonly byte TASKS_AREA_WIDTH = 40;
+    private static readonly byte TASKS_AREA_WIDTH = 46;
 
     /// <summary>
     /// Creates and configures the main UI for the Modern Build tool.
@@ -114,6 +114,7 @@ public static class BuildUI
         {
             state.Channel = BuildLogic.NextChannel(state.Channel);
             state.Configuration = state.Channel == ChannelType.Nightly ? "Debug" : BuildLogic.DefaultConfig(state.Channel);
+            NormalizeOpsActionForChannel(state);
             state.RequestRenderAll?.Invoke();
         });
         var tx1 = MakeText(0);
@@ -126,7 +127,7 @@ public static class BuildUI
             }
             else
             {
-                state.Action = NextOpsAction(state.Action);
+                state.Action = NextOpsAction(state);
             }
             state.RequestRenderAll?.Invoke();
         });
@@ -146,6 +147,7 @@ public static class BuildUI
             {
                 state.Action = BuildAction.Build;
             }
+            NormalizeOpsActionForChannel(state);
             if (state.TasksPage == TasksPage.NuGet)
             {
                 state.Configuration = "Release";
@@ -210,7 +212,7 @@ public static class BuildUI
 
         var hk9 = MakeHK("F9", 8, () =>
         {
-            state.PackMode = BuildLogic.NextPackMode(state.PackMode);
+            ApplyF9Action(state);
             state.RequestRenderAll?.Invoke();
         });
         var tx9 = MakeText(8);
@@ -488,6 +490,7 @@ public static class BuildUI
                 {
                     state.Channel = BuildLogic.NextChannel(state.Channel);
                     state.Configuration = state.Channel == ChannelType.Nightly ? "Debug" : BuildLogic.DefaultConfig(state.Channel);
+                    NormalizeOpsActionForChannel(state);
                     RenderAll(state, ui);
                     break;
                 }
@@ -499,7 +502,7 @@ public static class BuildUI
                     }
                     else
                     {
-                        state.Action = NextOpsAction(state.Action);
+                        state.Action = NextOpsAction(state);
                     }
                     RenderAll(state, ui);
                     break;
@@ -517,6 +520,7 @@ public static class BuildUI
                     {
                         state.Action = BuildAction.Build;
                     }
+                    NormalizeOpsActionForChannel(state);
                     if (state.TasksPage == TasksPage.NuGet)
                     {
                         state.Configuration = "Release";
@@ -583,7 +587,7 @@ public static class BuildUI
                 }
                 case KeyCode.F9:
                 {
-                    state.PackMode = BuildLogic.NextPackMode(state.PackMode);
+                    ApplyF9Action(state);
                     RenderAll(state, ui);
                     break;
                 }
@@ -773,6 +777,7 @@ public static class BuildUI
     /// <param name="ui">The UI context containing references to all UI components.</param>
     private static void RenderAll(AppState state, UIContext ui)
     {
+        NormalizeOpsActionForChannel(state);
         BuildLogic.EnsurePaths(state);
         RenderStatus(state, ui);
         RenderTasks(state, ui);
@@ -784,14 +789,20 @@ public static class BuildUI
     /// Gets the next build action in the Ops page cycle, excluding NuGet-specific actions.
     /// Provides a simplified cycle for the Ops page that skips NuGetTools and Installer actions.
     /// </summary>
-    /// <param name="action">The current build action.</param>
-    /// <returns>The next build action in the Ops cycle (Build → Rebuild → Pack → BuildPack → Debug → Build).</returns>
-    private static BuildAction NextOpsAction(BuildAction action)
+    /// <param name="state">The current application state.</param>
+    /// <returns>
+    /// The next build action in the Ops cycle.
+    /// Nightly: Build → Rebuild → Pack → BuildPack → Debug → Build.
+    /// Other channels: Build → Pack → BuildPack → Debug → Build.
+    /// </returns>
+    private static BuildAction NextOpsAction(AppState state)
     {
-        // Same cycle as BuildLogic.NextAction but skipping NuGetTools
-        return action switch
+        bool allowRebuild = SupportsRebuildForChannel(state.Channel);
+
+        // Ops action cycle excludes NuGet-specific actions and adapts when Rebuild isn't supported.
+        return state.Action switch
         {
-            BuildAction.Build       => BuildAction.Rebuild,
+            BuildAction.Build       => allowRebuild ? BuildAction.Rebuild : BuildAction.Pack,
             BuildAction.Rebuild     => BuildAction.Pack,
             BuildAction.Pack        => BuildAction.BuildPack,
             BuildAction.BuildPack   => BuildAction.Debug,
@@ -800,6 +811,72 @@ public static class BuildUI
             BuildAction.Installer   => BuildAction.Build, // sanitize if ever present
             _                       => BuildAction.Build
         };
+    }
+
+    /// <summary>
+    /// Returns whether the selected channel supports a dedicated Rebuild target.
+    /// </summary>
+    /// <param name="channel">The selected build channel.</param>
+    /// <returns>True for Nightly; otherwise false.</returns>
+    private static bool SupportsRebuildForChannel(ChannelType channel)
+    {
+        return channel == ChannelType.Nightly;
+    }
+
+    /// <summary>
+    /// Normalizes the Ops action when switching away from a channel that supports Rebuild.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
+    private static void NormalizeOpsActionForChannel(AppState state)
+    {
+        if (!SupportsRebuildForChannel(state.Channel) && state.Action == BuildAction.Rebuild)
+        {
+            state.Action = BuildAction.Build;
+        }
+    }
+
+    /// <summary>
+    /// Applies the F9 action based on the current page and action context.
+    /// In Stable Pack/BuildPack Ops context F9 cycles PackMode, otherwise it cycles Scripts profile.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
+    private static void ApplyF9Action(AppState state)
+    {
+        if (IsPackModeContext(state))
+        {
+            state.PackMode = BuildLogic.NextPackMode(state.PackMode);
+            return;
+        }
+
+        state.ScriptProfile = BuildLogic.NextScriptProfile(state.ScriptProfile);
+    }
+
+    /// <summary>
+    /// Determines whether F9 should cycle PackMode for the current state.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
+    /// <returns>True when PackMode should be cycled; otherwise false.</returns>
+    private static bool IsPackModeContext(AppState state)
+    {
+        return state.TasksPage == TasksPage.Ops &&
+               state.Channel == ChannelType.Stable &&
+               (state.Action == BuildAction.Pack || state.Action == BuildAction.BuildPack);
+    }
+
+    /// <summary>
+    /// Formats the scripts profile text for display in the UI.
+    /// </summary>
+    /// <param name="state">The current application state.</param>
+    /// <returns>A formatted scripts profile string, including effective profile for Auto mode.</returns>
+    private static string FormatScriptProfile(AppState state)
+    {
+        ScriptProfile effective = BuildLogic.GetEffectiveScriptProfile(state.ScriptProfile, state.MsBuildPath);
+        if (state.ScriptProfile == ScriptProfile.Auto)
+        {
+            return $"Auto ({effective})";
+        }
+
+        return state.ScriptProfile.ToString();
     }
 
     /// <summary>
@@ -824,16 +901,18 @@ public static class BuildUI
     /// Formats a NuGet action enum value into a user-friendly display string.
     /// Converts enum values to readable descriptions for UI display.
     /// </summary>
+    /// <param name="state">The current application state.</param>
     /// <param name="action">The NuGet action to format.</param>
     /// <returns>A formatted string representation of the NuGet action.</returns>
-    private static string FormatNuGetAction(NuGetAction action)
+    private static string FormatNuGetAction(AppState state, NuGetAction action)
     {
+        bool allowRebuild = SupportsRebuildForChannel(state.Channel);
         return action switch
         {
-            NuGetAction.RebuildPack     => "Rebuild+Pack",
+            NuGetAction.RebuildPack     => allowRebuild ? "Rebuild+Pack" : "Build+Pack",
             NuGetAction.Push            => "Push",
             NuGetAction.PackPush        => "Pack+Push",
-            NuGetAction.BuildPackPush   => "Rebuild+Pack+Push",
+            NuGetAction.BuildPackPush   => allowRebuild ? "Rebuild+Pack+Push" : "Build+Pack+Push",
             NuGetAction.Tools           => "Update NuGet",
             _                           => action.ToString()
         };
@@ -888,7 +967,19 @@ public static class BuildUI
         {
             st = "FAILED";
         }
-        TimeSpan? elapsed = state.IsRunning && state.StartTimeUtc.HasValue ? DateTime.UtcNow - state.StartTimeUtc.Value : (TimeSpan?)null;
+        TimeSpan? elapsed = null;
+        if (state.StartTimeUtc.HasValue)
+        {
+            DateTime? endTimeUtc = state.IsRunning ? DateTime.UtcNow : state.EndTimeUtc;
+            if (endTimeUtc.HasValue)
+            {
+                elapsed = endTimeUtc.Value - state.StartTimeUtc.Value;
+                if (elapsed.Value < TimeSpan.Zero)
+                {
+                    elapsed = TimeSpan.Zero;
+                }
+            }
+        }
         string elapsedText = elapsed.HasValue ? elapsed.Value.ToString("hh\\:mm\\:ss") : "--:--:--";
         if (ui.SummaryFrame != null)
         {
@@ -911,8 +1002,9 @@ public static class BuildUI
     {
         if (state.TasksPage == TasksPage.Ops)
         {
+            NormalizeOpsActionForChannel(state);
             ChannelType nextChannel = BuildLogic.NextChannel(state.Channel);
-            BuildAction nextAction = NextOpsAction(state.Action);
+            BuildAction nextAction = NextOpsAction(state);
             string FormatAction(BuildAction a)
             {
                 return a == BuildAction.Installer ? "Installer" : a.ToString();
@@ -969,8 +1061,7 @@ public static class BuildUI
             {
                 ui.CreateZip.Visible = false;
             }
-            bool showF9 = (state.Channel == ChannelType.Stable) &&
-                          (state.Action == BuildAction.Pack || state.Action == BuildAction.BuildPack);
+            bool showF9 = IsPackModeContext(state);
             if (showF9)
             {
                 PackMode nextPack = BuildLogic.NextPackMode(state.PackMode);
@@ -981,7 +1072,8 @@ public static class BuildUI
             }
             else
             {
-                if (ui.Tx9 != null) { ui.Tx9.Text = "PackMode  (Stable only)"; }
+                ScriptProfile nextProfile = BuildLogic.NextScriptProfile(state.ScriptProfile);
+                if (ui.Tx9 != null) { ui.Tx9.Text = $"Scripts   {FormatScriptProfile(state)} (next: {nextProfile})"; }
             }
             if (ui.TestBtn != null)
             {
@@ -991,7 +1083,9 @@ public static class BuildUI
             if (ui.TxTest != null) { ui.TxTest.Visible = false; ui.TxTest.Text = string.Empty; }
             if (ui.Hint != null)
             {
-                ui.Hint.Text = "F-keys cycle options.\nF5 toggles Run/Stop.";
+                ui.Hint.Text = showF9
+                    ? "F-keys cycle options.\nF9 cycles PackMode.\nF5 toggles Run/Stop."
+                    : "F-keys cycle options.\nF9 cycles Scripts profile.\nF5 toggles Run/Stop.";
             }
         }
         else
@@ -1013,7 +1107,7 @@ public static class BuildUI
             }
             if (ui.Tx2 != null)
             {
-                ui.Tx2.Text = $"Action    {FormatNuGetAction(state.NuGetAction)}";
+                ui.Tx2.Text = $"Action    {FormatNuGetAction(state, state.NuGetAction)}";
             }
             if (ui.Tx3 != null)
             {
@@ -1053,14 +1147,15 @@ public static class BuildUI
             }
 
             if (ui.TxTest != null) { ui.TxTest.Visible = true; ui.TxTest.Text = "Test      Preview commands"; }
-            if (ui.Tx9 != null) { ui.Tx9.Text = "PackMode  (Stable only)"; }
+            ScriptProfile nextProfile = BuildLogic.NextScriptProfile(state.ScriptProfile);
+            if (ui.Tx9 != null) { ui.Tx9.Text = $"Scripts   {FormatScriptProfile(state)} (next: {nextProfile})"; }
             if (ui.TxEsc != null)
             {
                 ui.TxEsc.Text = "Exit      Exit application";
             }
             if (ui.Hint != null)
             {
-                ui.Hint.Text = "NuGet page:\nF2 cycles NuGet actions.\nF5 runs the selected action(s).";
+                ui.Hint.Text = "NuGet page:\nF2 cycles NuGet actions.\nF9 cycles Scripts profile.";
             }
         }
     }
@@ -1132,6 +1227,7 @@ public static class BuildUI
         }
 
         AddKV("Project", TrimScriptsPath(state.ProjectFile));
+        AddKV("Scripts", FormatScriptProfile(state));
         AddKV("MSBuild", state.MsBuildPath);
 
         AddKV("Text Log", TrimLogsPath(Path.Combine(state.RootPath, "Logs", prefix + "-build-summary.log")));

--- a/Scripts/ModernBuild/General/Definitions.cs
+++ b/Scripts/ModernBuild/General/Definitions.cs
@@ -150,6 +150,28 @@ public enum TasksPage
 }
 
 /// <summary>
+/// Defines which scripts folder variant the Modern Build tool should target.
+/// This allows explicit distinction between VS2022 and Current script sets.
+/// </summary>
+public enum ScriptProfile
+{
+    /// <summary>
+    /// Automatically choose the best scripts folder based on the detected MSBuild path.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Force use of the Scripts/VS2022 project files.
+    /// </summary>
+    VS2022,
+
+    /// <summary>
+    /// Force use of the Scripts/Current project files.
+    /// </summary>
+    Current
+}
+
+/// <summary>
 /// Defines the different NuGet-specific actions available in the NuGet page.
 /// Each action represents a specific NuGet operation or combination of operations.
 /// </summary>

--- a/Scripts/ModernBuild/README.md
+++ b/Scripts/ModernBuild/README.md
@@ -16,11 +16,11 @@ It uses `Terminal.Gui` for the UI and drives `MSBuild.exe` and `nuget.exe` under
   - Download from `https://dist.nuget.org/win-x86-commandline/latest/nuget.exe` and place it in a folder on PATH, or in the repo’s `Scripts/` folder.
 
 ### Repository layout ModernBuild expects
-- Project files:
-  - `Scripts/nightly.proj` or `Scripts/Project-Files/nightly.proj`
-  - `Scripts/canary.proj` or `Scripts/Project-Files/canary.proj`
-  - `Scripts/build.proj` (used for Stable) or `Scripts/Project-Files/build.proj`
-  - `Scripts/installer.proj` or `Scripts/Project-Files/installer.proj` (not exposed via Ops page)
+- Project files are resolved from the selected scripts profile:
+  - `Scripts/VS2022/`
+  - `Scripts/Current/`
+  - `Scripts/Build/`
+  - legacy fallbacks: `Scripts/` and `Scripts/Project-Files/`
 - Logs are written to `Logs/`
 - Packages are produced into `Bin/Release/`
 
@@ -49,6 +49,7 @@ Tip: Run ModernBuild from the repository root so it can auto-detect the correct 
 ### Global controls
 - F4: switch between Ops and NuGet pages
 - F5: start/stop the current action
+- F9: cycles scripts profile, except Stable Pack/BuildPack where it cycles PackMode
 - ESC or F10: exit
 - Auto-Scroll checkbox: toggles following live output
 
@@ -56,25 +57,28 @@ Tip: Run ModernBuild from the repository root so it can auto-detect the correct 
 - F1 Channel: cycles Nightly → Canary → Stable
   - When Nightly is selected, the configuration defaults to Debug
   - For other channels, default configuration is the channel-appropriate one (e.g., Canary) or Release
-- F2 Action: cycles Build → Rebuild → Pack → BuildPack → Debug
-  - Build/Rebuild: runs `Rebuild`
+- F2 Action:
+  - Nightly cycles Build → Rebuild → Pack → BuildPack → Debug
+  - Canary/Stable cycles Build → Pack → BuildPack → Debug
+  - Build runs `Build`
+  - Rebuild runs `Rebuild` for Nightly only
   - Pack: runs channel-appropriate `Pack`
-  - BuildPack: runs `Rebuild` then `Pack`
+  - BuildPack: runs `Rebuild` then `Pack` for Nightly, otherwise `Build` then `Pack`
   - Debug: runs a clean, switches to Nightly, then executes `Rebuild`
 - F3 Config: toggles Release/Debug (Nightly may auto-switch to Debug)
 - F6 Tail: cycles live-output buffer size 200 → 500 → 1000 lines
 - F7 Clean: deletes `Bin/`, component `obj/`, and `Logs/`
 - F8 Clear: clears the live output and resets horizontal scroll
-- F9 PackMode: only visible on Stable when Action is Pack or BuildPack; cycles Pack → PackLite → PackAll
+- F9 Scripts: cycles Auto → VS2022 → Current, except Stable Pack/BuildPack where it cycles Pack → PackLite → PackAll
 
 ### NuGet page (packaging and publishing)
 - Configuration is set to Release when entering the NuGet page
 - F1 Channel: still available (affects which `.proj` may be used for pack steps)
 - F2 Action: cycles
-  - Rebuild+Pack: `Rebuild` then `Pack`
+  - Rebuild+Pack: `Rebuild` then `Pack` for Nightly, otherwise `Build` then `Pack`
   - Push: push existing packages only
   - Pack+Push: `Pack` then push
-  - Rebuild+Pack+Push: `Rebuild`, `Pack`, then push
+  - Rebuild+Pack+Push: `Rebuild`, `Pack`, then push for Nightly, otherwise `Build`, `Pack`, then push
   - Update NuGet: runs `nuget.exe update -Self -NonInteractive`
 - F3 Config: toggles Release/Debug (normally keep Release for publishing)
 - F5 Run/Stop: executes the selected action(s)
@@ -101,10 +105,17 @@ Tip: Run ModernBuild from the repository root so it can auto-detect the correct 
   - When focused, TextView handles its own navigation
 
 ### How ModernBuild chooses the project file
-- Nightly channel → `Scripts/nightly.proj` (or `Scripts/Project-Files/nightly.proj`)
-- Canary channel → `Scripts/canary.proj` (or `Scripts/Project-Files/canary.proj`)
-- Stable channel → `Scripts/build.proj` (or `Scripts/Project-Files/build.proj`)
-- Installer (not exposed on Ops page) → `Scripts/installer.proj` (or `Scripts/Project-Files/installer.proj`)
+- Nightly channel → `nightly.proj`
+- Canary channel → `canary.proj`
+- Stable channel → `build.proj`
+- Installer (not exposed on Ops page) → `installer.proj`
+
+The Auto scripts profile chooses `VS2022` when MSBuild is detected under Visual Studio 2022, `Current` when MSBuild is detected under Visual Studio 18 (VS 2026), and otherwise defaults to `Current`.
+
+The effective profile controls the search order:
+- VS2022: `Scripts/VS2022/`, then `Scripts/Current/`, then `Scripts/Build/`
+- Current: `Scripts/Current/`, then `Scripts/VS2022/`, then `Scripts/Build/`
+- Both profiles then fall back to `Scripts/` and `Scripts/Project-Files/`
 
 ### Troubleshooting
 - "Could not find MSBuild.exe"
@@ -112,7 +123,7 @@ Tip: Run ModernBuild from the repository root so it can auto-detect the correct 
 - `nuget.exe` not found
   - Put `nuget.exe` on PATH or in the repo’s `Scripts/` folder
 - "Project file not found: ..."
-  - Verify the channel project files exist in `Scripts/` or `Scripts/Project-Files/`
+  - Verify the channel project files exist in the selected scripts profile folder or fallback locations
 - Build succeeds with no observable work
   - ModernBuild will note this in output; verify your Configuration and the `.proj` target frameworks so targets aren’t skipped
 - No packages found to push


### PR DESCRIPTION
Followup PR for #3090 but for V105-LTS

Update ModernBuild to match the current repository build layout and prevent invalid build/action combinations.

The repo now has toolset-specific script folders (Scripts/VS2022 and Scripts/Current). ModernBuild now supports that structure directly by adding a Scripts profile (Auto, VS2022, Current), resolving project files using the selected/effective profile, and showing the active profile in the UI. In Auto mode, the effective profile is inferred from the detected MSBuild path.

It also fixes action validity and execution behavior: Canary/Stable no longer allow invalid Rebuild selection in Ops, rebuild-like workflows on channels without a Rebuild target use Build, and Build now actually runs MSBuild Build (instead of Rebuild). The left sidebar width was increased to avoid truncating the F9 row, and Scripts/ModernBuild/README.md was fully revised to document the new behavior, controls, and resolution rules.