### PR TITLE
* Fix VSIX manifest encoding for templates release (VSSDK1048)

### DIFF
--- a/.github/workflows/templates-release.yml
+++ b/.github/workflows/templates-release.yml
@@ -172,9 +172,11 @@ jobs:
           if (-not (Test-Path $manifestPath)) { throw "Missing VSIX manifest: $manifestPath" }
 
           $vsixVersion = '${{ steps.channel.outputs.vsix_version }}'
-          $manifest = Get-Content -Path $manifestPath -Raw
-          $manifest = $manifest -replace 'Version="[^"]+"', "Version=`"$vsixVersion`""
-          Set-Content -Path $manifestPath -Value $manifest -NoNewline
+          $manifest = Get-Content -Path $manifestPath -Raw -Encoding utf8
+          $manifest = $manifest.TrimStart([char]0xFEFF)
+          $manifest = $manifest -replace '(<Identity Id="Krypton\.Suite\.StandardToolkit\.Templates" Version=")[^"]*"', "`${1}$vsixVersion`""
+          $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+          [System.IO.File]::WriteAllText($manifestPath, $manifest, $utf8NoBom)
 
           dotnet restore $vsixProj
           dotnet msbuild $vsixProj `

--- a/Templates/.editorconfig
+++ b/Templates/.editorconfig
@@ -1,0 +1,3 @@
+# VSIX manifests must be UTF-8 without BOM (VSSDK1048 if a BOM precedes <?xml).
+[*.vsixmanifest]
+charset = utf-8

--- a/Templates/Vsix/Krypton.Templates.Vsix/source.extension.vsixmanifest
+++ b/Templates/Vsix/Krypton.Templates.Vsix/source.extension.vsixmanifest
@@ -1,32 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="Krypton.Suite.StandardToolkit.Templates" Version="110.0.0.0" Language="en-US" Publisher="Krypton Suite" />
-    <DisplayName>Krypton Templates</DisplayName>
-    <Description xml:space="preserve">Visual Studio item and project templates for the Krypton Standard Toolkit (Krypton Form, Krypton Ribbon Form, Krypton WinForms App, Krypton Ribbon WinForms App).</Description>
-    <Tags>Krypton, WinForms, Templates</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonForm" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonRibbonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonRibbonForm" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" />
-  </Assets>
-</PackageManifest>
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Krypton.Suite.StandardToolkit.Templates" Version="110.0.0.0" Language="en-US" Publisher="Krypton Suite" />
+    <DisplayName>Krypton Templates</DisplayName>
+    <Description xml:space="preserve">Visual Studio item and project templates for the Krypton Standard Toolkit (Krypton Form, Krypton Ribbon Form, Krypton WinForms App, Krypton Ribbon WinForms App).</Description>
+    <Tags>Krypton, WinForms, Templates</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonForm" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonRibbonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonRibbonForm" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" />
+  </Assets>
+</PackageManifest>


### PR DESCRIPTION
# Fix VSIX manifest encoding for templates release (VSSDK1048)

## Summary

- Resolves **VSSDK1048** during the **Visual Studio Templates Release** workflow: `source.extension.vsixmanifest` must be UTF-8 **without** a BOM so the XML declaration at line 1 is valid for VSSDK.
- Updates CI to write the manifest with `UTF8Encoding($false)` instead of `Set-Content`, which could reintroduce a BOM on each release run.
- Narrows the release-time version substitution to the `<Identity … Version="…">` element only (the previous regex replaced every `Version="…"` attribute, including installation targets and prerequisites).

## Problem

The templates release job failed while building the VSIX package:

```text
VSSDK1048: Error trying to read the VSIX manifest file "source.extension.vsixmanifest".
Syntax for an XML declaration is invalid. Line 1, position
```

A UTF-8 BOM (or a leading `U+FEFF` character) before `<?xml` causes VSSDK’s XML parser to reject the declaration. The workflow also rewrote the manifest before `dotnet msbuild`, which could worsen encoding issues and had been overwriting unrelated `Version` attributes.

## Changes

| File | Change |
|------|--------|
| `Templates/Vsix/Krypton.Templates.Vsix/source.extension.vsixmanifest` | Saved as UTF-8 without BOM (file begins with `<?xml`). | | `.github/workflows/templates-release.yml` | Read UTF-8, strip BOM if present, update Identity version only, write with `[System.IO.File]::WriteAllText` and `UTF8Encoding($false)`. | | `Templates/.editorconfig` | `charset = utf-8` for `*.vsixmanifest` so editors do not save with a signature. |

## Test plan

- [ ] Confirm `source.extension.vsixmanifest` has no BOM (first bytes should be `60, 63, 120` — `<?x`).
- [ ] Locally (optional): `dotnet msbuild Templates\Vsix\Krypton.Templates.Vsix\Krypton.Templates.Vsix.csproj /p:Configuration=Release /p:DeployExtension=false`
- [ ] Push to a branch that triggers **Visual Studio Templates Release** (or run `workflow_dispatch`) and verify the **Build template VSIX package** step succeeds.
- [ ] Confirm the published `.vsix` installs in Visual Studio 2022 and templates appear under **Add New Item** / **New Project**.

## Related

- Branch: `3517-feature-request-add-visx-package-for-itemproject-templates`
- Relates to #3517 (Krypton item/project template VSIX)