### PR TITLE
* Add Krypton Visual Studio template VSIX (#3517)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,9 @@
 ###############################################################################
 * text=auto
 
+# VSIX manifest: UTF-8 without BOM, LF (VSSDK; avoid CRLF churn in PRs).
+*.vsixmanifest text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/Templates/.editorconfig
+++ b/Templates/.editorconfig
@@ -1,3 +1,4 @@
 # VSIX manifests must be UTF-8 without BOM (VSSDK1048 if a BOM precedes <?xml).
 [*.vsixmanifest]
 charset = utf-8
+end_of_line = lf

--- a/Templates/Vsix/Krypton.Templates.Vsix/source.extension.vsixmanifest
+++ b/Templates/Vsix/Krypton.Templates.Vsix/source.extension.vsixmanifest
@@ -1,32 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="Krypton.Suite.StandardToolkit.Templates" Version="110.0.0.0" Language="en-US" Publisher="Krypton Suite" />
-    <DisplayName>Krypton Templates</DisplayName>
-    <Description xml:space="preserve">Visual Studio item and project templates for the Krypton Standard Toolkit (Krypton Form, Krypton Ribbon Form, Krypton WinForms App, Krypton Ribbon WinForms App).</Description>
-    <Tags>Krypton, WinForms, Templates</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0,19.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonForm" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonRibbonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonRibbonForm" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" />
-  </Assets>
-</PackageManifest>
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Krypton.Suite.StandardToolkit.Templates" Version="110.0.0.0" Language="en-US" Publisher="Krypton Suite" />
+    <DisplayName>Krypton Templates</DisplayName>
+    <Description xml:space="preserve">Visual Studio item and project templates for the Krypton Standard Toolkit (Krypton Form, Krypton Ribbon Form, Krypton WinForms App, Krypton Ribbon WinForms App).</Description>
+    <Tags>Krypton, WinForms, Templates</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.0,19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonForm" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates\CSharp\1033\KryptonRibbonForm" d:TargetPath="ItemTemplates\CSharp\1033\KryptonRibbonForm" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonWinFormsApp" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" d:TargetPath="ProjectTemplates\CSharp\1033\KryptonRibbonWinFormsApp" />
+  </Assets>
+</PackageManifest>


### PR DESCRIPTION
# Add Krypton Visual Studio template VSIX (#3517)

## Summary

- Adds a **VSIX** under `Templates/Vsix/Krypton.Templates.Vsix` that packages Krypton item and project templates (Krypton Form, Krypton Ribbon Form, Krypton WinForms App, Krypton Ribbon WinForms App) for Visual Studio 2022.
- Fixes **VSSDK1048** in the **Visual Studio Templates Release** workflow so CI can build and publish the `.vsix` reliably.
- Keeps `source.extension.vsixmanifest` as **UTF-8 without BOM** and **LF** line endings to satisfy VSSDK and avoid noisy full-file diffs (`^M` / CRLF churn).

## Problem

The templates release job failed at the VSIX build step:

```text
VSSDK1048: Error trying to read the VSIX manifest file "source.extension.vsixmanifest".
Syntax for an XML declaration is invalid. Line 1, position
```

Contributing factors:

1. **CI rewrite** — `Set-Content` could write UTF-8 **with** a BOM before `dotnet msbuild`, which invalidates the XML declaration for VSSDK.
2. **Over-broad version replace** — The workflow regex replaced every `Version="…"` attribute (installation targets, dependencies, prerequisites), not only `<Identity … Version="…">`.
3. **Line endings** — An intermediate fix normalized the manifest to CRLF, making the PR diff show every line as changed (`^M` in some viewers) even though the XML content was unchanged.

## Solution

| Area | Change |
|------|--------|
| **VSIX project** | `Templates/Vsix/Krypton.Templates.Vsix/` — manifest, SDK references, template assets linked from `Templates/ItemTemplates` and `Templates/ProjectTemplates`. | | **CI** (`.github/workflows/templates-release.yml`) | Read UTF-8, strip leading `U+FEFF`, update **Identity** version only, write with `[System.IO.File]::WriteAllText` and `UTF8Encoding($false)`. | | **Encoding** (`Templates/.editorconfig`) | `charset = utf-8`, `end_of_line = lf` for `*.vsixmanifest`. | | **Git** (`.gitattributes`) | `*.vsixmanifest text eol=lf` so Git does not convert the manifest to CRLF on Windows. | | **Manifest** | Restored to LF / UTF-8 without BOM (matches original content; no spurious line-ending diff). |

## Commits (branch)

1. `* Add VSIX package for Krypton Visual Studio templates`
2. `* Fix VSIX manifest encoding for templates release (VSSDK1048)`
3. *(pending)* Normalize VSIX manifest line endings (LF, `.gitattributes`, `.editorconfig`) — staged locally

## Test plan

- [ ] Confirm manifest bytes: starts with `3C 3F 78` (`<?x`), no `EF BB BF` BOM, LF line endings.
- [ ] Local build (optional): ```cmd dotnet msbuild Templates\Vsix\Krypton.Templates.Vsix\Krypton.Templates.Vsix.csproj /p:Configuration=Release /p:DeployExtension=false ```
- [ ] Push / `workflow_dispatch` **Visual Studio Templates Release** — **Build template VSIX package** succeeds.
- [ ] Install published `krypton-templates-*.vsix` in VS 2022; verify templates under **Add New Item** and **New Project**.
- [ ] PR diff: manifest should not show a full-file line-ending-only change after the normalization commit.

## Related

- Closes / relates to #3517
- Branch: `3517-feature-request-add-visx-package-for-itemproject-templates`