### PR TITLE
* Fix CI build failure: ensure shared output directory exists before …

### DIFF
--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -14,6 +14,11 @@
 		<UseCommonOutputDirectory>true</UseCommonOutputDirectory>
 	</PropertyGroup>
 
+	<!-- Rebuild/Clean removes shared Bin\<Configuration>\<tfm>\ folders; GenerateDepsFile runs before compile recreates them. -->
+	<Target Name="EnsureOutputDirectoryExists" BeforeTargets="GenerateBuildDependencyFile" Condition="'$(TargetFramework)' != ''">
+		<MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
+	</Target>
+
 	<!-- Outer cross-targeting build: default BuildInParallel=true dispatches inner TFMs concurrently. With custom
 	     OutputPath/IntermediateOutputPath, concurrent inner builds can still mis-resolve or overwrite outputs in
 	     practice (CS1705: referenced assembly built for a higher TFM). Serialize inner TFMs per project. -->


### PR DESCRIPTION
…GenerateDepsFile

# Fix CI build failure: ensure shared output directory exists before GenerateDepsFile

## Summary

- Fixes `DirectoryNotFoundException` during `GenerateDepsFile` when CI builds modern target frameworks (`net9.0-windows`, `net10.0-windows`, `net11.0-windows`).
- Adds a shared MSBuild target in `Directory.Build.targets` so all Krypton component projects create `$(OutputPath)` before `GenerateBuildDependencyFile` runs.
- Resolves [#3493](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3493).

## Problem

The **Build** workflow fails on `Rebuild` with errors similar to:

```text
System.IO.DirectoryNotFoundException: Could not find a part of the path
'D:\a\Standard-Toolkit\Standard-Toolkit\Bin\Release\net9.0-windows'
```

The failure occurs in the `GenerateDepsFile` task (via `GenerateBuildDependencyFile`) for multiple modern TFMs.

### Root cause

Krypton component projects use a **shared per-TFM output directory** (`UseCommonOutputDirectory=true`) under:

- `Bin\<Configuration>\<TargetFramework>\` (legacy), or
- `artifacts\bin\<Configuration>\<TargetFramework>\` when `UseArtifactsOutput=true` (CI).

CI invokes `msbuild ... nightly.proj /t:Rebuild`, which runs **Clean** before **Build**. Clean removes those shared folders. On the subsequent build, `GenerateDepsFile` can run **before** compile/copy recreates the output directory, so writing `*.deps.json` fails.

## Solution

Add `EnsureOutputDirectoryExists` to `Source/Krypton Components/Directory.Build.targets`:

```xml
<Target Name="EnsureOutputDirectoryExists" BeforeTargets="GenerateBuildDependencyFile" Condition="'$(TargetFramework)' != ''">
  <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
</Target>
```

This target:

- Runs only for inner (per-TFM) builds, not the outer cross-targeting project.
- Uses the same `$(OutputPath)` already set from `$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\`.
- Applies to **all** projects under `Source/Krypton Components/`, not only `Krypton.Toolkit`.

Placing the fix in `Directory.Build.targets` avoids duplicating the target across individual `.csproj` files and keeps behavior aligned with the shared output layout.

## Files changed

| File | Change |
|------|--------|
| `Source/Krypton Components/Directory.Build.targets` | Add `EnsureOutputDirectoryExists` MSBuild target |

## Test plan

- [ ] Local rebuild of a single modern TFM: ```cmd cd Source\Krypton Components\Krypton.Toolkit dotnet build "Krypton.Toolkit 2022.csproj" -c Release -f net9.0-windows -p:TFMs=all -t:Rebuild ```
- [ ] Local orchestrated rebuild (matches CI `Rebuild` path): ```cmd msbuild /m Scripts\Build\nightly.proj /t:Rebuild /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true ```
- [ ] Confirm **Build** workflow passes on a PR (all TFMs including `net9.0-windows`, `net10.0-windows`, `net11.0-windows`).
- [ ] Confirm `Bin\Release\<tfm>\` or `artifacts\bin\Release\<tfm>\` contains expected DLLs and `.deps.json` after build.

## Notes

- No breaking API or behavioral changes for consumers; build-time only.
- Changelog entry for [#3493](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3493) already exists in the current nightly section.