### PR TITLE
* CI: align NuGet restore with Pack/Build (fix NETSDK1005)

### DIFF
--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Restore
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Canary -p:TFMs=all
 
       - name: Prepare Code Signing Certificate (Optional)
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
@@ -219,6 +219,7 @@ jobs:
             '/m',
             'Scripts/Build/canarylongtermstable.proj',
             '/t:Build',
+            '/restore',
             '/p:Configuration=Canary',
             '/p:Platform=Any CPU',
             '/p:UseArtifactsOutput=true'
@@ -242,7 +243,7 @@ jobs:
       # /m: parallel pack across TFMs/projects on the runner (same as Build step above).
       - name: Pack Canary
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/canarylongtermstable.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canarylongtermstable.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -241,11 +241,11 @@ jobs:
 
       - name: Build Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -283,11 +283,11 @@ jobs:
 
       - name: Build Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
-        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,18 +190,18 @@ jobs:
       - name: Restore
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all
 
       # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -523,18 +523,18 @@ jobs:
       - name: Restore
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all
 
       # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -875,18 +875,18 @@ jobs:
       - name: Restore
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Canary -p:TFMs=all
 
       # /m: multi-processor MSBuild (all runner CPUs). canary.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Build /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Canary
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -1218,18 +1218,18 @@ jobs:
       - name: Restore
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Nightly -p:TFMs=all
 
       # /m: multi-processor MSBuild; nightly.proj sets BuildInParallel (project refs still order Toolkit → … → Docking).
       - name: Build Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Build /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Alpha
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       # Note: NuGet publishing for alpha/nightly builds is handled by nightly.yml workflow
       # which runs on a schedule and checks for changes in the last 24 hours


### PR DESCRIPTION
# CI: align NuGet restore with Pack/Build (fix NETSDK1005)

## Summary

- **Problem:** Pack steps could fail with **NETSDK1005** (missing `project.assets.json` under `artifacts/obj/...`) when using **`UseArtifactsOutput=true`**, because restore did not consistently run with the same MSBuild properties as the build/pack graph, or MSBuild was invoked without **`/restore`** on Build/Pack.
- **Change:** Align GitHub Actions workflows with the pattern already used in **`build.yml`** (`dotnet restore ... -p:Configuration=... -p:TFMs=all` and **`msbuild ... /restore`** on Build and Pack where applicable).

## Files changed

| Workflow | Updates |
|----------|---------|
| **`release.yml`** | Release jobs: restore adds `-p:Configuration=Release -p:TFMs=all`; Build Release / Pack Release add **`/restore`**. Canary segment: restore adds `-p:Configuration=Canary -p:TFMs=all`; Build/Pack add **`/restore`**. Alpha segment: restore adds `-p:Configuration=Nightly -p:TFMs=all`; Build Alpha / Pack Alpha add **`/restore`**. | | **`canary.yml`** | Build Canary / Pack Canary add **`/restore`**. | | **`nightly.yml`** | Build Nightly / Pack Nightly add **`/restore`**. | | **`canary-lts-release.yml`** | Restore adds `-p:Configuration=Canary -p:TFMs=all`; Build adds **`/restore`**; Pack Canary adds **`/restore`**. |

## Test plan

- [ ] Run **`build.yml`** release job path (or equivalent **`msbuild build.proj` /t:Pack** with **`UseArtifactsOutput=true`**) on CI and confirm Pack completes without NETSDK1005.
- [ ] **`release.yml`** smoke: trigger or verify on a branch where release kill-switch steps run; confirm Restore → Build → Pack succeeds for the affected configuration (Release / Canary / Nightly as relevant).
- [ ] **`canary.yml`** / **`nightly.yml`** / **`canary-lts-release.yml`**: confirm scheduled or manual runs still restore, build, and pack successfully.

## Notes

- **`build.yml`** was already using `-p:TFMs=all` on restore and **`/restore`** on **`build.proj`** Build/Pack; **`release.yml`** had drifted and is now aligned.
- If NETSDK1005 persists for **`build.proj`** Pack only, consider a follow-up review of **`Scripts/Build/build.proj`** **`PackLite`**/`**PackAll`** asset paths vs **`UseArtifactsOutput`** (`artifacts/obj` vs legacy `obj` under project folders).