### PR TITLE
* Scope the **Auto-label PR backup workflow**

### DIFF
--- a/.github/workflows/auto-label-pr-backup.yml
+++ b/.github/workflows/auto-label-pr-backup.yml
@@ -1,8 +1,8 @@
 # New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
 # Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, tobitege et al. 2026 - 2026. All rights reserved.
 #
-# Automatically adds the 'chore:automatic-backup' label to pull requests that modify
-# the alpha-backup-sync.yml workflow file.
+# Automatically adds the 'chore:automatic-backup' label to pull requests from branch
+# 'alpha' into 'alpha-backup' that modify the alpha-backup-sync.yml workflow file.
 
 name: Auto-label PR backup workflow
 
@@ -12,12 +12,16 @@ on:
       - opened
       - synchronize
       - reopened
+    branches:
+      - alpha-backup
 
 permissions:
   pull-requests: write
 
 jobs:
   label-backup-workflow:
+    # pull_request.branches filters base only; restrict head to sync-from-alpha scenarios
+    if: github.head_ref == 'alpha'
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR modifies alpha-backup-sync.yml


### PR DESCRIPTION
## Summary

- Scope the **Auto-label PR backup workflow** so it only fires for pull requests that **merge into `alpha-backup`**, using `pull_request.branches`.
- Further restrict the job with **`if: github.head_ref == 'alpha'`** so only PRs whose **source branch is `alpha`** are considered (the usual alpha → alpha-backup backup sync path).
- Update the workflow header comment to describe that **alpha → alpha-backup** routing; existing behavior is unchanged: when `.github/workflows/alpha-backup-sync.yml` is among the changed files, the workflow adds the `chore:automatic-backup` label if it is not already present.

## Rationale

Previously, the workflow ran on every eligible `pull_request` event repository-wide. Restricting **base** and **head** avoids unnecessary runs and mis-labeling on unrelated PRs while keeping the automatic backup label aligned with the intended sync workflow.

## Test plan

- [ ] Confirm repository label **`chore:automatic-backup`** exists (workflow logs a warning and does not fail if the label is missing).
- [ ] Open or update a PR **from `alpha` into `alpha-backup`** that touches `.github/workflows/alpha-backup-sync.yml`; verify the workflow runs and the label is applied (or noop if already present).
- [ ] Open a PR **into another base branch** with the same workflow file change; verify this workflow either does not trigger or the job is skipped (`branches` filter).
- [ ] Open a PR **into `alpha-backup` from a branch other than `alpha`** that changes `alpha-backup-sync.yml`; verify the job is skipped due to **`github.head_ref == 'alpha'`**.

## Notes

- **`pull_request.branches`** filters the **base** branch only; the **head** branch check requires an explicit **`if`** on the job.
- Fork PRs still expose `github.head_ref` as the contributor’s branch name; if backup PRs are always from the same repo’s `alpha` branch, this matches the intended use. If you rely on fork PRs with a differently named head branch, adjust the condition accordingly.