### PR TITLE
* Fixes release packaging failure caused by inconsistent restore/pack…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
         run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
       - name: Pack Release
-        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all
 
       - name: Get Version
         id: get_version


### PR DESCRIPTION
… target framework parameters in CI

## Summary
- Fixes release packaging failure caused by inconsistent restore/pack target framework parameters in CI.
- Aligns `Pack Release` with the existing `Restore` step so dependency assets are resolved for the same TFM graph.

## Root Cause
- The `Restore` step used `-p:TFMs=all` while `Pack Release` did not.
- During `Pack`, MSBuild attempted to resolve assets for a different framework set, which could leave required `project.assets.json` entries missing under artifacts output.

## Changes
- Updated `.github/workflows/build.yml`:
  - `Pack Release` now includes `/p:TFMs=all`.

## Validation
- Workflow YAML edited with no linter issues.
- Expected result: `Pack Release` reuses a restore graph consistent with `Restore`, preventing `NETSDK1005` for missing assets in release packaging.