### PR TITLE
3493-V110-fix-followup

### DIFF
--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -44,32 +44,42 @@ jobs:
             9.0.x
             10.0.x
 
-      # Stable TFMs only; rollForward latestPatch (matches Stable job intent).
-      - name: Pin SDK via global.json (stable)
+      - name: Setup .NET Preview
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_PREVIEW_SETUP_VERSION }}
+          dotnet-quality: preview
+
+      # Preview band is required because TFMs=all includes net11.0-windows.
+      - name: Pin SDK via global.json
         shell: pwsh
+        env:
+          SDK_BAND: ${{ env.DOTNET_PREVIEW_SDK_BAND }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $stableLine = dotnet --list-sdks |
-            Where-Object { $_ -match '^10\.0\.[0-9]+\s' } |
+          $band = $env:SDK_BAND
+          if (-not $band) {
+            Write-Error 'DOTNET_PREVIEW_SDK_BAND is not set.'
+          }
+          $escaped = [regex]::Escape($band)
+          $pick = dotnet --list-sdks |
+            Where-Object { $_ -match "^$escaped\." } |
             Select-Object -Last 1
-          $sdkVersion = $null
-          if ($stableLine -match '^(\d+\.\d+\.\d+)\s') {
+          if (-not $pick) {
+            Write-Error "No preview SDK found for band '$band'. Check DOTNET_PREVIEW_SETUP_VERSION / DOTNET_PREVIEW_SDK_BAND in the workflow env."
+          }
+          if ($pick -match '^(\S+)\s') {
             $sdkVersion = $Matches[1]
+          } else {
+            Write-Error "Could not parse SDK version from line: $pick"
           }
-          if (-not $sdkVersion) {
-            $fallback = dotnet --list-sdks | Where-Object { $_ -match '^9\.0\.[0-9]+\s' } | Select-Object -Last 1
-            if ($fallback -match '^(\d+\.\d+\.\d+)\s') { $sdkVersion = $Matches[1] }
-          }
-          if (-not $sdkVersion) {
-            Write-Error 'No 10.0.x or 9.0.x SDK found after setup-dotnet.'
-          }
-          Write-Host "Using SDK $sdkVersion"
+          Write-Host "Using preview SDK $sdkVersion (band $band)"
           @"
           {
             "sdk": {
               "version": "$sdkVersion",
-              "rollForward": "latestPatch",
-              "allowPrerelease": false
+              "rollForward": "latestFeature",
+              "allowPrerelease": true
             }
           }
           "@ | Out-File -Encoding utf8 global.json

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -12,25 +12,37 @@
 	</ItemGroup>
 
 	<!-- Target Framework Selection: Determines which .NET versions to build for based on configuration -->
+	<PropertyGroup>
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == '' And '$(CI)' != 'true' And '$(MSBuildRuntimeType)' == 'Full' And $([System.String]::Copy('$(VisualStudioVersion)').StartsWith('17.'))">true</ExcludeVs2022UnsupportedTargetFrameworks>
+	</PropertyGroup>
 	<Choose>
 		<!-- Nightly, Canary, and Debug configurations build for all target frameworks -->
 		<When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
 			<PropertyGroup>
-				<TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
 			</PropertyGroup>
 		</When>
 		<!-- When SkipNetFramework is true, only build for .NET 8+ (used for testing/CI scenarios) -->
 		<When Condition="'$(SkipNetFramework)' == 'true'">
 			<PropertyGroup>
-				<TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net8.0-windows;net9.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' == 'true'">net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' != 'true'">net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
 			</PropertyGroup>
 		</When>
 		<!-- Otherwise, build for .NET Framework 4.8+ and .NET 8+ (default) -->
 		<Otherwise>
 			<PropertyGroup>
-				<TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' == 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
 				<!-- When TFMs=all, include .NET Framework 4.7.2 as well -->
-				<TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+				<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeNet11)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows;net11.0-windows</TargetFrameworks>
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>


### PR DESCRIPTION
Restores the VS2022 target framework filtering that was lost during later branch alignment work.

Local VS2022 builds now stop at `net9.0-windows`, which avoids unsupported `net10.0-windows` warnings and `net11.0-windows` SDK errors in the IDE.

CI is excluded from that local VS2022 filter so GitHub workflows can still build the full target framework set when they install the required SDKs.

The TestForm workflow now installs and pins the configured preview SDK like the main CI build, so it also builds `TFMs=all` including `net11.0-windows`.
