### PR TITLE
3227-V105-Docking fix followup

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling
 * Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection/check updates; no per-node background repaint)
 * Resolved [#3451](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3451), Unable to add child controls into `KryptonHeaderGroup` at design time (`ReadOnly controls collection`). `DisplayRectangle` now reports the view fill rect, group container designers call `PerformLayout` after `EnableDesignMode`, and `KryptonGroupPanelDesigner.CanBeParentedTo` checks the parent component type correctly. Same `DisplayRectangle` improvement applied to `KryptonGroup` and `KryptonGroupBox`.
 * Resolved [#3367](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3367), ButtonSpec hover flicker on `KryptonTextBox`, `KryptonMaskedTextBox`, and `KryptonForm` (including `ImageStates.ImageNormal` without `Image`)

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege, Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -408,8 +408,6 @@ public class KryptonDockingDockspace : KryptonDockingSpace
         if (DockspaceControl.PageCount == 0)
         {
             DockspaceControl.Dispose();
-            // TODO: Is this safe ?. It means that whatever uses this afterwards could be accessing null things !
-            SpaceControl = null!;
         }
     }
     #endregion
@@ -417,7 +415,12 @@ public class KryptonDockingDockspace : KryptonDockingSpace
     #region Implementation
     private void OnDockspaceCellVisibleCountChanged(object? sender, EventArgs e)
     {
-        if (DockspaceControl.CellVisibleCount == 0)
+        if (sender is not KryptonDockspace dockspace)
+        {
+            return;
+        }
+
+        if (dockspace.CellVisibleCount == 0)
         {
             if (_cacheCellVisibleCount > 0)
             {
@@ -437,10 +440,15 @@ public class KryptonDockingDockspace : KryptonDockingSpace
 
     private void OnDockspaceCellCountChanged(object? sender, EventArgs e)
     {
-        // When all the cells (and so pages) have been removed we kill ourself
-        if (DockspaceControl.CellCount == 0)
+        if (sender is not KryptonDockspace dockspace)
         {
-            DockspaceControl.Dispose();
+            return;
+        }
+
+        // When all the cells (and so pages) have been removed we kill ourself
+        if (dockspace.CellCount == 0)
+        {
+            dockspace.Dispose();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, tobitege & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -924,11 +924,16 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
     private void OnSpaceDisposed(object? sender, EventArgs e)
     {
         // Unhook from events to prevent memory leaking
-        if (SpaceControl != null)
+        if (sender is KryptonSpace space)
         {
-            SpaceControl.Disposed -= OnSpaceDisposed;
-            SpaceControl.WorkspaceCellAdding -= OnSpaceCellAdding;
-            SpaceControl.PageDrop -= RaiseSpacePageDrop;
+            space.Disposed -= OnSpaceDisposed;
+            space.WorkspaceCellAdding -= OnSpaceCellAdding;
+            space.PageDrop -= RaiseSpacePageDrop;
+
+            if (ReferenceEquals(_space, space))
+            {
+                _space = null;
+            }
         }
 
         // Raise event to indicate the space control has been removed


### PR DESCRIPTION
## Summary

This follows up on #3227 and the intermediate fix in #3251.

The previous change avoided the original `SpaceControl` exception, but the visual repro using the supplied docking settings showed a second load-time failure. Empty saved dockspace sections can dispose their `KryptonDockspace` while load/layout events are still in flight. Some handlers then read back through `DockspaceControl`, which can now be cleared, causing a `NullReferenceException` when loading `ScriptBrowserCustomSettings.xml`.

This change makes disposal cleanup happen from the actual disposed sender and updates dockspace event handlers to use their sender instead of dereferencing the current `SpaceControl` property. That preserves the valid loaded layout while avoiding stale disposed-space access.