### PR TITLE
3227-alpha-Docking layout fix

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling
 * Implemented [#3517](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3517), Add VISX package for item/project templates
 * Resolved [#3493](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3493), Fix Scripts build issues related to framework targeting
 * Enhanced `KryptonWebView2` palette integration. `BackColor`, `ForeColor`, and `DefaultBackgroundColor` are now driven from the active Krypton palette via `StateCommon`, `StateNormal`, `StateActive`, and `StateDisabled` (with `WebViewBackStyle` / `WebViewContentStyle`). Legacy appearance properties and their change events are hidden from the designer; use the `State###` entries under **Visuals** instead.

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -408,8 +408,6 @@ public class KryptonDockingDockspace : KryptonDockingSpace
         if (DockspaceControl.PageCount == 0)
         {
             DockspaceControl.Dispose();
-            // TODO: Is this safe ?. It means that whatever uses this afterwards could be accessing null things !
-            SpaceControl = null!;
         }
     }
     #endregion
@@ -417,7 +415,12 @@ public class KryptonDockingDockspace : KryptonDockingSpace
     #region Implementation
     private void OnDockspaceCellVisibleCountChanged(object? sender, EventArgs e)
     {
-        if (DockspaceControl.CellVisibleCount == 0)
+        if (!(sender is KryptonDockspace dockspace))
+        {
+            return;
+        }
+
+        if (dockspace.CellVisibleCount == 0)
         {
             if (_cacheCellVisibleCount > 0)
             {
@@ -437,10 +440,15 @@ public class KryptonDockingDockspace : KryptonDockingSpace
 
     private void OnDockspaceCellCountChanged(object? sender, EventArgs e)
     {
-        // When all the cells (and so pages) have been removed we kill ourself
-        if (DockspaceControl.CellCount == 0)
+        if (!(sender is KryptonDockspace dockspace))
         {
-            DockspaceControl.Dispose();
+            return;
+        }
+
+        // When all the cells (and so pages) have been removed we kill ourself
+        if (dockspace.CellCount == 0)
+        {
+            dockspace.Dispose();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -1,12 +1,12 @@
 #region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -924,11 +924,16 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
     private void OnSpaceDisposed(object? sender, EventArgs e)
     {
         // Unhook from events to prevent memory leaking
-        if (SpaceControl != null)
+        if (sender is KryptonSpace space)
         {
-            SpaceControl.Disposed -= OnSpaceDisposed;
-            SpaceControl.WorkspaceCellAdding -= OnSpaceCellAdding;
-            SpaceControl.PageDrop -= RaiseSpacePageDrop;
+            space.Disposed -= OnSpaceDisposed;
+            space.WorkspaceCellAdding -= OnSpaceCellAdding;
+            space.PageDrop -= RaiseSpacePageDrop;
+
+            if (ReferenceEquals(_space, space))
+            {
+                _space = null;
+            }
         }
 
         // Raise event to indicate the space control has been removed


### PR DESCRIPTION
﻿Follows up #3227.

Relates to #3251 and #3542.

Root cause: a disposed and cleared dockspace could still raise events during load/layout, and stale handlers dereferenced the current DockspaceControl/SpaceControl after it had been cleared.

Fix: cleanup now uses the disposed sender, and dockspace event handlers use the sender instead of DockspaceControl.

Validation:
- Loaded the original wrapper file `D:\temp\docking\RibbonDesignerCustomSettings.xml` without exception.
- Loaded the original wrapper file `D:\temp\docking\ScriptBrowserCustomSettings.xml` without exception.
- Confirmed Ribbon layout: bottom auto-hide `_pageErrorList`; right docked `_pagePropertyGrid`/`_pageDataSources`/`_pageDocumentTree`.
- Confirmed Script layout: bottom auto-hide `_pageErrorList`; left docked `_pageTree`/`_pageFindReplace`; right docked `_pageDataSources`.