### PR TITLE
3227-v85-lts-Docking layout fix

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling
 * Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection updates; no per-node background repaint)
 * Resolved [#3383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3383), White inner border artifacts appear on `KryptonButton` when hovering (`StateTracking` rounding issue)
 * Resolved [#3385](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3385), Memory Retention in Krypton Controls via SystemEvents

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -418,8 +418,6 @@ namespace Krypton.Docking
             if (DockspaceControl.PageCount == 0)
             {
                 DockspaceControl.Dispose();
-                // TODO: Is this safe ?. It means that whatever uses this afterwards could be accessing null things !
-                SpaceControl = null;
             }
         }
         #endregion
@@ -427,7 +425,12 @@ namespace Krypton.Docking
         #region Implementation
         private void OnDockspaceCellVisibleCountChanged(object sender, EventArgs e)
         {
-            if (DockspaceControl.CellVisibleCount == 0)
+            if (!(sender is KryptonDockspace dockspace))
+            {
+                return;
+            }
+
+            if (dockspace.CellVisibleCount == 0)
             {
                 if (_cacheCellVisibleCount > 0)
                 {
@@ -447,10 +450,15 @@ namespace Krypton.Docking
 
         private void OnDockspaceCellCountChanged(object sender, EventArgs e)
         {
-            // When all the cells (and so pages) have been removed we kill ourself
-            if (DockspaceControl.CellCount == 0)
+            if (!(sender is KryptonDockspace dockspace))
             {
-                DockspaceControl.Dispose();
+                return;
+            }
+
+            // When all the cells (and so pages) have been removed we kill ourself
+            if (dockspace.CellCount == 0)
+            {
+                dockspace.Dispose();
             }
         }
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -6,7 +6,7 @@
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2026. All rights reserved.
- *a
+ *
  */
 #endregion
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2026. All rights reserved.
+ *a
  */
 #endregion
 
@@ -908,15 +908,20 @@ namespace Krypton.Docking
         private void OnSpaceDisposed(object sender, EventArgs e)
         {
             // Unhook from events to prevent memory leaking
-            if (SpaceControl != null)
+            if (sender is KryptonSpace space)
             {
-                SpaceControl.Disposed -= OnSpaceDisposed;
-                SpaceControl.WorkspaceCellAdding -= OnSpaceCellAdding;
-                SpaceControl.PageDrop -= RaiseSpacePageDrop;
+                space.Disposed -= OnSpaceDisposed;
+                space.WorkspaceCellAdding -= OnSpaceCellAdding;
+                space.PageDrop -= RaiseSpacePageDrop;
             }
 
             // Raise event to indicate the space control has been removed
             RaiseRemoved();
+
+            if (ReferenceEquals(sender, _space))
+            {
+                _space = null;
+            }
         }
 
         private void OnSpaceCellAdding(object sender, WorkspaceCellEventArgs e)


### PR DESCRIPTION
Follows up #3227.

Relates to #3251 and #3542.

Root cause: a disposed and cleared dockspace could still raise load/layout events, and stale handlers dereferenced DockspaceControl/SpaceControl after it had been cleared.

Fix: cleanup now uses the disposed sender, and dockspace event handlers use their sender instead of DockspaceControl.

Validation:
- Loaded D:\temp\docking\RibbonDesignerCustomSettings.xml successfully.
- Loaded D:\temp\docking\ScriptBrowserCustomSettings.xml successfully.
- Confirmed Ribbon layout: bottom auto-hide _pageErrorList; right docked _pagePropertyGrid/_pageDataSources/_pageDocumentTree.
- Confirmed Script layout: bottom auto-hide _pageErrorList; left docked _pageTree/_pageFindReplace; right docked _pageDataSources.
