### PR TITLE
* Auto complete issues

### DIFF
--- a/.github/workflows/auto-complete-issues.yml
+++ b/.github/workflows/auto-complete-issues.yml
@@ -1,0 +1,195 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+
+name: Auto-complete linked issues
+
+on:
+  pull_request_target:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to process
+        required: true
+        type: number
+      dry_run:
+        description: Log actions only, do not mutate issues
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  complete-linked-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issues and tidy metadata
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const isManualDispatch = context.eventName === 'workflow_dispatch';
+            const isDryRun = isManualDispatch && String(context.payload.inputs?.dry_run) === 'true';
+            let pr = context.payload.pull_request;
+
+            if (isManualDispatch) {
+              const prNumberInput = context.payload.inputs?.pr_number;
+              const prNumber = Number(prNumberInput);
+              if (!prNumber || Number.isNaN(prNumber)) {
+                core.setFailed(`Invalid pr_number input: ${prNumberInput}`);
+                return;
+              }
+
+              const { data: fetchedPr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              pr = fetchedPr;
+              console.log(`Manual run for PR #${pr.number} (dry_run=${isDryRun}).`);
+            }
+
+            if (!pr?.merged) {
+              console.log('PR was closed without merge; skipping.');
+              return;
+            }
+
+            if (pr.base?.ref !== 'master') {
+              console.log(`PR merged into '${pr.base?.ref}', not 'master'; skipping.`);
+              return;
+            }
+
+            // Prefer GitHub's parsed closing references, then fall back to regex.
+            const closingIssueNumbers = new Set();
+
+            try {
+              const result = await github.graphql(
+                `
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 100) {
+                        nodes {
+                          number
+                        }
+                      }
+                    }
+                  }
+                }
+                `,
+                {
+                  owner,
+                  repo,
+                  number: pr.number,
+                }
+              );
+
+              const nodes = result?.repository?.pullRequest?.closingIssuesReferences?.nodes || [];
+              for (const issue of nodes) {
+                if (issue?.number) {
+                  closingIssueNumbers.add(issue.number);
+                }
+              }
+            } catch (error) {
+              console.warn(`GraphQL closing issue lookup failed: ${error.message}`);
+            }
+
+            if (closingIssueNumbers.size === 0) {
+              const body = pr.body || '';
+              const keywordPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+              let match;
+              while ((match = keywordPattern.exec(body)) !== null) {
+                closingIssueNumbers.add(Number(match[1]));
+              }
+            }
+
+            if (closingIssueNumbers.size === 0) {
+              console.log(`No linked issues found for PR #${pr.number}.`);
+              return;
+            }
+
+            console.log(`Processing linked issues: ${Array.from(closingIssueNumbers).join(', ')}`);
+
+            for (const issueNumber of closingIssueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                });
+
+                // Skip pull requests referenced in text.
+                if (issue.pull_request) {
+                  console.log(`#${issueNumber} is a pull request, not an issue; skipping.`);
+                  continue;
+                }
+
+                const currentLabels = (issue.labels || []).map(label =>
+                  typeof label === 'string' ? label : label.name
+                );
+
+                const title = issue.title || '';
+                let labelToAdd = null;
+                if (/^\[bug\]:?/i.test(title)) {
+                  labelToAdd = 'fixed';
+                } else if (/^\[feature request\]:?/i.test(title)) {
+                  labelToAdd = 'completed';
+                }
+
+                if (labelToAdd && !currentLabels.includes(labelToAdd)) {
+                  try {
+                    if (isDryRun) {
+                      console.log(`[dry-run] Would add '${labelToAdd}' to issue #${issueNumber}.`);
+                    } else {
+                      await github.rest.issues.addLabels({
+                        owner,
+                        repo,
+                        issue_number: issueNumber,
+                        labels: [labelToAdd],
+                      });
+                      console.log(`Added '${labelToAdd}' to issue #${issueNumber}.`);
+                    }
+                  } catch (labelError) {
+                    console.warn(`Could not add '${labelToAdd}' to issue #${issueNumber}: ${labelError.message}`);
+                  }
+                }
+
+                if (issue.state !== 'closed') {
+                  if (isDryRun) {
+                    console.log(`[dry-run] Would close issue #${issueNumber}.`);
+                  } else {
+                    await github.rest.issues.update({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      state: 'closed',
+                    });
+                    console.log(`Closed issue #${issueNumber}.`);
+                  }
+                } else {
+                  console.log(`Issue #${issueNumber} already closed.`);
+                }
+
+                const assignees = (issue.assignees || []).map(assignee => assignee.login).filter(Boolean);
+                if (assignees.length > 0) {
+                  if (isDryRun) {
+                    console.log(`[dry-run] Would remove assignees from issue #${issueNumber}: ${assignees.join(', ')}`);
+                  } else {
+                    await github.rest.issues.removeAssignees({
+                      owner,
+                      repo,
+                      issue_number: issueNumber,
+                      assignees,
+                    });
+                    console.log(`Removed assignees from issue #${issueNumber}: ${assignees.join(', ')}`);
+                  }
+                }
+              } catch (issueError) {
+                console.warn(`Failed to process issue #${issueNumber}: ${issueError.message}`);
+              }
+            }

--- a/.github/workflows/auto-complete-issues.yml
+++ b/.github/workflows/auto-complete-issues.yml
@@ -33,6 +33,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
+            const expectedHeadBranch = 'compare';
+            const expectedBaseBranch = 'base';
             const isManualDispatch = context.eventName === 'workflow_dispatch';
             const isDryRun = isManualDispatch && String(context.payload.inputs?.dry_run) === 'true';
             let pr = context.payload.pull_request;
@@ -59,8 +61,11 @@ jobs:
               return;
             }
 
-            if (pr.base?.ref !== 'master') {
-              console.log(`PR merged into '${pr.base?.ref}', not 'master'; skipping.`);
+            if (pr.base?.ref !== expectedBaseBranch || pr.head?.ref !== expectedHeadBranch) {
+              console.log(
+                `PR direction '${pr.head?.ref}' -> '${pr.base?.ref}' does not match ` +
+                `'${expectedHeadBranch}' -> '${expectedBaseBranch}'; skipping.`
+              );
               return;
             }
 


### PR DESCRIPTION
## Summary
- Add new GitHub Actions workflow `auto-complete-issues.yml` to automate issue completion when PRs are merged from `compare` into `base`.
- Detect linked issues from PR closing references (GraphQL) with regex fallback for `fixes/closes/resolves #<number>` patterns.
- For linked issues, apply `fixed` for `[Bug]` titles or `completed` for `[Feature Request]` titles, close the issue, and remove assignees.
- Add `workflow_dispatch` with `pr_number` and `dry_run` inputs for safe manual validation before live use.

## Why
- Implements issue [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550) so linked issues are consistently completed outside default branch-only auto-close behavior.
- Reduces manual triage work by standardizing post-merge labeling and assignment cleanup.

## Scope
- New file: `.github/workflows/auto-complete-issues.yml`
- No product/runtime code changes.

## Behavior
- Triggered automatically on `pull_request_target` `closed` events.
- Continues only when:
  - PR is merged, and
  - PR direction is `compare` -> `base`.
- In manual runs (`workflow_dispatch`):
  - `dry_run=true` logs intended actions only.
  - `dry_run=false` performs label/close/unassign operations.

## Test Plan
- [ ] Manual run with `dry_run=true` against a known merged PR linked to a `[Bug]` issue; verify logs show:
  - `Would add 'fixed'`
  - `Would close issue`
  - `Would remove assignees`
- [ ] Manual run with `dry_run=true` against a known merged PR linked to a `[Feature Request]` issue; verify logs show:
  - `Would add 'completed'`
- [ ] Manual run with `dry_run=true` for PR direction other than `compare` -> `base`; verify workflow skips.
- [ ] Manual run with `dry_run=false` on a safe test issue; verify issue is labeled, closed, and assignees removed.
- [ ] Confirm no-op behavior when no linked issues are found.

## Notes
- Repository labels `fixed` and `completed` should exist; missing labels are logged as warnings.