### PR TITLE
2926-V110-Fix themed scrollbar sync and painting

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2926](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2926), Really fix themed scrollbars part of KryptonListBox
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling
 * Implemented [#3517](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3517), Add VISX package for item/project templates
 * Resolved [#3493](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3493), Fix Scripts build issues related to framework targeting

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHScrollBar.cs
@@ -1,9 +1,9 @@
-#region BSD License
+﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -132,7 +132,7 @@ public class KryptonHScrollBar : Control
         _stateNormal.Border.Color1 = _borderColor;
         _stateActive.Border.Color1 = _borderColor;
         _stateDisabled.Border.Color1 = _disabledBorderColor;
-        
+
         // Ensure border is drawn by default (all palette border properties are accessible through StateCommon/StateNormal/StateDisabled/StateActive.Border)
         // Available properties: Draw, DrawBorders, Width, Color1, Color2, ColorStyle, ColorAlign, ColorAngle, Rounding, Image, ImageStyle, ImageAlign, GraphicsHint
 
@@ -200,6 +200,8 @@ public class KryptonHScrollBar : Control
             if (_value < value)
             {
                 _value = value;
+                ChangeThumbPosition(GetThumbPosition());
+                Refresh();
             }
             else
             {
@@ -240,9 +242,12 @@ public class KryptonHScrollBar : Control
             SetUpScrollBar();
 
             // is current value greater than new maximum value - adjust
-            if (_value > value)
+            int scrollableMaximum = GetScrollableMaximum();
+            if (_value > scrollableMaximum)
             {
-                _value = _maximum;
+                _value = scrollableMaximum;
+                ChangeThumbPosition(GetThumbPosition());
+                Refresh();
             }
             else
             {
@@ -307,6 +312,7 @@ public class KryptonHScrollBar : Control
                 _largeChange = value;
             }
 
+            _value = CoerceValue(_value);
             SetUpScrollBar();
         }
     }
@@ -324,18 +330,24 @@ public class KryptonHScrollBar : Control
         set
         {
             // no change or invalid value - return
-            if (_value == value || value < _minimum || value > _maximum)
+            if (value < _minimum || value > _maximum)
             {
                 return;
             }
 
-            _value = value;
+            int newValue = CoerceValue(value);
+            if (_value == newValue)
+            {
+                return;
+            }
+
+            _value = newValue;
 
             // adjust thumb position
             ChangeThumbPosition(GetThumbPosition());
 
             // raise scroll event
-            OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, -1, value, ScrollOrientation.HorizontalScroll));
+            OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, -1, newValue, ScrollOrientation.HorizontalScroll));
 
             Refresh();
         }
@@ -372,7 +384,7 @@ public class KryptonHScrollBar : Control
             if (_borderColor != value)
             {
                 _borderColor = value;
-                
+
                 // Sync with palette system
                 _stateNormal.Border.Color1 = value;
                 _stateActive.Border.Color1 = value;
@@ -400,7 +412,7 @@ public class KryptonHScrollBar : Control
             if (_disabledBorderColor != value)
             {
                 _disabledBorderColor = value;
-                
+
                 // Sync with palette system
                 _stateDisabled.Border.Color1 = value;
 
@@ -539,11 +551,11 @@ public class KryptonHScrollBar : Control
         {
             IRenderer renderer = _palette.GetRenderer();
             PaletteState borderState = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-            IPaletteBorder paletteBorder = borderState == PaletteState.Disabled 
-                ? _stateDisabled.PaletteBorder 
+            IPaletteBorder paletteBorder = borderState == PaletteState.Disabled
+                ? _stateDisabled.PaletteBorder
                 : _stateNormal.PaletteBorder;
             borderRounding = paletteBorder.GetBorderRounding(borderState);
-            
+
             // Ensure rounding doesn't exceed what can fit in the control
             if (borderRounding > 0)
             {
@@ -663,21 +675,21 @@ public class KryptonHScrollBar : Control
         {
             IRenderer renderer = _palette.GetRenderer();
             using var renderContext = new RenderContext(this, e.Graphics, e.ClipRectangle, renderer);
-            
+
             // Determine the appropriate palette state
             PaletteState borderState = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-            
+
             // Get the appropriate border palette
-            IPaletteBorder paletteBorder = borderState == PaletteState.Disabled 
-                ? _stateDisabled.PaletteBorder 
+            IPaletteBorder paletteBorder = borderState == PaletteState.Disabled
+                ? _stateDisabled.PaletteBorder
                 : _stateNormal.PaletteBorder;
-            
+
             // Render the border with rounding support
             renderer.RenderStandardBorder.DrawBorder(
-                renderContext, 
-                ClientRectangle, 
-                paletteBorder, 
-                VisualOrientation.Top, 
+                renderContext,
+                ClientRectangle,
+                paletteBorder,
+                VisualOrientation.Top,
                 borderState);
         }
         else
@@ -865,35 +877,17 @@ public class KryptonHScrollBar : Control
                 else if (pos >= (_thumbRightLimitLeft + _thumbPosition))
                 {
                     // The thumb is all the way to the right
-                    ChangeThumbPosition(_thumbRightLimitLeft);
-
-                    _value = _maximum;
+                    _value = GetScrollableMaximum();
                 }
                 else
                 {
-                    // The thumb is between the ends of the track.
-                    ChangeThumbPosition(pos - _thumbPosition);
-
-                    var pixelRange = Width - (2 * _arrowWidth) - _thumbWidth;
-                    var thumbPos = _thumbRectangle.X;
-                    var arrowSize = _arrowWidth;
-
-                    var percent = 0f;
-
-                    if (pixelRange != 0)
-                    {
-                        // percent of the new position
-                        percent = (thumbPos - arrowSize) / (float)pixelRange;
-                    }
-
-                    // the new value is somewhere between max and min, starting
-                    // at min position
-                    _value = Convert.ToInt32((percent * (_maximum - _minimum)) + _minimum);
+                    _value = GetValueFromThumbLeft(pos - _thumbPosition);
                 }
 
                 // raise scroll event if new value different
                 if (oldScrollValue != _value)
                 {
+                    ChangeThumbPosition(GetThumbPosition());
                     OnScroll(new ScrollEventArgs(ScrollEventType.ThumbTrack, oldScrollValue, _value, ScrollOrientation.HorizontalScroll));
 
                     Refresh();
@@ -976,9 +970,10 @@ public class KryptonHScrollBar : Control
                 return true;
             case Keys.PageDown:
             {
-                if (_value + _largeChange > _maximum)
+                int scrollableMaximum = GetScrollableMaximum();
+                if (_value + _largeChange > scrollableMaximum)
                 {
-                    Value = _maximum;
+                    Value = scrollableMaximum;
                 }
                 else
                 {
@@ -994,7 +989,7 @@ public class KryptonHScrollBar : Control
                 return true;
             case Keys.End:
             case Keys.Control | Keys.End:
-                Value = _maximum;
+                Value = GetScrollableMaximum();
 
                 return true;
             default:
@@ -1110,7 +1105,7 @@ public class KryptonHScrollBar : Control
 
         // Set the right limit of the thumb's right border.
         _thumbRightLimitRight =
-            ClientRectangle.Right - _arrowWidth - verticalOffset;
+            ClientRectangle.Right - _arrowWidth - borderOffset;
 
         // Set the right limit of the thumb's left border.
         _thumbRightLimitLeft =
@@ -1173,6 +1168,7 @@ public class KryptonHScrollBar : Control
     private int GetValue(bool smallIncrement, bool left)
     {
         int newValue;
+        int scrollableMaximum = GetScrollableMaximum();
 
         // calculate the new value of the scrollbar
         // with checking if new value is in bounds (min/max)
@@ -1189,13 +1185,47 @@ public class KryptonHScrollBar : Control
         {
             newValue = _value + (smallIncrement ? _smallChange : _largeChange);
 
-            if (newValue > _maximum)
+            if (newValue > scrollableMaximum)
             {
-                newValue = _maximum;
+                newValue = scrollableMaximum;
             }
         }
 
         return newValue;
+    }
+
+    private int GetScrollableMaximum()
+    {
+        int page = Math.Max(1, _largeChange);
+        long scrollableMaximum = (long)_maximum - page + 1;
+
+        if (scrollableMaximum < _minimum)
+        {
+            return _minimum;
+        }
+
+        return scrollableMaximum > int.MaxValue ? int.MaxValue : (int)scrollableMaximum;
+    }
+
+    private int CoerceValue(int value) => Math.Max(_minimum, Math.Min(value, GetScrollableMaximum()));
+
+    private int GetThumbTravelRange() => Math.Max(0, _thumbRightLimitLeft - _thumbLeftLimit);
+
+    private int GetValueFromThumbLeft(int thumbLeft)
+    {
+        int pixelRange = GetThumbTravelRange();
+        int scrollableMaximum = GetScrollableMaximum();
+        int realRange = scrollableMaximum - _minimum;
+
+        if (pixelRange == 0 || realRange == 0)
+        {
+            return _minimum;
+        }
+
+        int clampedThumbLeft = Math.Max(_thumbLeftLimit, Math.Min(thumbLeft, _thumbRightLimitLeft));
+        float percent = (clampedThumbLeft - _thumbLeftLimit) / (float)pixelRange;
+
+        return CoerceValue(Convert.ToInt32((percent * realRange) + _minimum));
     }
 
     /// <summary>
@@ -1204,10 +1234,8 @@ public class KryptonHScrollBar : Control
     /// <returns>The new thumb position.</returns>
     private int GetThumbPosition()
     {
-        var pixelRange = Width - (2 * _arrowWidth) - _thumbWidth;
-        var arrowSize = _arrowWidth;
-
-        var realRange = _maximum - _minimum;
+        var pixelRange = GetThumbTravelRange();
+        var realRange = GetScrollableMaximum() - _minimum;
         var perc = 0f;
 
         if (realRange != 0)
@@ -1217,7 +1245,7 @@ public class KryptonHScrollBar : Control
 
         return Math.Max(_thumbLeftLimit, Math.Min(
             _thumbRightLimitLeft,
-            Convert.ToInt32((perc * pixelRange) + arrowSize)));
+            Convert.ToInt32((perc * pixelRange) + _thumbLeftLimit)));
     }
 
     /// <summary>
@@ -1226,14 +1254,16 @@ public class KryptonHScrollBar : Control
     /// <returns>The width of the thumb.</returns>
     private int GetThumbSize()
     {
-        var trackSize = Width - (2 * _arrowWidth);
+        int borderOffset = (int)Math.Round(1 * GetDpiFactor());
+        var trackSize = Math.Max(0, Width - (2 * _arrowWidth) - (borderOffset * 2));
 
         if (_maximum == 0 || _largeChange == 0)
         {
             return trackSize;
         }
 
-        var newThumbSize = _largeChange * trackSize / (float)_maximum;
+        int contentRange = Math.Max(1, _maximum - _minimum + 1);
+        var newThumbSize = _largeChange * trackSize / (float)contentRange;
 
         return Convert.ToInt32(Math.Min(trackSize, Math.Max(newThumbSize, 10f)));
     }
@@ -1267,7 +1297,7 @@ public class KryptonHScrollBar : Control
     /// <param name="position">The new position.</param>
     private void ChangeThumbPosition(int position)
     {
-        _thumbRectangle.X = position;
+        _thumbRectangle.X = Math.Max(_thumbLeftLimit, Math.Min(position, _thumbRightLimitLeft));
     }
 
     /// <summary>
@@ -1288,7 +1318,7 @@ public class KryptonHScrollBar : Control
 
             _value = GetValue(_rightArrowClicked, false);
 
-            if (_value == _maximum)
+            if (_value == GetScrollableMaximum())
             {
                 ChangeThumbPosition(_thumbRightLimitLeft);
 
@@ -1428,25 +1458,10 @@ public class KryptonHScrollBar : Control
     /// <param name="e">The event arguments.</param>
     private void ScrollHereClick(object? sender, EventArgs e)
     {
-        var thumbSize = _thumbWidth;
-        var arrowSize = _arrowWidth;
-        var size = Width;
-
-        ChangeThumbPosition(Math.Max(_thumbLeftLimit, Math.Min(_thumbRightLimitLeft, _trackPosition - (_thumbRectangle.Width / 2))));
-
-        var thumbPos = _thumbRectangle.X;
-
-        var pixelRange = size - (2 * arrowSize) - thumbSize;
-        var perc = 0f;
-
-        if (pixelRange != 0)
-        {
-            perc = (thumbPos - arrowSize) / (float)pixelRange;
-        }
-
         var oldValue = _value;
 
-        _value = Convert.ToInt32((perc * (_maximum - _minimum)) + _minimum);
+        _value = GetValueFromThumbLeft(_trackPosition - (_thumbRectangle.Width / 2));
+        ChangeThumbPosition(GetThumbPosition());
 
         OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, oldValue, _value, ScrollOrientation.HorizontalScroll));
 
@@ -1465,7 +1480,7 @@ public class KryptonHScrollBar : Control
     /// </summary>
     /// <param name="sender">The sender.</param>
     /// <param name="e">The event arguments.</param>
-    private void RightClick(object? sender, EventArgs e) => Value = _maximum;
+    private void RightClick(object? sender, EventArgs e) => Value = GetScrollableMaximum();
 
     /// <summary>
     /// Context menu handler.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -36,7 +36,7 @@ public class KryptonListBox : VisualControlBase,
         private readonly IntPtr _screenDC;
         private bool _mouseOver;
         // Capture scroll position before user click
-        private int _preClickTopIndex;
+        private int _preClickTopIndex = -1;
 
         #endregion
 
@@ -372,6 +372,7 @@ public class KryptonListBox : VisualControlBase,
             finally
             {
                 EndUpdate();
+                _preClickTopIndex = -1;
                 // Re-enable redraw and repaint
                 PI.SendMessage(Handle, PI.SETREDRAW, (IntPtr)1, IntPtr.Zero);
                 Invalidate();
@@ -397,6 +398,10 @@ public class KryptonListBox : VisualControlBase,
                     // For non-visible items, don't capture - let normal scrolling happen
                     _preClickTopIndex = -1;
                 }
+            }
+            else
+            {
+                _preClickTopIndex = -1;
             }
         }
     }
@@ -426,9 +431,10 @@ public class KryptonListBox : VisualControlBase,
     private bool _forcedLayout;
     private bool _trackingMouseEnter;
     // Captures the scroll position before a click/selection change
-    private int _preClickTopIndex;
+    private int _preClickTopIndex = -1;
     private KryptonScrollbarManager? _scrollbarManager;
     private bool? _useKryptonScrollbars;
+    private bool _pendingScrollbarManagerRefresh;
 
     #endregion
 
@@ -689,7 +695,7 @@ public class KryptonListBox : VisualControlBase,
         }
 
         base.Dispose(disposing);
-        
+
         if (_screenDC != IntPtr.Zero)
         {
             PI.DeleteDC(_screenDC);
@@ -1206,7 +1212,11 @@ public class KryptonListBox : VisualControlBase,
 
     private bool ShouldSerializeUseKryptonScrollbars() => _useKryptonScrollbars.HasValue;
 
-    private void ResetUseKryptonScrollbars() => _useKryptonScrollbars = null;
+    private void ResetUseKryptonScrollbars()
+    {
+        _useKryptonScrollbars = null;
+        UpdateScrollbarManager();
+    }
 
     /// <summary>
     /// Gets access to the scrollbar manager when UseKryptonScrollbars is enabled.
@@ -1449,6 +1459,8 @@ public class KryptonListBox : VisualControlBase,
             _listBox.EndUpdate();
         }
         base.OnPaletteChanged(e);
+        RecreateScrollbarManager();
+        QueueScrollbarManagerRefresh();
     }
 
     /// <summary>
@@ -1459,6 +1471,7 @@ public class KryptonListBox : VisualControlBase,
     protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
         _listBox.RefreshItemSizes();
+        RefreshScrollbarManager();
         base.OnPaletteChanged(e);
     }
 
@@ -1571,7 +1584,7 @@ public class KryptonListBox : VisualControlBase,
         InvokeLayout();
 
         // Update scrollbars to match current setting
-        if (KryptonManager.UseKryptonScrollbars)
+        if (UseKryptonScrollbars)
         {
             UpdateScrollbarManager();
         }
@@ -1935,7 +1948,7 @@ public class KryptonListBox : VisualControlBase,
 
     private void UpdateScrollbarManager()
     {
-        if (KryptonManager.UseKryptonScrollbars)
+        if (UseKryptonScrollbars)
         {
             if (_scrollbarManager == null)
             {
@@ -1953,6 +1966,52 @@ public class KryptonListBox : VisualControlBase,
                 _scrollbarManager = null;
             }
         }
+    }
+
+    private void RefreshScrollbarManager()
+    {
+        if (!UseKryptonScrollbars)
+        {
+            return;
+        }
+
+        UpdateScrollbarManager();
+        _scrollbarManager?.UpdateScrollbars();
+    }
+
+    private void RecreateScrollbarManager()
+    {
+        if (!UseKryptonScrollbars)
+        {
+            return;
+        }
+
+        if (_scrollbarManager != null)
+        {
+            _scrollbarManager.Dispose();
+            _scrollbarManager = null;
+        }
+
+        UpdateScrollbarManager();
+        _scrollbarManager?.UpdateScrollbars();
+    }
+
+    private void QueueScrollbarManagerRefresh()
+    {
+        if (_pendingScrollbarManagerRefresh || !IsHandleCreated || IsDisposed)
+        {
+            return;
+        }
+
+        _pendingScrollbarManagerRefresh = true;
+        BeginInvoke((System.Windows.Forms.MethodInvoker)(() =>
+        {
+            _pendingScrollbarManagerRefresh = false;
+            if (!IsDisposed && IsHandleCreated)
+            {
+                RefreshScrollbarManager();
+            }
+        }));
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonVScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonVScrollBar.cs
@@ -1,9 +1,9 @@
-#region BSD License
+﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -57,6 +57,7 @@ public class KryptonVScrollBar : Control
     private int _thumbTopLimit;
     private int _thumbPosition;
     private int _trackPosition;
+    private const string DebugLogFileName = "KryptonVScrollBarDrag.log";
 
     /// <summary>
     /// The progress timer for moving the thumb.
@@ -200,6 +201,8 @@ public class KryptonVScrollBar : Control
             if (_value < value)
             {
                 _value = value;
+                ChangeThumbPosition(GetThumbPosition());
+                Refresh();
             }
             else
             {
@@ -240,9 +243,12 @@ public class KryptonVScrollBar : Control
             SetUpScrollBar();
 
             // is current value greater than new maximum value - adjust
-            if (_value > value)
+            int scrollableMaximum = GetScrollableMaximum();
+            if (_value > scrollableMaximum)
             {
-                _value = _maximum;
+                _value = scrollableMaximum;
+                ChangeThumbPosition(GetThumbPosition());
+                Refresh();
             }
             else
             {
@@ -307,6 +313,7 @@ public class KryptonVScrollBar : Control
                 _largeChange = value;
             }
 
+            _value = CoerceValue(_value);
             SetUpScrollBar();
         }
     }
@@ -324,18 +331,24 @@ public class KryptonVScrollBar : Control
         set
         {
             // no change or invalid value - return
-            if (_value == value || value < _minimum || value > _maximum)
+            if (value < _minimum || value > _maximum)
             {
                 return;
             }
 
-            _value = value;
+            int newValue = CoerceValue(value);
+            if (_value == newValue)
+            {
+                return;
+            }
+
+            _value = newValue;
 
             // adjust thumb position
             ChangeThumbPosition(GetThumbPosition());
 
             // raise scroll event
-            OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, -1, value, ScrollOrientation.VerticalScroll));
+            OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, -1, newValue, ScrollOrientation.VerticalScroll));
 
             Refresh();
         }
@@ -711,6 +724,7 @@ public class KryptonVScrollBar : Control
                         _thumbPosition = mouseLocation.Y - _thumbRectangle.Y;
                         _thumbState = ScrollBarState.Pressed;
 
+                        AppendDebugLog($"down y={mouseLocation.Y} value={_value} min={_minimum} max={_maximum} scrollMax={GetScrollableMaximum()} large={_largeChange} thumb={FormatRectangle(_thumbRectangle)} limits={_thumbTopLimit},{_thumbBottomLimitTop} grab={_thumbPosition} bounds={FormatRectangle(Bounds)}");
                         Invalidate(_thumbRectangle);
                     }
                     else if (_topArrowRectangle.Contains(mouseLocation))
@@ -865,35 +879,18 @@ public class KryptonVScrollBar : Control
                 else if (pos >= (_thumbBottomLimitTop + _thumbPosition))
                 {
                     // The thumb is all the way to the bottom
-                    ChangeThumbPosition(_thumbBottomLimitTop);
-
-                    _value = _maximum;
+                    _value = GetScrollableMaximum();
                 }
                 else
                 {
-                    // The thumb is between the ends of the track.
-                    ChangeThumbPosition(pos - _thumbPosition);
-
-                    var pixelRange = Height - (2 * _arrowHeight) - _thumbHeight;
-                    var thumbPos = _thumbRectangle.Y;
-                    var arrowSize = _arrowHeight;
-
-                    var percent = 0f;
-
-                    if (pixelRange != 0)
-                    {
-                        // percent of the new position
-                        percent = (thumbPos - arrowSize) / (float)pixelRange;
-                    }
-
-                    // the new value is somewhere between max and min, starting
-                    // at min position
-                    _value = Convert.ToInt32((percent * (_maximum - _minimum)) + _minimum);
+                    _value = GetValueFromThumbTop(pos - _thumbPosition);
                 }
 
                 // raise scroll event if new value different
                 if (oldScrollValue != _value)
                 {
+                    ChangeThumbPosition(GetThumbPosition());
+                    AppendDebugLog($"move y={e.Location.Y} old={oldScrollValue} new={_value} min={_minimum} max={_maximum} scrollMax={GetScrollableMaximum()} large={_largeChange} thumb={FormatRectangle(_thumbRectangle)} limits={_thumbTopLimit},{_thumbBottomLimitTop} grab={_thumbPosition} bounds={FormatRectangle(Bounds)}");
                     OnScroll(new ScrollEventArgs(ScrollEventType.ThumbTrack, oldScrollValue, _value, ScrollOrientation.VerticalScroll));
 
                     Refresh();
@@ -933,6 +930,27 @@ public class KryptonVScrollBar : Control
                 Invalidate();
             }
         }
+    }
+
+    /// <summary>
+    /// Raises the MouseWheel event.
+    /// </summary>
+    /// <param name="e">A <see cref="MouseEventArgs"/> that contains the event data.</param>
+    protected override void OnMouseWheel(MouseEventArgs e)
+    {
+        base.OnMouseWheel(e);
+
+        if (e.Delta == 0)
+        {
+            return;
+        }
+
+        int wheelLines = SystemInformation.MouseWheelScrollLines;
+        int change = wheelLines < 0
+            ? _largeChange
+            : Math.Max(1, wheelLines) * _smallChange;
+
+        Value = e.Delta > 0 ? _value - change : _value + change;
     }
 
     /// <summary>
@@ -976,9 +994,10 @@ public class KryptonVScrollBar : Control
                 return true;
             case Keys.PageDown:
             {
-                if (_value + _largeChange > _maximum)
+                int scrollableMaximum = GetScrollableMaximum();
+                if (_value + _largeChange > scrollableMaximum)
                 {
-                    Value = _maximum;
+                    Value = scrollableMaximum;
                 }
                 else
                 {
@@ -994,7 +1013,7 @@ public class KryptonVScrollBar : Control
                 return true;
             case Keys.End:
             case Keys.Control | Keys.End:
-                Value = _maximum;
+                Value = GetScrollableMaximum();
 
                 return true;
             default:
@@ -1110,7 +1129,7 @@ public class KryptonVScrollBar : Control
 
         // Set the bottom limit of the thumb's bottom border.
         _thumbBottomLimitBottom =
-            ClientRectangle.Bottom - _arrowHeight - horizontalOffset;
+            ClientRectangle.Bottom - _arrowHeight - borderOffset;
 
         // Set the bottom limit of the thumb's top border.
         _thumbBottomLimitTop =
@@ -1173,6 +1192,7 @@ public class KryptonVScrollBar : Control
     private int GetValue(bool smallIncrement, bool up)
     {
         int newValue;
+        int scrollableMaximum = GetScrollableMaximum();
 
         // calculate the new value of the scrollbar
         // with checking if new value is in bounds (min/max)
@@ -1189,13 +1209,62 @@ public class KryptonVScrollBar : Control
         {
             newValue = _value + (smallIncrement ? _smallChange : _largeChange);
 
-            if (newValue > _maximum)
+            if (newValue > scrollableMaximum)
             {
-                newValue = _maximum;
+                newValue = scrollableMaximum;
             }
         }
 
         return newValue;
+    }
+
+    private int GetScrollableMaximum()
+    {
+        int page = Math.Max(1, _largeChange);
+        long scrollableMaximum = (long)_maximum - page + 1;
+
+        if (scrollableMaximum < _minimum)
+        {
+            return _minimum;
+        }
+
+        return scrollableMaximum > int.MaxValue ? int.MaxValue : (int)scrollableMaximum;
+    }
+
+    private int CoerceValue(int value) => Math.Max(_minimum, Math.Min(value, GetScrollableMaximum()));
+
+    private int GetThumbTravelRange() => Math.Max(0, _thumbBottomLimitTop - _thumbTopLimit);
+
+    private static string FormatRectangle(Rectangle rectangle) => $"{rectangle.X},{rectangle.Y},{rectangle.Width},{rectangle.Height}";
+
+    private static void AppendDebugLog(string message)
+    {
+        try
+        {
+            string path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), DebugLogFileName);
+            System.IO.File.AppendAllText(path, $"{DateTime.Now:O} KryptonVScrollBar {message}{Environment.NewLine}");
+        }
+        catch
+        {
+            // Debug logging must never affect scrollbar behavior.
+        }
+    }
+
+    private int GetValueFromThumbTop(int thumbTop)
+    {
+        int pixelRange = GetThumbTravelRange();
+        int scrollableMaximum = GetScrollableMaximum();
+        int realRange = scrollableMaximum - _minimum;
+
+        if (pixelRange == 0 || realRange == 0)
+        {
+            return _minimum;
+        }
+
+        int clampedThumbTop = Math.Max(_thumbTopLimit, Math.Min(thumbTop, _thumbBottomLimitTop));
+        float percent = (clampedThumbTop - _thumbTopLimit) / (float)pixelRange;
+
+        return CoerceValue(Convert.ToInt32((percent * realRange) + _minimum));
     }
 
     /// <summary>
@@ -1204,10 +1273,8 @@ public class KryptonVScrollBar : Control
     /// <returns>The new thumb position.</returns>
     private int GetThumbPosition()
     {
-        var pixelRange = Height - (2 * _arrowHeight) - _thumbHeight;
-        var arrowSize = _arrowHeight;
-
-        var realRange = _maximum - _minimum;
+        var pixelRange = GetThumbTravelRange();
+        var realRange = GetScrollableMaximum() - _minimum;
         var perc = 0f;
 
         if (realRange != 0)
@@ -1217,7 +1284,7 @@ public class KryptonVScrollBar : Control
 
         return Math.Max(_thumbTopLimit, Math.Min(
             _thumbBottomLimitTop,
-            Convert.ToInt32((perc * pixelRange) + arrowSize)));
+            Convert.ToInt32((perc * pixelRange) + _thumbTopLimit)));
     }
 
     /// <summary>
@@ -1226,14 +1293,16 @@ public class KryptonVScrollBar : Control
     /// <returns>The height of the thumb.</returns>
     private int GetThumbSize()
     {
-        var trackSize = Height - (2 * _arrowHeight);
+        int borderOffset = (int)Math.Round(1 * GetDpiFactor());
+        var trackSize = Math.Max(0, Height - (2 * _arrowHeight) - (borderOffset * 2));
 
         if (_maximum == 0 || _largeChange == 0)
         {
             return trackSize;
         }
 
-        var newThumbSize = _largeChange * trackSize / (float)_maximum;
+        int contentRange = Math.Max(1, _maximum - _minimum + 1);
+        var newThumbSize = _largeChange * trackSize / (float)contentRange;
 
         return Convert.ToInt32(Math.Min(trackSize, Math.Max(newThumbSize, 10f)));
     }
@@ -1267,7 +1336,7 @@ public class KryptonVScrollBar : Control
     /// <param name="position">The new position.</param>
     private void ChangeThumbPosition(int position)
     {
-        _thumbRectangle.Y = position;
+        _thumbRectangle.Y = Math.Max(_thumbTopLimit, Math.Min(position, _thumbBottomLimitTop));
     }
 
     /// <summary>
@@ -1288,7 +1357,7 @@ public class KryptonVScrollBar : Control
 
             _value = GetValue(_bottomArrowClicked, false);
 
-            if (_value == _maximum)
+            if (_value == GetScrollableMaximum())
             {
                 ChangeThumbPosition(_thumbBottomLimitTop);
 
@@ -1428,25 +1497,10 @@ public class KryptonVScrollBar : Control
     /// <param name="e">The event arguments.</param>
     private void ScrollHereClick(object? sender, EventArgs e)
     {
-        var thumbSize = _thumbHeight;
-        var arrowSize = _arrowHeight;
-        var size = Height;
-
-        ChangeThumbPosition(Math.Max(_thumbTopLimit, Math.Min(_thumbBottomLimitTop, _trackPosition - (_thumbRectangle.Height / 2))));
-
-        var thumbPos = _thumbRectangle.Y;
-
-        var pixelRange = size - (2 * arrowSize) - thumbSize;
-        var perc = 0f;
-
-        if (pixelRange != 0)
-        {
-            perc = (thumbPos - arrowSize) / (float)pixelRange;
-        }
-
         var oldValue = _value;
 
-        _value = Convert.ToInt32((perc * (_maximum - _minimum)) + _minimum);
+        _value = GetValueFromThumbTop(_trackPosition - (_thumbRectangle.Height / 2));
+        ChangeThumbPosition(GetThumbPosition());
 
         OnScroll(new ScrollEventArgs(ScrollEventType.ThumbPosition, oldValue, _value, ScrollOrientation.VerticalScroll));
 
@@ -1465,7 +1519,7 @@ public class KryptonVScrollBar : Control
     /// </summary>
     /// <param name="sender">The sender.</param>
     /// <param name="e">The event arguments.</param>
-    private void BottomClick(object? sender, EventArgs e) => Value = _maximum;
+    private void BottomClick(object? sender, EventArgs e) => Value = GetScrollableMaximum();
 
     /// <summary>
     /// Context menu handler.

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/KryptonScrollBarRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/KryptonScrollBarRenderer.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -132,6 +132,11 @@ internal static class KryptonScrollBarRenderer
          * | |-----------------------------------------| |
          * |                                             |
          * ----------------------------------------------- (15,17)
+         *
+         * The 15x17 diagram describes the source arrow bitmap only.
+         * Track and thumb rectangles are supplied by the controls and can
+         * be larger at high DPI, so those paint paths must fill rect, not a
+         * fixed 15px interior.
          */
 
         // hot state
@@ -434,6 +439,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawBackgroundVertical(Graphics g, Rectangle rect)
     {
+        // Fill the full supplied bounds first. At high DPI the themed scrollbar is
+        // wider than the original 15px bitmap math, and fixed interior widths leave
+        // stale pixels along the inner edge while dragging.
+        using (var brush = new SolidBrush(_backgroundColors[4]))
+        {
+            g.FillRectangle(brush, rect);
+        }
+
         using (var p = new Pen(_backgroundColors[0]))
         {
             g.DrawLine(p, rect.Left + 1, rect.Top + 1, rect.Left + 1, rect.Bottom - 1);
@@ -445,20 +458,31 @@ internal static class KryptonScrollBarRenderer
             g.DrawLine(p, rect.Left + 2, rect.Top + 1, rect.Left + 2, rect.Bottom - 1);
         }
 
-        var firstRect = new Rectangle(rect.Left + 3, rect.Top, 8, rect.Height);
+        int gradientLeft = rect.Left + 3;
+        int gradientRight = rect.Right - 2;
 
-        var secondRect = new Rectangle(firstRect.Right - 1, firstRect.Top, 7, firstRect.Height);
-
-        using (var brush = new LinearGradientBrush(firstRect, _backgroundColors[2],
-                   _backgroundColors[3], LinearGradientMode.Horizontal))
+        if (gradientRight <= gradientLeft)
         {
-            g.FillRectangle(brush, firstRect);
+            return;
         }
 
-        using (var brush = new LinearGradientBrush(secondRect, _backgroundColors[3],
+        var gradientRect = Rectangle.FromLTRB(gradientLeft, rect.Top, gradientRight, rect.Bottom);
+
+        using (var brush = new LinearGradientBrush(gradientRect, _backgroundColors[2],
                    _backgroundColors[4], LinearGradientMode.Horizontal))
         {
-            g.FillRectangle(brush, secondRect);
+            brush.InterpolationColors = new ColorBlend(3)
+            {
+                Colors =
+                [
+                    _backgroundColors[2],
+                    _backgroundColors[3],
+                    _backgroundColors[4]
+                ],
+                Positions = [0f, .5f, 1f]
+            };
+
+            g.FillRectangle(brush, gradientRect);
         }
     }
 
@@ -469,6 +493,13 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawBackgroundHorizontal(Graphics g, Rectangle rect)
     {
+        // See DrawBackgroundVertical: this rect can be DPI-scaled, so the whole
+        // background must be repainted before drawing the themed interior.
+        using (var brush = new SolidBrush(_backgroundColors[4]))
+        {
+            g.FillRectangle(brush, rect);
+        }
+
         using (var p = new Pen(_backgroundColors[0]))
         {
             g.DrawLine(p, rect.Left + 1, rect.Top + 1, rect.Right - 1, rect.Top + 1);
@@ -480,20 +511,31 @@ internal static class KryptonScrollBarRenderer
             g.DrawLine(p, rect.Left + 1, rect.Top + 2, rect.Right - 1, rect.Top + 2);
         }
 
-        var firstRect = new Rectangle(rect.Left, rect.Top + 3, rect.Width, 8);
+        int gradientTop = rect.Top + 3;
+        int gradientBottom = rect.Bottom - 2;
 
-        var secondRect = new Rectangle(firstRect.Left, firstRect.Bottom - 1, firstRect.Width, 7);
-
-        using (var brush = new LinearGradientBrush(firstRect, _backgroundColors[2],
-                   _backgroundColors[3], LinearGradientMode.Vertical))
+        if (gradientBottom <= gradientTop)
         {
-            g.FillRectangle(brush, firstRect);
+            return;
         }
 
-        using (var brush = new LinearGradientBrush(secondRect, _backgroundColors[3],
+        var gradientRect = Rectangle.FromLTRB(rect.Left, gradientTop, rect.Right, gradientBottom);
+
+        using (var brush = new LinearGradientBrush(gradientRect, _backgroundColors[2],
                    _backgroundColors[4], LinearGradientMode.Vertical))
         {
-            g.FillRectangle(brush, secondRect);
+            brush.InterpolationColors = new ColorBlend(3)
+            {
+                Colors =
+                [
+                    _backgroundColors[2],
+                    _backgroundColors[3],
+                    _backgroundColors[4]
+                ],
+                Positions = [0f, .5f, 1f]
+            };
+
+            g.FillRectangle(brush, gradientRect);
         }
     }
 
@@ -504,7 +546,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawTrackVertical(Graphics g, Rectangle rect)
     {
-        var innerRect = new Rectangle(rect.Left + 1, rect.Top, 15, rect.Height);
+        // Keep this relative to rect.Width; hard-coded 15px track painting misses
+        // the right-side pixels when the scrollbar is scaled.
+        var innerRect = new Rectangle(rect.Left + 1, rect.Top, Math.Max(0, rect.Width - 2), rect.Height);
+
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
 
         using var brush = new LinearGradientBrush(innerRect, _trackColors[0], _trackColors[1],
             LinearGradientMode.Horizontal);
@@ -518,7 +567,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawTrackHorizontal(Graphics g, Rectangle rect)
     {
-        var innerRect = new Rectangle(rect.Left, rect.Top + 1, rect.Width, 15);
+        // Keep this relative to rect.Height; hard-coded 15px track painting misses
+        // the lower pixels when the scrollbar is scaled.
+        var innerRect = new Rectangle(rect.Left, rect.Top + 1, rect.Width, Math.Max(0, rect.Height - 2));
+
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
 
         using var brush = new LinearGradientBrush(innerRect, _trackColors[0], _trackColors[1],
             LinearGradientMode.Vertical);
@@ -582,9 +638,22 @@ internal static class KryptonScrollBarRenderer
         Rectangle innerRect = rect;
         innerRect.Inflate(-1, -1);
 
-        Rectangle r = innerRect;
-        r.Width = 6;
-        r.Height++;
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
+
+        // Clear the full inner thumb before applying the split gradient. The old
+        // fixed 6px halves only covered a 12px interior and could leave stale
+        // vertical strips at high DPI.
+        using (var brush = new SolidBrush(_thumbColors[index, 5]))
+        {
+            g.FillRectangle(brush, innerRect);
+        }
+
+        int leftWidth = Math.Max(1, innerRect.Width / 2);
+
+        Rectangle r = new Rectangle(innerRect.Left, innerRect.Top, leftWidth, innerRect.Height + 1);
 
         // draw left gradient
         using (var brush = new LinearGradientBrush(r, _thumbColors[index, 1],
@@ -593,7 +662,7 @@ internal static class KryptonScrollBarRenderer
             g.FillRectangle(brush, r);
         }
 
-        r.X = r.Right;
+        r = new Rectangle(r.Right, innerRect.Top, Math.Max(1, innerRect.Right - r.Right), innerRect.Height + 1);
 
         // draw right gradient
         if (index == 0)
@@ -666,9 +735,22 @@ internal static class KryptonScrollBarRenderer
         Rectangle innerRect = rect;
         innerRect.Inflate(-1, -1);
 
-        Rectangle r = innerRect;
-        r.Height = 6;
-        r.Width++;
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
+
+        // Clear the full inner thumb before applying the split gradient. The old
+        // fixed 6px halves only covered a 12px interior and could leave stale
+        // horizontal strips at high DPI.
+        using (var brush = new SolidBrush(_thumbColors[index, 5]))
+        {
+            g.FillRectangle(brush, innerRect);
+        }
+
+        int topHeight = Math.Max(1, innerRect.Height / 2);
+
+        Rectangle r = new Rectangle(innerRect.Left, innerRect.Top, innerRect.Width + 1, topHeight);
 
         // draw left gradient
         using (var brush = new LinearGradientBrush(r, _thumbColors[index, 1],
@@ -677,7 +759,7 @@ internal static class KryptonScrollBarRenderer
             g.FillRectangle(brush, r);
         }
 
-        r.Y = r.Bottom;
+        r = new Rectangle(innerRect.Left, r.Bottom, innerRect.Width + 1, Math.Max(1, innerRect.Bottom - r.Bottom));
 
         // draw right gradient
         if (index == 0)

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
@@ -1,9 +1,9 @@
-#region BSD License
+﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -39,6 +39,22 @@ public class KryptonScrollbarManager : IDisposable
     private readonly Timer _syncTimer;
     private RichTextBoxScrollBars? _originalRichTextBoxScrollBars;
     private ScrollBars? _originalTextBoxScrollBars;
+    private bool _nativeThumbTracking;
+    private IntPtr _hiddenNativeScrollbarsHandle;
+    private Control? _scrollbarHostControl;
+    private int _lastListBoxItemCount = -1;
+    private int _lastListBoxVisibleItems = -1;
+    private int _lastListBoxMaximumTopIndex = -1;
+    private int _lastListBoxHorizontalContentWidth = -1;
+    private int _lastListBoxHorizontalPageWidth = -1;
+    private int _lastListBoxMaximumLeftOffset = -1;
+    private int _trackedListBoxItemCount = -1;
+    private int _trackedListBoxVisibleItems = -1;
+    private int _trackedListBoxMaximumTopIndex = -1;
+    private int _trackedListBoxHorizontalContentWidth = -1;
+    private int _trackedListBoxHorizontalPageWidth = -1;
+    private int _trackedListBoxMaximumLeftOffset = -1;
+    private const string DebugLogFileName = "KryptonVScrollBarDrag.log";
 
     #endregion
 
@@ -198,6 +214,8 @@ public class KryptonScrollbarManager : IDisposable
         _targetControl.HandleDestroyed += OnTargetControlHandleDestroyed;
         _targetControl.Resize += OnTargetControlResize;
         _targetControl.Layout += OnTargetControlLayout;
+        _targetControl.ParentChanged += OnTargetControlParentChanged;
+        UpdateScrollbarHostHook();
 
         // Initialize based on mode
         switch (_mode)
@@ -233,6 +251,8 @@ public class KryptonScrollbarManager : IDisposable
             _targetControl.HandleDestroyed -= OnTargetControlHandleDestroyed;
             _targetControl.Resize -= OnTargetControlResize;
             _targetControl.Layout -= OnTargetControlLayout;
+            _targetControl.ParentChanged -= OnTargetControlParentChanged;
+            UnhookScrollbarHostControl();
 
             // Restore original ScrollBars values for RichTextBox/TextBox
             if (_targetControl is RichTextBox richTextBox && _originalRichTextBoxScrollBars.HasValue)
@@ -261,6 +281,7 @@ public class KryptonScrollbarManager : IDisposable
         // Remove and dispose scrollbars
         RemoveScrollbars();
         _contentContainer = null;
+        InvalidateNativeScrollbarState();
     }
 
     /// <summary>
@@ -268,7 +289,7 @@ public class KryptonScrollbarManager : IDisposable
     /// </summary>
     public void UpdateScrollbars()
     {
-        if (_targetControl == null || !_enabled || _isUpdating)
+        if (_targetControl == null || !_enabled || _isUpdating || (_mode == ScrollbarManagerMode.NativeWrapper && _nativeThumbTracking))
         {
             return;
         }
@@ -536,8 +557,13 @@ public class KryptonScrollbarManager : IDisposable
             return;
         }
 
-        // Hide native scrollbars
-        HideNativeScrollbars();
+        UpdateScrollbarHostHook();
+        if (NativeScrollbarsAppearVisible())
+        {
+            InvalidateNativeScrollbarHiddenState();
+        }
+
+        EnsureNativeScrollbarsHidden();
 
         // Get scroll information from native control
         var hScrollInfo = new WIN32ScrollBars.ScrollInfo
@@ -554,9 +580,14 @@ public class KryptonScrollbarManager : IDisposable
 
         bool hasHScroll = PI.GetScrollInfo(_targetControl.Handle, PI.SB_.HORZ, ref hScrollInfo);
         bool hasVScroll = PI.GetScrollInfo(_targetControl.Handle, PI.SB_.VERT, ref vScrollInfo);
+        int hScrollableMaximum = GetNativeScrollableMaximum(hScrollInfo);
+        int vScrollableMaximum = GetNativeScrollableMaximum(vScrollInfo);
 
-        // Update or create horizontal scrollbar
-        if (hasHScroll && hScrollInfo.nMax >= hScrollInfo.nPage)
+        if (_targetControl is ListBox listBox)
+        {
+            UpdateListBoxHorizontalScrollbar(listBox, hScrollInfo, hasHScroll);
+        }
+        else if (hasHScroll && hScrollableMaximum > hScrollInfo.nMin)
         {
             if (_horizontalScrollBar == null)
             {
@@ -566,13 +597,19 @@ public class KryptonScrollbarManager : IDisposable
             if (_horizontalScrollBar != null)
             {
                 _suppressScrollEvents = true;
-                _horizontalScrollBar.Visible = true;
-                _horizontalScrollBar.Minimum = hScrollInfo.nMin;
-                _horizontalScrollBar.Maximum = hScrollInfo.nMax;
-                _horizontalScrollBar.LargeChange = hScrollInfo.nPage;
-                _horizontalScrollBar.SmallChange = 1;
-                _horizontalScrollBar.Value = Math.Min(hScrollInfo.nPos, _horizontalScrollBar.Maximum);
-                _suppressScrollEvents = false;
+                try
+                {
+                    _horizontalScrollBar.Visible = true;
+                    _horizontalScrollBar.Minimum = hScrollInfo.nMin;
+                    _horizontalScrollBar.Maximum = hScrollInfo.nMax;
+                    _horizontalScrollBar.LargeChange = hScrollInfo.nPage;
+                    _horizontalScrollBar.SmallChange = 1;
+                    _horizontalScrollBar.Value = Math.Min(hScrollInfo.nPos, hScrollableMaximum);
+                }
+                finally
+                {
+                    _suppressScrollEvents = false;
+                }
             }
         }
         else
@@ -583,8 +620,11 @@ public class KryptonScrollbarManager : IDisposable
             }
         }
 
-        // Update or create vertical scrollbar
-        if (hasVScroll && vScrollInfo.nMax >= vScrollInfo.nPage)
+        if (_targetControl is ListBox listBoxForVertical)
+        {
+            UpdateListBoxVerticalScrollbar(listBoxForVertical);
+        }
+        else if (hasVScroll && vScrollableMaximum > vScrollInfo.nMin)
         {
             if (_verticalScrollBar == null)
             {
@@ -594,13 +634,19 @@ public class KryptonScrollbarManager : IDisposable
             if (_verticalScrollBar != null)
             {
                 _suppressScrollEvents = true;
-                _verticalScrollBar.Visible = true;
-                _verticalScrollBar.Minimum = vScrollInfo.nMin;
-                _verticalScrollBar.Maximum = vScrollInfo.nMax;
-                _verticalScrollBar.LargeChange = vScrollInfo.nPage;
-                _verticalScrollBar.SmallChange = 1;
-                _verticalScrollBar.Value = Math.Min(vScrollInfo.nPos, _verticalScrollBar.Maximum);
-                _suppressScrollEvents = false;
+                try
+                {
+                    _verticalScrollBar.Visible = true;
+                    _verticalScrollBar.Minimum = vScrollInfo.nMin;
+                    _verticalScrollBar.Maximum = vScrollInfo.nMax;
+                    _verticalScrollBar.LargeChange = vScrollInfo.nPage;
+                    _verticalScrollBar.SmallChange = 1;
+                    _verticalScrollBar.Value = Math.Min(vScrollInfo.nPos, vScrollableMaximum);
+                }
+                finally
+                {
+                    _suppressScrollEvents = false;
+                }
             }
         }
         else
@@ -615,6 +661,286 @@ public class KryptonScrollbarManager : IDisposable
         PositionScrollbars();
 
         OnScrollbarsChanged();
+    }
+
+    private void UpdateListBoxHorizontalScrollbar(ListBox listBox, WIN32ScrollBars.ScrollInfo hScrollInfo, bool hasHScroll)
+    {
+        int contentWidth = GetListBoxHorizontalContentWidth(listBox, hScrollInfo, hasHScroll);
+        int pageWidth = GetListBoxHorizontalPageWidth(listBox);
+        int maximumLeftOffset = Math.Max(0, contentWidth - pageWidth);
+
+        if (contentWidth != _lastListBoxHorizontalContentWidth ||
+            pageWidth != _lastListBoxHorizontalPageWidth ||
+            maximumLeftOffset != _lastListBoxMaximumLeftOffset)
+        {
+            _lastListBoxHorizontalContentWidth = contentWidth;
+            _lastListBoxHorizontalPageWidth = pageWidth;
+            _lastListBoxMaximumLeftOffset = maximumLeftOffset;
+            InvalidateNativeScrollbarHiddenState();
+            EnsureNativeScrollbarsHidden();
+        }
+
+        if (maximumLeftOffset > 0)
+        {
+            if (_horizontalScrollBar == null)
+            {
+                CreateHorizontalScrollbar();
+            }
+
+            if (_horizontalScrollBar != null)
+            {
+                _suppressScrollEvents = true;
+                try
+                {
+                    _horizontalScrollBar.Visible = true;
+                    _horizontalScrollBar.Minimum = 0;
+                    _horizontalScrollBar.Maximum = Math.Max(0, contentWidth - 1);
+                    _horizontalScrollBar.LargeChange = pageWidth;
+                    _horizontalScrollBar.SmallChange = Math.Max(1, Math.Min(16, pageWidth / 10));
+                    _horizontalScrollBar.Value = Math.Min(Math.Max(0, hScrollInfo.nPos), maximumLeftOffset);
+                }
+                finally
+                {
+                    _suppressScrollEvents = false;
+                }
+            }
+        }
+        else if (_horizontalScrollBar != null)
+        {
+            _horizontalScrollBar.Visible = false;
+        }
+    }
+
+    private void UpdateListBoxVerticalScrollbar(ListBox listBox)
+    {
+        int visibleItems = GetListBoxVisibleItemCount(listBox);
+        int itemCount = listBox.Items.Count;
+        int maximumTopIndex = Math.Max(0, itemCount - visibleItems);
+        if (itemCount != _lastListBoxItemCount ||
+            visibleItems != _lastListBoxVisibleItems ||
+            maximumTopIndex != _lastListBoxMaximumTopIndex)
+        {
+            _lastListBoxItemCount = itemCount;
+            _lastListBoxVisibleItems = visibleItems;
+            _lastListBoxMaximumTopIndex = maximumTopIndex;
+            InvalidateNativeScrollbarHiddenState();
+            EnsureNativeScrollbarsHidden();
+        }
+
+        if (itemCount > visibleItems)
+        {
+            if (_verticalScrollBar == null)
+            {
+                CreateVerticalScrollbar();
+            }
+
+            if (_verticalScrollBar != null)
+            {
+                _suppressScrollEvents = true;
+                try
+                {
+                    _verticalScrollBar.Visible = true;
+                    _verticalScrollBar.Minimum = 0;
+                    _verticalScrollBar.Maximum = Math.Max(0, itemCount - 1);
+                    _verticalScrollBar.LargeChange = visibleItems;
+                    _verticalScrollBar.SmallChange = 1;
+                    _verticalScrollBar.Value = Math.Min(listBox.TopIndex, maximumTopIndex);
+                }
+                finally
+                {
+                    _suppressScrollEvents = false;
+                }
+            }
+        }
+        else if (_verticalScrollBar != null)
+        {
+            _verticalScrollBar.Visible = false;
+        }
+    }
+
+    private static int GetListBoxVisibleItemCount(ListBox listBox)
+    {
+        if (listBox.Items.Count == 0)
+        {
+            return 1;
+        }
+
+        int itemHeight = Math.Max(1, listBox.ItemHeight);
+        try
+        {
+            itemHeight = Math.Max(itemHeight, listBox.GetItemRectangle(0).Height);
+        }
+        catch
+        {
+            // Use ItemHeight when the native item rectangle is not available.
+        }
+
+        return Math.Max(1, listBox.ClientSize.Height / itemHeight);
+    }
+
+    private static int GetListBoxHorizontalPageWidth(ListBox listBox) => Math.Max(1, listBox.ClientSize.Width);
+
+    private static int GetListBoxHorizontalContentWidth(ListBox listBox, WIN32ScrollBars.ScrollInfo hScrollInfo, bool hasHScroll)
+    {
+        int contentWidth = Math.Max(0, listBox.HorizontalExtent);
+        if (hasHScroll && hScrollInfo.nMax > hScrollInfo.nMin)
+        {
+            contentWidth = Math.Max(contentWidth, hScrollInfo.nMax - hScrollInfo.nMin + 1);
+        }
+
+        return contentWidth;
+    }
+
+    private static int GetNativeScrollableMaximum(WIN32ScrollBars.ScrollInfo scrollInfo)
+    {
+        int page = Math.Max(1, scrollInfo.nPage);
+        long scrollableMaximum = (long)scrollInfo.nMax - page + 1;
+
+        if (scrollableMaximum < scrollInfo.nMin)
+        {
+            return scrollInfo.nMin;
+        }
+
+        return scrollableMaximum > int.MaxValue ? int.MaxValue : (int)scrollableMaximum;
+    }
+
+    private void EnsureNativeScrollbarsHidden()
+    {
+        if (_targetControl == null || !_targetControl.IsHandleCreated || _hiddenNativeScrollbarsHandle == _targetControl.Handle)
+        {
+            return;
+        }
+
+        HideNativeScrollbars();
+        _hiddenNativeScrollbarsHandle = _targetControl.Handle;
+    }
+
+    private void InvalidateNativeScrollbarState()
+    {
+        _hiddenNativeScrollbarsHandle = IntPtr.Zero;
+        _lastListBoxItemCount = -1;
+        _lastListBoxVisibleItems = -1;
+        _lastListBoxMaximumTopIndex = -1;
+        _lastListBoxHorizontalContentWidth = -1;
+        _lastListBoxHorizontalPageWidth = -1;
+        _lastListBoxMaximumLeftOffset = -1;
+        ClearTrackedListBoxMetrics();
+    }
+
+    private void InvalidateNativeScrollbarHiddenState()
+    {
+        _hiddenNativeScrollbarsHandle = IntPtr.Zero;
+    }
+
+    private bool NativeScrollbarsAppearVisible()
+    {
+        if (_targetControl is not ListBox listBox)
+        {
+            return false;
+        }
+
+        int widthDifference = listBox.Width - listBox.ClientSize.Width;
+        int heightDifference = listBox.Height - listBox.ClientSize.Height;
+
+        return widthDifference >= SystemInformation.VerticalScrollBarWidth / 2 ||
+               heightDifference >= SystemInformation.HorizontalScrollBarHeight / 2;
+    }
+
+    private void BeginNativeThumbTracking()
+    {
+        if (_nativeThumbTracking)
+        {
+            return;
+        }
+
+        _nativeThumbTracking = true;
+
+        if (_targetControl is ListBox listBox)
+        {
+            int itemCount = listBox.Items.Count;
+            int visibleItems = _lastListBoxVisibleItems > 0
+                ? _lastListBoxVisibleItems
+                : GetListBoxVisibleItemCount(listBox);
+
+            _trackedListBoxItemCount = itemCount;
+            _trackedListBoxVisibleItems = visibleItems;
+            _trackedListBoxMaximumTopIndex = Math.Max(0, itemCount - visibleItems);
+            _trackedListBoxHorizontalContentWidth = _lastListBoxHorizontalContentWidth;
+            _trackedListBoxHorizontalPageWidth = _lastListBoxHorizontalPageWidth;
+            _trackedListBoxMaximumLeftOffset = _lastListBoxMaximumLeftOffset;
+        }
+    }
+
+    private void EndNativeThumbTracking()
+    {
+        _nativeThumbTracking = false;
+        ClearTrackedListBoxMetrics();
+    }
+
+    private void ClearTrackedListBoxMetrics()
+    {
+        _trackedListBoxItemCount = -1;
+        _trackedListBoxVisibleItems = -1;
+        _trackedListBoxMaximumTopIndex = -1;
+        _trackedListBoxHorizontalContentWidth = -1;
+        _trackedListBoxHorizontalPageWidth = -1;
+        _trackedListBoxMaximumLeftOffset = -1;
+    }
+
+    private int GetListBoxVisibleItemsForSync(ListBox listBox)
+    {
+        if (_nativeThumbTracking &&
+            _trackedListBoxItemCount == listBox.Items.Count &&
+            _trackedListBoxVisibleItems > 0)
+        {
+            return _trackedListBoxVisibleItems;
+        }
+
+        return GetListBoxVisibleItemCount(listBox);
+    }
+
+    private int GetListBoxMaximumTopIndexForSync(ListBox listBox, int visibleItems)
+    {
+        if (_nativeThumbTracking &&
+            _trackedListBoxItemCount == listBox.Items.Count &&
+            _trackedListBoxVisibleItems == visibleItems &&
+            _trackedListBoxMaximumTopIndex >= 0)
+        {
+            return _trackedListBoxMaximumTopIndex;
+        }
+
+        return Math.Max(0, listBox.Items.Count - visibleItems);
+    }
+
+    private int GetListBoxHorizontalPageWidthForSync(ListBox listBox)
+    {
+        if (_nativeThumbTracking &&
+            _trackedListBoxHorizontalPageWidth > 0)
+        {
+            return _trackedListBoxHorizontalPageWidth;
+        }
+
+        return GetListBoxHorizontalPageWidth(listBox);
+    }
+
+    private int GetListBoxMaximumLeftOffsetForSync(ListBox listBox, int pageWidth)
+    {
+        if (_nativeThumbTracking &&
+            _trackedListBoxHorizontalPageWidth == pageWidth &&
+            _trackedListBoxMaximumLeftOffset >= 0)
+        {
+            return _trackedListBoxMaximumLeftOffset;
+        }
+
+        var hScrollInfo = new WIN32ScrollBars.ScrollInfo
+        {
+            cbSize = Marshal.SizeOf(typeof(WIN32ScrollBars.ScrollInfo)),
+            fMask = (int)PI.SIF_.ALL
+        };
+        bool hasHScroll = PI.GetScrollInfo(listBox.Handle, PI.SB_.HORZ, ref hScrollInfo);
+        int contentWidth = GetListBoxHorizontalContentWidth(listBox, hScrollInfo, hasHScroll);
+
+        return Math.Max(0, contentWidth - pageWidth);
     }
 
     private void HideNativeScrollbars()
@@ -654,6 +980,12 @@ public class KryptonScrollbarManager : IDisposable
             // scrollbars via ShowScrollBar so only Krypton scrollbars are visible.
             _ = PI.ShowScrollBar(_targetControl.Handle, (int)PI.SB_.BOTH, false);
 
+            if (_targetControl is ListBox)
+            {
+                _targetControl.Invalidate();
+                return;
+            }
+
             // Also remove scrollbar window styles so they stay hidden; frame change is required
             // for style changes to take effect (see SetWindowLong / SetWindowPos docs).
             uint style = PI.GetWindowLong(_targetControl.Handle, PI.GWL_.STYLE);
@@ -672,7 +1004,7 @@ public class KryptonScrollbarManager : IDisposable
         }
     }
 
-    private void SyncNativeScrollPosition(bool horizontal, int value)
+    private void SyncNativeScrollPosition(bool horizontal, ScrollEventArgs e)
     {
         if (_targetControl == null || !_targetControl.IsHandleCreated || _suppressScrollEvents)
         {
@@ -681,16 +1013,258 @@ public class KryptonScrollbarManager : IDisposable
 
         try
         {
+            if (horizontal && _targetControl is ListBox horizontalListBox)
+            {
+                int pageWidth = GetListBoxHorizontalPageWidthForSync(horizontalListBox);
+                int maximumLeftOffset = GetListBoxMaximumLeftOffsetForSync(horizontalListBox, pageWidth);
+                int requestedLeftOffset = Math.Max(0, Math.Min(e.NewValue, maximumLeftOffset));
+                PI.SetScrollPos(horizontalListBox.Handle, PI.SB_.HORZ, requestedLeftOffset, true);
+
+                int horizontalScrollRequest = e.Type == ScrollEventType.ThumbTrack
+                    ? (int)PI.SB_.THUMBTRACK
+                    : (int)PI.SB_.THUMBPOSITION;
+
+                PI.SendMessage(horizontalListBox.Handle, PI.WM_.HSCROLL,
+                    (IntPtr)(horizontalScrollRequest | (requestedLeftOffset << 16)), IntPtr.Zero);
+
+                EnsureNativeScrollbarsHidden();
+                horizontalListBox.Invalidate();
+                SyncListBoxHorizontalScrollbarValue(horizontalListBox, requestedLeftOffset);
+                return;
+            }
+
+            if (!horizontal && _targetControl is ListBox listBox)
+            {
+                if (listBox.Items.Count == 0)
+                {
+                    return;
+                }
+
+                int visibleItems = GetListBoxVisibleItemsForSync(listBox);
+                int maximumTopIndex = GetListBoxMaximumTopIndexForSync(listBox, visibleItems);
+                int requestedTopIndex = Math.Max(0, Math.Min(e.NewValue, maximumTopIndex));
+
+                if (listBox.TopIndex != requestedTopIndex)
+                {
+                    listBox.TopIndex = requestedTopIndex;
+                }
+
+                EnsureNativeScrollbarsHidden();
+                listBox.Invalidate();
+                AppendDebugLog($"sync type={e.Type} requested={e.NewValue} accepted={listBox.TopIndex} visible={visibleItems} items={listBox.Items.Count} maxTop={maximumTopIndex} scrollbarValue={_verticalScrollBar?.Value.ToString() ?? "<null>"} scrollbarBounds={FormatRectangle(_verticalScrollBar?.Bounds ?? Rectangle.Empty)} targetClient={FormatRectangle(listBox.ClientRectangle)}");
+                SyncListBoxVerticalScrollbarValue(listBox);
+                return;
+            }
+
             PI.SB_ scrollBar = horizontal ? PI.SB_.HORZ : PI.SB_.VERT;
+            int value = e.NewValue;
             PI.SetScrollPos(_targetControl.Handle, scrollBar, value, true);
+            int scrollRequest = e.Type == ScrollEventType.ThumbTrack
+                ? (int)PI.SB_.THUMBTRACK
+                : (int)PI.SB_.THUMBPOSITION;
 
             // Send scroll message to update the control
             PI.SendMessage(_targetControl.Handle, horizontal ? PI.WM_.HSCROLL : PI.WM_.VSCROLL,
-                (IntPtr)((int)PI.SB_.THUMBPOSITION | (value << 16)), IntPtr.Zero);
+                (IntPtr)(scrollRequest | (value << 16)), IntPtr.Zero);
         }
         catch
         {
             // Ignore errors
+        }
+    }
+
+    private void SyncListBoxHorizontalScrollbarValue(ListBox listBox, int requestedLeftOffset)
+    {
+        if (_horizontalScrollBar == null)
+        {
+            return;
+        }
+
+        int pageWidth = GetListBoxHorizontalPageWidthForSync(listBox);
+        int maximumLeftOffset = GetListBoxMaximumLeftOffsetForSync(listBox, pageWidth);
+        int value = Math.Min(requestedLeftOffset, maximumLeftOffset);
+
+        var hScrollInfo = new WIN32ScrollBars.ScrollInfo
+        {
+            cbSize = Marshal.SizeOf(typeof(WIN32ScrollBars.ScrollInfo)),
+            fMask = (int)PI.SIF_.POS
+        };
+        if (PI.GetScrollInfo(listBox.Handle, PI.SB_.HORZ, ref hScrollInfo))
+        {
+            value = Math.Min(Math.Max(0, hScrollInfo.nPos), maximumLeftOffset);
+        }
+
+        _suppressScrollEvents = true;
+        try
+        {
+            _horizontalScrollBar.Value = value;
+        }
+        finally
+        {
+            _suppressScrollEvents = false;
+        }
+    }
+
+    private void SyncListBoxVerticalScrollbarValue(ListBox listBox)
+    {
+        if (_verticalScrollBar == null)
+        {
+            return;
+        }
+
+        int visibleItems = GetListBoxVisibleItemsForSync(listBox);
+        int maximumTopIndex = GetListBoxMaximumTopIndexForSync(listBox, visibleItems);
+        int value = Math.Min(listBox.TopIndex, maximumTopIndex);
+
+        _suppressScrollEvents = true;
+        try
+        {
+            _verticalScrollBar.Value = value;
+        }
+        finally
+        {
+            _suppressScrollEvents = false;
+        }
+    }
+
+    private Control? GetScrollbarHostControl()
+    {
+        if (_targetControl == null)
+        {
+            return null;
+        }
+
+        if (_mode == ScrollbarManagerMode.NativeWrapper &&
+            _targetControl is ListBox &&
+            _targetControl.Parent != null)
+        {
+            return _targetControl.Parent;
+        }
+
+        return _targetControl;
+    }
+
+    private void UpdateScrollbarHostHook()
+    {
+        Control? host = GetScrollbarHostControl();
+        if (_scrollbarHostControl == host)
+        {
+            MoveExistingScrollbarsToHost(host);
+            return;
+        }
+
+        UnhookScrollbarHostControl();
+
+        _scrollbarHostControl = host;
+        if (_scrollbarHostControl != null && _scrollbarHostControl != _targetControl)
+        {
+            _scrollbarHostControl.Resize += OnScrollbarHostResize;
+            _scrollbarHostControl.Layout += OnScrollbarHostLayout;
+        }
+
+        MoveExistingScrollbarsToHost(host);
+    }
+
+    private void UnhookScrollbarHostControl()
+    {
+        if (_scrollbarHostControl != null && _scrollbarHostControl != _targetControl)
+        {
+            _scrollbarHostControl.Resize -= OnScrollbarHostResize;
+            _scrollbarHostControl.Layout -= OnScrollbarHostLayout;
+        }
+
+        _scrollbarHostControl = null;
+    }
+
+    private Rectangle GetTargetClientRectangleInHost()
+    {
+        if (_targetControl == null)
+        {
+            return Rectangle.Empty;
+        }
+
+        Control? host = GetScrollbarHostControl();
+        if (host == null)
+        {
+            return Rectangle.Empty;
+        }
+
+        if (host == _targetControl)
+        {
+            return _targetControl.ClientRectangle;
+        }
+
+        Point location = host.PointToClient(_targetControl.PointToScreen(Point.Empty));
+        return new Rectangle(location, _targetControl.Size);
+    }
+
+    private void MoveExistingScrollbarsToHost(Control? host)
+    {
+        MoveScrollbarToHost(_horizontalScrollBar, host);
+        MoveScrollbarToHost(_verticalScrollBar, host);
+    }
+
+    private static void MoveScrollbarToHost(Control? scrollbar, Control? host)
+    {
+        if (scrollbar == null || scrollbar.Parent == host)
+        {
+            return;
+        }
+
+        if (scrollbar.Parent != null)
+        {
+            RemoveScrollbarFromHost(scrollbar);
+        }
+
+        if (host != null && host.IsHandleCreated)
+        {
+            AddScrollbarToHost(host, scrollbar);
+            scrollbar.BringToFront();
+        }
+    }
+
+    private static void AddScrollbarToHost(Control host, Control scrollbar)
+    {
+        if (host.Controls is KryptonControlCollection kryptonControls)
+        {
+            kryptonControls.AddInternal(scrollbar);
+        }
+        else
+        {
+            host.Controls.Add(scrollbar);
+        }
+    }
+
+    private static void RemoveScrollbarFromHost(Control scrollbar)
+    {
+        Control? parent = scrollbar.Parent;
+        if (parent == null)
+        {
+            return;
+        }
+
+        if (parent.Controls is KryptonControlCollection kryptonControls)
+        {
+            kryptonControls.RemoveInternal(scrollbar);
+        }
+        else
+        {
+            parent.Controls.Remove(scrollbar);
+        }
+    }
+
+    private static string FormatRectangle(Rectangle rectangle) => $"{rectangle.X},{rectangle.Y},{rectangle.Width},{rectangle.Height}";
+
+    private static void AppendDebugLog(string message)
+    {
+        try
+        {
+            string path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), DebugLogFileName);
+            System.IO.File.AppendAllText(path, $"{DateTime.Now:O} KryptonScrollbarManager {message}{Environment.NewLine}");
+        }
+        catch
+        {
+            // Debug logging must never affect scrollbar behavior.
         }
     }
 
@@ -719,9 +1293,10 @@ public class KryptonScrollbarManager : IDisposable
 
         _horizontalScrollBar.Scroll += OnHorizontalScroll;
 
-        if (_targetControl.IsHandleCreated)
+        Control? host = GetScrollbarHostControl();
+        if (host != null && host.IsHandleCreated)
         {
-            _targetControl.Controls.Add(_horizontalScrollBar);
+            AddScrollbarToHost(host, _horizontalScrollBar);
             _horizontalScrollBar.BringToFront();
         }
     }
@@ -747,9 +1322,10 @@ public class KryptonScrollbarManager : IDisposable
 
         _verticalScrollBar.Scroll += OnVerticalScroll;
 
-        if (_targetControl.IsHandleCreated)
+        Control? host = GetScrollbarHostControl();
+        if (host != null && host.IsHandleCreated)
         {
-            _targetControl.Controls.Add(_verticalScrollBar);
+            AddScrollbarToHost(host, _verticalScrollBar);
             _verticalScrollBar.BringToFront();
         }
     }
@@ -761,7 +1337,7 @@ public class KryptonScrollbarManager : IDisposable
             _horizontalScrollBar.Scroll -= OnHorizontalScroll;
             if (_horizontalScrollBar.Parent != null)
             {
-                _horizontalScrollBar.Parent.Controls.Remove(_horizontalScrollBar);
+                RemoveScrollbarFromHost(_horizontalScrollBar);
             }
 
             _horizontalScrollBar.Dispose();
@@ -773,7 +1349,7 @@ public class KryptonScrollbarManager : IDisposable
             _verticalScrollBar.Scroll -= OnVerticalScroll;
             if (_verticalScrollBar.Parent != null)
             {
-                _verticalScrollBar.Parent.Controls.Remove(_verticalScrollBar);
+                RemoveScrollbarFromHost(_verticalScrollBar);
             }
 
             _verticalScrollBar.Dispose();
@@ -790,7 +1366,7 @@ public class KryptonScrollbarManager : IDisposable
             return;
         }
 
-        Rectangle clientRect = _targetControl.ClientRectangle;
+        Rectangle clientRect = GetTargetClientRectangleInHost();
         int scrollbarWidth = SystemInformation.VerticalScrollBarWidth;
         int scrollbarHeight = SystemInformation.HorizontalScrollBarHeight;
 
@@ -799,11 +1375,11 @@ public class KryptonScrollbarManager : IDisposable
         {
             int hScrollY = clientRect.Bottom - scrollbarHeight;
             int hScrollWidth = clientRect.Width - (_verticalScrollBar?.Visible == true ? scrollbarWidth : 0);
-            
+
             // Ensure scrollbar stays within bounds
             hScrollY = Math.Max(clientRect.Top, Math.Min(hScrollY, clientRect.Bottom - 1));
             hScrollWidth = Math.Max(0, Math.Min(hScrollWidth, clientRect.Width));
-            
+
             _horizontalScrollBar.Location = new Point(clientRect.Left, hScrollY);
             _horizontalScrollBar.Width = hScrollWidth;
             _horizontalScrollBar.Height = scrollbarHeight;
@@ -814,14 +1390,29 @@ public class KryptonScrollbarManager : IDisposable
         {
             int vScrollX = clientRect.Right - scrollbarWidth;
             int vScrollHeight = clientRect.Height - (_horizontalScrollBar?.Visible == true ? scrollbarHeight : 0);
-            
+
             // Ensure scrollbar stays within bounds
             vScrollX = Math.Max(clientRect.Left, Math.Min(vScrollX, clientRect.Right - 1));
             vScrollHeight = Math.Max(0, Math.Min(vScrollHeight, clientRect.Height));
-            
+
             _verticalScrollBar.Location = new Point(vScrollX, clientRect.Top);
             _verticalScrollBar.Width = scrollbarWidth;
             _verticalScrollBar.Height = vScrollHeight;
+        }
+
+        BringScrollbarsToFront();
+    }
+
+    private void BringScrollbarsToFront()
+    {
+        if (_horizontalScrollBar != null && _horizontalScrollBar.Visible)
+        {
+            _horizontalScrollBar.BringToFront();
+        }
+
+        if (_verticalScrollBar != null && _verticalScrollBar.Visible)
+        {
+            _verticalScrollBar.BringToFront();
         }
     }
 
@@ -831,16 +1422,21 @@ public class KryptonScrollbarManager : IDisposable
 
     private void OnTargetControlHandleCreated(object? sender, EventArgs e)
     {
+        InvalidateNativeScrollbarState();
+        UpdateScrollbarHostHook();
         UpdateScrollbars();
     }
 
     private void OnTargetControlHandleDestroyed(object? sender, EventArgs e)
     {
         // Scrollbars will be cleaned up in Detach
+        _nativeThumbTracking = false;
+        InvalidateNativeScrollbarState();
     }
 
     private void OnTargetControlResize(object? sender, EventArgs e)
     {
+        InvalidateNativeScrollbarHiddenState();
         UpdateScrollbars();
     }
 
@@ -848,6 +1444,29 @@ public class KryptonScrollbarManager : IDisposable
     {
         if (!_isUpdating)
         {
+            InvalidateNativeScrollbarHiddenState();
+            UpdateScrollbars();
+        }
+    }
+
+    private void OnTargetControlParentChanged(object? sender, EventArgs e)
+    {
+        UpdateScrollbarHostHook();
+        InvalidateNativeScrollbarHiddenState();
+        UpdateScrollbars();
+    }
+
+    private void OnScrollbarHostResize(object? sender, EventArgs e)
+    {
+        InvalidateNativeScrollbarHiddenState();
+        UpdateScrollbars();
+    }
+
+    private void OnScrollbarHostLayout(object? sender, LayoutEventArgs e)
+    {
+        if (!_isUpdating)
+        {
+            InvalidateNativeScrollbarHiddenState();
             UpdateScrollbars();
         }
     }
@@ -867,7 +1486,17 @@ public class KryptonScrollbarManager : IDisposable
         }
         else if (_mode == ScrollbarManagerMode.NativeWrapper)
         {
-            SyncNativeScrollPosition(true, e.NewValue);
+            if (e.Type == ScrollEventType.ThumbTrack)
+            {
+                BeginNativeThumbTracking();
+            }
+
+            SyncNativeScrollPosition(true, e);
+            if (e.Type == ScrollEventType.EndScroll)
+            {
+                EndNativeThumbTracking();
+                UpdateScrollbars();
+            }
         }
     }
 
@@ -886,7 +1515,17 @@ public class KryptonScrollbarManager : IDisposable
         }
         else if (_mode == ScrollbarManagerMode.NativeWrapper)
         {
-            SyncNativeScrollPosition(false, e.NewValue);
+            if (e.Type == ScrollEventType.ThumbTrack)
+            {
+                BeginNativeThumbTracking();
+            }
+
+            SyncNativeScrollPosition(false, e);
+            if (e.Type == ScrollEventType.EndScroll)
+            {
+                EndNativeThumbTracking();
+                UpdateScrollbars();
+            }
         }
     }
 
@@ -897,7 +1536,7 @@ public class KryptonScrollbarManager : IDisposable
 
     private void SyncTimer_Tick(object? sender, EventArgs e)
     {
-        if (_mode == ScrollbarManagerMode.NativeWrapper && _enabled && !_isUpdating)
+        if (_mode == ScrollbarManagerMode.NativeWrapper && _enabled && !_isUpdating && !_nativeThumbTracking)
         {
             UpdateNativeWrapperScrollbars();
         }


### PR DESCRIPTION
Followup fix for #2926 

﻿This fixes the themed scrollbars used by KryptonListBox and the TestForm theme list.

The ListBox now respects its instance UseKryptonScrollbars setting and keeps the custom scrollbars synchronized with the scroll position accepted by the native ListBox. That removes the feedback loop where dragging the vertical thumb could fight ListBox.TopIndex and jump while the mouse button was still down.

The native ListBox scrollbars are hidden without repeatedly reframing them on every sync tick. The custom scrollbars are also hosted and refreshed in a way that survives resizing and theme changes.

The horizontal ListBox scrollbar now uses the actual content width and viewport width for its range, so the thumb size reflects the real scrollable width instead of appearing as if the content were many times wider.

The scrollbar renderer now paints the actual DPI-scaled background, track, and thumb bounds instead of fixed 15px interiors from the original arrow bitmap diagram. That prevents stale edge pixels from being left behind at 125% scaling while dragging.