### PR TITLE
* Fix nightly WebView2 cache failures

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -169,7 +169,9 @@ jobs:
 
       - name: Cache NuGet
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        uses: actions/cache@v5
+        id: nuget_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -246,6 +248,14 @@ jobs:
       - name: Pack Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      - name: Save NuGet cache
+        if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -204,11 +204,39 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - uses: actions/cache@v5
+      - name: Resolve WebView2 version
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
+        id: webview2_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $packageId = "Microsoft.Web.WebView2"
+
+          Write-Host "Querying NuGet for latest WebView2 prerelease..."
+
+          try {
+              $search = Invoke-RestMethod `
+                  -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=true&semVerLevel=2.0.0&take=1"
+              $latestVersion = $search.data[0].version
+          }
+          catch {
+              Write-Warning "NuGet search failed, using fallback version"
+              $latestVersion = "1.0.3595.46"
+          }
+
+          Write-Host "Using WebView2 version: $latestVersion"
+          "version=$latestVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Restore WebView2 cache
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
+        id: webview2_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ${{ runner.temp }}/webview2
-          key: webview2-${{ runner.os }}
+          key: webview2-${{ runner.os }}-${{ steps.webview2_version.outputs.version }}
+          restore-keys: |
+            webview2-${{ runner.os }}-
 
       - name: Populate WebView2 (Preview)
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
@@ -226,34 +254,31 @@ jobs:
           New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
           $packageId = "Microsoft.Web.WebView2"
-
-          Write-Host "Querying NuGet for latest WebView2 prerelease..."
-
-          try {
-              $search = Invoke-RestMethod `
-                  -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=true&semVerLevel=2.0.0&take=1"
-
-              $latestVersion = $search.data[0].version
-          }
-          catch {
-              Write-Warning "NuGet search failed, using fallback version"
-              $latestVersion = "1.0.3595.46"
-          }
-
-          Write-Host "Using WebView2 version: $latestVersion"
+          $latestVersion = "${{ steps.webview2_version.outputs.version }}"
 
           $nupkg = Join-Path $tempDir "$packageId.$latestVersion.nupkg"
           $extractDir = Join-Path $tempDir "extract"
+          $expectedExtractedDll = Join-Path $extractDir "build\native\WebView2Loader.dll"
 
-          Write-Host "Downloading package..."
+          if (Test-Path -LiteralPath $tempDir -and -not (Test-Path -LiteralPath $expectedExtractedDll)) {
+              Write-Warning "Detected incomplete WebView2 cache state, rebuilding cache folder."
+              Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+              New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+          }
 
-          Invoke-WebRequest `
-              -Uri "https://www.nuget.org/api/v2/package/$packageId/$latestVersion" `
-              -OutFile $nupkg
+          if (-not (Test-Path -LiteralPath $expectedExtractedDll)) {
+              Write-Host "Downloading package..."
 
-          Write-Host "Extracting package..."
+              Invoke-WebRequest `
+                  -Uri "https://www.nuget.org/api/v2/package/$packageId/$latestVersion" `
+                  -OutFile $nupkg
 
-          Expand-Archive $nupkg $extractDir -Force
+              Write-Host "Extracting package..."
+              Expand-Archive $nupkg $extractDir -Force
+          }
+          else {
+              Write-Host "Using cached WebView2 package extraction."
+          }
 
           Write-Host "Copying required DLLs..."
 
@@ -275,6 +300,14 @@ jobs:
           }
 
           Write-Host "WebView2 population complete."
+
+      - name: Save WebView2 cache
+        if: success() && steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: ${{ steps.webview2_cache_restore.outputs.cache-primary-key }}
 
       # /m: multi-processor MSBuild (all runner CPUs). nightly.proj uses BuildInParallel; project references still order builds.
       - name: Restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,9 @@ jobs:
       - name: Cache NuGet
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        uses: actions/cache@v5
+        id: nuget_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -202,6 +204,15 @@ jobs:
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      - name: Save NuGet cache
+        # Kill switch check
+        if: success() && steps.release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -475,7 +486,9 @@ jobs:
       - name: Cache NuGet
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
-        uses: actions/cache@v5
+        id: nuget_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -535,6 +548,15 @@ jobs:
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      - name: Save NuGet cache
+        # Kill switch check
+        if: success() && steps.release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -826,7 +848,9 @@ jobs:
       - name: Cache NuGet
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
-        uses: actions/cache@v5
+        id: nuget_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -887,6 +911,15 @@ jobs:
         # Kill switch check
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      - name: Save NuGet cache
+        # Kill switch check
+        if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       - name: Push NuGet Packages to nuget.org
         # Kill switch check
@@ -1159,7 +1192,9 @@ jobs:
       - name: Cache NuGet
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
-        uses: actions/cache@v5
+        id: nuget_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -1230,6 +1265,15 @@ jobs:
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      - name: Save NuGet cache
+        # Kill switch check
+        if: success() && steps.nightly_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       # Note: NuGet publishing for alpha/nightly builds is handled by nightly.yml workflow
       # which runs on a schedule and checks for changes in the last 24 hours


### PR DESCRIPTION
# Fix nightly WebView2 cache failures (#3557)

## Summary

Hardens GitHub Actions cache usage across nightly, canary, and release workflows so transient cache restore failures (including WebView2 cache crashes) no longer fail entire release jobs.

Fixes [#3557](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3557).

## Problem

The nightly workflow failed during the WebView2 cache step when `actions/cache@v5` crashed while restoring a cached artifact (process exit code `-1073740791`). A single OS-scoped cache key (`webview2-${{ runner.os }}`) could also retain corrupted or incomplete extracted package state across runs.

## Solution

### Nightly (`nightly.yml`) — WebView2

- Resolve the latest WebView2 prerelease version in a dedicated step and use it in the cache key: `webview2-${{ runner.os }}-<version>`.
- Split cache into **restore** and **save** (`actions/cache/restore@v5` / `actions/cache/save@v5`) with `continue-on-error: true` so cache infrastructure issues are non-fatal.
- Add a corruption guard in **Populate WebView2 (Preview)**: if the cache folder exists but the expected extracted DLL is missing, delete and rebuild the temp folder.
- Skip download/extract when a valid cached extraction is already present.

### Canary & release (`canary.yml`, `release.yml`) — NuGet

- Apply the same restore/save split and `continue-on-error: true` pattern to NuGet package caches in all affected jobs (release stable/LTS, canary, and alpha/nightly release jobs).

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/nightly.yml` | WebView2 versioned cache key, restore/save split, corruption fallback, conditional download | | `.github/workflows/canary.yml` | NuGet cache restore/save with non-fatal errors | | `.github/workflows/release.yml` | NuGet cache restore/save (4 jobs) with non-fatal errors |

## Test plan

- [ ] Re-run the failed nightly workflow (or dispatch manually) and confirm the WebView2 steps complete even if cache restore warns or is skipped.
- [ ] Verify **Populate WebView2 (Preview)** logs `Using cached WebView2 package extraction.` on a second consecutive run with the same WebView2 version.
- [ ] Confirm nightly build, pack, and NuGet push still succeed end-to-end.
- [ ] Spot-check one canary and one release workflow run to ensure NuGet restore/save steps do not fail the job on cache warnings.

## Notes

- Cache keys are versioned by WebView2 package version (not `github.run_number`), so cache reuse remains effective while invalidating stale entries when the package updates.
- `continue-on-error: true` on cache steps means a bad cache no longer blocks the pipeline; the populate step rebuilds content as needed.