### PR TITLE
3561-V110-Fix net472 TestForm startup resource dependency

### DIFF
--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
@@ -22,7 +22,12 @@
 	        AfterTargets="ResolveAssemblyReferences"
 	        BeforeTargets="_GenerateSuggestedBindingRedirectsCache"
 	        Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(GenerateBindingRedirectsOutputType)' == 'true' And '$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true'">
+		<ItemGroup>
+			<_KryptonSreReference Include="@(ReferenceCopyLocalPaths)"
+			                     Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Resources.Extensions' Or '%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions'" />
+		</ItemGroup>
 		<PropertyGroup>
+			<_KryptonSreDllPath Condition="'@(_KryptonSreReference)' != ''">%(_KryptonSreReference.FullPath)</_KryptonSreDllPath>
 			<_KryptonSreDllPath Condition="'$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll</_KryptonSreDllPath>
 			<_KryptonSreDllPath Condition="'$(_KryptonSreDllPath)' == '' And '$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll</_KryptonSreDllPath>
 		</PropertyGroup>

--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
@@ -35,8 +35,17 @@
 
 	<Target Name="KryptonCopyPreserializedResourceDependenciesToOutput"
 	        AfterTargets="Build"
-	        Condition="'$(GenerateResourceUsePreserializedResources)' == 'true' And '$(DesignTimeBuild)' != 'true' And '$(_KryptonSreDllPath)' != ''">
+	        Condition="'$(GenerateResourceUsePreserializedResources)' == 'true' And '$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)"
+			                            Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Resources.Extensions'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Formats.Nrbf'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Memory'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Buffers'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Runtime.CompilerServices.Unsafe'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Collections.Immutable'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Reflection.Metadata'
+			                                       Or '%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Numerics.Vectors'" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonSreDllPath)" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonNrbfDllPath)" Condition="'$(_KryptonNrbfDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonMemoryDllPath)" Condition="'$(_KryptonMemoryDllPath)' != ''" />
@@ -48,6 +57,7 @@
 		</ItemGroup>
 		<Copy SourceFiles="@(_KryptonResourceRuntimeDll)"
 		      DestinationFolder="$(OutputPath)"
+		      Condition="'@(_KryptonResourceRuntimeDll)' != ''"
 		      SkipUnchangedFiles="true" />
 	</Target>
 


### PR DESCRIPTION
Fixes #3561

## Summary

Fixes the .NET 4.7.2 `TestForm` startup crash caused by missing preserialized resource runtime dependencies.

The MSBuild support for .NET Framework resource dependencies now uses the resolved `ReferenceCopyLocalPaths` items. Those items already contain `System.Resources.Extensions` and the related runtime DLLs, so project-reference apps get the same files and binding redirects that the package path expected.

## Root cause

The repo enables preserialized WinForms resources for net4x builds. At startup, `Krypton.Toolkit` loads image resources and .NET Framework needs `System.Resources.Extensions` for that resource format.

The existing copy and binding redirect targets only looked at `PkgSystem_Resources_Extensions` package path properties. In this project-reference build those properties were empty, even though MSBuild had already resolved the dependency. As a result, `Bin\Debug\net472` did not contain `System.Resources.Extensions.dll`, and `TestForm` failed on startup.

## Impact

`TestForm` and other .NET Framework project-reference apps now receive the required resource runtime DLLs and the matching `System.Resources.Extensions` binding redirect. The package-path fallback remains in place.


