### PR TITLE
* Fix failing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,52 +103,44 @@ jobs:
             ${{ runner.os }}-nuget-
 
       # TODO: Remove the step-level `if` below in November 2026 so WebView2 runs on all branches.
-      - name: Populate WebView2 (latest)
+      # Prerelease WebView2 required for net11.0-windows on alpha/canary; stable packages do not support .NET 11 yet.
+      - name: Resolve WebView2 version
         if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        id: webview2_version
         shell: pwsh
         run: |
-          $root = $env:GITHUB_WORKSPACE
-          if (-not $root) { $root = (Get-Location).Path }
-          $utilProj = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj"
-          $libDir = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2"
-          if (-not (Test-Path $utilProj)) { Write-Error "Project not found: $utilProj"; exit 1 }
-          if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force }
-          $packageId = "Microsoft.Web.WebView2"
-          # Prerelease WebView2 on alpha/canary (NuGet search ordering); dotnet CLI still needs an SDK that supports net11.0-windows for restore.
-          $usePrerelease = ($env:GITHUB_REF -eq 'refs/heads/alpha' -or $env:GITHUB_REF -eq 'refs/heads/canary')
-          $prereleaseParam = if ($usePrerelease) { "true" } else { "false" }
-          Write-Host "Using prerelease=$prereleaseParam for WebView2 SDK lookup"
-          $latestVersion = $null
-          try {
-            $searchResponse = Invoke-RestMethod -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=$prereleaseParam&semVerLevel=2.0.0&take=1" -Method Get
-            if ($searchResponse.data -and $searchResponse.data.Count -gt 0) { $latestVersion = $searchResponse.data[0].version }
-          } catch {
-            try {
-              $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$packageId/index.json" -Method Get
-              if ($usePrerelease) {
-                # Include prerelease versions
-                $allVersions = $response.versions | Where-Object { $_ -match '^\d+\.\d+\.\d+' }
-                if ($allVersions) { $latestVersion = $allVersions | Sort-Object { [System.Version]($_ -replace '-.*', '') } -Descending | Select-Object -First 1 }
-              } else {
-                $stableVersions = $response.versions | Where-Object { $_ -notmatch '[-]' -and $_ -match '^\d+\.\d+\.\d+$' }
-                if ($stableVersions) { $latestVersion = $stableVersions | Sort-Object { [System.Version]$_ } -Descending | Select-Object -First 1 }
-              }
-            } catch {}
-          }
-          if (-not $latestVersion) { $latestVersion = "1.0.3595.46" }
-          Write-Host "Using WebView2 ($(if ($usePrerelease) { 'preview' } else { 'latest' })): $latestVersion"
-          dotnet add "$utilProj" package $packageId --version $latestVersion
-          dotnet restore "$utilProj"
-          $nugetBase = Join-Path $env:USERPROFILE ".nuget\packages\microsoft.web.webview2\$latestVersion"
-          @("Microsoft.Web.WebView2.Core.dll","Microsoft.Web.WebView2.WinForms.dll","WebView2Loader.dll") | ForEach-Object {
-            $f = Get-ChildItem -Path $nugetBase -Recurse -Name $_ -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($f) { Copy-Item (Join-Path $nugetBase $f) $libDir -Force; Write-Host "Copied $_" }
-          }
-          [xml]$proj = Get-Content $utilProj
-          $nodes = $proj.SelectNodes("//PackageReference[@Include='$packageId']")
-          foreach ($node in $nodes) { $node.ParentNode.RemoveChild($node) | Out-Null }
-          $proj.Save($utilProj)
-          Write-Host "Removed temporary WebView2 PackageReference entries"
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion
+
+      - name: Restore WebView2 cache
+        if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        id: webview2_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: webview2-${{ runner.os }}-${{ steps.webview2_version.outputs.version }}
+          restore-keys: |
+            webview2-${{ runner.os }}-
+
+      - name: Populate WebView2 (Preview)
+        if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        shell: pwsh
+        env:
+          WEBVIEW2_VERSION: ${{ steps.webview2_version.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -Version $env:WEBVIEW2_VERSION
+
+      - name: Save WebView2 cache
+        if: success() && (github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary')
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: ${{ steps.webview2_cache_restore.outputs.cache-primary-key }}
 
       # Match nightly.proj: Release + TFMs=all so TargetFrameworks / package graphs align (avoids CS7069 / prune mismatches).
       - name: Restore
@@ -233,52 +225,44 @@ jobs:
             ${{ runner.os }}-nuget-
 
       # TODO: Remove the step-level `if` below in November 2026 so WebView2 runs on all branches.
-      - name: Populate WebView2 (latest)
+      # Prerelease WebView2 required for net11.0-windows on alpha/canary; stable packages do not support .NET 11 yet.
+      - name: Resolve WebView2 version
         if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        id: webview2_version_release
         shell: pwsh
         run: |
-          $root = $env:GITHUB_WORKSPACE
-          if (-not $root) { $root = (Get-Location).Path }
-          $utilProj = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj"
-          $libDir = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2"
-          if (-not (Test-Path $utilProj)) { Write-Error "Project not found: $utilProj"; exit 1 }
-          if (-not (Test-Path $libDir)) { New-Item -ItemType Directory -Path $libDir -Force }
-          $packageId = "Microsoft.Web.WebView2"
-          # Prerelease WebView2 on alpha/canary (NuGet search ordering); dotnet CLI still needs an SDK that supports net11.0-windows for restore.
-          $usePrerelease = ($env:GITHUB_REF -eq 'refs/heads/alpha' -or $env:GITHUB_REF -eq 'refs/heads/canary')
-          $prereleaseParam = if ($usePrerelease) { "true" } else { "false" }
-          Write-Host "Using prerelease=$prereleaseParam for WebView2 SDK lookup"
-          $latestVersion = $null
-          try {
-            $searchResponse = Invoke-RestMethod -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=$prereleaseParam&semVerLevel=2.0.0&take=1" -Method Get
-            if ($searchResponse.data -and $searchResponse.data.Count -gt 0) { $latestVersion = $searchResponse.data[0].version }
-          } catch {
-            try {
-              $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$packageId/index.json" -Method Get
-              if ($usePrerelease) {
-                # Include prerelease versions
-                $allVersions = $response.versions | Where-Object { $_ -match '^\d+\.\d+\.\d+' }
-                if ($allVersions) { $latestVersion = $allVersions | Sort-Object { [System.Version]($_ -replace '-.*', '') } -Descending | Select-Object -First 1 }
-              } else {
-                $stableVersions = $response.versions | Where-Object { $_ -notmatch '[-]' -and $_ -match '^\d+\.\d+\.\d+$' }
-                if ($stableVersions) { $latestVersion = $stableVersions | Sort-Object { [System.Version]$_ } -Descending | Select-Object -First 1 }
-              }
-            } catch {}
-          }
-          if (-not $latestVersion) { $latestVersion = "1.0.3595.46" }
-          Write-Host "Using WebView2 ($(if ($usePrerelease) { 'preview' } else { 'latest' })): $latestVersion"
-          dotnet add "$utilProj" package $packageId --version $latestVersion
-          dotnet restore "$utilProj"
-          $nugetBase = Join-Path $env:USERPROFILE ".nuget\packages\microsoft.web.webview2\$latestVersion"
-          @("Microsoft.Web.WebView2.Core.dll","Microsoft.Web.WebView2.WinForms.dll","WebView2Loader.dll") | ForEach-Object {
-            $f = Get-ChildItem -Path $nugetBase -Recurse -Name $_ -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($f) { Copy-Item (Join-Path $nugetBase $f) $libDir -Force; Write-Host "Copied $_" }
-          }
-          [xml]$proj = Get-Content $utilProj
-          $nodes = $proj.SelectNodes("//PackageReference[@Include='$packageId']")
-          foreach ($node in $nodes) { $node.ParentNode.RemoveChild($node) | Out-Null }
-          $proj.Save($utilProj)
-          Write-Host "Removed temporary WebView2 PackageReference entries"
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion
+
+      - name: Restore WebView2 cache
+        if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        id: webview2_cache_restore_release
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: webview2-${{ runner.os }}-${{ steps.webview2_version_release.outputs.version }}
+          restore-keys: |
+            webview2-${{ runner.os }}-
+
+      - name: Populate WebView2 (Preview)
+        if: github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary'
+        shell: pwsh
+        env:
+          WEBVIEW2_VERSION: ${{ steps.webview2_version_release.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -Version $env:WEBVIEW2_VERSION
+
+      - name: Save WebView2 cache
+        if: success() && (github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/canary' || github.head_ref == 'alpha' || github.head_ref == 'canary')
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: ${{ steps.webview2_cache_restore_release.outputs.cache-primary-key }}
 
       - name: Restore
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -178,63 +178,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      # Prerelease WebView2 required for net11.0-windows; stable packages do not support .NET 11 yet.
+      - name: Resolve WebView2 version
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        id: webview2_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion
+
+      - name: Restore WebView2 cache
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        id: webview2_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: webview2-${{ runner.os }}-${{ steps.webview2_version.outputs.version }}
+          restore-keys: |
+            webview2-${{ runner.os }}-
+
       - name: Populate WebView2 (Preview)
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         shell: pwsh
+        env:
+          WEBVIEW2_VERSION: ${{ steps.webview2_version.outputs.version }}
         run: |
-          $ErrorActionPreference = "Stop"
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -Version $env:WEBVIEW2_VERSION
 
-          $root = $env:GITHUB_WORKSPACE
-          if (-not $root) { $root = (Get-Location).Path }
-
-          $libDir = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2"
-          $tempDir = Join-Path $env:RUNNER_TEMP "webview2"
-                try {
-                    $search = Invoke-RestMethod `
-                        -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=true&semVerLevel=2.0.0&take=1"
-      
-                    $latestVersion = $search.data[0].version
-                }
-                catch {
-                    Write-Warning "NuGet search failed, using fallback version"
-                    $latestVersion = "1.0.3595.46"
-                }
-      
-                Write-Host "Using WebView2 version: $latestVersion"
-      
-                $nupkg = Join-Path $tempDir "$packageId.$latestVersion.nupkg"
-                $extractDir = Join-Path $tempDir "extract"
-      
-                Write-Host "Downloading package..."
-      
-                Invoke-WebRequest `
-                    -Uri "https://www.nuget.org/api/v2/package/$packageId/$latestVersion" `
-                    -OutFile $nupkg
-      
-                Write-Host "Extracting package..."
-      
-                Expand-Archive $nupkg $extractDir -Force
-      
-                Write-Host "Copying required DLLs..."
-      
-                $files = @(
-                    "Microsoft.Web.WebView2.Core.dll"
-                    "Microsoft.Web.WebView2.WinForms.dll"
-                    "WebView2Loader.dll"
-                )
-      
-                foreach ($file in $files) {
-                    $found = Get-ChildItem $extractDir -Recurse -Filter $file | Select-Object -First 1
-                    if ($found) {
-                        Copy-Item $found.FullName $libDir -Force
-                        Write-Host "Copied $file"
-                    }
-                    else {
-                        Write-Warning "$file not found in package"
-                    }
-                }
-      
-                Write-Host "WebView2 population complete."
+      - name: Save WebView2 cache
+        if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/webview2
+          key: ${{ steps.webview2_cache_restore.outputs.cache-primary-key }}
 
       # /m: multi-processor MSBuild (all runner CPUs). canary.proj orchestrates Krypton.* projects in parallel where references allow.
       - name: Restore

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -204,28 +204,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      # Prerelease WebView2 required for net11.0-windows; stable packages do not support .NET 11 yet.
       - name: Resolve WebView2 version
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         id: webview2_version
         shell: pwsh
         run: |
-          $ErrorActionPreference = "Stop"
-          $packageId = "Microsoft.Web.WebView2"
-
-          Write-Host "Querying NuGet for latest WebView2 prerelease..."
-
-          try {
-              $search = Invoke-RestMethod `
-                  -Uri "https://azuresearch-usnc.nuget.org/query?q=$packageId&prerelease=true&semVerLevel=2.0.0&take=1"
-              $latestVersion = $search.data[0].version
-          }
-          catch {
-              Write-Warning "NuGet search failed, using fallback version"
-              $latestVersion = "1.0.3595.46"
-          }
-
-          Write-Host "Using WebView2 version: $latestVersion"
-          "version=$latestVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion
 
       - name: Restore WebView2 cache
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
@@ -241,65 +228,12 @@ jobs:
       - name: Populate WebView2 (Preview)
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         shell: pwsh
+        env:
+          WEBVIEW2_VERSION: ${{ steps.webview2_version.outputs.version }}
         run: |
-          $ErrorActionPreference = "Stop"
-
-          $root = $env:GITHUB_WORKSPACE
-          if (-not $root) { $root = (Get-Location).Path }
-
-          $libDir = Join-Path $root "Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2"
-          $tempDir = Join-Path $env:RUNNER_TEMP "webview2"
-
-          New-Item -ItemType Directory -Force -Path $libDir | Out-Null
-          New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
-
-          $packageId = "Microsoft.Web.WebView2"
-          $latestVersion = "${{ steps.webview2_version.outputs.version }}"
-
-          $nupkg = Join-Path $tempDir "$packageId.$latestVersion.nupkg"
-          $extractDir = Join-Path $tempDir "extract"
-          $expectedExtractedDll = Join-Path $extractDir "build\native\WebView2Loader.dll"
-
-          if (Test-Path -LiteralPath $tempDir -and -not (Test-Path -LiteralPath $expectedExtractedDll)) {
-              Write-Warning "Detected incomplete WebView2 cache state, rebuilding cache folder."
-              Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
-              New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
-          }
-
-          if (-not (Test-Path -LiteralPath $expectedExtractedDll)) {
-              Write-Host "Downloading package..."
-
-              Invoke-WebRequest `
-                  -Uri "https://www.nuget.org/api/v2/package/$packageId/$latestVersion" `
-                  -OutFile $nupkg
-
-              Write-Host "Extracting package..."
-              Expand-Archive $nupkg $extractDir -Force
-          }
-          else {
-              Write-Host "Using cached WebView2 package extraction."
-          }
-
-          Write-Host "Copying required DLLs..."
-
-          $files = @(
-              "Microsoft.Web.WebView2.Core.dll"
-              "Microsoft.Web.WebView2.WinForms.dll"
-              "WebView2Loader.dll"
-          )
-
-          foreach ($file in $files) {
-              $found = Get-ChildItem $extractDir -Recurse -Filter $file | Select-Object -First 1
-              if ($found) {
-                  Copy-Item $found.FullName $libDir -Force
-                  Write-Host "Copied $file"
-              }
-              else {
-                  Write-Warning "$file not found in package"
-              }
-          }
-
-          Write-Host "WebView2 population complete."
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          & (Join-Path $repoRoot 'Scripts/CI/Populate-WebView2.ps1') -Prerelease -Version $env:WEBVIEW2_VERSION
 
       - name: Save WebView2 cache
         if: success() && steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'

--- a/Scripts/CI/Populate-WebView2.ps1
+++ b/Scripts/CI/Populate-WebView2.ps1
@@ -1,0 +1,162 @@
+# Downloads Microsoft.Web.WebView2 into Krypton.Toolkit.Utilities\Lib\WebView2 for CI builds.
+#
+# -Prerelease: required for alpha/canary/nightly (net11.0-windows). Stable WebView2 packages do not support .NET 11 yet.
+# -ResolveVersionOnly -WriteGitHubOutputVersion: emit version= for actions/cache keys (nightly/canary).
+# -Version: skip NuGet resolution when the workflow already resolved the version.
+
+[CmdletBinding()]
+param(
+    [switch]$Prerelease,
+    [string]$Version,
+    [switch]$ResolveVersionOnly,
+    [switch]$WriteGitHubOutputVersion,
+    [string]$RepoRoot,
+    [string]$CacheRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$PackageId = 'Microsoft.Web.WebView2'
+$DefaultFallbackVersion = '1.0.3595.46'
+$LibRelativePath = 'Source\Krypton Components\Krypton.Toolkit.Utilities\Lib\WebView2'
+$RequiredDllNames = @(
+    'Microsoft.Web.WebView2.Core.dll',
+    'Microsoft.Web.WebView2.WinForms.dll',
+    'WebView2Loader.dll'
+)
+
+function Get-WebView2NuGetVersion {
+    param(
+        [bool]$UsePrerelease,
+        [string]$FallbackVersion
+    )
+
+    $prereleaseParam = if ($UsePrerelease) { 'true' } else { 'false' }
+    Write-Host "Querying NuGet for WebView2 (prerelease=$prereleaseParam)..."
+
+    $latestVersion = $null
+    try {
+        $searchResponse = Invoke-RestMethod `
+            -Uri "https://azuresearch-usnc.nuget.org/query?q=$PackageId&prerelease=$prereleaseParam&semVerLevel=2.0.0&take=1" `
+            -Method Get
+        if ($searchResponse.data -and $searchResponse.data.Count -gt 0) {
+            $latestVersion = $searchResponse.data[0].version
+        }
+    }
+    catch {
+        Write-Warning "NuGet search API failed: $_"
+    }
+
+    if (-not $latestVersion) {
+        try {
+            $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$PackageId/index.json" -Method Get
+            if ($UsePrerelease) {
+                $allVersions = $response.versions | Where-Object { $_ -match '^\d+\.\d+\.\d+' }
+                if ($allVersions) {
+                    $latestVersion = $allVersions | Sort-Object { [System.Version]($_ -replace '-.*', '') } -Descending | Select-Object -First 1
+                }
+            }
+            else {
+                $stableVersions = $response.versions | Where-Object { $_ -notmatch '[-]' -and $_ -match '^\d+\.\d+\.\d+$' }
+                if ($stableVersions) {
+                    $latestVersion = $stableVersions | Sort-Object { [System.Version]$_ } -Descending | Select-Object -First 1
+                }
+            }
+        }
+        catch {
+            Write-Warning "NuGet flatcontainer fallback failed: $_"
+        }
+    }
+
+    if (-not $latestVersion) {
+        Write-Warning "Using fallback WebView2 version: $FallbackVersion"
+        $latestVersion = $FallbackVersion
+    }
+
+    return $latestVersion
+}
+
+function Invoke-PopulateWebView2Lib {
+    param(
+        [string]$ResolvedVersion,
+        [string]$Root,
+        [string]$TempDir
+    )
+
+    $libDir = Join-Path $Root $LibRelativePath
+    New-Item -ItemType Directory -Force -Path $libDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+
+    $nupkg = Join-Path $TempDir "$PackageId.$ResolvedVersion.nupkg"
+    $extractDir = Join-Path $TempDir 'extract'
+    $expectedExtractedDll = Join-Path $extractDir 'build\native\WebView2Loader.dll'
+
+    if ((Test-Path -LiteralPath $TempDir) -and -not (Test-Path -LiteralPath $expectedExtractedDll)) {
+        Write-Warning 'Detected incomplete WebView2 cache state, rebuilding cache folder.'
+        Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+    }
+
+    if (-not (Test-Path -LiteralPath $expectedExtractedDll)) {
+        Write-Host 'Downloading package...'
+        Invoke-WebRequest `
+            -Uri "https://www.nuget.org/api/v2/package/$PackageId/$ResolvedVersion" `
+            -OutFile $nupkg
+
+        Write-Host 'Extracting package...'
+        Expand-Archive $nupkg $extractDir -Force
+    }
+    else {
+        Write-Host 'Using cached WebView2 package extraction.'
+    }
+
+    Write-Host 'Copying required DLLs...'
+    foreach ($file in $RequiredDllNames) {
+        $found = Get-ChildItem $extractDir -Recurse -Filter $file | Select-Object -First 1
+        if ($found) {
+            Copy-Item $found.FullName $libDir -Force
+            Write-Host "Copied $file"
+        }
+        else {
+            Write-Warning "$file not found in package"
+        }
+    }
+
+    Write-Host 'WebView2 population complete.'
+}
+
+if (-not $RepoRoot) {
+    $RepoRoot = $env:GITHUB_WORKSPACE
+    if (-not $RepoRoot) {
+        $RepoRoot = (Get-Location).Path
+    }
+}
+
+if (-not $CacheRoot) {
+    $runnerTemp = $env:RUNNER_TEMP
+    if (-not $runnerTemp) {
+        $runnerTemp = [System.IO.Path]::GetTempPath()
+    }
+    $CacheRoot = Join-Path $runnerTemp 'webview2'
+}
+
+$resolvedVersion = $Version
+if ([string]::IsNullOrWhiteSpace($resolvedVersion)) {
+    $resolvedVersion = Get-WebView2NuGetVersion -UsePrerelease ([bool]$Prerelease) -FallbackVersion $DefaultFallbackVersion
+}
+
+$channelLabel = if ($Prerelease) { 'preview/prerelease' } else { 'latest stable' }
+Write-Host "Using WebView2 ($channelLabel): $resolvedVersion"
+
+if ($WriteGitHubOutputVersion) {
+    if (-not $env:GITHUB_OUTPUT) {
+        Write-Error 'GITHUB_OUTPUT is not set; cannot write version output.'
+    }
+    "version=$resolvedVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+if ($ResolveVersionOnly) {
+    return
+}
+
+Invoke-PopulateWebView2Lib -ResolvedVersion $resolvedVersion -Root $RepoRoot -TempDir $CacheRoot


### PR DESCRIPTION
## Summary

Fixes failing **Populate WebView2** steps in CI and consolidates WebView2 setup into a single shared PowerShell script used by nightly, canary, and build workflows.

- Fixes a PowerShell parse error (`-and` treated as a `Test-Path` parameter) that caused nightly builds to fail.
- Adds `Scripts/CI/Populate-WebView2.ps1` for version resolution, download/extract, DLL copy, and cache-friendly incomplete-state cleanup.
- Repairs the broken inline WebView2 step in `canary.yml` and aligns canary/nightly/build on the same prerelease + cache flow.
- Ensures alpha/canary CI always uses **prerelease** WebView2 (required for **net11.0-windows**; stable packages do not support .NET 11 yet).

## Problem

The nightly workflow failed in **Populate WebView2 (Preview)** with:

```text
A parameter cannot be found that matches parameter name 'and'.
```

Root cause: `if (Test-Path -LiteralPath $tempDir -and -not (...))` — PowerShell binds `-and` to `Test-Path` unless the first expression is parenthesized.

Separately:

- `canary.yml` had a corrupted WebView2 step (missing `$packageId`, directory setup, and coherent script structure).
- `build.yml` duplicated ~45 lines of WebView2 logic twice and could select **stable** WebView2 on PRs (when `GITHUB_REF` is `refs/pull/...`) even though the step only runs for alpha/canary branches that build **net11.0-windows**.

## Solution

### Shared script: `Scripts/CI/Populate-WebView2.ps1`

| Parameter | Purpose |
|-----------|---------|
| `-Prerelease` | Query NuGet for prerelease packages (alpha/canary/nightly) | | `-ResolveVersionOnly` | Resolve version only (for cache key / `GITHUB_OUTPUT`) | | `-WriteGitHubOutputVersion` | Write `version=` to `GITHUB_OUTPUT` | | `-Version` | Use a version already resolved by a prior workflow step |

The script:

- Resolves the latest package via NuGet search API with flatcontainer fallback.
- Downloads and extracts the `.nupkg` under `RUNNER_TEMP/webview2` (compatible with `actions/cache`).
- Detects incomplete cache state with correct `((Test-Path ...) -and ...)` syntax.
- Copies `Microsoft.Web.WebView2.Core.dll`, `Microsoft.Web.WebView2.WinForms.dll`, and `WebView2Loader.dll` into `Krypton.Toolkit.Utilities\Lib\WebView2`.

### Workflow updates

| Workflow | Changes |
|----------|---------|
| `nightly.yml` | Fix `Test-Path` condition; replace inline scripts with shared script + cache steps | | `canary.yml` | Replace broken step; add resolve/cache/populate/save (prerelease) | | `build.yml` | Replace duplicated `dotnet add` blocks in **build** and **release** jobs; always `-Prerelease` when WebView2 runs |

All three workflows now follow:

1. **Resolve WebView2 version** (`-Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion`)
2. **Restore WebView2 cache**
3. **Populate WebView2 (Preview)** (`-Prerelease -Version $env:WEBVIEW2_VERSION`)
4. **Save WebView2 cache**

## Files changed

- `Scripts/CI/Populate-WebView2.ps1` (new)
- `.github/workflows/nightly.yml`
- `.github/workflows/canary.yml`
- `.github/workflows/build.yml`

> **Note:** Exclude unrelated local changes (e.g. `ToastNotificationImageResources.Designer.cs`) from this PR unless they are intentional.

## Test plan

- [ ] Push branch and confirm **Build** workflow passes on alpha (or open a PR targeting alpha).
- [ ] Manually dispatch **Nightly Release** (or wait for schedule) and confirm WebView2 steps succeed when `has_changes=true`.
- [ ] Push to **Canary** (or dispatch **Canary Release**) and confirm WebView2 resolve/populate/cache steps complete.
- [ ] In workflow logs, verify resolved version is a **prerelease** (e.g. contains `-prerelease`), not latest stable only.
- [ ] Confirm `Krypton.Toolkit.Utilities\Lib\WebView2` contains the three DLLs before MSBuild restore/build.
- [ ] Optional: run locally: ```powershell pwsh -File Scripts/CI/Populate-WebView2.ps1 -Prerelease -ResolveVersionOnly ```

## Breaking changes

None for consumers. CI-only change.

## Related

- Stable `Microsoft.Web.WebView2` on NuGet does not yet support .NET 11; prerelease packages are required until Microsoft ships stable support.