### PR TITLE
* Fix race condition

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -76,6 +76,37 @@ jobs:
           ref: Canary
           fetch-depth: 0
 
+      # Canary always builds Canary; the workflow file may land before Populate-WebView2.ps1 is merged to Canary.
+      - name: Checkout WebView2 CI script overlay
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: Scripts/CI/Populate-WebView2.ps1
+          sparse-checkout-cone-mode: true
+          path: _ci-overlay
+
+      - name: Ensure WebView2 CI script
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = Join-Path $env:GITHUB_WORKSPACE 'Scripts/CI/Populate-WebView2.ps1'
+          if (Test-Path -LiteralPath $dest) {
+            Write-Host 'WebView2 CI script already present on checked-out branch.'
+            exit 0
+          }
+          $src = Join-Path $env:GITHUB_WORKSPACE '_ci-overlay/Scripts/CI/Populate-WebView2.ps1'
+          if (-not (Test-Path -LiteralPath $src)) {
+            Write-Error @"
+          Scripts/CI/Populate-WebView2.ps1 is missing on Canary and on workflow ref ($env:GITHUB_SHA).
+          Merge Scripts/CI/Populate-WebView2.ps1 into Canary in the same change set as these workflow updates.
+          "@
+          }
+          New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+          Copy-Item -LiteralPath $src -Destination $dest -Force
+          Write-Host 'Copied WebView2 CI script from workflow ref onto Canary checkout.'
+
       # .NET 9 and 10; .NET 11 for net11.0-windows (DOTNET_PREVIEW_SETUP_VERSION when set, else 11.0.x).
       - name: Setup .NET (9 and 10)
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,37 @@ jobs:
           ref: alpha
           fetch-depth: 0
 
+      # Nightly always builds alpha; the workflow file may land before Populate-WebView2.ps1 is merged to alpha.
+      - name: Checkout WebView2 CI script overlay
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: Scripts/CI/Populate-WebView2.ps1
+          sparse-checkout-cone-mode: true
+          path: _ci-overlay
+
+      - name: Ensure WebView2 CI script
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = Join-Path $env:GITHUB_WORKSPACE 'Scripts/CI/Populate-WebView2.ps1'
+          if (Test-Path -LiteralPath $dest) {
+            Write-Host 'WebView2 CI script already present on checked-out branch.'
+            exit 0
+          }
+          $src = Join-Path $env:GITHUB_WORKSPACE '_ci-overlay/Scripts/CI/Populate-WebView2.ps1'
+          if (-not (Test-Path -LiteralPath $src)) {
+            Write-Error @"
+          Scripts/CI/Populate-WebView2.ps1 is missing on alpha and on workflow ref ($env:GITHUB_SHA).
+          Merge Scripts/CI/Populate-WebView2.ps1 into alpha in the same change set as these workflow updates.
+          "@
+          }
+          New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dest) | Out-Null
+          Copy-Item -LiteralPath $src -Destination $dest -Force
+          Write-Host 'Copied WebView2 CI script from workflow ref onto alpha checkout.'
+
       - name: Check for changes in last 24 hours
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         id: check_changes

--- a/Scripts/CI/Populate-WebView2.ps1
+++ b/Scripts/CI/Populate-WebView2.ps1
@@ -1,5 +1,6 @@
 # Downloads Microsoft.Web.WebView2 into Krypton.Toolkit.Utilities\Lib\WebView2 for CI builds.
 #
+# Must be committed on alpha (nightly) and Canary (canary release). build.yml checks out the triggering ref.
 # -Prerelease: required for alpha/canary/nightly (net11.0-windows). Stable WebView2 packages do not support .NET 11 yet.
 # -ResolveVersionOnly -WriteGitHubOutputVersion: emit version= for actions/cache keys (nightly/canary).
 # -Version: skip NuGet resolution when the workflow already resolved the version.


### PR DESCRIPTION
# Fix CI WebView2 setup (shared script, nightly/canary/build)

## Summary

Fixes failing **Populate WebView2** steps in GitHub Actions and consolidates WebView2 setup into one shared PowerShell script used by **nightly**, **canary**, and **build** workflows.

- Fixes nightly PowerShell parse error: `-and` was bound as a `Test-Path` parameter.
- Adds `Scripts/CI/Populate-WebView2.ps1` (resolve, download/extract, DLL copy, cache-safe cleanup).
- Repairs broken inline WebView2 logic in `canary.yml`.
- Aligns all affected workflows on **prerelease** WebView2 + `actions/cache` (required for **net11.0-windows**; stable WebView2 does not support .NET 11 yet).
- Adds overlay steps so nightly/canary succeed when workflow YAML lands before the script is merged to `alpha` / `Canary`.

## Problems addressed

### 1. Nightly: `Test-Path` / `-and` syntax

```text
A parameter cannot be found that matches parameter name 'and'.
```

Cause: `if (Test-Path -LiteralPath $tempDir -and -not (...))` — the first `Test-Path` must be wrapped in parentheses before `-and`.

### 2. Canary: corrupted WebView2 step

The inline step was incomplete (missing `$packageId`, directory creation, and valid structure), so canary releases could not populate `Lib\WebView2`.

### 3. Build: duplicated logic and wrong package channel on PRs

`build.yml` duplicated ~45 lines in two jobs and set prerelease only from `GITHUB_REF` on push. On PRs (`refs/pull/...`), the step still ran for alpha/canary but could resolve **stable** WebView2 while building **net11.0-windows**.

### 4. Nightly/Canary: script not found on the runner

Workflows call `Scripts/CI/Populate-WebView2.ps1`, but **checkout** uses a fixed branch ref:

| Workflow | Checkout ref |
|----------|----------------|
| Nightly | `alpha` |
| Canary | `Canary` |

If workflow YAML is updated on a PR/default branch before the script is on `alpha` / `Canary`, the runner reports:

```text
The term '...\Scripts\CI\Populate-WebView2.ps1' is not recognized...
```

## Solution

### Shared script: `Scripts/CI/Populate-WebView2.ps1`

| Switch | Purpose |
|--------|---------|
| `-Prerelease` | NuGet prerelease lookup (alpha/canary/nightly / net11) | | `-ResolveVersionOnly` | Resolve version only |
| `-WriteGitHubOutputVersion` | Write `version=` to `GITHUB_OUTPUT` | | `-Version` | Use version from a prior workflow step |

Behavior:

- NuGet search API + flatcontainer fallback.
- Download/extract under `RUNNER_TEMP/webview2` (works with `actions/cache`).
- Incomplete cache detection: `((Test-Path ...) -and -not (...))`.
- Copies `Microsoft.Web.WebView2.Core.dll`, `Microsoft.Web.WebView2.WinForms.dll`, `WebView2Loader.dll` into `Krypton.Toolkit.Utilities\Lib\WebView2`.

### Workflow pattern (nightly, canary, build)

1. **Resolve WebView2 version** — `-Prerelease -ResolveVersionOnly -WriteGitHubOutputVersion`
2. **Restore WebView2 cache**
3. **Populate WebView2 (Preview)** — `-Prerelease -Version $env:WEBVIEW2_VERSION`
4. **Save WebView2 cache**

`build.yml` always passes **`-Prerelease`** when WebView2 runs (alpha/canary only).

### Nightly / Canary: script overlay (rollout safety)

After checkout of `alpha` / `Canary`:

1. **Checkout WebView2 CI script overlay** — sparse checkout of `Populate-WebView2.ps1` from `github.sha`
2. **Ensure WebView2 CI script** — copy into the workspace if missing on the build branch

**Still merge `Populate-WebView2.ps1` into `alpha` and `Canary`** so production does not depend on the overlay indefinitely.

## Files changed

| File | Change |
|------|--------|
| `Scripts/CI/Populate-WebView2.ps1` | **New** shared CI script | | `.github/workflows/nightly.yml` | Script + cache + overlay steps | | `.github/workflows/canary.yml` | Fix step, script + cache + overlay | | `.github/workflows/build.yml` | Script + cache in build and release jobs |

> Exclude unrelated changes (e.g. `ToastNotificationImageResources.Designer.cs`) unless intentional.

## Test plan

- [ ] Open/update PR and confirm **Build** passes for a branch targeting alpha (WebView2 steps on alpha/canary refs).
- [ ] Re-run or dispatch **Nightly Release**; confirm **Resolve** / **Populate WebView2** succeed when there are commits in the last 24 hours.
- [ ] Push or dispatch **Canary Release**; confirm WebView2 resolve, populate, and cache steps complete.
- [ ] In logs, confirm resolved version is **prerelease** (e.g. contains `-prerelease`), not stable-only.
- [ ] Confirm three DLLs exist under `Source/Krypton Components/Krypton.Toolkit.Utilities/Lib/WebView2` before MSBuild restore.
- [ ] After merge to `alpha`, confirm overlay step logs *“already present on checked-out branch”* (optional).
- [ ] Local smoke test: ```powershell pwsh -File Scripts/CI/Populate-WebView2.ps1 -Prerelease -ResolveVersionOnly ```

## Breaking changes

None for NuGet consumers. CI-only.

## Follow-up

- Merge this PR (including `Scripts/CI/Populate-WebView2.ps1`) into **`alpha`** and **`Canary`**, not only the default/PR target branch.
- Stable `Microsoft.Web.WebView2` on NuGet does not yet support .NET 11; keep **`-Prerelease`** until Microsoft ships stable net11 support.