### PR TITLE
3493-V110-Regression-Build-Fixes

### DIFF
--- a/Scripts/Build/Krypton.Orchestration.targets
+++ b/Scripts/Build/Krypton.Orchestration.targets
@@ -12,6 +12,10 @@
 		<KryptonNavigatorProject>$(KryptonComponentsRoot)\Krypton.Navigator\Krypton.Navigator 2022.csproj</KryptonNavigatorProject>
 		<KryptonWorkspaceProject>$(KryptonComponentsRoot)\Krypton.Workspace\Krypton.Workspace 2022.csproj</KryptonWorkspaceProject>
 		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
+		<KryptonToolkitJumpListProject>$(KryptonComponentsRoot)\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj</KryptonToolkitJumpListProject>
+		<KryptonNavigatorUtilitiesProject>$(KryptonComponentsRoot)\Krypton.Navigator.Utilities\Krypton.Navigator.Utilities.csproj</KryptonNavigatorUtilitiesProject>
+		<KryptonToolkitUtilitiesProject>$(KryptonComponentsRoot)\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj</KryptonToolkitUtilitiesProject>
+		<KryptonStandardToolkitProject>$(KryptonComponentsRoot)\Krypton.Standard.Toolkit\Krypton.Standard.Toolkit.csproj</KryptonStandardToolkitProject>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs)</KryptonComponentBuildProperties>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all</KryptonComponentBuildProperties>
 	</PropertyGroup>
@@ -19,9 +23,40 @@
 	<ItemGroup>
 		<KryptonParallelAfterToolkit Include="$(KryptonRibbonProject)" />
 		<KryptonParallelAfterToolkit Include="$(KryptonNavigatorProject)" />
+		<KryptonParallelAfterToolkit Include="$(KryptonToolkitJumpListProject)" />
+		<KryptonParallelAfterNavigator Include="$(KryptonNavigatorUtilitiesProject)" />
+		<KryptonParallelAfterNavigator Include="$(KryptonWorkspaceProject)" />
 	</ItemGroup>
 
-	<Target Name="KryptonBuild">
+	<Target Name="KryptonRestore">
+		<MSBuild Projects="$(KryptonToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore" />
+
+		<MSBuild Projects="@(KryptonParallelAfterToolkit)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="@(KryptonParallelAfterNavigator)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore" />
+
+		<MSBuild Projects="$(KryptonToolkitUtilitiesProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore" />
+
+		<MSBuild Projects="$(KryptonStandardToolkitProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Restore" />
+	</Target>
+
+	<Target Name="KryptonBuild" DependsOnTargets="KryptonRestore">
 		<MSBuild Projects="$(KryptonToolkitProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Build" />
@@ -31,11 +66,20 @@
 		         Targets="Build"
 		         BuildInParallel="true" />
 
-		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		<MSBuild Projects="@(KryptonParallelAfterNavigator)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Build" />
 
-		<MSBuild Projects="$(KryptonDockingProject)"
+		<MSBuild Projects="$(KryptonToolkitUtilitiesProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="$(KryptonStandardToolkitProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Build" />
 	</Target>
@@ -50,11 +94,20 @@
 		         Targets="Pack"
 		         BuildInParallel="true" />
 
-		<MSBuild Projects="$(KryptonWorkspaceProject)"
+		<MSBuild Projects="@(KryptonParallelAfterNavigator)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack"
+		         BuildInParallel="true" />
+
+		<MSBuild Projects="$(KryptonDockingProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Pack" />
 
-		<MSBuild Projects="$(KryptonDockingProject)"
+		<MSBuild Projects="$(KryptonToolkitUtilitiesProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<MSBuild Projects="$(KryptonStandardToolkitProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Pack" />
 	</Target>

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -45,6 +45,7 @@ set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -44,6 +44,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
+endlocal
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -1,114 +1,50 @@
-echo off
+@echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-echo Do you want to build using Visual Studio 2019 or 2026? (2019/2026)
-set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019build
-if /I "%INPUT%"=="2026" goto vs2026build
-
-:vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
 pause
-
 goto exitbatch
 
 :vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
-goto build2019
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+goto build
 
 :vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+goto build
 
 :vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
+goto build
 
 :vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
+goto build
 
 :vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build2019
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
+goto build
 
-:build2019
+:build
 @echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
-:vs2026build
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-goto exitbatch
+@echo Build Completed: %date% %time%
+@echo:
 pause
-
-:vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
-goto build2026
-
-:build2026
-set targets=Build
-if not "%~1" == "" set targets=%~1
-REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
-
-echo Do you now want to create NuGet packages? (y/n)
-set INPUT=
-set /PINPUT=Type input: %=%
-if /I "%INPUT%"=="y" goto createpackages
-if /I "%INPUT%"=="n" goto break
-
-:createpackages
-echo Do you want to pack using Visual Studio 2019 or 2026? (2019/2026)
-set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
-if /I "%INPUT%"=="2026" goto vs2026pack
-
-:vs2019pack
-build-2019.cmd Pack
-
-@echo Build Completed: %date% %time%
-
-:vs2026pack
-build-2026.cmd Pack
-
-@echo Build Completed: %date% %time%
-
-:break
-pause
-@echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -1,48 +1,51 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
 pause
 goto exitbatch
 
 :vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
 :vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
 :vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
 :vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
 :vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
-@echo
+@echo:
 echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.cmd' script!
-
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -1,34 +1,34 @@
 @echo off
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -40,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%~dp0nightly.proj" /fl /flp:logfile="%~dp0..\..\Logs\nightly-build-log.log" /bl:"%~dp0..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -46,7 +46,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%canary.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\canary-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\canary-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 @echo:
 @echo Canary release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build-installer.cmd
+++ b/Scripts/Current/build-installer.cmd
@@ -44,7 +44,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%..\Project Files\installer.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\installer-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\installer-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -46,7 +46,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%longtermstable.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\long-term-stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build-nightly-custom.cmd
+++ b/Scripts/Current/build-nightly-custom.cmd
@@ -43,7 +43,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\build.log"
+endlocal
 
 @echo Build Completed: %date% %time% %zone%
 

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -46,7 +46,10 @@ REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets
 @echo:
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 @echo:
 :: -t:rebuild
 

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -46,7 +46,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 set "targets=Build"
 if not "%~1" == "" set "targets=%~1"
 REM Phased Krypton.* build + /m (see Scripts\Build\Krypton.Orchestration.targets).
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\stable-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\stable-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 @echo:
 @echo Stable release build completed: %date% %time% %zone%
 @echo:

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
@@ -58,6 +60,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -1,53 +1,8 @@
-echo off
+@echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-echo Do you want to build using Visual Studio 2019 or 2026? (2019/2026)
-set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019build
-if /I "%INPUT%"=="2026" goto vs2026build
-
-:vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
-pause
-
-goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build2019
-
-:build2019
-@echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
-REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
-
-:vs2026build
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
@@ -55,60 +10,44 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bi
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-goto exitbatch
 pause
+goto exitbatch
 
 :vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
-goto build2026
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+goto build
 
 :vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
-goto build2026
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+goto build
 
 :vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
-goto build2026
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+goto build
 
 :vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
-goto build2026
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+goto build
 
 :vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
-goto build2026
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+goto build
 
-:build2026
-set targets=Build
-if not "%~1" == "" set targets=%~1
+:build
+@echo Started: %date% %time%
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
-
-echo Do you now want to create NuGet packages? (y/n)
-set INPUT=
-set /PINPUT=Type input: %=%
-if /I "%INPUT%"=="y" goto createpackages
-if /I "%INPUT%"=="n" goto break
-
-:createpackages
-echo Do you want to pack using Visual Studio 2019 or 2026? (2019/2026)
-set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
-if /I "%INPUT%"=="2026" goto vs2026pack
-
-:vs2019pack
-build-2019.cmd Pack
+setlocal
+call "%SCRIPT_DIR%..\Build\setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 
 @echo Build Completed: %date% %time%
-
-:vs2026pack
-build-2026.cmd Pack
-
-@echo Build Completed: %date% %time%
-
-:break
+@echo:
 pause
-@echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/canarylongtermstable.proj
+++ b/Scripts/Current/canarylongtermstable.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -1,48 +1,54 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
+echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 pause
 goto exitbatch
 
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+:vscurrentinsiders
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+:vscurrentent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+:vscurrentpro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build
 
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+:vscurrentcom
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build
 
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+:vscurrentbuild
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+setlocal
+call "%SCRIPT_DIR%..\Build\setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 
 @echo Build Completed: %date% %time%
-@echo
+@echo:
 echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.cmd' script!
-
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Current/debug.proj
+++ b/Scripts/Current/debug.proj
@@ -11,6 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 

--- a/Scripts/Current/installer.proj
+++ b/Scripts/Current/installer.proj
@@ -10,6 +10,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 	</Target>	
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -11,6 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -40,6 +41,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
@@ -56,6 +58,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -40,7 +40,10 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+setlocal
+call "%~dp0setup-dotnet11-sdk.cmd" || (endlocal & goto exitbatch)
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%~dp0nightly.proj" /fl /flp:logfile="%~dp0..\..\Logs\nightly-build-log.log" /bl:"%~dp0..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
+endlocal
 
 :: -t:rebuild
 

--- a/Scripts/Current/setup-dotnet11-sdk.cmd
+++ b/Scripts/Current/setup-dotnet11-sdk.cmd
@@ -1,0 +1,16 @@
+@echo off
+
+set "DOTNET_ROLL_FORWARD_TO_PRERELEASE=1"
+
+for /f "delims=" %%S in ('dir /b /ad /o-n "%ProgramFiles%\dotnet\sdk\11.*" 2^>nul') do (
+    set "DOTNET_11_SDK_VERSION=%%S"
+    set "DOTNET_11_SDK_ROOT=%ProgramFiles%\dotnet\sdk\%%S"
+    set "MSBuildSDKsPath=%ProgramFiles%\dotnet\sdk\%%S\Sdks"
+    set "DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=%ProgramFiles%\dotnet"
+    set "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR=%ProgramFiles%\dotnet\sdk\%%S\Sdks"
+    set "DOTNET_MSBUILD_SDK_RESOLVER_SDKS_VER=%%S"
+    exit /b 0
+)
+
+echo "Unable to detect .NET 11 SDK under %ProgramFiles%\dotnet\sdk."
+exit /b 1

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs17prev
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs17ent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs17pro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs17com
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs17build
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -1,53 +1,8 @@
-echo off
+@echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-echo Do you want to build using Visual Studio 2019 or 2022? (2019/2022)
-set INPUT=
-set /P INPUT=Type 2019 or 2022: %=%
-if /I "%INPUT%"=="2019" goto vs2019build
-if /I "%INPUT%"=="2022" goto vs2022build
-
-:vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
-pause
-
-goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build2019
-
-:build2019
-@echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
-REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
-
-:vs2022build
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
@@ -55,60 +10,41 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
-goto exitbatch
 pause
+goto exitbatch
 
 :vs17prev
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
-goto build2022
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+goto build
 
 :vs17ent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin
-goto build2022
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
+goto build
 
 :vs17pro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin
-goto build2022
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
+goto build
 
 :vs17com
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin
-goto build2022
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
+goto build
 
 :vs17build
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin
-goto build2022
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+goto build
 
-:build2022
-set targets=Build
-if not "%~1" == "" set targets=%~1
+:build
+@echo Started: %date% %time%
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
-
-echo Do you now want to create NuGet packages? (y/n)
-set INPUT=
-set /PINPUT=Type input: %=%
-if /I "%INPUT%"=="y" goto createpackages
-if /I "%INPUT%"=="n" goto break
-
-:createpackages
-echo Do you want to pack using Visual Studio 2019 or 2022? (2019/2022)
-set INPUT=
-set /P INPUT=Type 2019 or 2022: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
-if /I "%INPUT%"=="2022" goto vs2022pack
-
-:vs2019pack
-build-2019.cmd Pack
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
-
-:vs2022pack
-build-2022.cmd Pack
-
-@echo Build Completed: %date% %time%
-
-:break
+@echo:
 pause
-@echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -1,48 +1,51 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
+echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 pause
 goto exitbatch
 
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
+:vs17prev
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build
 
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+:vs17ent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+:vs17pro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build
 
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+:vs17com
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build
 
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+:vs17build
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo:
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
-@echo
+@echo:
 echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.cmd' script!
-
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -40,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Rebuild
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%~dp0nightly.proj" /fl /flp:logfile="%~dp0..\..\Logs\nightly-build-log.log" /bl:"%~dp0..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 

--- a/Scripts/main-menu.cmd
+++ b/Scripts/main-menu.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd ..
-
-run.cmd
+call "%~dp0..\run.cmd"

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -73,7 +73,7 @@
 		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<!-- Per-TFM obj avoids races when msbuild /m compiles multiple target frameworks at once -->
-		<IntermediateOutputPath>$(MSBuildProjectDirectory)obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+		<IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 		<AppendTargetFrameworkToIntermediateOutputPath>false</AppendTargetFrameworkToIntermediateOutputPath>
 	</PropertyGroup>
 

--- a/run.cmd
+++ b/run.cmd
@@ -6,6 +6,7 @@ setlocal EnableExtensions
 
 title Krypton Toolkit Build System
 
+set "REPO_ROOT=%~dp0"
 set "VS_VERSION="
 set "VS_SCRIPTS_DIR="
 
@@ -48,7 +49,7 @@ goto mainmenu
 
 :configurevsversion
 set "VS_VERSION=%~1"
-set "VS_SCRIPTS_DIR=Scripts\%~1"
+set "VS_SCRIPTS_DIR=%REPO_ROOT%Scripts\%~1"
 if not exist "%VS_SCRIPTS_DIR%" (
     echo.
     echo ERROR: Could not find "%VS_SCRIPTS_DIR%".
@@ -69,33 +70,33 @@ exit /b 0
 
 :cleanbinandobj
 echo Deleting the 'Bin' folder
-if exist "Bin\" rd /s /q "Bin"
+if exist "%REPO_ROOT%Bin\" rd /s /q "%REPO_ROOT%Bin"
 echo Deleted the 'Bin' folder
 echo Deleting the 'Krypton.Docking\obj' folder
-if exist "Source\Krypton Components\Krypton.Docking\obj\" rd /s /q "Source\Krypton Components\Krypton.Docking\obj"
+if exist "%REPO_ROOT%Source\Krypton Components\Krypton.Docking\obj\" rd /s /q "%REPO_ROOT%Source\Krypton Components\Krypton.Docking\obj"
 echo Deleted the 'Krypton.Docking\obj' folder
 echo Deleting the 'Krypton.Navigator\obj' folder
-if exist "Source\Krypton Components\Krypton.Navigator\obj\" rd /s /q "Source\Krypton Components\Krypton.Navigator\obj"
+if exist "%REPO_ROOT%Source\Krypton Components\Krypton.Navigator\obj\" rd /s /q "%REPO_ROOT%Source\Krypton Components\Krypton.Navigator\obj"
 echo Deleted the 'Krypton.Navigator\obj' folder
 echo Deleting the 'Krypton.Ribbon\obj' folder
-if exist "Source\Krypton Components\Krypton.Ribbon\obj\" rd /s /q "Source\Krypton Components\Krypton.Ribbon\obj"
+if exist "%REPO_ROOT%Source\Krypton Components\Krypton.Ribbon\obj\" rd /s /q "%REPO_ROOT%Source\Krypton Components\Krypton.Ribbon\obj"
 echo Deleted the 'Krypton.Ribbon\obj' folder
 echo Deleting the 'Krypton.Toolkit\obj' folder
-if exist "Source\Krypton Components\Krypton.Toolkit\obj\" rd /s /q "Source\Krypton Components\Krypton.Toolkit\obj"
+if exist "%REPO_ROOT%Source\Krypton Components\Krypton.Toolkit\obj\" rd /s /q "%REPO_ROOT%Source\Krypton Components\Krypton.Toolkit\obj"
 echo Deleted the 'Krypton.Toolkit\obj' folder
 echo Deleting the 'Krypton.Workspace\obj' folder
-if exist "Source\Krypton Components\Krypton.Workspace\obj\" rd /s /q "Source\Krypton Components\Krypton.Workspace\obj"
+if exist "%REPO_ROOT%Source\Krypton Components\Krypton.Workspace\obj\" rd /s /q "%REPO_ROOT%Source\Krypton Components\Krypton.Workspace\obj"
 echo Deleted the 'Krypton.Workspace\obj' folder
 exit /b 0
 
 :cleanlogs
 echo Deleting the 'Logs' folder
-del /f "Logs"
+del /f "%REPO_ROOT%Logs"
 exit /b 0
 
 :cleanrootbuildlog
 echo Deleting the 'build.log' file
-del /f build.log
+del /f "%REPO_ROOT%build.log"
 echo Deleted the 'build.log' file
 exit /b 0
 
@@ -904,4 +905,4 @@ cls
 echo Running TestForm project...
 
 :: Allows running the TestForm project without needing to open the solution in Visual Studio.
-dotnet run --project "Source\Krypton Components\TestForm\TestForm.csproj" -c Debug
+dotnet run --project "%REPO_ROOT%Source\Krypton Components\TestForm\TestForm.csproj" -c Debug


### PR DESCRIPTION
Regression fixes for changes since #3493 

This PR fixes regressions in the (local) build scripts that appeared after the original framework-targeting changes for V110.

The fixes keep each script folder tied to the intended Visual Studio version:

- `Scripts/Build` uses Visual Studio 2019.
- `Scripts/VS2022` uses Visual Studio 2022.
- `Scripts/Current` uses Visual Studio 2026.

It also fixes paths that depended on the current working directory, restores the missing separator in the intermediate output path, and makes the Current/VS 2026 build select the installed .NET 11 SDK so `net11.0-windows` projects can build.

## Why

The menu and script wrappers could return with a different working directory, which made later menu choices look for folders in the wrong place. Some scripts also pointed at the wrong Visual Studio installation for their folder. The Current nightly build then hit stale or incomplete restore assets because not all Krypton projects were restored in the same target framework set that the build used.