### PR TITLE
* Use correct NuGet versions in VS templates

### DIFF
--- a/.github/workflows/templates-release.yml
+++ b/.github/workflows/templates-release.yml
@@ -16,6 +16,7 @@ on:
       - V110
     paths:
       - "Templates/**"
+      - "Scripts/CI/Apply-TemplatesNuGetPackage.ps1"
       - ".github/workflows/templates-release.yml"
   workflow_dispatch:
 
@@ -107,6 +108,15 @@ jobs:
           echo "prerelease=$prerelease" >> $env:GITHUB_OUTPUT
           echo "version=$version" >> $env:GITHUB_OUTPUT
           echo "vsix_version=$vsixVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Apply channel NuGet package to project templates
+        if: steps.templates_release_kill_switch.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "${{ github.workspace }}/Scripts/CI/Apply-TemplatesNuGetPackage.ps1" `
+            -Channel '${{ steps.channel.outputs.channel }}' `
+            -RepoRoot '${{ github.workspace }}'
 
       - name: Build Visual Studio Templates zip artifacts
         if: steps.templates_release_kill_switch.outputs.enabled == 'true'
@@ -224,6 +234,8 @@ jobs:
             - Project template (`Krypton WinForms App`)
             - Project template (`Krypton Ribbon WinForms App`)
             - Bundle archive with all templates and documentation
+
+            Project templates reference the NuGet package for this channel (`Krypton.Standard.Toolkit`, `.Canary`, or `.Nightly`).
 
             Source branch: `${{ steps.channel.outputs.branch }}`
             Build stamp: `${{ steps.channel.outputs.version }}`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true"> Standard Toolkit - ChangeLog
+﻿# <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true"> Standard Toolkit - ChangeLog
 
 ====
 

--- a/Scripts/CI/Apply-TemplatesNuGetPackage.ps1
+++ b/Scripts/CI/Apply-TemplatesNuGetPackage.ps1
@@ -1,0 +1,45 @@
+# Rewrites project template PackageReference IDs to match the templates release channel.
+# Used by .github/workflows/templates-release.yml and for local VSIX builds.
+#
+# Channel mapping (see https://github.com/Krypton-Suite/Standard-Toolkit/issues/3566):
+#   stable / current / dev-*  -> Krypton.Standard.Toolkit
+#   canary                    -> Krypton.Standard.Toolkit.Canary
+#   alpha                     -> Krypton.Standard.Toolkit.Nightly
+
+[CmdletBinding()]
+param(
+    [string]$Channel = 'stable',
+    [string]$RepoRoot = (Get-Location).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$packageId = switch ($Channel.ToLowerInvariant()) {
+    'canary' { 'Krypton.Standard.Toolkit.Canary' }
+    'alpha' { 'Krypton.Standard.Toolkit.Nightly' }
+    default { 'Krypton.Standard.Toolkit' }
+}
+
+$templateCsprojs = @(
+    (Join-Path $RepoRoot 'Templates\ProjectTemplates\KryptonWinFormsApp\KryptonWinFormsApp.csproj'),
+    (Join-Path $RepoRoot 'Templates\ProjectTemplates\KryptonRibbonWinFormsApp\KryptonRibbonWinFormsApp.csproj')
+)
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+$pattern = 'Include="Krypton\.Standard\.Toolkit(?:\.Canary|\.Nightly)?"'
+
+foreach ($path in $templateCsprojs) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Missing template project file: $path"
+    }
+
+    $text = [System.IO.File]::ReadAllText($path, $utf8NoBom)
+    $updated = [regex]::Replace($text, $pattern, "Include=`"$packageId`"")
+    if ($updated -eq $text) {
+        throw "PackageReference for Krypton.Standard.Toolkit was not found in: $path"
+    }
+
+    [System.IO.File]::WriteAllText($path, $updated, $utf8NoBom)
+}
+
+Write-Host "Applied templates NuGet package '$packageId' (channel: $Channel)."

--- a/Templates/README.md
+++ b/Templates/README.md
@@ -32,6 +32,16 @@ For maintainer-focused implementation and release details, see:
 
 ## Local VSIX build
 
+Source project templates default to the **stable** NuGet package (`Krypton.Standard.Toolkit`). Before building a canary or nightly VSIX locally, apply the matching channel (this matches CI):
+
+```cmd
+pwsh -NoProfile -File "Scripts\CI\Apply-TemplatesNuGetPackage.ps1" -Channel stable
+pwsh -NoProfile -File "Scripts\CI\Apply-TemplatesNuGetPackage.ps1" -Channel canary
+pwsh -NoProfile -File "Scripts\CI\Apply-TemplatesNuGetPackage.ps1" -Channel alpha
+```
+
+Then build:
+
 ```cmd
 dotnet restore "Templates\Vsix\Krypton.Templates.Vsix\Krypton.Templates.Vsix.csproj"
 dotnet msbuild "Templates\Vsix\Krypton.Templates.Vsix\Krypton.Templates.Vsix.csproj" /p:Configuration=Release /p:DeployExtension=false
@@ -43,4 +53,4 @@ Output: `Templates\Vsix\Krypton.Templates.Vsix\bin\Release\net472\Krypton.Templa
 
 - These templates use `Krypton.Toolkit` and `KryptonManager`.
 - The ribbon item template also uses `Krypton.Ribbon`.
-- The project template references `Krypton.Standard.Toolkit` from NuGet.
+- Project templates reference a `Krypton.Standard.Toolkit` aggregate package from NuGet. Published VSIX/zip releases use the package for that channel: stable (`Krypton.Standard.Toolkit`), canary (`.Canary`), or alpha/nightly (`.Nightly`).


### PR DESCRIPTION
## Summary

Fixes [#3566](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3566).

Visual Studio **project** templates (`Krypton WinForms App`, `Krypton Ribbon WinForms App`) previously always referenced the stable aggregate package `Krypton.Standard.Toolkit`, even when templates were published from `canary` or `alpha`. Published releases should instead align with the toolkit channel:

| Templates release branch | Channel | NuGet package | |--------------------------|---------|---------------| | `master` | stable | `Krypton.Standard.Toolkit` | | `canary` | canary | `Krypton.Standard.Toolkit.Canary` | | `alpha` | alpha | `Krypton.Standard.Toolkit.Nightly` |

This PR adds `Scripts/CI/Apply-TemplatesNuGetPackage.ps1`, which rewrites the `PackageReference` in both project template `.csproj` files before packaging. The **Visual Studio Templates Release** workflow invokes it after channel resolution and before zip/VSIX build. Source templates in git remain on the stable package ID; only CI (or an explicit local script run) applies channel-specific IDs.

Item templates are unchanged (they do not add NuGet references).

## Changes

- **`Scripts/CI/Apply-TemplatesNuGetPackage.ps1`** — Shared channel → package ID mapping and `.csproj` rewrite.
- **`.github/workflows/templates-release.yml`** — New CI step; workflow path filter includes the script; release notes mention channel-specific packages.
- **`Templates/README.md`** — Documents local VSIX builds and channel/package mapping.

## Test plan

- [ ] Run `pwsh -NoProfile -File Scripts\CI\Apply-TemplatesNuGetPackage.ps1 -Channel canary` and confirm both project template `.csproj` files reference `Krypton.Standard.Toolkit.Canary`.
- [ ] Run with `-Channel alpha` and confirm `.Nightly` package ID.
- [ ] Run with `-Channel stable` and confirm IDs revert to `Krypton.Standard.Toolkit`.
- [ ] After merge, trigger or wait for **Visual Studio Templates Release** on `canary` / `alpha` (push under `Templates/` or workflow_dispatch).
- [ ] Download the published VSIX from `templates-canary` / `templates-alpha` release, create a new project from a Krypton project template, and verify the generated `.csproj` uses the expected `PackageReference Include`.