### PR TITLE
3598-V105-lts Fix KryptonContextMenu disposal leaks

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling
 * Resolved [#3282](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3282), `KryptonTreeView` items flicker when selected/clicked (`DrawDefault = false` for `OwnerDrawAll`; composite `WM_PAINT` off-screen buffer with `TVS_EX_DOUBLEBUFFER`; batch selection/check updates; no per-node background repaint)

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege, Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -162,6 +162,11 @@ public abstract class KryptonSpace : KryptonWorkspace
     {
         if (disposing)
         {
+            foreach (CachedCellState cellState in _lookupCellState.Values)
+            {
+                DisposeCachedCellState(cellState);
+            }
+
             _lookupCellState.Clear();
         }
 
@@ -289,7 +294,7 @@ public abstract class KryptonSpace : KryptonWorkspace
         string uniqueName,
         UniqueNameToPage existingPages)
     {
-        // If a matching page with the unique name already exists then use it, 
+        // If a matching page with the unique name already exists then use it,
         // otherwise we need to create an entirely new page instance.
         if (existingPages.TryGetValue(uniqueName, out KryptonPage? page))
         {
@@ -328,7 +333,7 @@ public abstract class KryptonSpace : KryptonWorkspace
             }
         }
 
-        // Read past the page start element                 
+        // Read past the page start element
         if (!xmlReader.Read())
         {
             throw new ArgumentException(@"An element was expected, but could not be read in.", nameof(xmlReader));
@@ -495,6 +500,10 @@ public abstract class KryptonSpace : KryptonWorkspace
     protected override void ExistingCellDetach(KryptonWorkspaceCell cell)
     {
         // Grab the per-cell cached state
+        if (_lookupCellState.TryGetValue(cell, out CachedCellState? cellState))
+        {
+            DisposeCachedCellState(cellState);
+        }
 
         // Remove all those event hooks used to monitor focus changes
         FocusMonitorControl(cell, false);
@@ -629,7 +638,7 @@ public abstract class KryptonSpace : KryptonWorkspace
         if (!_awaitingFocusUpdate && IsHandleCreated)
         {
             // Async invoke ensures the delegate is called in sync with the message queue, this means that all the
-            // focus messages will have finished and the focus will have settled onto its new location. This is 
+            // focus messages will have finished and the focus will have settled onto its new location. This is
             // always true because SETFOCUS/KILLFOCUS messages are always 'send' and not 'post' messages.
             BeginInvoke(_focusUpdate);
             _awaitingFocusUpdate = true;
@@ -731,6 +740,7 @@ public abstract class KryptonSpace : KryptonWorkspace
     private void OnCellShowContextMenu(object? sender, ShowContextMenuArgs e)
     {
         // Make sure we have a menu for displaying
+        var disposeMenu = e.KryptonContextMenu == null;
         e.KryptonContextMenu ??= new KryptonContextMenu();
 
         // Use event to allow customization of the context menu
@@ -740,6 +750,19 @@ public abstract class KryptonSpace : KryptonWorkspace
         };
         OnPageDropDownClicked(args);
         e.Cancel = args.Cancel;
+
+        if (disposeMenu)
+        {
+            if (e.Cancel)
+            {
+                e.KryptonContextMenu.Dispose();
+                e.KryptonContextMenu = null;
+            }
+            else
+            {
+                e.KryptonContextMenu.Closed += OnTransientKryptonContextMenuClosed;
+            }
+        }
     }
 
     private void OnCellPrimaryHeaderLeftClicked(object? sender, EventArgs e)
@@ -774,7 +797,12 @@ public abstract class KryptonSpace : KryptonWorkspace
                 // Do we need to show a context menu
                 if (!args.Cancel && CommonHelper.ValidKryptonContextMenu(args.KryptonContextMenu))
                 {
-                    args.KryptonContextMenu?.Show(this, MousePosition);
+                    args.KryptonContextMenu!.Closed += OnTransientKryptonContextMenuClosed;
+                    args.KryptonContextMenu.Show(this, MousePosition);
+                }
+                else
+                {
+                    kcm.Dispose();
                 }
             }
         }
@@ -945,6 +973,26 @@ public abstract class KryptonSpace : KryptonWorkspace
 
                 break;
             }
+        }
+    }
+
+    private static void OnTransientKryptonContextMenuClosed(object? sender, EventArgs e)
+    {
+        if (sender is KryptonContextMenu contextMenu)
+        {
+            contextMenu.Closed -= OnTransientKryptonContextMenuClosed;
+            contextMenu.Dispose();
+        }
+    }
+
+    private void DisposeCachedCellState(CachedCellState cellState)
+    {
+        if (cellState.DropDownButtonSpec?.KryptonContextMenu != null)
+        {
+            cellState.DropDownButtonSpec.KryptonContextMenu.Opening -= OnCellDropDownOpening;
+            cellState.DropDownButtonSpec.KryptonContextMenu.Close();
+            cellState.DropDownButtonSpec.KryptonContextMenu.Dispose();
+            cellState.DropDownButtonSpec.KryptonContextMenu = null;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege, Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -29,6 +29,18 @@ public class ButtonSpecNavContext : ButtonSpecNavFixed
         // and the menu is shown. We add an items child so it has some content
         KryptonContextMenu = new KryptonContextMenu();
         KryptonContextMenu.Items.Add(new KryptonContextMenuItems());
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            KryptonContextMenu?.Dispose();
+            KryptonContextMenu = null;
+        }
+
+        base.Dispose(disposing);
     }
     #endregion
 
@@ -112,5 +124,5 @@ public class ButtonSpecNavContext : ButtonSpecNavFixed
         // Context button is never shown as checked
         ButtonCheckState.NotCheckButton;
 
-    #endregion    
+    #endregion
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
@@ -1,11 +1,11 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege, Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  */
 #endregion
 
@@ -151,6 +151,9 @@ public class KryptonGallery : VisualSimpleBase
     {
         if (disposing)
         {
+            _dropMenu?.Close();
+            _dropMenu?.Dispose();
+            _dropMenu = null;
         }
 
         base.Dispose(disposing);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  *
  *  Modified: Monday 12th April, 2021 @ 18:00 GMT
  *
@@ -192,6 +192,22 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
 
         // Listen for palette switches so we can refresh dynamic theme colors
         Krypton.Toolkit.KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChangedForThemeColors;
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Krypton.Toolkit.KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChangedForThemeColors;
+            _kryptonContextMenu?.Close();
+            _kryptonContextMenu?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupColorButton.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 20265. All rights reserved.
  *
  *  Modified: Monday 12th April, 2021 @ 18:00 GMT
  *
@@ -199,6 +199,22 @@ public class KryptonRibbonGroupColorButton : KryptonRibbonGroupItem
 
         // Listen for palette switches so we can refresh dynamic theme colors
         Krypton.Toolkit.KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChangedForThemeColors;
+    }
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Krypton.Toolkit.KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChangedForThemeColors;
+            _kryptonContextMenu?.Close();
+            _kryptonContextMenu?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -985,6 +985,8 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
         if (disposing)
         {
             KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChangedForThemeColors;
+            _kryptonContextMenu?.Close();
+            _kryptonContextMenu?.Dispose();
         }
 
         base.Dispose(disposing);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -233,6 +233,7 @@ public class KryptonPropertyGrid : VisualControlBase,
     private readonly IntPtr _screenDC;
     private bool _alwaysActive;
     private bool _forcedLayout;
+    private readonly KryptonContextMenu _resetContextMenu;
     private readonly KryptonContextMenuItem _resetMenuItem;
     private Font? _normalFont;
     private Font? _disabledFont;
@@ -314,7 +315,8 @@ public class KryptonPropertyGrid : VisualControlBase,
         ((KryptonReadOnlyControls)Controls).AddInternal(_propertyGrid);
 
         // Create a new KryptonContextMenu
-        KryptonContextMenu = new KryptonContextMenu();
+        _resetContextMenu = new KryptonContextMenu();
+        KryptonContextMenu = _resetContextMenu;
 
         KryptonContextMenuItems menuItems = new KryptonContextMenuItems();
 
@@ -322,7 +324,7 @@ public class KryptonPropertyGrid : VisualControlBase,
 
         menuItems.Items.Add(_resetMenuItem);
 
-        KryptonContextMenu.Items.Add(menuItems);
+        _resetContextMenu.Items.Add(menuItems);
     }
 
     /// <summary>
@@ -331,6 +333,12 @@ public class KryptonPropertyGrid : VisualControlBase,
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing)
     {
+        if (disposing)
+        {
+            _resetContextMenu.Close();
+            _resetContextMenu.Dispose();
+        }
+
         base.Dispose(disposing);
         if (_screenDC != IntPtr.Zero)
         {


### PR DESCRIPTION
Fixes #3598 
 
- Dispose the navigator context button's owned KryptonContextMenu so FocusLostMenuHelper deregisters it. 
- Dispose owned context menus in KryptonColorButton, KryptonPropertyGrid, KryptonGallery, and ribbon color button variants. 
- Dispose docking workspace drop-down and transient context menus on detach, close, and dispose.
 