### PR TITLE
3493-V105-Build-fixes

### DIFF
--- a/Scripts/Build/Krypton.Orchestration.targets
+++ b/Scripts/Build/Krypton.Orchestration.targets
@@ -14,6 +14,8 @@
 		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs)</KryptonComponentBuildProperties>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all</KryptonComponentBuildProperties>
+		<KryptonComponentBuildProperties Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != ''">$(KryptonComponentBuildProperties);ExcludeVs2019UnsupportedTargetFrameworks=$(ExcludeVs2019UnsupportedTargetFrameworks)</KryptonComponentBuildProperties>
+		<KryptonComponentBuildProperties Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != ''">$(KryptonComponentBuildProperties);ExcludeVs2022UnsupportedTargetFrameworks=$(ExcludeVs2022UnsupportedTargetFrameworks)</KryptonComponentBuildProperties>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/Build/build.proj
+++ b/Scripts/Build/build.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
@@ -58,6 +60,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -1,10 +1,14 @@
 echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
 echo Do you want to build using Visual Studio 2019 or 2026? (2019/2026)
 set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
+set /P "INPUT=Type 2019 or 2026: "
 if /I "%INPUT%"=="2019" goto vs2019build
 if /I "%INPUT%"=="2026" goto vs2026build
+goto exitbatch
 
 :vs2019build
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
@@ -20,32 +24,34 @@ pause
 goto exitbatch
 
 :vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build2019
 
 :vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build2019
 
 :vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build2019
 
 :vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build2019
 
 :vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build2019
 
 :build2019
 @echo Started: %date% %time%
 @echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+if "%targets%" == "" set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+if "%afterpack%" == "1" goto packdone
+goto postbuild
 
 :vs2026build
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
@@ -55,60 +61,76 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bi
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-goto exitbatch
+
 pause
 
+goto exitbatch
+
 :vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build2026
 
 :build2026
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo Started: %date% %time%
+@echo
+if "%targets%" == "" set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+if "%afterpack%" == "1" goto packdone
+goto postbuild
 
+:postbuild
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=
-set /PINPUT=Type input: %=%
+set /P "INPUT=Type input: "
 if /I "%INPUT%"=="y" goto createpackages
 if /I "%INPUT%"=="n" goto break
+goto break
 
 :createpackages
 echo Do you want to pack using Visual Studio 2019 or 2026? (2019/2026)
 set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
-if /I "%INPUT%"=="2026" goto vs2026pack
+set /P "INPUT=Type 2019 or 2026: "
+if /I "%INPUT%"=="2019" goto pack2019
+if /I "%INPUT%"=="2026" goto pack2026
+goto break
 
-:vs2019pack
-build-2019.cmd Pack
+:pack2019
+set "targets=Pack"
+set "afterpack=1"
+goto vs2019build
 
+:pack2026
+set "targets=Pack"
+set "afterpack=1"
+goto vs2026build
+
+:packdone
 @echo Build Completed: %date% %time%
+goto break
 
-:vs2026pack
-build-2026.cmd Pack
-
-@echo Build Completed: %date% %time%
 
 :break
 pause
 @echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Build/canary.proj
+++ b/Scripts/Build/canary.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Build/canarylongtermstable.proj
+++ b/Scripts/Build/canarylongtermstable.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -1,4 +1,7 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
@@ -12,32 +15,32 @@ pause
 goto exitbatch
 
 :vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
 :vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
 :vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
 :vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
 :vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
 @echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo
@@ -46,3 +49,5 @@ echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.c
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Build/debug.proj
+++ b/Scripts/Build/debug.proj
@@ -11,6 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 

--- a/Scripts/Build/installer.proj
+++ b/Scripts/Build/installer.proj
@@ -10,6 +10,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 	</Target>	
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />

--- a/Scripts/Build/longtermstable.proj
+++ b/Scripts/Build/longtermstable.proj
@@ -1,73 +1,148 @@
-<Project>
-	<Import Project="..\..\Directory.Build.props" />
-	<Import Project="Krypton.Orchestration.targets" />
-
-	<PropertyGroup>
-		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
-		<Configuration>Release</Configuration>
-	</PropertyGroup>
-
-	<Target Name="Clean">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
-
-	<Target Name="CleanPackages">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
-		</ItemGroup>
-		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
-
-	<Target Name="Push">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
-		</ItemGroup>
-		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
-	</Target>
-</Project>
+<Project>
+
+	<Import Project="..\..\Directory.Build.props" />
+
+	<Import Project="Krypton.Orchestration.targets" />
+
+
+
+	<PropertyGroup>
+
+		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
+
+		<Configuration>Release</Configuration>
+
+	</PropertyGroup>
+
+
+
+	<Target Name="Clean">
+
+		<ItemGroup>
+
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+
+		</ItemGroup>
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+
+	</Target>
+
+
+
+	<Target Name="Restore">
+
+		<ItemGroup>
+
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+
+		</ItemGroup>
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+
+	</Target>
+
+
+
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
+
+
+
+	<Target Name="CleanPackages">
+
+		<ItemGroup>
+
+			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+
+		</ItemGroup>
+
+		<Delete Files="@(NugetPkgs)" />
+
+	</Target>
+
+
+
+	<Target Name="PackLite">
+
+		<ItemGroup>
+
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+
+		</ItemGroup>
+
+		<ItemGroup>
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+
+		</ItemGroup>
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+
+		<Delete Files="@(NugetAssets)" />
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
+
+	</Target>
+
+
+
+	<Target Name="PackAll">
+
+		<ItemGroup>
+
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+
+		</ItemGroup>
+
+		<ItemGroup>
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+
+		</ItemGroup>
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+
+		<Delete Files="@(NugetAssets)" />
+
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+
+		<CallTarget Targets="KryptonPack" />
+
+	</Target>
+
+
+
+	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
+
+
+
+	<Target Name="Push">
+
+		<ItemGroup>
+
+			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+
+		</ItemGroup>
+
+		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
+
+	</Target>
+
+</Project>

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -1,34 +1,37 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
+:vs16prev
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
+:vs16ent
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
+:vs16pro
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+:vs16com
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+:vs16build
+set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -38,9 +41,9 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 
 @echo Rebuild Started: %date% %time% %zone%
 @echo
-set targets=Rebuild
-if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+set "targets=Rebuild"
+if not "%~1" == "" set "targets=%~1"
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 
@@ -58,8 +61,11 @@ if %answer%==n exit
 @echo Invalid input, please try again.
 
 :run
-cd ../..
+popd
 
-run.cmd
+"%SCRIPT_DIR%..\..\run.cmd"
+exit /b
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
@@ -58,6 +60,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -1,51 +1,13 @@
 echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-echo Do you want to build using Visual Studio 2019 or 2026? (2019/2026)
+echo Do you want to build using Visual Studio 2026? (2026)
 set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019build
+set /P "INPUT=Type 2026: "
 if /I "%INPUT%"=="2026" goto vs2026build
-
-:vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
-pause
-
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build2019
-
-:build2019
-@echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
-REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2026build
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
@@ -55,60 +17,66 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bi
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-goto exitbatch
+
 pause
 
+goto exitbatch
+
 :vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build2026
 
 :vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build2026
 
 :build2026
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo Started: %date% %time%
+@echo
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
+goto postbuild
 
+:postbuild
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=
-set /PINPUT=Type input: %=%
+set /P "INPUT=Type input: "
 if /I "%INPUT%"=="y" goto createpackages
 if /I "%INPUT%"=="n" goto break
+goto break
 
 :createpackages
-echo Do you want to pack using Visual Studio 2019 or 2026? (2019/2026)
+echo Do you want to pack using Visual Studio 2026? (2026)
 set INPUT=
-set /P INPUT=Type 2019 or 2026: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
+set /P "INPUT=Type 2026: "
 if /I "%INPUT%"=="2026" goto vs2026pack
-
-:vs2019pack
-build-2019.cmd Pack
-
-@echo Build Completed: %date% %time%
+goto break
 
 :vs2026pack
-build-2026.cmd Pack
+"%msbuildpath%\msbuild.exe" /m /t:Pack "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-pack-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-pack-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
+goto break
+
 
 :break
 pause
 @echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/canarylongtermstable.proj
+++ b/Scripts/Current/canarylongtermstable.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -42,6 +43,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -1,43 +1,46 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
+if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
 
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
+echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 
 pause
 goto exitbatch
 
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+:vscurrentinsiders
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build
 
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+:vscurrentent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+:vscurrentpro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build
 
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+:vscurrentcom
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build
 
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+:vscurrentbuild
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
 @echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo
@@ -46,3 +49,5 @@ echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.c
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/Current/debug.proj
+++ b/Scripts/Current/debug.proj
@@ -11,6 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 

--- a/Scripts/Current/installer.proj
+++ b/Scripts/Current/installer.proj
@@ -10,6 +10,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 	</Target>	
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -11,6 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -40,6 +41,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
@@ -56,6 +58,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -13,6 +13,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
@@ -44,6 +45,7 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -1,4 +1,7 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
 if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
@@ -12,23 +15,23 @@ pause
 goto exitbatch
 
 :vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
 goto build
 
 :vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
 goto build
 
 :vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
 goto build
 
 :vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
 goto build
 
 :vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -38,9 +41,9 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 
 @echo Rebuild Started: %date% %time% %zone%
 @echo
-set targets=Rebuild
-if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+set "targets=Rebuild"
+if not "%~1" == "" set "targets=%~1"
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 
@@ -58,8 +61,11 @@ if %answer%==n exit
 @echo Invalid input, please try again.
 
 :run
-cd ../..
+popd
 
-run.cmd
+"%SCRIPT_DIR%..\..\run.cmd"
+exit /b
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/ModernBuild/ModernBuild.csproj
+++ b/Scripts/ModernBuild/ModernBuild.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<ExcludeVs2022UnsupportedTargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == '' And '$(CI)' != 'true' And '$(MSBuildRuntimeType)' == 'Full' And $([System.String]::Copy('$(VisualStudioVersion)').StartsWith('17.'))">true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
   	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -3,35 +3,35 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
 goto exitbatch
 
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+:vs17prev
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build
 
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
+:vs17ent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
+:vs17pro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build
 
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
+:vs17com
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build
 
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+:vs17build
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build

--- a/Scripts/VS2022/build.proj
+++ b/Scripts/VS2022/build.proj
@@ -5,6 +5,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
@@ -13,14 +14,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
@@ -42,10 +44,11 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="PackAll">
@@ -58,9 +61,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -1,51 +1,13 @@
 echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-echo Do you want to build using Visual Studio 2019 or 2022? (2019/2022)
+echo Do you want to build using Visual Studio 2022? (2022)
 set INPUT=
-set /P INPUT=Type 2019 or 2022: %=%
-if /I "%INPUT%"=="2019" goto vs2019build
+set /P "INPUT=Type 2022: "
 if /I "%INPUT%"=="2022" goto vs2022build
-
-:vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
-pause
-
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build2019
-
-:build2019
-@echo Started: %date% %time%
-@echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
-REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/solution-build-log.log /bl:solution-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2022build
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
@@ -59,56 +21,58 @@ goto exitbatch
 pause
 
 :vs17prev
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build2022
 
 :vs17ent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build2022
 
 :vs17pro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build2022
 
 :vs17com
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build2022
 
 :vs17build
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build2022
 
 :build2022
-set targets=Build
-if not "%~1" == "" set targets=%~1
+@echo Started: %date% %time%
+@echo
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=build.log
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
+:postbuild
 echo Do you now want to create NuGet packages? (y/n)
 set INPUT=
-set /PINPUT=Type input: %=%
+set /P "INPUT=Type input: "
 if /I "%INPUT%"=="y" goto createpackages
 if /I "%INPUT%"=="n" goto break
+goto break
 
 :createpackages
-echo Do you want to pack using Visual Studio 2019 or 2022? (2019/2022)
+echo Do you want to pack using Visual Studio 2022? (2022)
 set INPUT=
-set /P INPUT=Type 2019 or 2022: %=%
-if /I "%INPUT%"=="2019" goto vs2019pack
+set /P "INPUT=Type 2022: "
 if /I "%INPUT%"=="2022" goto vs2022pack
-
-:vs2019pack
-build-2019.cmd Pack
-
-@echo Build Completed: %date% %time%
+goto break
 
 :vs2022pack
-build-2022.cmd Pack
+"%msbuildpath%\msbuild.exe" /m /t:Pack "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-pack-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-pack-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
+goto break
 
 :break
 pause
 @echo Build Completed: %date% %time%
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/VS2022/canary.proj
+++ b/Scripts/VS2022/canary.proj
@@ -5,6 +5,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
@@ -13,14 +14,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
@@ -42,9 +44,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/VS2022/canarylongtermstable.proj
+++ b/Scripts/VS2022/canarylongtermstable.proj
@@ -5,6 +5,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
@@ -13,14 +14,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
@@ -42,9 +44,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -1,43 +1,46 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
+echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
 goto exitbatch
 
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
+:vs17prev
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build
 
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
+:vs17ent
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build
 
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
+:vs17pro
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build
 
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
+:vs17com
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build
 
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+:vs17build
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
 @echo Started: %date% %time%
 @echo
-set targets=Build
-if not "%~1" == "" set targets=%~1
+set "targets=Build"
+if not "%~1" == "" set "targets=%~1"
 REM /m: multi-processor MSBuild (all logical CPUs).
-"%msbuildpath%\msbuild.exe" /m /t:%targets% build.proj /fl /flp:logfile=../Logs/debug-build-log.log /bl:../Logs/debug-build-log.binlog /clp:Summary;ShowTimestamp /v:quiet
+"%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%debug.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\debug-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\debug-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 @echo Build Completed: %date% %time%
 @echo
@@ -46,3 +49,5 @@ echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.c
 pause
 
 :exitbatch
+popd
+exit /b

--- a/Scripts/VS2022/debug.proj
+++ b/Scripts/VS2022/debug.proj
@@ -5,20 +5,22 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Debug</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 	</PropertyGroup>
 
 	<Target Name="Clean">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>	
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 	
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />

--- a/Scripts/VS2022/installer.proj
+++ b/Scripts/VS2022/installer.proj
@@ -4,27 +4,29 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Installer</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 	</PropertyGroup>
 
 	<Target Name="Clean">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" />
 	</Target>	
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
 	</Target>
 	
 	<Target Name="Build" DependsOnTargets="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" />
 	</Target>
 	
 	<Target Name="CleanPackages">
@@ -44,10 +46,11 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" />
 	</Target>
 	
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/longtermstable.proj
+++ b/Scripts/VS2022/longtermstable.proj
@@ -5,20 +5,22 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 	</PropertyGroup>
 
 	<Target Name="Clean">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
@@ -40,10 +42,11 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="PackAll">
@@ -56,9 +59,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -5,6 +5,7 @@
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
+		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
 		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
@@ -13,14 +14,15 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Restore">
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 	</Target>
 
 	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
@@ -44,9 +46,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -1,4 +1,7 @@
 @echo off
+setlocal EnableExtensions
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
 
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
@@ -12,23 +15,23 @@ pause
 goto exitbatch
 
 :vs17prev
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
 goto build
 
 :vs17ent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
 goto build
 
 :vs17pro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
 goto build
 
 :vs17com
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
 goto build
 
 :vs17build
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin
+set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
 goto build
 
 :build
@@ -38,9 +41,9 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 
 @echo Rebuild Started: %date% %time% %zone%
 @echo
-set targets=Rebuild
-if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" /m -t:%targets% nightly.proj /fl /flp:logfile=../Logs/nightly-build-log.log /bl:../Logs/nightly-build-log.binlog  /clp:Summary;ShowTimestamp /v:quiet
+set "targets=Rebuild"
+if not "%~1" == "" set "targets=%~1"
+"%msbuildpath%\msbuild.exe" /m -t:%targets% "%SCRIPT_DIR%nightly.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\nightly-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\nightly-build-log.binlog"  /clp:Summary;ShowTimestamp /v:quiet
 
 :: -t:rebuild
 
@@ -58,8 +61,11 @@ if %answer%==n exit
 @echo Invalid input, please try again.
 
 :run
-cd ../..
+popd
 
-run.cmd
+"%SCRIPT_DIR%..\..\run.cmd"
+exit /b
 
 :exitbatch
+popd
+exit /b

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -5,6 +5,11 @@
 	<!--https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#configure-multiple-projects-->
 	<PropertyGroup>
 		<LangVersion>preview</LangVersion>
+		<Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+		<ExcludeVs2019UnsupportedTargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == '' And '$(CI)' != 'true' And '$(MSBuildRuntimeType)' == 'Full' And $([System.String]::Copy('$(VisualStudioVersion)').StartsWith('16.'))">true</ExcludeVs2019UnsupportedTargetFrameworks>
+		<ExcludeVs2022UnsupportedTargetFrameworks Condition="'$(ExcludeVs2022UnsupportedTargetFrameworks)' == '' And '$(CI)' != 'true' And '$(MSBuildRuntimeType)' == 'Full' And $([System.String]::Copy('$(VisualStudioVersion)').StartsWith('17.'))">true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonBuildOutputRoot Condition="'$(KryptonBuildOutputRoot)' == ''">$(MSBuildThisFileDirectory)..\..\Bin\</KryptonBuildOutputRoot>
+		<KryptonPackageOutputRoot Condition="'$(KryptonPackageOutputRoot)' == ''">$(MSBuildThisFileDirectory)..\..\Bin\Packages\</KryptonPackageOutputRoot>
 	</PropertyGroup>
 
 	<!--Handle AssemblyInfo-->
@@ -27,17 +32,17 @@
 
 	<ItemGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
 		<PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.14.0" PrivateAssets="all" Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'" />
 	</ItemGroup>
 
 	<!-- Configure NuGet package output to separate directory for easier management -->
 	<PropertyGroup>
-		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\Bin\Packages\$(Configuration)\</PackageOutputPath>
+		<PackageOutputPath>$(KryptonPackageOutputRoot)$(Configuration)\</PackageOutputPath>
 		<!-- Ensure multi-target outputs don't overwrite each other -->
-		<OutputPath>$(MSBuildThisFileDirectory)..\..\Bin\$(Configuration)\$(TargetFramework)\</OutputPath>
-		<IntermediateOutputPath>obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+		<OutputPath>$(KryptonBuildOutputRoot)$(Configuration)\$(TargetFramework)\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<!-- Per-TFM obj avoids races when msbuild /m compiles multiple target frameworks at once -->
-		<IntermediateOutputPath>$(MSBuildProjectDirectory)obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+		<IntermediateOutputPath>$(MSBuildProjectDirectory)\obj\$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 		<AppendTargetFrameworkToIntermediateOutputPath>false</AppendTargetFrameworkToIntermediateOutputPath>
 	</PropertyGroup>
 

--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
@@ -3,14 +3,20 @@
   <Choose>
 	<When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
 	  <PropertyGroup>
-		<TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 	  </PropertyGroup>
 	</When>
 	<Otherwise>
 	  <PropertyGroup>
-		<TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
-		<TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 	  </PropertyGroup>
 	</Otherwise>
   </Choose>

--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
@@ -10,9 +10,9 @@
 	</When>
 	<Otherwise>
 	  <PropertyGroup>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
@@ -10,9 +10,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
         <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
@@ -3,14 +3,20 @@
   <Choose>
     <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
       <PropertyGroup>
-        <TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
-        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
@@ -10,9 +10,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
         <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
@@ -3,14 +3,20 @@
   <Choose>
     <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
       <PropertyGroup>
-        <TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
-        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -3,14 +3,20 @@
   <Choose>
 	<When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
 	  <PropertyGroup>
-		<TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 	  </PropertyGroup>
 	</When>
 	<Otherwise>
 	  <PropertyGroup>
-		<TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
-		<TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 	  </PropertyGroup>
 	</Otherwise>
   </Choose>

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -10,9 +10,9 @@
 	</When>
 	<Otherwise>
 	  <PropertyGroup>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
@@ -10,9 +10,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
         <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
 		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
@@ -3,14 +3,20 @@
   <Choose>
     <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
       <PropertyGroup>
-        <TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
-        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -25,9 +25,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 
         <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
         <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
     <WarningLevel>8</WarningLevel>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
-    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-    <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
     <WarningLevel>8</WarningLevel>
@@ -17,6 +14,27 @@
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />


### PR DESCRIPTION
This fixes the V105-LTS build scripts similar to the ones applied in alpha so local and CI builds resolve projects from the script folder instead of depending on the caller's current directory.

## What changed
- Restored absolute script-directory based MSBuild calls and log paths across the V105 script folders.
- Kept the toolset mapping explicit: Build direct wrappers use VS 2019, Current uses VS 2026, VS2022 uses VS 2022, and Build/buildsolution keeps both 2019 and 2026 choices.
- Added Visual Studio generation based target framework filtering so VS 2019 and VS 2022 do not try to build unsupported TFMs.
- Added a VS2019-only Roslyn compiler toolset package so the current V105 source syntax compiles under VS2019 MSBuild.
- Updated orchestration to restore before clean/build flows and pass the TFM filter properties through the Krypton build graph.

## Checks run
- Scripts/Build/buildsolution.cmd with 2019 and 2026
- Scripts/Current/buildsolution.cmd with 2026
- Scripts/VS2022/buildsolution.cmd with 2022
- Build, Current, and VS2022 debug wrappers
- Build, Current, and VS2022 nightly rebuild wrappers
- XML parse over changed project files