### PR TITLE
* KryptonDataGridView external corner rounding

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Implemented [3566](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3566), Use correct NuGet versions in VS templates
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#2926](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2926), Really fix themed scrollbars part of KryptonListBox

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -178,6 +178,12 @@ public class KryptonDataGridView : DataGridView
     private Point _cellDown;
     private System.Windows.Forms.Timer? _showTimer;
     private bool _hideOuterBorders;
+    private ScrollBars _savedScrollBarsForRounding;
+    private bool _roundingUsesDetachedScrollbars;
+    private KryptonVScrollBar? _roundingVScrollBar;
+    private KryptonHScrollBar? _roundingHScrollBar;
+    private bool _suppressRoundingScrollSync;
+    private System.Windows.Forms.Timer? _roundingScrollSyncTimer;
     private string _toolTipText;
     private byte _oldLocation;
     private DataGridViewCell? _oldCell;
@@ -237,6 +243,37 @@ public class KryptonDataGridView : DataGridView
         SetupViewAndStates();
         SetupDefaults();
         SetupSyncCellStyles();
+        UpdateRoundingAppearance();
+    }
+
+    /// <inheritdoc />
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+        UpdateRoundingAppearance();
+    }
+
+    /// <summary>
+    /// Gets or sets which scroll bars are visible when corner rounding is disabled.
+    /// </summary>
+    [Category(@"Layout")]
+    [DefaultValue(ScrollBars.Both)]
+    public new ScrollBars ScrollBars
+    {
+        get => _roundingUsesDetachedScrollbars ? _savedScrollBarsForRounding : base.ScrollBars;
+
+        set
+        {
+            _savedScrollBarsForRounding = value;
+            base.ScrollBars = value;
+
+            if (_roundingUsesDetachedScrollbars)
+            {
+                HideNativeScrollbarsForRounding();
+                SyncDetachedRoundingScrollbarsFromGrid();
+                LayoutDetachedRoundingScrollbars();
+            }
+        }
     }
 
     /// <summary>
@@ -269,6 +306,8 @@ public class KryptonDataGridView : DataGridView
 
             // Dispose of view manager related resources
             ViewManager?.Dispose();
+
+            DisableDetachedRoundingScrollbars();
         }
 
         base.Dispose(disposing);
@@ -986,6 +1025,8 @@ public class KryptonDataGridView : DataGridView
         // palette setting and any state overrides that are defined
         SyncCellStylesWithPalette();
 
+        UpdateRoundingAppearance();
+
         // Continue with usual painting logic
         OnNeedPaint(sender, e);
     }
@@ -1118,6 +1159,11 @@ public class KryptonDataGridView : DataGridView
     protected override void OnScroll(ScrollEventArgs e)
     {
         base.OnScroll(e);
+
+        if (_roundingUsesDetachedScrollbars && !_suppressRoundingScrollSync)
+        {
+            SyncDetachedRoundingScrollbarsFromGrid();
+        }
 
         // #2681 - work-around
         // Headers not correctly repainted on horizontal mouse scroll
@@ -1392,8 +1438,15 @@ public class KryptonDataGridView : DataGridView
                     Rectangle headerContentBounds = Rectangle.Empty;
 
                     // Force the border to have a specified maximum border edge
+                    _borderForced.ClearForcedState();
                     _borderForced.SetInherit(paletteBorder);
                     _borderForced.MaxBorderEdges = GetCellMaxBorderEdges(e.CellBounds, e.ColumnIndex, e.RowIndex);
+
+                    if (HasCornerRounding && TryGetOuterCornerBorderEdges(e.CellBounds, out _))
+                    {
+                        _borderForced.ForceBorderRounding(GetEffectiveCornerRounding());
+                        _borderForced.ForceGraphicsHint = PaletteGraphicsHint.AntiAlias;
+                    }
 
                     // Get the padding used to decide how to draw the background
                     Padding borderPadding = Renderer!.RenderStandardBorder.GetBorderRawPadding(_borderForced, state, VisualOrientation.Top);
@@ -1806,11 +1859,25 @@ public class KryptonDataGridView : DataGridView
             // Use the view manager to paint the view panel that fills the entire areas as the background
             using var context = new RenderContext(this, graphics, clipBounds, Renderer!);
             ViewManager.Paint(context);
+
+            if (HasCornerRounding)
+            {
+                IPaletteBorder paletteBorder = Enabled ? StateNormal.Border : StateDisabled.Border;
+                PaletteState borderState = Enabled ? PaletteState.Normal : PaletteState.Disabled;
+                Renderer!.RenderStandardBorder.DrawBorder(context, GetOuterRoundingBounds(), paletteBorder, VisualOrientation.Top, borderState);
+            }
         }
 
         // Request for a refresh has been serviced
         _refresh = false;
         _refreshAll = false;
+    }
+
+    /// <inheritdoc />
+    protected override void OnResize(EventArgs e)
+    {
+        base.OnResize(e);
+        UpdateRoundingAppearance();
     }
 
     /// <summary>
@@ -1843,6 +1910,8 @@ public class KryptonDataGridView : DataGridView
 
         // Let base class layout child controls
         base.OnLayout(levent);
+
+        UpdateRoundingAppearance();
     }
     #endregion
 
@@ -2514,6 +2583,11 @@ public class KryptonDataGridView : DataGridView
         int column,
         int row)
     {
+        if (HasCornerRounding && TryGetOuterCornerBorderEdges(cellBounds, out PaletteDrawBorders cornerEdges))
+        {
+            return cornerEdges;
+        }
+
         // We always draw the bottom border and left/right depending on RTL setting
         PaletteDrawBorders maxBorders = PaletteDrawBorders.Bottom |
                                         (RightToLeftInternal ? PaletteDrawBorders.Left :
@@ -2534,12 +2608,14 @@ public class KryptonDataGridView : DataGridView
 
         // Check if the cell is hard against the far or bottom edges, if so do not need to draw
         // border that is hard against the edge as it will then look like it has double borders
-        if (HideOuterBorders)
+        Rectangle outerBounds = GetOuterRoundingBounds();
+
+        if (HideOuterBorders || HasCornerRounding)
         {
             // With RTL we check the left border
             if (RightToLeftInternal)
             {
-                if (cellBounds.Left == 0)
+                if (IsAtOuterLeft(cellBounds))
                 {
                     maxBorders &= ~PaletteDrawBorders.Left;
                 }
@@ -2547,20 +2623,769 @@ public class KryptonDataGridView : DataGridView
             else
             {
                 // Check the right border
-                if (cellBounds.Right == Width)
+                if (IsAtOuterRight(cellBounds, outerBounds))
                 {
                     maxBorders &= ~PaletteDrawBorders.Right;
                 }
             }
 
             // Check the bottom border
-            if (cellBounds.Bottom == Height)
+            if (IsAtOuterBottom(cellBounds, outerBounds))
             {
                 maxBorders &= ~PaletteDrawBorders.Bottom;
             }
         }
 
+        if (HasCornerRounding)
+        {
+            if (IsAtOuterTop(cellBounds))
+            {
+                maxBorders &= ~PaletteDrawBorders.Top;
+            }
+
+            if (RightToLeftInternal)
+            {
+                if (IsAtOuterRight(cellBounds, outerBounds))
+                {
+                    maxBorders &= ~PaletteDrawBorders.Right;
+                }
+            }
+            else
+            {
+                if (IsAtOuterLeft(cellBounds))
+                {
+                    maxBorders &= ~PaletteDrawBorders.Left;
+                }
+            }
+        }
+
         return maxBorders;
+    }
+
+    private bool TryGetOuterCornerBorderEdges(Rectangle cellBounds, out PaletteDrawBorders cornerEdges)
+    {
+        cornerEdges = PaletteDrawBorders.None;
+
+        if (!HasCornerRounding)
+        {
+            return false;
+        }
+
+        Rectangle outerBounds = GetOuterRoundingBounds();
+        bool atTop = IsAtOuterTop(cellBounds);
+        bool atBottom = IsAtOuterBottom(cellBounds, outerBounds);
+        bool atLeft = IsAtOuterLeft(cellBounds);
+        bool atRight = IsAtOuterRight(cellBounds, outerBounds);
+
+        if (atTop && atLeft)
+        {
+            cornerEdges = PaletteDrawBorders.Top | PaletteDrawBorders.Left;
+            return true;
+        }
+
+        if (atTop && atRight)
+        {
+            cornerEdges = PaletteDrawBorders.Top | PaletteDrawBorders.Right;
+            return true;
+        }
+
+        if (atBottom && atLeft)
+        {
+            cornerEdges = PaletteDrawBorders.Bottom | PaletteDrawBorders.Left;
+            return true;
+        }
+
+        if (atBottom && atRight)
+        {
+            cornerEdges = PaletteDrawBorders.Bottom | PaletteDrawBorders.Right;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool AreCornerRoundingStatesReady() => StateNormal != null && StateDisabled != null;
+
+    private bool HasCornerRounding => AreCornerRoundingStatesReady() && GetEffectiveCornerRounding() > 0f;
+
+    private float GetEffectiveCornerRounding()
+    {
+        if (!AreCornerRoundingStatesReady())
+        {
+            return 0f;
+        }
+
+        PaletteBorder border = Enabled ? StateNormal.Border : StateDisabled.Border;
+        PaletteState state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
+        return border.GetBorderRounding(state);
+    }
+
+    /// <summary>
+    /// Outer rectangle used for region clipping, outer border, and corner-cell detection.
+    /// </summary>
+    private Rectangle GetOuterRoundingBounds() =>
+        _roundingUsesDetachedScrollbars ? GetDataAreaBounds() : ClientRectangle;
+
+    private Rectangle GetDataAreaBounds()
+    {
+        Rectangle bounds = ClientRectangle;
+
+        if (_roundingUsesDetachedScrollbars)
+        {
+            if (_roundingVScrollBar != null && _roundingVScrollBar.Visible)
+            {
+                bounds.Width = Math.Max(0, bounds.Width - _roundingVScrollBar.Width);
+            }
+
+            if (_roundingHScrollBar != null && _roundingHScrollBar.Visible)
+            {
+                bounds.Height = Math.Max(0, bounds.Height - _roundingHScrollBar.Height);
+            }
+        }
+
+        return bounds;
+    }
+
+    private void UpdateRoundingAppearance()
+    {
+        UpdateRoundingScrollbars();
+        UpdateCornerRoundingRegion();
+    }
+
+    private void UpdateRoundingScrollbars()
+    {
+        if (!AreCornerRoundingStatesReady())
+        {
+            return;
+        }
+
+        if (HasCornerRounding)
+        {
+            if (!_roundingUsesDetachedScrollbars)
+            {
+                EnableDetachedRoundingScrollbars();
+            }
+            else
+            {
+                LayoutDetachedRoundingScrollbars();
+                SyncDetachedRoundingScrollbarsFromGrid();
+            }
+        }
+        else if (_roundingUsesDetachedScrollbars)
+        {
+            DisableDetachedRoundingScrollbars();
+        }
+    }
+
+    private void EnableDetachedRoundingScrollbars()
+    {
+        _savedScrollBarsForRounding = base.ScrollBars;
+        _roundingUsesDetachedScrollbars = true;
+
+        if (_roundingScrollSyncTimer == null)
+        {
+            _roundingScrollSyncTimer = new System.Windows.Forms.Timer { Interval = 50 };
+            _roundingScrollSyncTimer.Tick += OnRoundingScrollSyncTimerTick;
+        }
+
+        _roundingScrollSyncTimer.Start();
+
+        EnsureDetachedRoundingScrollbarsCreated();
+        HideNativeScrollbarsForRounding();
+        SyncDetachedRoundingScrollbarsFromGrid();
+        LayoutDetachedRoundingScrollbars();
+        PerformLayout();
+    }
+
+    private void DisableDetachedRoundingScrollbars()
+    {
+        if (_roundingScrollSyncTimer != null)
+        {
+            _roundingScrollSyncTimer.Stop();
+            _roundingScrollSyncTimer.Tick -= OnRoundingScrollSyncTimerTick;
+            _roundingScrollSyncTimer.Dispose();
+            _roundingScrollSyncTimer = null;
+        }
+
+        if (_roundingVScrollBar != null)
+        {
+            _roundingVScrollBar.Scroll -= OnDetachedRoundingVScroll;
+            Controls.Remove(_roundingVScrollBar);
+            _roundingVScrollBar.Dispose();
+            _roundingVScrollBar = null;
+        }
+
+        if (_roundingHScrollBar != null)
+        {
+            _roundingHScrollBar.Scroll -= OnDetachedRoundingHScroll;
+            Controls.Remove(_roundingHScrollBar);
+            _roundingHScrollBar.Dispose();
+            _roundingHScrollBar = null;
+        }
+
+        if (_roundingUsesDetachedScrollbars)
+        {
+            ShowNativeScrollbarsAfterRounding();
+            _roundingUsesDetachedScrollbars = false;
+            PerformLayout();
+        }
+    }
+
+    private void EnsureDetachedRoundingScrollbarsCreated()
+    {
+        if (_roundingVScrollBar == null)
+        {
+            _roundingVScrollBar = new KryptonVScrollBar
+            {
+                TabStop = false,
+                Visible = false
+            };
+            _roundingVScrollBar.Scroll += OnDetachedRoundingVScroll;
+            Controls.Add(_roundingVScrollBar);
+        }
+
+        if (_roundingHScrollBar == null)
+        {
+            _roundingHScrollBar = new KryptonHScrollBar
+            {
+                TabStop = false,
+                Visible = false
+            };
+            _roundingHScrollBar.Scroll += OnDetachedRoundingHScroll;
+            Controls.Add(_roundingHScrollBar);
+        }
+    }
+
+    private void HideNativeScrollbarsForRounding()
+    {
+        for (int i = 0; i < Controls.Count; i++)
+        {
+            Control control = Controls[i];
+            if (control is VScrollBar || control is HScrollBar)
+            {
+                control.Visible = false;
+            }
+        }
+
+        if (!IsHandleCreated)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = PI.ShowScrollBar(Handle, (int)PI.SB_.BOTH, false);
+        }
+        catch
+        {
+            // If native scrollbars cannot be hidden, continue with detached Krypton scrollbars
+        }
+    }
+
+    private void ShowNativeScrollbarsAfterRounding()
+    {
+        if (IsHandleCreated)
+        {
+            try
+            {
+                _ = PI.ShowScrollBar(Handle, (int)PI.SB_.BOTH, true);
+            }
+            catch
+            {
+                // Ignore restore failures
+            }
+        }
+
+        for (int i = 0; i < Controls.Count; i++)
+        {
+            Control control = Controls[i];
+            if (control is VScrollBar || control is HScrollBar)
+            {
+                control.Visible = true;
+            }
+        }
+    }
+
+    private bool WantsDetachedVerticalScrollBar() =>
+        _savedScrollBarsForRounding == ScrollBars.Vertical || _savedScrollBarsForRounding == ScrollBars.Both;
+
+    private bool WantsDetachedHorizontalScrollBar() =>
+        _savedScrollBarsForRounding == ScrollBars.Horizontal || _savedScrollBarsForRounding == ScrollBars.Both;
+
+    private void LayoutDetachedRoundingScrollbars()
+    {
+        if (!_roundingUsesDetachedScrollbars)
+        {
+            return;
+        }
+
+        EnsureDetachedRoundingScrollbarsCreated();
+
+        int scrollbarWidth = SystemInformation.VerticalScrollBarWidth;
+        int scrollbarHeight = SystemInformation.HorizontalScrollBarHeight;
+        bool showVertical = WantsDetachedVerticalScrollBar() && _roundingVScrollBar != null && _roundingVScrollBar.Visible;
+        bool showHorizontal = WantsDetachedHorizontalScrollBar() && _roundingHScrollBar != null && _roundingHScrollBar.Visible;
+
+        int dataRight = ClientSize.Width - (showVertical ? scrollbarWidth : 0);
+        int dataBottom = ClientSize.Height - (showHorizontal ? scrollbarHeight : 0);
+
+        if (_roundingVScrollBar != null)
+        {
+            _roundingVScrollBar.SetBounds(dataRight, 0, scrollbarWidth, Math.Max(0, dataBottom));
+            _roundingVScrollBar.BringToFront();
+        }
+
+        if (_roundingHScrollBar != null)
+        {
+            _roundingHScrollBar.SetBounds(0, dataBottom, Math.Max(0, dataRight), scrollbarHeight);
+            _roundingHScrollBar.BringToFront();
+        }
+
+        UpdateCornerRoundingRegion();
+    }
+
+    private void SyncDetachedRoundingScrollbarsFromGrid()
+    {
+        if (!_roundingUsesDetachedScrollbars || !IsHandleCreated || _suppressRoundingScrollSync)
+        {
+            return;
+        }
+
+        var hScrollInfo = new WIN32ScrollBars.ScrollInfo
+        {
+            cbSize = Marshal.SizeOf(typeof(WIN32ScrollBars.ScrollInfo)),
+            fMask = (int)PI.SIF_.ALL
+        };
+        var vScrollInfo = new WIN32ScrollBars.ScrollInfo
+        {
+            cbSize = Marshal.SizeOf(typeof(WIN32ScrollBars.ScrollInfo)),
+            fMask = (int)PI.SIF_.ALL
+        };
+
+        bool hasHScroll = PI.GetScrollInfo(Handle, PI.SB_.HORZ, ref hScrollInfo);
+        bool hasVScroll = PI.GetScrollInfo(Handle, PI.SB_.VERT, ref vScrollInfo);
+
+        _suppressRoundingScrollSync = true;
+        try
+        {
+            UpdateDetachedHorizontalScrollBar(hasHScroll, hScrollInfo);
+            UpdateDetachedVerticalScrollBar(hasVScroll, vScrollInfo);
+        }
+        finally
+        {
+            _suppressRoundingScrollSync = false;
+        }
+
+        LayoutDetachedRoundingScrollbars();
+    }
+
+    private void UpdateDetachedHorizontalScrollBar(bool hasNativeScrollInfo, WIN32ScrollBars.ScrollInfo scrollInfo)
+    {
+        if (_roundingHScrollBar == null || !WantsDetachedHorizontalScrollBar())
+        {
+            if (_roundingHScrollBar != null)
+            {
+                _roundingHScrollBar.Visible = false;
+            }
+
+            return;
+        }
+
+        int minimum;
+        int maximum;
+        int page;
+        int position;
+        if (hasNativeScrollInfo && TryGetNativeScrollMetrics(scrollInfo, out minimum, out maximum, out page, out position))
+        {
+            ApplyDetachedScrollBarMetrics(_roundingHScrollBar, minimum, maximum, page, position);
+            return;
+        }
+
+        if (TryComputeHorizontalScrollMetrics(out minimum, out maximum, out page, out position))
+        {
+            ApplyDetachedScrollBarMetrics(_roundingHScrollBar, minimum, maximum, page, position);
+        }
+        else
+        {
+            _roundingHScrollBar.Visible = false;
+        }
+    }
+
+    private void UpdateDetachedVerticalScrollBar(bool hasNativeScrollInfo, WIN32ScrollBars.ScrollInfo scrollInfo)
+    {
+        if (_roundingVScrollBar == null || !WantsDetachedVerticalScrollBar())
+        {
+            if (_roundingVScrollBar != null)
+            {
+                _roundingVScrollBar.Visible = false;
+            }
+
+            return;
+        }
+
+        int minimum;
+        int maximum;
+        int page;
+        int position;
+        if (hasNativeScrollInfo && TryGetNativeScrollMetrics(scrollInfo, out minimum, out maximum, out page, out position))
+        {
+            ApplyDetachedScrollBarMetrics(_roundingVScrollBar, minimum, maximum, page, position);
+            return;
+        }
+
+        if (TryComputeVerticalScrollMetrics(out minimum, out maximum, out page, out position))
+        {
+            ApplyDetachedScrollBarMetrics(_roundingVScrollBar, minimum, maximum, page, position);
+        }
+        else
+        {
+            _roundingVScrollBar.Visible = false;
+        }
+    }
+
+    private static bool TryGetNativeScrollMetrics(WIN32ScrollBars.ScrollInfo scrollInfo,
+        out int minimum,
+        out int maximum,
+        out int page,
+        out int position)
+    {
+        minimum = scrollInfo.nMin;
+        maximum = scrollInfo.nMax;
+        page = Math.Max(1, scrollInfo.nPage);
+        position = scrollInfo.nPos;
+
+        int scrollableMaximum = GetNativeScrollableMaximum(scrollInfo);
+        if (scrollableMaximum <= minimum)
+        {
+            return false;
+        }
+
+        position = Math.Min(position, scrollableMaximum);
+        return true;
+    }
+
+    private static void ApplyDetachedScrollBarMetrics(KryptonVScrollBar scrollBar,
+        int minimum,
+        int maximum,
+        int page,
+        int position)
+    {
+        scrollBar.Visible = true;
+        scrollBar.Minimum = minimum;
+        scrollBar.Maximum = maximum;
+        scrollBar.LargeChange = page;
+        scrollBar.SmallChange = 1;
+        scrollBar.Value = position;
+    }
+
+    private static void ApplyDetachedScrollBarMetrics(KryptonHScrollBar scrollBar,
+        int minimum,
+        int maximum,
+        int page,
+        int position)
+    {
+        scrollBar.Visible = true;
+        scrollBar.Minimum = minimum;
+        scrollBar.Maximum = maximum;
+        scrollBar.LargeChange = page;
+        scrollBar.SmallChange = 1;
+        scrollBar.Value = position;
+    }
+
+    private int GetDetachedScrollContentHeight()
+    {
+        int contentHeight = Rows.GetRowsHeight(DataGridViewElementStates.Visible);
+        if (ColumnHeadersVisible)
+        {
+            contentHeight += ColumnHeadersHeight;
+        }
+
+        return contentHeight;
+    }
+
+    private int GetDetachedScrollContentWidth()
+    {
+        int contentWidth = RowHeadersVisible ? RowHeadersWidth : 0;
+        for (int i = 0; i < Columns.Count; i++)
+        {
+            DataGridViewColumn column = Columns[i];
+            if (column.Visible)
+            {
+                contentWidth += column.Width;
+            }
+        }
+
+        return contentWidth;
+    }
+
+    private void GetDetachedScrollBarVisibility(out bool showVertical, out bool showHorizontal)
+    {
+        showVertical = false;
+        showHorizontal = false;
+
+        bool wantsVertical = WantsDetachedVerticalScrollBar();
+        bool wantsHorizontal = WantsDetachedHorizontalScrollBar();
+        if (!wantsVertical && !wantsHorizontal)
+        {
+            return;
+        }
+
+        int contentHeight = wantsVertical ? GetDetachedScrollContentHeight() : 0;
+        int contentWidth = wantsHorizontal ? GetDetachedScrollContentWidth() : 0;
+        int clientHeight = ClientSize.Height;
+        int clientWidth = ClientSize.Width;
+        int horizontalScrollBarHeight = SystemInformation.HorizontalScrollBarHeight;
+        int verticalScrollBarWidth = SystemInformation.VerticalScrollBarWidth;
+
+        for (int iteration = 0; iteration < 3; iteration++)
+        {
+            int viewportHeight = clientHeight - (showHorizontal ? horizontalScrollBarHeight : 0);
+            int viewportWidth = clientWidth - (showVertical ? verticalScrollBarWidth : 0);
+
+            bool newShowVertical = wantsVertical && contentHeight > viewportHeight;
+            bool newShowHorizontal = wantsHorizontal && contentWidth > viewportWidth;
+
+            if (newShowVertical == showVertical && newShowHorizontal == showHorizontal)
+            {
+                break;
+            }
+
+            showVertical = newShowVertical;
+            showHorizontal = newShowHorizontal;
+        }
+    }
+
+    private int GetDetachedScrollViewportHeight()
+    {
+        GetDetachedScrollBarVisibility(out _, out bool showHorizontal);
+
+        int viewportHeight = ClientSize.Height;
+        if (showHorizontal)
+        {
+            viewportHeight -= SystemInformation.HorizontalScrollBarHeight;
+        }
+
+        return Math.Max(0, viewportHeight);
+    }
+
+    private int GetDetachedScrollViewportWidth()
+    {
+        GetDetachedScrollBarVisibility(out bool showVertical, out _);
+
+        int viewportWidth = ClientSize.Width;
+        if (showVertical)
+        {
+            viewportWidth -= SystemInformation.VerticalScrollBarWidth;
+        }
+
+        return Math.Max(0, viewportWidth);
+    }
+
+    private bool TryComputeVerticalScrollMetrics(out int minimum,
+        out int maximum,
+        out int page,
+        out int position)
+    {
+        minimum = 0;
+        maximum = 0;
+        page = 1;
+        position = 0;
+
+        int contentHeight = GetDetachedScrollContentHeight();
+
+        page = Math.Max(1, GetDetachedScrollViewportHeight());
+        if (contentHeight <= page)
+        {
+            return false;
+        }
+
+        maximum = Math.Max(minimum, contentHeight - 1);
+        position = Math.Min(GetVerticalScrollPositionInPixels(), GetNativeScrollableMaximum(minimum, maximum, page));
+        return true;
+    }
+
+    private bool TryComputeHorizontalScrollMetrics(out int minimum,
+        out int maximum,
+        out int page,
+        out int position)
+    {
+        minimum = 0;
+        maximum = 0;
+        page = 1;
+        position = 0;
+
+        int contentWidth = GetDetachedScrollContentWidth();
+
+        page = Math.Max(1, GetDetachedScrollViewportWidth());
+        if (contentWidth <= page)
+        {
+            return false;
+        }
+
+        maximum = Math.Max(minimum, contentWidth - 1);
+        position = Math.Min(GetHorizontalScrollPositionInPixels(), GetNativeScrollableMaximum(minimum, maximum, page));
+        return true;
+    }
+
+    private int GetVerticalScrollPositionInPixels()
+    {
+        int position = 0;
+        int firstRow = Math.Max(0, FirstDisplayedScrollingRowIndex);
+
+        for (int i = 0; i < firstRow && i < Rows.Count; i++)
+        {
+            if (Rows[i].Visible)
+            {
+                position += Rows[i].Height;
+            }
+        }
+
+        return position;
+    }
+
+    private int GetHorizontalScrollPositionInPixels()
+    {
+        var hScrollInfo = new WIN32ScrollBars.ScrollInfo
+        {
+            cbSize = Marshal.SizeOf(typeof(WIN32ScrollBars.ScrollInfo)),
+            fMask = (int)PI.SIF_.POS
+        };
+
+        if (IsHandleCreated && PI.GetScrollInfo(Handle, PI.SB_.HORZ, ref hScrollInfo))
+        {
+            return hScrollInfo.nPos;
+        }
+
+        int position = 0;
+        int firstColumn = Math.Max(0, FirstDisplayedScrollingColumnIndex);
+        if (RowHeadersVisible)
+        {
+            position += RowHeadersWidth;
+        }
+
+        for (int i = 0; i < firstColumn && i < Columns.Count; i++)
+        {
+            if (Columns[i].Visible)
+            {
+                position += Columns[i].Width;
+            }
+        }
+
+        return position;
+    }
+
+    private static int GetNativeScrollableMaximum(int minimum, int maximum, int page) =>
+        Math.Max(minimum, maximum - Math.Max(1, page) + 1);
+
+    private static int GetNativeScrollableMaximum(WIN32ScrollBars.ScrollInfo scrollInfo)
+    {
+        int page = Math.Max(1, scrollInfo.nPage);
+        long scrollableMaximum = (long)scrollInfo.nMax - page + 1;
+
+        if (scrollableMaximum < scrollInfo.nMin)
+        {
+            return scrollInfo.nMin;
+        }
+
+        return scrollableMaximum > int.MaxValue ? int.MaxValue : (int)scrollableMaximum;
+    }
+
+    private void OnDetachedRoundingVScroll(object? sender, ScrollEventArgs e) =>
+        ApplyDetachedRoundingScrollToGrid(false, e);
+
+    private void OnDetachedRoundingHScroll(object? sender, ScrollEventArgs e) =>
+        ApplyDetachedRoundingScrollToGrid(true, e);
+
+    private void ApplyDetachedRoundingScrollToGrid(bool horizontal, ScrollEventArgs e)
+    {
+        if (!_roundingUsesDetachedScrollbars || !IsHandleCreated || _suppressRoundingScrollSync)
+        {
+            return;
+        }
+
+        try
+        {
+            PI.SB_ scrollBar = horizontal ? PI.SB_.HORZ : PI.SB_.VERT;
+            int value = e.NewValue;
+            PI.SetScrollPos(Handle, scrollBar, value, true);
+            int scrollRequest = e.Type == ScrollEventType.ThumbTrack
+                ? (int)PI.SB_.THUMBTRACK
+                : (int)PI.SB_.THUMBPOSITION;
+
+            PI.SendMessage(Handle, horizontal ? PI.WM_.HSCROLL : PI.WM_.VSCROLL,
+                (IntPtr)(scrollRequest | (value << 16)), IntPtr.Zero);
+        }
+        catch
+        {
+            // Ignore scroll sync failures
+        }
+    }
+
+    private void OnRoundingScrollSyncTimerTick(object? sender, EventArgs e) =>
+        SyncDetachedRoundingScrollbarsFromGrid();
+
+    private static bool IsAtOuterTop(Rectangle cellBounds) => cellBounds.Top == 0;
+
+    private static bool IsAtOuterLeft(Rectangle cellBounds) => cellBounds.Left == 0;
+
+    private static bool IsAtOuterBottom(Rectangle cellBounds, Rectangle outerBounds) =>
+        cellBounds.Bottom >= outerBounds.Bottom;
+
+    private static bool IsAtOuterRight(Rectangle cellBounds, Rectangle outerBounds) =>
+        cellBounds.Right >= outerBounds.Right;
+
+    private void UpdateCornerRoundingRegion()
+    {
+        float rounding = GetEffectiveCornerRounding();
+        Rectangle outerBounds = GetOuterRoundingBounds();
+        if (rounding <= 0f || outerBounds.Width <= 0 || outerBounds.Height <= 0)
+        {
+            Region?.Dispose();
+            Region = null;
+            return;
+        }
+
+        int radius = (int)Math.Round(rounding, MidpointRounding.AwayFromZero);
+        using GraphicsPath path = new GraphicsPath();
+        using (GraphicsPath roundedPath = CommonHelper.RoundedRectanglePath(outerBounds, radius))
+        {
+            path.AddPath(roundedPath, false);
+        }
+
+        AppendDetachedScrollbarGuttersToPath(path, outerBounds);
+
+        Region? oldRegion = Region;
+        Region = new Region(path);
+        oldRegion?.Dispose();
+    }
+
+    private void AppendDetachedScrollbarGuttersToPath(GraphicsPath path, Rectangle dataBounds)
+    {
+        if (!_roundingUsesDetachedScrollbars)
+        {
+            return;
+        }
+
+        int scrollbarWidth = SystemInformation.VerticalScrollBarWidth;
+        int scrollbarHeight = SystemInformation.HorizontalScrollBarHeight;
+        bool showVertical = WantsDetachedVerticalScrollBar() && _roundingVScrollBar != null && _roundingVScrollBar.Visible;
+        bool showHorizontal = WantsDetachedHorizontalScrollBar() && _roundingHScrollBar != null && _roundingHScrollBar.Visible;
+
+        if (showVertical)
+        {
+            path.AddRectangle(new Rectangle(dataBounds.Right, 0, scrollbarWidth, ClientSize.Height));
+        }
+
+        if (showHorizontal)
+        {
+            int horizontalWidth = showVertical ? dataBounds.Width : ClientSize.Width;
+            path.AddRectangle(new Rectangle(0, dataBounds.Bottom, horizontalWidth, scrollbarHeight));
+        }
+
+        if (showVertical && showHorizontal)
+        {
+            path.AddRectangle(new Rectangle(dataBounds.Right, dataBounds.Bottom, scrollbarWidth, scrollbarHeight));
+        }
     }
 
     private void ViewManagerLayout()

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritForced.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritForced.cs
@@ -21,6 +21,8 @@ public class PaletteBorderInheritForced : PaletteBorderInherit
     private IPaletteBorder? _inherit;
     private PaletteDrawBorders _forceBorderEdges;
     private bool _forceBorders;
+    private float _forceBorderRounding;
+    private bool _forceBorderRoundingActive;
 
     #endregion
 
@@ -38,6 +40,32 @@ public class PaletteBorderInheritForced : PaletteBorderInherit
         MaxBorderEdges = PaletteDrawBorders.All;
         ForceGraphicsHint = PaletteGraphicsHint.Inherit;
         BorderIgnoreNormal = false;
+        _forceBorderRounding = -1f;
+        _forceBorderRoundingActive = false;
+    }
+    #endregion
+
+    #region ClearForcedState
+    /// <summary>
+    /// Reset forced border edge and rounding overrides.
+    /// </summary>
+    public void ClearForcedState()
+    {
+        _forceBorders = false;
+        _forceBorderRoundingActive = false;
+        ForceGraphicsHint = PaletteGraphicsHint.Inherit;
+    }
+    #endregion
+
+    #region ForceBorderRounding
+    /// <summary>
+    /// Force the border rounding to a particular value.
+    /// </summary>
+    /// <param name="rounding">Rounding to apply.</param>
+    public void ForceBorderRounding(float rounding)
+    {
+        _forceBorderRounding = rounding;
+        _forceBorderRoundingActive = true;
     }
     #endregion
 
@@ -184,7 +212,8 @@ public class PaletteBorderInheritForced : PaletteBorderInherit
     /// </summary>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>Border rounding.</returns>
-    public override float GetBorderRounding(PaletteState state) => _inherit?.GetBorderRounding(state) ?? 0.0f;
+    public override float GetBorderRounding(PaletteState state) =>
+        _forceBorderRoundingActive ? _forceBorderRounding : _inherit?.GetBorderRounding(state) ?? 0.0f;
 
     /// <summary>
     /// Gets a border image.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
@@ -94,17 +94,28 @@ public class PaletteDataGridViewAll : PaletteDataGridViewCells
 
     #endregion
 
-    #region PaletteBorder
+    #region Border
     /// <summary>
-    /// Gets access to the data grid view background palette details.
+    /// Gets access to the data grid view border appearance.
     /// </summary>
     [KryptonPersist]
     [Category(@"Visuals")]
     [Description(@"Overrides for defining data grid view border appearance.")]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public virtual PaletteBorder PaletteBorder => _background.Border;
+    public virtual PaletteBorder Border => _background.Border;
 
-    private bool ShouldSerializePaletteBorder() => !_background.Border.IsDefault;
+    private bool ShouldSerializeBorder() => !_background.Border.IsDefault;
+
+    #endregion
+
+    #region PaletteBorder
+    /// <summary>
+    /// Gets access to the data grid view border appearance.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public virtual PaletteBorder PaletteBorder => _background.Border;
 
     #endregion
 }

--- a/Source/Krypton Components/TestForm/DataGridViewDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewDemo.Designer.cs
@@ -38,17 +38,27 @@ namespace TestForm
         private void InitializeComponent()
         {
             Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec1 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DataGridViewDemo));
             Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec2 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec3 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
             Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec4 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
             Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec5 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
-            Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec6 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DataGridViewDemo));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec columnButtonSpec6 = new Krypton.Toolkit.KryptonDataGridViewIconColumn.ColumnButtonSpec();
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.kcbGridRtl = new Krypton.Toolkit.KryptonCheckBox();
             this.kdgvMain = new Krypton.Toolkit.KryptonDataGridView();
+            this.colId = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.colName = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
+            this.colDate = new Krypton.Toolkit.KryptonDataGridViewDateTimePickerColumn();
+            this.colCombo = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
+            this.colQuantity = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
+            this.colDomain = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
+            this.colActive = new Krypton.Toolkit.KryptonDataGridViewCheckBoxColumn();
+            this.colMasked = new Krypton.Toolkit.KryptonDataGridViewMaskedTextBoxColumn();
+            this.colProgress = new Krypton.Toolkit.KryptonDataGridViewProgressColumn();
+            this.colRating = new Krypton.Toolkit.KryptonDataGridViewRatingColumn();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.pnlOptions = new Krypton.Toolkit.KryptonPanel();
             this.klblColumnHeadersHeight = new Krypton.Toolkit.KryptonLabel();
@@ -70,21 +80,14 @@ namespace TestForm
             this.kchkRowHeadersVisible = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkReadOnly = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkShowGridLines = new Krypton.Toolkit.KryptonCheckBox();
+            this.kchkCornerRounding = new Krypton.Toolkit.KryptonCheckBox();
+            this.klblCornerRoundingRadius = new Krypton.Toolkit.KryptonLabel();
+            this.knudCornerRoundingRadius = new Krypton.Toolkit.KryptonNumericUpDown();
             this.kchkMultiSelect = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkAllowUserToResizeRows = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkAllowUserToResizeColumns = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkAllowUserToDeleteRows = new Krypton.Toolkit.KryptonCheckBox();
             this.kchkAllowUserToAddRows = new Krypton.Toolkit.KryptonCheckBox();
-            this.colId = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
-            this.colName = new Krypton.Toolkit.KryptonDataGridViewTextBoxColumn();
-            this.colDate = new Krypton.Toolkit.KryptonDataGridViewDateTimePickerColumn();
-            this.colCombo = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
-            this.colQuantity = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
-            this.colDomain = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
-            this.colActive = new Krypton.Toolkit.KryptonDataGridViewCheckBoxColumn();
-            this.colMasked = new Krypton.Toolkit.KryptonDataGridViewMaskedTextBoxColumn();
-            this.colProgress = new Krypton.Toolkit.KryptonDataGridViewProgressColumn();
-            this.colRating = new Krypton.Toolkit.KryptonDataGridViewRatingColumn();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kdgvMain)).BeginInit();
@@ -145,8 +148,134 @@ namespace TestForm
             this.kdgvMain.ColumnHeadersHeightChanged += new System.EventHandler(this.kdgvMain_ColumnHeadersHeightChanged);
             this.kdgvMain.RowHeadersWidthChanged += new System.EventHandler(this.kdgvMain_RowHeadersWidthChanged);
             // 
+            // colId
+            // 
+            this.colId.HeaderText = "Id";
+            this.colId.Name = "colId";
+            this.colId.Width = 46;
+            // 
+            // colName
+            // 
+            columnButtonSpec1.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec1.ExtraText = null;
+            columnButtonSpec1.Icon = ((System.Drawing.Image)(resources.GetObject("columnButtonSpec1.Icon")));
+            columnButtonSpec1.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec1.Text = null;
+            columnButtonSpec1.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colName.ButtonSpecs.Add(columnButtonSpec1);
+            this.colName.HeaderText = "Name";
+            this.colName.Name = "colName";
+            this.colName.Width = 68;
+            // 
+            // colDate
+            // 
+            columnButtonSpec2.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec2.ExtraText = null;
+            columnButtonSpec2.Icon = null;
+            columnButtonSpec2.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec2.Text = null;
+            columnButtonSpec2.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colDate.ButtonSpecs.Add(columnButtonSpec2);
+            this.colDate.Checked = false;
+            this.colDate.CustomFormat = "dd.MM.yyyy";
+            dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(0, 0, 17, 0);
+            this.colDate.DefaultCellStyle = dataGridViewCellStyle1;
+            this.colDate.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            this.colDate.HeaderText = "Date";
+            this.colDate.MinimumWidth = 19;
+            this.colDate.Name = "colDate";
+            this.colDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colDate.Width = 60;
+            // 
+            // colCombo
+            // 
+            columnButtonSpec3.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec3.ExtraText = null;
+            columnButtonSpec3.Icon = null;
+            columnButtonSpec3.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec3.Text = null;
+            columnButtonSpec3.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colCombo.ButtonSpecs.Add(columnButtonSpec3);
+            this.colCombo.DropDownWidth = 121;
+            this.colCombo.HeaderText = "Combo";
+            this.colCombo.Name = "colCombo";
+            this.colCombo.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colCombo.Width = 76;
+            // 
+            // colQuantity
+            // 
+            this.colQuantity.AllowDecimals = false;
+            columnButtonSpec4.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec4.ExtraText = null;
+            columnButtonSpec4.Icon = null;
+            columnButtonSpec4.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec4.Text = null;
+            columnButtonSpec4.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colQuantity.ButtonSpecs.Add(columnButtonSpec4);
+            this.colQuantity.HeaderText = "Quantity";
+            this.colQuantity.Name = "colQuantity";
+            this.colQuantity.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colQuantity.Width = 82;
+            // 
+            // colDomain
+            // 
+            columnButtonSpec5.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec5.ExtraText = null;
+            columnButtonSpec5.Icon = null;
+            columnButtonSpec5.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec5.Text = null;
+            columnButtonSpec5.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colDomain.ButtonSpecs.Add(columnButtonSpec5);
+            this.colDomain.HeaderText = "Domain";
+            this.colDomain.Name = "colDomain";
+            this.colDomain.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colDomain.Width = 78;
+            // 
+            // colActive
+            // 
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle2.NullValue = false;
+            this.colActive.DefaultCellStyle = dataGridViewCellStyle2;
+            this.colActive.FalseValue = null;
+            this.colActive.HeaderText = "Active";
+            this.colActive.IndeterminateValue = null;
+            this.colActive.Name = "colActive";
+            this.colActive.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colActive.TrueValue = null;
+            this.colActive.Width = 69;
+            // 
+            // colMasked
+            // 
+            columnButtonSpec6.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
+            columnButtonSpec6.ExtraText = null;
+            columnButtonSpec6.Icon = null;
+            columnButtonSpec6.ImageTransparentColor = System.Drawing.Color.Empty;
+            columnButtonSpec6.Text = null;
+            columnButtonSpec6.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
+            this.colMasked.ButtonSpecs.Add(columnButtonSpec6);
+            this.colMasked.HeaderText = "Masked";
+            this.colMasked.Name = "colMasked";
+            this.colMasked.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colMasked.Width = 77;
+            // 
+            // colProgress
+            // 
+            this.colProgress.HeaderText = "Progress";
+            this.colProgress.Name = "colProgress";
+            this.colProgress.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colProgress.Width = 81;
+            // 
+            // colRating
+            // 
+            this.colRating.HeaderText = "Rating";
+            this.colRating.Name = "colRating";
+            this.colRating.RatingMaximum = ((byte)(0));
+            this.colRating.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.colRating.Width = 70;
+            // 
             // kryptonThemeComboBox1
             // 
+            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 500;
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(12, 8);
@@ -176,6 +305,9 @@ namespace TestForm
             this.pnlOptions.Controls.Add(this.kchkRowHeadersVisible);
             this.pnlOptions.Controls.Add(this.kchkReadOnly);
             this.pnlOptions.Controls.Add(this.kchkShowGridLines);
+            this.pnlOptions.Controls.Add(this.kchkCornerRounding);
+            this.pnlOptions.Controls.Add(this.klblCornerRoundingRadius);
+            this.pnlOptions.Controls.Add(this.knudCornerRoundingRadius);
             this.pnlOptions.Controls.Add(this.kchkMultiSelect);
             this.pnlOptions.Controls.Add(this.kchkAllowUserToResizeRows);
             this.pnlOptions.Controls.Add(this.kchkAllowUserToResizeColumns);
@@ -450,6 +582,53 @@ namespace TestForm
             this.kchkShowGridLines.Values.Text = "Show Grid Lines";
             this.kchkShowGridLines.CheckedChanged += new System.EventHandler(this.kchkShowGridLines_CheckedChanged);
             // 
+            // kchkCornerRounding
+            // 
+            this.kchkCornerRounding.Location = new System.Drawing.Point(650, 148);
+            this.kchkCornerRounding.Name = "kchkCornerRounding";
+            this.kchkCornerRounding.Size = new System.Drawing.Size(117, 20);
+            this.kchkCornerRounding.TabIndex = 14;
+            this.kchkCornerRounding.Values.Text = "Corner Rounding";
+            this.kchkCornerRounding.CheckedChanged += new System.EventHandler(this.kchkCornerRounding_CheckedChanged);
+            // 
+            // klblCornerRoundingRadius
+            // 
+            this.klblCornerRoundingRadius.Enabled = false;
+            this.klblCornerRoundingRadius.Location = new System.Drawing.Point(773, 148);
+            this.klblCornerRoundingRadius.Name = "klblCornerRoundingRadius";
+            this.klblCornerRoundingRadius.Size = new System.Drawing.Size(49, 20);
+            this.klblCornerRoundingRadius.TabIndex = 15;
+            this.klblCornerRoundingRadius.Values.Text = "Radius:";
+            // 
+            // knudCornerRoundingRadius
+            // 
+            this.knudCornerRoundingRadius.Enabled = false;
+            this.knudCornerRoundingRadius.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.knudCornerRoundingRadius.Location = new System.Drawing.Point(828, 146);
+            this.knudCornerRoundingRadius.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.knudCornerRoundingRadius.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.knudCornerRoundingRadius.Name = "knudCornerRoundingRadius";
+            this.knudCornerRoundingRadius.Size = new System.Drawing.Size(56, 22);
+            this.knudCornerRoundingRadius.TabIndex = 16;
+            this.knudCornerRoundingRadius.Value = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.knudCornerRoundingRadius.ValueChanged += new System.EventHandler(this.knudCornerRoundingRadius_ValueChanged);
+            // 
             // kchkMultiSelect
             // 
             this.kchkMultiSelect.Checked = true;
@@ -504,131 +683,6 @@ namespace TestForm
             this.kchkAllowUserToAddRows.TabIndex = 0;
             this.kchkAllowUserToAddRows.Values.Text = "AllowUserToAddRows";
             this.kchkAllowUserToAddRows.CheckedChanged += new System.EventHandler(this.kchkAllowUserToAddRows_CheckedChanged);
-            // 
-            // colId
-            // 
-            this.colId.HeaderText = "Id";
-            this.colId.Name = "colId";
-            this.colId.Width = 46;
-            // 
-            // colName
-            // 
-            columnButtonSpec1.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec1.ExtraText = null;
-            columnButtonSpec1.Icon = ((System.Drawing.Image)(resources.GetObject("columnButtonSpec1.Icon")));
-            columnButtonSpec1.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec1.Text = null;
-            columnButtonSpec1.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colName.ButtonSpecs.Add(columnButtonSpec1);
-            this.colName.HeaderText = "Name";
-            this.colName.Name = "colName";
-            this.colName.Width = 68;
-            // 
-            // colDate
-            // 
-            this.colDate.Checked = false;
-            this.colDate.CustomFormat = "dd.MM.yyyy";
-            dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(0, 0, 17, 0);
-            this.colDate.DefaultCellStyle = dataGridViewCellStyle1;
-            this.colDate.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            columnButtonSpec2.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec2.ExtraText = null;
-            columnButtonSpec2.Icon = null;
-            columnButtonSpec2.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec2.Text = null;
-            columnButtonSpec2.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colDate.ButtonSpecs.Add(columnButtonSpec2);
-            this.colDate.HeaderText = "Date";
-            this.colDate.MinimumWidth = 19;
-            this.colDate.Name = "colDate";
-            this.colDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colDate.Width = 60;
-            // 
-            // colCombo
-            // 
-            this.colCombo.DropDownWidth = 121;
-            columnButtonSpec3.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec3.ExtraText = null;
-            columnButtonSpec3.Icon = null;
-            columnButtonSpec3.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec3.Text = null;
-            columnButtonSpec3.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colCombo.ButtonSpecs.Add(columnButtonSpec3);
-            this.colCombo.HeaderText = "Combo";
-            this.colCombo.Name = "colCombo";
-            this.colCombo.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colCombo.Width = 76;
-            // 
-            // colQuantity
-            // 
-            this.colQuantity.AllowDecimals = false;
-            columnButtonSpec4.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec4.ExtraText = null;
-            columnButtonSpec4.Icon = null;
-            columnButtonSpec4.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec4.Text = null;
-            columnButtonSpec4.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colQuantity.ButtonSpecs.Add(columnButtonSpec4);
-            this.colQuantity.HeaderText = "Quantity";
-            this.colQuantity.Name = "colQuantity";
-            this.colQuantity.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colQuantity.Width = 82;
-            // 
-            // colDomain
-            // 
-            columnButtonSpec5.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec5.ExtraText = null;
-            columnButtonSpec5.Icon = null;
-            columnButtonSpec5.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec5.Text = null;
-            columnButtonSpec5.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colDomain.ButtonSpecs.Add(columnButtonSpec5);
-            this.colDomain.HeaderText = "Domain";
-            this.colDomain.Name = "colDomain";
-            this.colDomain.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colDomain.Width = 78;
-            // 
-            // colActive
-            // 
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle2.NullValue = false;
-            this.colActive.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colActive.FalseValue = null;
-            this.colActive.HeaderText = "Active";
-            this.colActive.IndeterminateValue = null;
-            this.colActive.Name = "colActive";
-            this.colActive.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colActive.TrueValue = null;
-            this.colActive.Width = 69;
-            // 
-            // colMasked
-            // 
-            columnButtonSpec6.Alignment = Krypton.Toolkit.IconSpec.IconAlignment.Right;
-            columnButtonSpec6.ExtraText = null;
-            columnButtonSpec6.Icon = null;
-            columnButtonSpec6.ImageTransparentColor = System.Drawing.Color.Empty;
-            columnButtonSpec6.Text = null;
-            columnButtonSpec6.Type = Krypton.Toolkit.PaletteButtonSpecStyle.FormClose;
-            this.colMasked.ButtonSpecs.Add(columnButtonSpec6);
-            this.colMasked.HeaderText = "Masked";
-            this.colMasked.Name = "colMasked";
-            this.colMasked.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colMasked.Width = 77;
-            // 
-            // colProgress
-            // 
-            this.colProgress.HeaderText = "Progress";
-            this.colProgress.Name = "colProgress";
-            this.colProgress.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colProgress.Width = 81;
-            // 
-            // colRating
-            // 
-            this.colRating.HeaderText = "Rating";
-            this.colRating.Name = "colRating";
-            this.colRating.RatingMaximum = ((byte)(0));
-            this.colRating.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colRating.Width = 70;
             // 
             // DataGridViewDemo
             // 
@@ -686,6 +740,9 @@ namespace TestForm
         private Krypton.Toolkit.KryptonLabel klblColumnHeadersHeight;
         private Krypton.Toolkit.KryptonNumericUpDown knudColumnHeadersHeight;
         private Krypton.Toolkit.KryptonCheckBox kchkShowGridLines;
+        private Krypton.Toolkit.KryptonCheckBox kchkCornerRounding;
+        private Krypton.Toolkit.KryptonLabel klblCornerRoundingRadius;
+        private Krypton.Toolkit.KryptonNumericUpDown knudCornerRoundingRadius;
         private KryptonCheckBox kcbGridRtl;
         private KryptonDataGridViewTextBoxColumn colId;
         private KryptonDataGridViewTextBoxColumn colName;

--- a/Source/Krypton Components/TestForm/DataGridViewDemo.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewDemo.cs
@@ -191,6 +191,19 @@ public partial class DataGridViewDemo : KryptonForm
         kdgvMain.HideOuterBorders = !kchkShowGridLines.Checked;
     }
 
+    private void kchkCornerRounding_CheckedChanged(object sender, EventArgs e) => ApplyCornerRoundingFromDemo();
+
+    private void knudCornerRoundingRadius_ValueChanged(object sender, EventArgs e) => ApplyCornerRoundingFromDemo();
+
+    private void ApplyCornerRoundingFromDemo()
+    {
+        knudCornerRoundingRadius.Enabled = kchkCornerRounding.Checked;
+
+        float rounding = kchkCornerRounding.Checked ? (float)knudCornerRoundingRadius.Value : -1f;
+        kdgvMain.StateNormal.Border.Rounding = rounding;
+        kdgvMain.StateDisabled.Border.Rounding = rounding;
+    }
+
     private void kcmbAutoSizeColumnsMode_SelectedIndexChanged(object sender, EventArgs e)
     {
         if (kcmbAutoSizeColumnsMode.SelectedItem is string name)

--- a/Source/Krypton Components/TestForm/DataGridViewDemo.resx
+++ b/Source/Krypton Components/TestForm/DataGridViewDemo.resx
@@ -121,19 +121,19 @@
   <data name="columnButtonSpec1.Icon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DwAACw8BkvkDpQAAAAd0SU1FB9gEDw0NJWkouy0AAAK4SURBVDhPdVNbSFRRFN3jYxwHxbcovt9+KOiH
-        KAgiZlg6VpqO3pEczBgbRdR8IBGk0EOs7z6DCOrDyNBSC7FmHEctfGQPK4iIKKuv7CMwwdW6M02g5IbD
-        3Nlnr7XXWfsc8cRBkeoDIpuHRBr4V+PO7o4qkVqDyK9jIvV/U+4oE6lTdLqd6b4+NAcEoFrEzPQuErIq
-        LVrtzp2SErT4+aFOpNG1oXau1+t3ZgcGsDI0BEd/P6x6PdjiHwk/lHaCJsrLMV5aipHCQpz29UUt80LZ
-        Px62tWFlcBALPT1wdnTAbrGgS6eDQqwK7tZqMV1WhgfFxRjNy8NITg5upaaqBNuqfGMj5dusVji47E1N
-        cJrNmDMa0csuPQQ72NVG6Y/y8zGWnY3RlBT0enurDZpUhXKcXSwsfKIocJpMmK+pwbOqKhdwrqgI87m5
-        mImLw0RwMO75++OcCE6KWAj1chGowTMr7ezoqKjAUmUlVnneJUp9GhXlWguRkbCT4IKXF6x7wZ5Qne70
-        8YGzoADLSUl4EROD9fh4rCckYCk8HMMEt+4HVuMECc5Q3nRgIF5R8ofkZHxOT8entDSskeCKRoPu/4zY
-        FarbHSyYJHg1NhbvCf6WkYGfNG0zKwsb/H5Nkqus6dtLQjeVVm7c5fznIiKwRoKPdPpNdDQ2EhOxRRO/
-        Z2a6SJdDQnCJtV0eEl5L4ymRnZu8KJNBQZhll+ckWCXRRZ55mMVf6MNXKnhHX1boi411g8zTjAY5IrJ1
-        jTO9zTGO8xo/DguDLTQUA27DzPTEoMp+SzUvSbTIicxw/z7VsvG2HBUxNdO46xzhKJNjJOl3j8pzTg3P
-        bLjMJotUZ+eaok9nSUqcSbVA1IfRwsQNqujkL6/XXqc1PLPhPImn2EAFU537MXmihmy8279p6H7PWUPJ
-        h7m2uNydReQPiLFB/uRDeL0AAAAASUVORK5CYII=
+        DgAACw4BQL7hQQAAAAd0SU1FB9gEDw0NJWkouy0AAALVSURBVDhPdVNdSJNhFH7eb+3b/NjQ1mc4Nldq
+        OS8cuAtRCEKmYS0rLX/2TXIsx2xGmGYiEaTQH9V1l0EEdVFk9GM/SKXpzMKf7D+IiCirq+wisGBPfbNF
+        ST1wbt7D85xznvMe4BfWAJvLgdm1QCMAkXr/EzVAXRXwtRoI/JWoBBo0szkx0NXFZouFm4HQQpFGQGuR
+        5cR5n48tJhMbgKZkQq8cUJTE3Z4eTh45wuHubsYUhYE/REKAttNkYr/fz8sVFTy3ahW3G42sAzSUA59v
+        7NjByd5e3uvsZLytjUPRKNvNZmpASCfvlmUOVFbyalkZ+4qLea6oiGdWrNAFvuvt1zeZzYnBWIzDsRiH
+        wmHGQyGO1Ndzj9HITlnmcEUFB30+3iwp4SWPh315edxjMOgFwskxtgBaVJZ5R9MYDwY5WlvLBzU1SeLI
+        6tUc9Xp5Kzub/RkZvJiWxn0AtwFRANJvkwL6nEYjh9ev5/iGDZzy+zleVMT7WVnJuLd0KYcyMnhAkhhb
+        SE5Bd3rXokWMl5ZyIieHjxwOPnO5+GzZMo6rKo9KElv/R9axFdA6AA5YrXySnc3Xubl8l5/PtytXclpV
+        eUwI7v7HipPQ3W4TgtesVk45nXyVm8uPbje/eDycLSzkjNvNp6rK40Kwa6GIBmitQvCConAkM5PTTiff
+        5OXxud3OmeXLOef18lNBQVJ0YvFiHhKC7SmRaqA+AiROm0y8lp7Ou6rKh04npzIzeVCSeFQIvne5+MHt
+        5sucHE46HBxMT2evEIzqtm0E5k4YDDwry7xssfD2kiUctNnYM29YqAOo0tt+YbfzscvFsaws3rLZeEVR
+        GNE/0iYg2AzwpNHIPkXhJYuF3fOrSs0puoCqwwYDx1SVQ6rK61Yr9wrBZiCY9EA/jBYheEqWuUsIhhea
+        BIh2oGq/JPG6xZIkt6aOKYVaIFgHfNP+f84iAqyLAHORVOWf+AGIsUH+OoOTngAAAABJRU5ErkJggg==
 </value>
   </data>
 </root>


### PR DESCRIPTION
# KryptonDataGridView external corner rounding (#804)

## Summary

Implements [issue #804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804) — optional rounded **external** corners on `KryptonDataGridView`, aligned with how other Krypton controls expose border rounding through the palette.

Rounding is controlled via **`StateNormal.Border.Rounding`** (and **`StateDisabled.Border`** for the disabled state). Use `-1` to inherit theme defaults (grid border styles resolve to `0`, so rounding is off unless explicitly set). Any value `> 0` enables corner rounding in logical pixels.

## What changed

### `KryptonDataGridView`

- **Region clipping** — control clip region follows a rounded rectangle when rounding is active.
- **Outer border** — painted in `PaintBackground` using `StateNormal.Border` / `StateDisabled.Border` and `RenderStandardBorder`, sized to the grid cell area (scrollbar-aware).
- **Corner cells** — outer corner cells draw rounded backgrounds and borders via `PaletteBorderInheritForced.ForceBorderRounding` and restricted border edges (`Top|Left`, `Top|Right`, etc.).
- **Perimeter cells** — non-corner outer cells suppress edges that would double-draw against the outer frame (same pattern as `HideOuterBorders`).
- **Scrollbar awareness** — `GetGridCornerBounds()` excludes visible vertical/horizontal scrollbar gutters when detecting corners and drawing the outer border.
- **Constructor safety** — corner-rounding logic guards against `OnLayout` running before `StateNormal` / `StateDisabled` exist (fixes `NullReferenceException` during designer/ctor layout).

### `PaletteDataGridViewAll`

- Exposes **`Border`** in the designer under **Visuals** (consistent with `KryptonListView`, `KryptonButton`, etc.).
- **`PaletteBorder`** remains for code compatibility but is hidden from the designer (`Browsable(false)`).

### `PaletteBorderInheritForced`

- **`ForceBorderRounding(float)`** — per-cell rounding override for corner painting.
- **`ClearForcedState()`** — resets forced edges, rounding, and graphics hint before each cell paint.

### TestForm

- **DataGridView demo** — **Corner Rounding** checkbox toggles `StateNormal.Border.Rounding` / `StateDisabled.Border.Rounding` (`5` / `-1`).

### Changelog

- V110 nightly entry for #804.

## API / designer usage

```csharp
// Enable (5px radius)
kryptonDataGridView1.StateNormal.Border.Rounding = 5f;
kryptonDataGridView1.StateDisabled.Border.Rounding = 5f;

// Disable
kryptonDataGridView1.StateNormal.Border.Rounding = -1f;
kryptonDataGridView1.StateDisabled.Border.Rounding = -1f;
```

**Designer path:** `KryptonDataGridView` → **StateNormal** → **Border** → **Rounding**

Other border properties (`Draw`, `DrawBorders`, `Width`, `Color1`, etc.) on the same node apply to the outer frame.

## Files touched

| File | Change |
|------|--------|
| `KryptonDataGridView.cs` | Corner rounding paint, region, grid bounds, corner cell logic, ctor/layout guards | | `PaletteDataGridViewAll.cs` | `Border` designer property; hide `PaletteBorder` from designer | | `PaletteBorderInheritForced.cs` | Forced rounding + clear state | | `DataGridViewDemo.cs` / `.Designer.cs` | Demo checkbox | | `Documents/Changelog/Changelog.md` | Release note |

## Test plan

- [ ] Build `Krypton.Toolkit` (at least `net48` and one `-windows` TFM used locally).
- [ ] Run **TestForm** → **DataGridView demo**.
- [ ] Toggle **Corner Rounding** — grid shows rounded outer corners; no crash on open.
- [ ] With **ScrollBars = Both** and enough rows/columns to show scrollbars, confirm bottom-right rounding aligns with the last cell (not the scrollbar corner square).
- [ ] Toggle **Show Grid Lines** / **HideOuterBorders** behaviour — no double outer frame with rounding on.
- [ ] Change theme via theme combo — border colours follow palette; rounding still applies.
- [ ] Set **StateNormal.Border.Rounding** in designer, save form, reload — value persists and applies at runtime.
- [ ] Optional: RTL checkbox — corners still look correct on physical edges.
- [ ] Optional: disabled grid — `StateDisabled.Border.Rounding` used when `Enabled = false`.

## Breaking changes

None intended.

- No standalone `CornerRounding` property (uses palette `Border.Rounding` like other controls).
- `PaletteDataGridViewAll.PaletteBorder` is still available in code; designer now prefers **`Border`**.

## Related issues

- Closes #804
- Related: #519 (grid background border exposure), #1268 (suite direction away from per-control `CornerRoundingRadius`)