### PR TITLE
* Alpha Backup Synchronisation workflow fails to run

### DIFF
--- a/.github/workflows/alpha-backup-sync.yml
+++ b/.github/workflows/alpha-backup-sync.yml
@@ -190,10 +190,10 @@ jobs:
           today=$(date -u +%Y-%m-%d)
           dir_name="$prefix - $today"
           echo "dir_name=$dir_name" >> "$GITHUB_OUTPUT"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git clone --depth 1 "https://x-access-token:$BACKUP_REPO_TOKEN@github.com/$repo_path.git" backup-repo
           cd backup-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch" 2>/dev/null || git checkout "$branch" 2>/dev/null || true
           mkdir -p "$dir_name"
           rsync -a --exclude='.git' --exclude='backup-repo' ../. "$dir_name/"

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3616](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3616), Alpha Backup Synchronisation workflow fails to run
 * Implemented [#3611](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3611), Badges for workflows
 * Resolved [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks
 * Resolved [#2926](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2926), Really fix themed scrollbars part of KryptonListBox


### PR DESCRIPTION
# Fix Alpha Backup Synchronisation workflow git identity (#3616)

## Summary

- Fixes the **Push alpha to backup repository** step in `alpha-backup-sync.yml`, which failed with `fatal: empty ident name` when committing to the backup repo.
- Configures `user.name` and `user.email` inside the cloned `backup-repo` directory so automated commits use the GitHub Actions bot identity.
- Adds a changelog entry for [#3616](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3616).

## Problem

The Alpha to Alpha-Backup Sync workflow runs daily (and on `workflow_dispatch`). When alpha has changes and backup-repo variables/secrets are set, it clones the backup repository, rsyncs the alpha tree into a dated folder, commits, and pushes.

The job failed at **Push alpha to backup repository** with:

```text
fatal: empty ident name (for <runner@...>) not allowed
```

`git config user.name` and `git config user.email` were applied in the workflow workspace **before** `git clone` and **before** `cd backup-repo`. The commit ran inside `backup-repo`, which did not inherit a valid author identity from the runner’s default git config.

## Fix

Move the git identity configuration to immediately after `cd backup-repo`:

```yaml
git clone --depth 1 "https://x-access-token:$BACKUP_REPO_TOKEN@github.com/$repo_path.git" backup-repo
cd backup-repo
git config user.name "github-actions[bot]"
git config user.email "github-actions[bot]@users.noreply.github.com"
```

No other workflow behavior changes.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/alpha-backup-sync.yml` | Relocate `git config` after entering `backup-repo` | | `Documents/Changelog/Changelog.md` | Note resolution of #3616 |

## Test plan

- [ ] Confirm `BACKUP_REPO`, `BACKUP_REPO_TOKEN`, and related variables/secrets are configured on the repository (or expect the step to skip gracefully when unset).
- [ ] Run **Alpha to Alpha-Backup Sync** via **workflow_dispatch** on a branch that includes this fix (with kill switch off and alpha changes present, or use a test repo if available).
- [ ] Verify the **Push alpha to backup repository** step completes without `empty ident name`.
- [ ] Confirm a new dated directory appears on the backup repo’s configured branch with an automated commit authored as `github-actions[bot]`.
- [ ] Optional: confirm Discord notification still fires when `DISCORD_WEBHOOK_ALPHA_BACKUP` is set.

## Related

- Closes [#3616](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3616)