### PR TITLE
* Canary LTS Release workflow fails (V105 LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,7 @@ jobs:
           # Backup source: evaluated MSBuild Version when assembly probing fails.
           if (-not $version) {
             try {
-              $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+              $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
               if ($evaluated) {
                 if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                   $version = $evaluated

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -307,7 +307,7 @@ jobs:
           $msbuildConfig = 'Canary'
 
           try {
-            $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+            $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
             if ($evaluated) {
               if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                 $version = $evaluated

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -335,7 +335,7 @@ jobs:
           $msbuildConfig = 'Canary'
 
           try {
-            $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+            $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
             if ($evaluated) {
               if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                 $version = $evaluated

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -391,7 +391,7 @@ jobs:
           # Backup source: evaluated MSBuild Version when assembly probing fails.
           if (-not $version) {
             try {
-              $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+              $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
               if ($evaluated) {
                 if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                   $version = $evaluated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,7 +283,7 @@ jobs:
           $msbuildConfig = 'Release'
 
           try {
-            $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+            $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
             if ($evaluated) {
               if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                 $version = $evaluated
@@ -627,7 +627,7 @@ jobs:
           $msbuildConfig = 'Release'
 
           try {
-            $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+            $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
             if ($evaluated) {
               if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                 $version = $evaluated
@@ -990,7 +990,7 @@ jobs:
           $msbuildConfig = 'Canary'
 
           try {
-            $evaluated = (& dotnet msbuild "$proj" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
+            $evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
             if ($evaluated) {
               if ($evaluated -match '^[1-9]\d{2,}\.\d+\.\d+\.\d+$') {
                 $version = $evaluated

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails
 * Implemented [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling


### PR DESCRIPTION
# Fix Canary LTS Release workflow MSBuild path quoting (#3618)

## Summary

- Fixes the **Get Version** step in CI workflows where `dotnet msbuild` failed with `MSB1009: Project file does not exist` because the project path contains spaces (`Krypton Components`, `Krypton.Toolkit 2022.csproj`).
- Wraps the project path in backtick-escaped quotes when invoking MSBuild from PowerShell so the full path is passed as a single argument.
- Applies the same fix across all workflows that read the version via MSBuild, not only `canary-lts-release.yml`.

Closes [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618).

## Problem

The Canary LTS Release workflow failed at the **Get Version** step with:

```text
WARNING: Ignoring unexpected MSBuild version 'MSBUILD : error MSB1009: Project file does not exist. Switch: Source/Current/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj'.
```

The script used:

```powershell
$evaluated = (& dotnet msbuild "$proj" -getProperty:Version ...).Trim()
```

On the GitHub Actions `pwsh` runner, MSBuild parsed everything after the first space in the path as separate switches instead of treating the path as one project file argument.

## Solution

Quote the project path explicitly for the native MSBuild invocation:

```powershell
$evaluated = (& dotnet msbuild "`"$proj`"" -getProperty:Version -p:Configuration=$msbuildConfig -nologo -v:q).Trim()
```

Existing fallback logic (assembly version probe, then hard-coded fallback) is unchanged; the primary MSBuild path should now succeed.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/canary-lts-release.yml` | Fix **Get Version** MSBuild quoting | | `.github/workflows/canary.yml` | Same fix |
| `.github/workflows/release.yml` | Same fix (3 jobs) | | `.github/workflows/nightly.yml` | Same fix |
| `.github/workflows/build.yml` | Same fix |
| `Documents/Changelog/Changelog.md` | Changelog entry for #3618 |

## Test plan

- [ ] Push branch and confirm the **Canary LTS Release** workflow completes the **Get Version** step without `MSB1009`.
- [ ] Verify log output shows `Got version from MSBuild: <version>` instead of the MSBuild error warning.
- [ ] Confirm the workflow proceeds to tag/release steps using the correct version (not the fallback `100.25.1.1`).
- [ ] Optionally re-run **Canary**, **Release**, **Nightly**, or **Build** workflows to confirm no regression in their **Get Version** steps.

## Base branch

`V105-LTS`