### PR TITLE
1976-V105-LTS-Fix MenuItem theme settings

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#1976](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1976), `MenuItem###` theme settings now apply to menu item selected, pressed, and border rendering.
 * Implemented [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages
 * Resolved [#3227](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3227), Fix disposed docking space load handling

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonMaterialRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonMaterialRenderer.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -118,6 +118,11 @@ public sealed class KryptonMaterialRenderer : KryptonProfessionalRenderer
 
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
     {
+        if (TryRenderMenuItemOverride(e))
+        {
+            return;
+        }
+
         if (e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu)
         {
             if (e.Item.Selected)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
@@ -220,14 +220,25 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
 
     #region MenuItem Per-Item Override Helper
     /// <summary>
-    /// If the item is a KryptonToolStripMenuItem and it has any per-item palette overrides,
+    /// If the menu item has any per-item or color table overrides,
     /// draw its background/border here and return true to signal the caller to skip default painting.
     /// </summary>
     /// <param name="e">Item render event args.</param>
-    /// <returns>True if the item was painted using per-item overrides; otherwise false.</returns>
+    /// <returns>True if the item was painted using overrides; otherwise false.</returns>
     protected bool TryRenderMenuItemOverride(ToolStripItemRenderEventArgs e)
     {
-        if (e.Item is not KryptonToolStripMenuItem ktmi)
+        if (TryRenderMenuItemPaletteOverride(e))
+        {
+            return true;
+        }
+
+        return TryRenderMenuItemColorTableOverride(e);
+    }
+
+    private static bool TryRenderMenuItemPaletteOverride(ToolStripItemRenderEventArgs e)
+    {
+        var ktmi = e.Item as KryptonToolStripMenuItem;
+        if (ktmi == null)
         {
             return false;
         }
@@ -256,9 +267,9 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
         }
 
         Rectangle rect = e.Item.ContentRectangle;
-        if (hasBack)
+        if (hasBack || hasBorder)
         {
-            // Use a simple fill based on Color1; this is sufficient for per-item testing without full renderer path
+            // Use Color1 so border-only overrides still preserve a complete item background.
             var state = !ktmi.Enabled ? PaletteState.Disabled : (ktmi.Pressed || ktmi.Selected ? PaletteState.Tracking : PaletteState.Normal);
             Color c1 = highlight.Back.GetBackColor1(state);
             using var brush = new SolidBrush(c1);
@@ -274,6 +285,138 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
         }
 
         return true;
+    }
+
+    private bool TryRenderMenuItemColorTableOverride(ToolStripItemRenderEventArgs e)
+    {
+        var internalKCT = KCT as KryptonInternalKCT;
+        if (internalKCT == null || e.ToolStrip == null)
+        {
+            return false;
+        }
+
+        if (!(e.ToolStrip is MenuStrip || e.ToolStrip is ContextMenuStrip || e.ToolStrip is ToolStripDropDownMenu))
+        {
+            return false;
+        }
+
+        if (!e.Item.Enabled)
+        {
+            return false;
+        }
+
+        bool pressedMenuItem = e.Item.Pressed && e.ToolStrip is MenuStrip;
+        bool selectedMenuItem = e.Item.Selected;
+        if (!pressedMenuItem && !selectedMenuItem)
+        {
+            return false;
+        }
+
+        bool hasBorder = HasMenuItemOverrideColor(internalKCT.InternalMenuItemBorder);
+        bool hasBack;
+        Color color1;
+        Color color2;
+        Color colorMiddle;
+        bool useMiddle;
+
+        if (pressedMenuItem)
+        {
+            hasBack = HasMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientBegin) ||
+                      HasMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientMiddle) ||
+                      HasMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientEnd);
+            color1 = ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientBegin, KCT.MenuItemPressedGradientBegin);
+            color2 = ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientEnd, KCT.MenuItemPressedGradientEnd);
+            colorMiddle = ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientMiddle, KCT.MenuItemPressedGradientMiddle);
+            useMiddle = HasMenuItemOverrideColor(internalKCT.InternalMenuItemPressedGradientMiddle);
+        }
+        else
+        {
+            bool isDropDownMenuItem = !(e.ToolStrip is MenuStrip);
+            bool hasSelected = isDropDownMenuItem && HasMenuItemOverrideColor(internalKCT.InternalMenuItemSelected);
+            bool hasSelectedGradient = HasMenuItemOverrideColor(internalKCT.InternalMenuItemSelectedGradientBegin) ||
+                                       HasMenuItemOverrideColor(internalKCT.InternalMenuItemSelectedGradientEnd);
+            bool useSelectedSolid = hasSelected || (isDropDownMenuItem && !hasSelectedGradient);
+            hasBack = hasSelected || hasSelectedGradient;
+            color1 = useSelectedSolid
+                ? ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemSelected, KCT.MenuItemSelected)
+                : ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemSelectedGradientBegin, KCT.MenuItemSelectedGradientBegin);
+            color2 = useSelectedSolid
+                ? color1
+                : ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemSelectedGradientEnd, KCT.MenuItemSelectedGradientEnd);
+            colorMiddle = GlobalStaticValues.EMPTY_COLOR;
+            useMiddle = false;
+        }
+
+        if (!hasBack && !hasBorder)
+        {
+            return false;
+        }
+
+        Rectangle rect = new Rectangle(Point.Empty, e.Item.Bounds.Size);
+        if (e.ToolStrip is ContextMenuStrip || e.ToolStrip is ToolStripDropDownMenu)
+        {
+            rect.X = 2;
+            rect.Width -= 3;
+        }
+
+        if (rect.Width <= 0 || rect.Height <= 0)
+        {
+            return false;
+        }
+
+        DrawMenuItemOverrideBackground(e.Graphics, rect, color1, color2, colorMiddle, useMiddle);
+
+        Color border = ResolveMenuItemOverrideColor(internalKCT.InternalMenuItemBorder, KCT.MenuItemBorder);
+        DrawMenuItemOverrideBorder(e.Graphics, rect, border);
+
+        return true;
+    }
+
+    private static bool HasMenuItemOverrideColor(Color color) => color != GlobalStaticValues.EMPTY_COLOR && !color.IsEmpty;
+
+    private static Color ResolveMenuItemOverrideColor(Color color, Color fallback) => HasMenuItemOverrideColor(color) ? color : fallback;
+
+    private static void DrawMenuItemOverrideBackground(Graphics graphics,
+        Rectangle rect,
+        Color color1,
+        Color color2,
+        Color colorMiddle,
+        bool useMiddle)
+    {
+        if (color1 == color2 && !useMiddle)
+        {
+            using (var brush = new SolidBrush(color1))
+            {
+                graphics.FillRectangle(brush, rect);
+            }
+        }
+        else
+        {
+            using (var brush = new LinearGradientBrush(rect, color1, color2, 90f))
+            {
+                if (useMiddle)
+                {
+                    brush.InterpolationColors = new ColorBlend
+                    {
+                        Colors = new[] { color1, colorMiddle, color2 },
+                        Positions = new[] { 0f, 0.5f, 1f }
+                    };
+                }
+
+                graphics.FillRectangle(brush, rect);
+            }
+        }
+    }
+
+    private static void DrawMenuItemOverrideBorder(Graphics graphics, Rectangle rect, Color border)
+    {
+        rect.Width -= 1;
+        rect.Height -= 1;
+
+        using (var pen = new Pen(border))
+        {
+            graphics.DrawRectangle(pen, rect);
+        }
     }
     #endregion
 

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/MenuItemThemeSettingsRepro.csproj
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/MenuItemThemeSettingsRepro.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <AssemblyName>MenuItemThemeSettingsRepro</AssemblyName>
+    <RootNamespace>MenuItemThemeSettingsRepro</RootNamespace>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Platforms>AnyCPU</Platforms>
+    <OutputType>WinExe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Krypton.Toolkit;
+
+namespace MenuItemThemeSettingsRepro
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new ReproForm());
+        }
+    }
+
+    internal sealed class ReproForm : Form
+    {
+        private readonly KryptonCustomPaletteBase _palette;
+        private readonly KryptonManager _manager;
+        private readonly MenuStrip _menuStrip;
+        private readonly ContextMenuStrip _contextMenuStrip;
+        private readonly Panel _contextPanel;
+
+        public ReproForm()
+        {
+            _palette = new KryptonCustomPaletteBase();
+            _manager = new KryptonManager
+            {
+                GlobalCustomPalette = _palette,
+                GlobalPaletteMode = PaletteMode.Custom
+            };
+
+            Text = @"MenuItem Theme Settings Repro";
+            StartPosition = FormStartPosition.CenterScreen;
+            Width = 760;
+            Height = 420;
+
+            _menuStrip = CreateMenuStrip();
+            _contextMenuStrip = CreateContextMenuStrip();
+            _contextPanel = CreateContextPanel();
+
+            var buttonsPanel = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                AutoSize = true,
+                Padding = new Padding(8),
+                FlowDirection = FlowDirection.LeftToRight
+            };
+
+            var fullButton = new Button
+            {
+                Text = @"Full colors",
+                AutoSize = true
+            };
+            fullButton.Click += delegate { ApplyFullColors(); };
+
+            var borderOnlyButton = new Button
+            {
+                Text = @"Border only",
+                AutoSize = true
+            };
+            borderOnlyButton.Click += delegate { ApplyBorderOnly(); };
+
+            buttonsPanel.Controls.Add(fullButton);
+            buttonsPanel.Controls.Add(borderOnlyButton);
+
+            Controls.Add(_contextPanel);
+            Controls.Add(buttonsPanel);
+            Controls.Add(_menuStrip);
+            MainMenuStrip = _menuStrip;
+
+            ApplyFullColors();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _manager.Dispose();
+                _palette.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private static MenuStrip CreateMenuStrip()
+        {
+            var menuStrip = new MenuStrip();
+            var menu = new ToolStripMenuItem(@"Menu");
+            var nested = new ToolStripMenuItem(@"Nested");
+
+            nested.DropDownItems.Add(new ToolStripMenuItem(@"Nested child"));
+            menu.DropDownItems.Add(new ToolStripMenuItem(@"Drop-down item"));
+            menu.DropDownItems.Add(nested);
+            menu.DropDownItems.Add(new ToolStripSeparator());
+            menu.DropDownItems.Add(new ToolStripMenuItem(@"Disabled item") { Enabled = false });
+
+            menuStrip.Items.Add(menu);
+            menuStrip.Items.Add(new ToolStripMenuItem(@"Second menu")
+            {
+                DropDownItems =
+                {
+                    new ToolStripMenuItem(@"Second item")
+                }
+            });
+
+            return menuStrip;
+        }
+
+        private static ContextMenuStrip CreateContextMenuStrip()
+        {
+            var contextMenuStrip = new ContextMenuStrip();
+            contextMenuStrip.Items.Add(new ToolStripMenuItem(@"Context item"));
+            contextMenuStrip.Items.Add(new ToolStripMenuItem(@"Context submenu")
+            {
+                DropDownItems =
+                {
+                    new ToolStripMenuItem(@"Context child")
+                }
+            });
+
+            return contextMenuStrip;
+        }
+
+        private Panel CreateContextPanel()
+        {
+            var panel = new Panel
+            {
+                Dock = DockStyle.Fill,
+                BackColor = Color.White,
+                ContextMenuStrip = _contextMenuStrip
+            };
+
+            var label = new Label
+            {
+                Text = @"Hover menu items; right-click this area for context menu.",
+                AutoSize = true,
+                Location = new Point(16, 24)
+            };
+
+            panel.Controls.Add(label);
+            return panel;
+        }
+
+        private void ApplyFullColors()
+        {
+            ResetMenuItemColors();
+
+            _palette.ToolMenuStatus.Menu.MenuItemText = Color.FromArgb(20, 20, 20);
+            _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.FromArgb(192, 32, 48);
+            _palette.ToolMenuStatus.Menu.MenuItemSelected = Color.FromArgb(255, 238, 128);
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientBegin = Color.FromArgb(103, 220, 255);
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientEnd = Color.FromArgb(0, 96, 160);
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientBegin = Color.FromArgb(246, 169, 255);
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientMiddle = Color.FromArgb(180, 74, 220);
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientEnd = Color.FromArgb(74, 20, 140);
+
+            RefreshRenderers();
+        }
+
+        private void ApplyBorderOnly()
+        {
+            ResetMenuItemColors();
+            _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.FromArgb(192, 32, 48);
+            RefreshRenderers();
+        }
+
+        private void ResetMenuItemColors()
+        {
+            _palette.ToolMenuStatus.Menu.MenuItemText = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemSelected = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientBegin = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientEnd = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientBegin = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientMiddle = Color.Empty;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientEnd = Color.Empty;
+        }
+
+        private void RefreshRenderers()
+        {
+            var renderer = _palette.GetRenderer().RenderToolStrip(_palette);
+            _menuStrip.Renderer = renderer;
+            _contextMenuStrip.Renderer = renderer;
+            _menuStrip.Invalidate(true);
+            _contextMenuStrip.Invalidate(true);
+        }
+    }
+}

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
@@ -168,7 +168,7 @@ namespace MenuItemThemeSettingsRepro
             _palette.ToolMenuStatus.Menu.MenuItemPressedGradientMiddle = Color.White;
             _palette.ToolMenuStatus.Menu.MenuItemPressedGradientEnd = Color.Purple;
 
-            _modeLabel.Text = @"Full colors: top-level hover is magenta/cyan, drop-down hover is lime.";
+            _modeLabel.Text = @"Full colors: drop-down and context menu hover use the lime MenuItemSelected override.";
             RefreshRenderers();
         }
 

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/Program.cs
@@ -23,6 +23,7 @@ namespace MenuItemThemeSettingsRepro
         private readonly MenuStrip _menuStrip;
         private readonly ContextMenuStrip _contextMenuStrip;
         private readonly Panel _contextPanel;
+        private readonly Label _modeLabel;
 
         public ReproForm()
         {
@@ -42,7 +43,7 @@ namespace MenuItemThemeSettingsRepro
             _contextMenuStrip = CreateContextMenuStrip();
             _contextPanel = CreateContextPanel();
 
-            var buttonsPanel = new FlowLayoutPanel
+            var optionsPanel = new FlowLayoutPanel
             {
                 Dock = DockStyle.Top,
                 AutoSize = true,
@@ -50,25 +51,34 @@ namespace MenuItemThemeSettingsRepro
                 FlowDirection = FlowDirection.LeftToRight
             };
 
-            var fullButton = new Button
-            {
-                Text = @"Full colors",
-                AutoSize = true
-            };
-            fullButton.Click += delegate { ApplyFullColors(); };
-
-            var borderOnlyButton = new Button
+            var borderOnlyCheckBox = new CheckBox
             {
                 Text = @"Border only",
                 AutoSize = true
             };
-            borderOnlyButton.Click += delegate { ApplyBorderOnly(); };
+            borderOnlyCheckBox.CheckedChanged += delegate
+            {
+                if (borderOnlyCheckBox.Checked)
+                {
+                    ApplyBorderOnly();
+                }
+                else
+                {
+                    ApplyFullColors();
+                }
+            };
 
-            buttonsPanel.Controls.Add(fullButton);
-            buttonsPanel.Controls.Add(borderOnlyButton);
+            _modeLabel = new Label
+            {
+                AutoSize = true,
+                Margin = new Padding(16, 4, 0, 0)
+            };
+
+            optionsPanel.Controls.Add(borderOnlyCheckBox);
+            optionsPanel.Controls.Add(_modeLabel);
 
             Controls.Add(_contextPanel);
-            Controls.Add(buttonsPanel);
+            Controls.Add(optionsPanel);
             Controls.Add(_menuStrip);
             MainMenuStrip = _menuStrip;
 
@@ -149,15 +159,16 @@ namespace MenuItemThemeSettingsRepro
         {
             ResetMenuItemColors();
 
-            _palette.ToolMenuStatus.Menu.MenuItemText = Color.FromArgb(20, 20, 20);
-            _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.FromArgb(192, 32, 48);
-            _palette.ToolMenuStatus.Menu.MenuItemSelected = Color.FromArgb(255, 238, 128);
-            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientBegin = Color.FromArgb(103, 220, 255);
-            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientEnd = Color.FromArgb(0, 96, 160);
-            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientBegin = Color.FromArgb(246, 169, 255);
-            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientMiddle = Color.FromArgb(180, 74, 220);
-            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientEnd = Color.FromArgb(74, 20, 140);
+            _palette.ToolMenuStatus.Menu.MenuItemText = Color.Black;
+            _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.Black;
+            _palette.ToolMenuStatus.Menu.MenuItemSelected = Color.Lime;
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientBegin = Color.Magenta;
+            _palette.ToolMenuStatus.Menu.MenuItemSelectedGradientEnd = Color.Cyan;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientBegin = Color.Orange;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientMiddle = Color.White;
+            _palette.ToolMenuStatus.Menu.MenuItemPressedGradientEnd = Color.Purple;
 
+            _modeLabel.Text = @"Full colors: top-level hover is magenta/cyan, drop-down hover is lime.";
             RefreshRenderers();
         }
 
@@ -165,6 +176,7 @@ namespace MenuItemThemeSettingsRepro
         {
             ResetMenuItemColors();
             _palette.ToolMenuStatus.Menu.MenuItemBorder = Color.FromArgb(192, 32, 48);
+            _modeLabel.Text = @"Border only: normal highlight remains, red border is the only override.";
             RefreshRenderers();
         }
 

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
@@ -1,0 +1,13 @@
+﻿# MenuItem Theme Settings Repro
+
+Run:
+
+```powershell
+dotnet run --project "Source/TestHarnesses/MenuItemThemeSettingsRepro/MenuItemThemeSettingsRepro.csproj" -c Debug
+```
+
+Validation:
+
+1. Click `Full colors`, then hover and press the top-level menu. The top-level selected and pressed colors should use the configured `MenuItemSelectedGradient###` and `MenuItemPressedGradient###` values.
+2. Open a drop-down menu and hover items. Drop-down and context menu item highlights should use `MenuItemSelected`.
+3. Click `Border only`, then hover top-level, drop-down, and context menu items. The red `MenuItemBorder` should appear while the normal highlight background remains visible.

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
@@ -8,6 +8,6 @@ dotnet run --project "Source/TestHarnesses/MenuItemThemeSettingsRepro/MenuItemTh
 
 Validation:
 
-1. Click `Full colors`, then hover and press the top-level menu. The top-level selected and pressed colors should use the configured `MenuItemSelectedGradient###` and `MenuItemPressedGradient###` values.
+1. Leave `Border only` unchecked, then hover and press the top-level menu. The top-level selected and pressed colors should use the configured `MenuItemSelectedGradient###` and `MenuItemPressedGradient###` values.
 2. Open a drop-down menu and hover items. Drop-down and context menu item highlights should use `MenuItemSelected`.
-3. Click `Border only`, then hover top-level, drop-down, and context menu items. The red `MenuItemBorder` should appear while the normal highlight background remains visible.
+3. Check `Border only`, then hover top-level, drop-down, and context menu items. The red `MenuItemBorder` should appear while the normal highlight background remains visible.

--- a/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
+++ b/Source/TestHarnesses/MenuItemThemeSettingsRepro/README.md
@@ -8,6 +8,6 @@ dotnet run --project "Source/TestHarnesses/MenuItemThemeSettingsRepro/MenuItemTh
 
 Validation:
 
-1. Leave `Border only` unchecked, then hover and press the top-level menu. The top-level selected and pressed colors should use the configured `MenuItemSelectedGradient###` and `MenuItemPressedGradient###` values.
-2. Open a drop-down menu and hover items. Drop-down and context menu item highlights should use `MenuItemSelected`.
+1. Leave `Border only` unchecked.
+2. Open a drop-down or context menu and hover items. Drop-down and context menu item highlights should use the lime `MenuItemSelected` override.
 3. Check `Border only`, then hover top-level, drop-down, and context menu items. The red `MenuItemBorder` should appear while the normal highlight background remains visible.


### PR DESCRIPTION
Fixes #1976

This updates ToolStrip menu item rendering so custom `ToolMenuStatus.Menu.MenuItem###` colors are used for selected, pressed, and border states.

The renderer now handles custom MenuItem color-table overrides before falling back to the existing renderer behavior, including the border-only case where the normal highlight background should remain visible.

A focused WinForms repro harness was added under `Source/TestHarnesses/MenuItemThemeSettingsRepro` for checking full MenuItem colors and border-only overrides.
