### PR TITLE
* V110 Fix stable workflow for .net 11

### DIFF
--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -86,7 +86,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Restore TestForm
-        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all -p:ExcludeNet11=true
 
       - name: Validate TestForm linked resources
         shell: pwsh
@@ -137,7 +137,7 @@ jobs:
           }
 
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -p:ExcludeNet11=true -m:1 -p:BuildInParallel=false
 
       - name: Save NuGet cache
         if: success() && github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Adds `ExcludeNet11=true` to the Stable TestForm restore/build commands.
- Keeps `net11.0-windows` coverage in the existing Preview job.

## Root Cause
The Stable job pins a stable .NET SDK from the 10.0/9.0 bands, but still passed `TFMs=all`. That target set includes `net11.0-windows` unless `ExcludeNet11` is set, so restore failed with NETSDK1045 under the stable SDK.
