### PR TITLE
3580-V105-TLS Fix docking auto-sizing

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing
 * Resolved [#397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/397), normal context menus now use the same palette colours as `KryptonContextMenu`
 * Resolved [#1976](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1976), `MenuItem###` theme settings now apply to menu item selected, pressed, and border rendering.
 * Implemented [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege, Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -164,14 +164,44 @@ public abstract class VisualSimpleBase : VisualControlBase
             {
                 if (GetAutoSizeMode() == AutoSizeMode.GrowAndShrink)
                 {
-                    width = preferredSize.Width;
-                    height = preferredSize.Height;
+                    switch (Dock)
+                    {
+                        case DockStyle.Top:
+                        case DockStyle.Bottom:
+                            height = preferredSize.Height;
+                            break;
+                        case DockStyle.Left:
+                        case DockStyle.Right:
+                            width = preferredSize.Width;
+                            break;
+                        case DockStyle.Fill:
+                            break;
+                        default:
+                            width = preferredSize.Width;
+                            height = preferredSize.Height;
+                            break;
+                    }
                 }
                 else
                 {
-                    // GrowOnly semantics: allow growth to preferred size, never force shrink.
-                    width = Math.Max(Width, preferredSize.Width);
-                    height = Math.Max(Height, preferredSize.Height);
+                    switch (Dock)
+                    {
+                        case DockStyle.Top:
+                        case DockStyle.Bottom:
+                            height = Math.Max(Height, preferredSize.Height);
+                            break;
+                        case DockStyle.Left:
+                        case DockStyle.Right:
+                            width = Math.Max(Width, preferredSize.Width);
+                            break;
+                        case DockStyle.Fill:
+                            break;
+                        default:
+                            // GrowOnly semantics: allow growth to preferred size, never force shrink.
+                            width = Math.Max(Width, preferredSize.Width);
+                            height = Math.Max(Height, preferredSize.Height);
+                            break;
+                    }
                 }
 
                 specified |= BoundsSpecified.Size;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
@@ -45,7 +45,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             e.TextColor = e.Item.Enabled ? KCT.ContextMenuItemText : KCT.ContextMenuItemDisabledText;
         }
@@ -61,7 +66,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             using (var backBrush = new SolidBrush(KCT.ContextMenuBack))
             {
@@ -82,7 +92,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             using (var backBrush = new SolidBrush(KCT.ContextMenuImageColumnBack))
             {
@@ -103,7 +118,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
     {
-        if ((e != null) && TryRenderMenuItemOverride(e))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (TryRenderMenuItemOverride(e))
         {
             return;
         }
@@ -500,8 +520,8 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// </summary>
     /// <param name="toolStrip">Tool strip to test.</param>
     /// <returns>True if the tool strip is a context menu; otherwise false.</returns>
-    protected static bool IsContextMenuToolStrip(ToolStrip toolStrip) =>
-        (toolStrip is ContextMenuStrip) || (toolStrip is ToolStripDropDownMenu);
+    protected static bool IsContextMenuToolStrip(ToolStrip? toolStrip) =>
+        toolStrip is ContextMenuStrip || toolStrip is ToolStripDropDownMenu;
 
     private bool TryRenderContextMenuItemBackground(ToolStripItemRenderEventArgs e)
     {

--- a/Source/Krypton Components/TestForm/HeaderExamples.Designer.cs
+++ b/Source/Krypton Components/TestForm/HeaderExamples.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -37,31 +37,58 @@ namespace TestForm
         /// </summary>
         private void InitializeComponent()
         {
-            this.kryptonHeader1 = new Krypton.Toolkit.KryptonHeader();
+            this.kryptonHeaderTop = new Krypton.Toolkit.KryptonHeader();
+            this.kryptonHeaderBottom = new Krypton.Toolkit.KryptonHeader();
+            this.labelInstructions = new System.Windows.Forms.Label();
             this.SuspendLayout();
-            // 
-            // kryptonHeader1
-            // 
-            this.kryptonHeader1.Location = new System.Drawing.Point(13, 13);
-            this.kryptonHeader1.Name = "kryptonHeader1";
-            this.kryptonHeader1.Size = new System.Drawing.Size(251, 31);
-            this.kryptonHeader1.TabIndex = 2;
-            this.kryptonHeader1.Values.Heading = "kryptonHeader1";
-            // 
+            //
+            // kryptonHeaderTop
+            //
+            this.kryptonHeaderTop.Dock = System.Windows.Forms.DockStyle.Top;
+            this.kryptonHeaderTop.Location = new System.Drawing.Point(0, 0);
+            this.kryptonHeaderTop.Name = "kryptonHeaderTop";
+            this.kryptonHeaderTop.Size = new System.Drawing.Size(800, 31);
+            this.kryptonHeaderTop.TabIndex = 0;
+            this.kryptonHeaderTop.Values.Description = "AutoSize = true, Dock = Top";
+            this.kryptonHeaderTop.Values.Heading = "Top docked header";
+            //
+            // kryptonHeaderBottom
+            //
+            this.kryptonHeaderBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.kryptonHeaderBottom.Location = new System.Drawing.Point(0, 419);
+            this.kryptonHeaderBottom.Name = "kryptonHeaderBottom";
+            this.kryptonHeaderBottom.Size = new System.Drawing.Size(800, 31);
+            this.kryptonHeaderBottom.TabIndex = 1;
+            this.kryptonHeaderBottom.Values.Description = "AutoSize = true, Dock = Bottom";
+            this.kryptonHeaderBottom.Values.Heading = "Bottom docked header";
+            //
+            // labelInstructions
+            //
+            this.labelInstructions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelInstructions.Location = new System.Drawing.Point(0, 31);
+            this.labelInstructions.Name = "labelInstructions";
+            this.labelInstructions.Size = new System.Drawing.Size(800, 388);
+            this.labelInstructions.TabIndex = 2;
+            this.labelInstructions.Text = "Resize this form. Both KryptonHeader controls should keep the full client width while AutoSize keeps their preferred height.";
+            this.labelInstructions.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            //
             // HeaderExamples
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.kryptonHeader1);
+            this.Controls.Add(this.labelInstructions);
+            this.Controls.Add(this.kryptonHeaderBottom);
+            this.Controls.Add(this.kryptonHeaderTop);
             this.Name = "HeaderExamples";
             this.Text = "HeaderExamples";
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
-        private KryptonHeader kryptonHeader1;
+        private KryptonHeader kryptonHeaderTop;
+        private KryptonHeader kryptonHeaderBottom;
+        private System.Windows.Forms.Label labelInstructions;
     }
 }


### PR DESCRIPTION
Fixes #3580 - KryptonHeader autosizing when the control is docked.

The autosize path now preserves the axis managed by WinForms docking. Top and bottom docked headers keep the full assigned width while using their preferred height, and left and right docked controls keep the assigned height while using their preferred width.

Header Examples (in TestForm app) now includes top and bottom docked KryptonHeader controls so the behavior can be verified by resizing the form.

Also guards the professional renderer callbacks against nullable event data and toolstrips.