### PR TITLE
3580-V110-followup-fix

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
@@ -309,7 +309,7 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
         return TryRenderMenuItemColorTableOverride(e);
     }
 
-    private static bool TryRenderMenuItemPaletteOverride(ToolStripItemRenderEventArgs e)
+    private bool TryRenderMenuItemPaletteOverride(ToolStripItemRenderEventArgs e)
     {
         var ktmi = e.Item as KryptonToolStripMenuItem;
         if (ktmi == null)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
@@ -45,7 +45,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             e.TextColor = e.Item.Enabled ? KCT.ContextMenuItemText : KCT.ContextMenuItemDisabledText;
         }
@@ -61,7 +66,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             using (var backBrush = new SolidBrush(KCT.ContextMenuBack))
             {
@@ -82,7 +92,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
     {
-        if ((e != null) && IsContextMenuToolStrip(e.ToolStrip))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (IsContextMenuToolStrip(e.ToolStrip))
         {
             using (var backBrush = new SolidBrush(KCT.ContextMenuImageColumnBack))
             {
@@ -103,7 +118,12 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
     {
-        if ((e != null) && TryRenderMenuItemOverride(e))
+        if (e == null)
+        {
+            return;
+        }
+
+        if (TryRenderMenuItemOverride(e))
         {
             return;
         }
@@ -500,7 +520,7 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     /// </summary>
     /// <param name="toolStrip">Tool strip to test.</param>
     /// <returns>True if the tool strip is a context menu; otherwise false.</returns>
-    protected static bool IsContextMenuToolStrip(ToolStrip toolStrip) =>
+    protected static bool IsContextMenuToolStrip(ToolStrip? toolStrip) =>
         (toolStrip is ContextMenuStrip) || (toolStrip is ToolStripDropDownMenu);
 
     private bool TryRenderContextMenuItemBackground(ToolStripItemRenderEventArgs e)


### PR DESCRIPTION
Followup fix for merge regression in V110.

- Fix the renderer menu override helper so the context-menu fallback can use the renderer instance state.
- Resolve multiple nullable warnings in `KryptonProfessionalRenderer` event override paths and context-menu helper flow.

## Root cause

PR 2878 left `TryRenderMenuItemPaletteOverride` static while it calls an instance helper that depends on `KCT`. The same renderer paths also had nullable flow warnings for event args and nullable `ToolStrip` references.

