### PR TITLE
* Improve 'Nightly' Release Workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,12 @@
 # KILL-SWITCH: To disable this workflow, set repository variable NIGHTLY_DISABLED=true
 # Location: Repository Settings → Secrets and variables → Actions → Variables tab
 # To re-enable: Set NIGHTLY_DISABLED=false or delete the variable
+#
+# Optional:
+#   Variable  NIGHTLY_RELEASE_RETENTION_CHECK_DAYS  When no commits in 24h, scan alpha for
+#             commits in this many days (e.g. 7 after re-enabling the kill switch).
+# Manual run: Actions → Nightly Release → Run workflow → optional "Retention check days"
+#             (overrides NIGHTLY_RELEASE_RETENTION_CHECK_DAYS when set).
 
 name: Nightly Release
 
@@ -14,7 +20,14 @@ on:
   schedule:
     # Run nightly build automatically at midnight UTC every day
     - cron: '0 0 * * *'
-  workflow_dispatch:  # Allow manual triggering for testing
+  workflow_dispatch:
+    inputs:
+      retention_check_days:
+        description: >-
+          Days to look back on alpha when no commits in 24h (overrides
+          NIGHTLY_RELEASE_RETENTION_CHECK_DAYS when set)
+        type: number
+        required: false
 
 jobs:
   nightly:
@@ -76,31 +89,69 @@ jobs:
           ref: alpha
           fetch-depth: 0
 
-      - name: Check for changes in last 24 hours
+      - name: Check for changes on alpha
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         id: check_changes
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 
-          # Get commits from last 24 hours on alpha branch
+          function Get-RetentionCheckDays {
+            $inputDays = '${{ github.event.inputs.retention_check_days }}'
+            $varDays = '${{ vars.NIGHTLY_RELEASE_RETENTION_CHECK_DAYS }}'
+
+            if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch' -and $inputDays -ne '' -and $inputDays -match '^\d+$') {
+              return [int]$inputDays
+            }
+            if ($varDays -ne '' -and $varDays -match '^\d+$') {
+              return [int]$varDays
+            }
+            return 0
+          }
+
           $yesterday = (Get-Date).AddDays(-1).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")
-          $commitCount = git rev-list --count --since="$yesterday" alpha
+          $commitCount24h = [int](git rev-list --count --since="$yesterday" alpha)
+          Write-Host "Commits in last 24 hours: $commitCount24h"
 
-          Write-Host "Commits in last 24 hours: $commitCount"
-
-          if ([int]$commitCount -gt 0) {
-            Write-Host "Changes detected - proceeding with nightly build"
+          if ($commitCount24h -gt 0) {
+            Write-Host "Changes in last 24 hours - proceeding with nightly build"
             echo "has_changes=true" >> $env:GITHUB_OUTPUT
-          } else {
-            Write-Host "No changes detected - skipping nightly build"
+            echo "change_window=24h" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          $retentionDays = Get-RetentionCheckDays
+          if ($retentionDays -gt 90) {
+            Write-Host "::warning::Retention check days ($retentionDays) exceeds 90; using 90"
+            $retentionDays = 90
+          }
+          Write-Host "Retention check days: $retentionDays"
+
+          if ($retentionDays -le 0) {
+            Write-Host "No extended retention window configured - skipping nightly build"
             echo "has_changes=false" >> $env:GITHUB_OUTPUT
+            echo "change_window=none" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+
+          $since = (Get-Date).AddDays(-$retentionDays).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")
+          $commitCountRetention = [int](git rev-list --count --since="$since" alpha)
+          Write-Host "Commits in last $retentionDays day(s): $commitCountRetention"
+
+          if ($commitCountRetention -gt 0) {
+            Write-Host "Changes in retention window ($retentionDays days) - proceeding with nightly build"
+            echo "has_changes=true" >> $env:GITHUB_OUTPUT
+            echo "change_window=retention_${retentionDays}d" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "No changes in 24h or retention window - skipping nightly build"
+            echo "has_changes=false" >> $env:GITHUB_OUTPUT
+            echo "change_window=none" >> $env:GITHUB_OUTPUT
           }
 
       - name: Skip notification
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'false'
         run: |
-          Write-Host "::notice::No commits in the last 24 hours. Skipping nightly build and publish."
+          Write-Host "::notice::No commits on alpha in the last 24 hours (and none in the configured retention window). Skipping nightly build and publish."
 
       # .NET 9 and 10; .NET 11 for net11.0-windows (DOTNET_PREVIEW_SETUP_VERSION when set, else 11.0.x).
       - name: Setup .NET (9 and 10)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1276,5 +1276,5 @@ jobs:
           key: ${{ steps.nuget_cache_restore.outputs.cache-primary-key }}
 
       # Note: NuGet publishing for alpha/nightly builds is handled by nightly.yml workflow
-      # which runs on a schedule and checks for changes in the last 24 hours
+      # which runs on a schedule and checks for changes on alpha (24h, then optional retention window)
       

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3636](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3636), Improve 'Nightly' Release Workflow
 * Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing


### PR DESCRIPTION
# Improve Nightly release retention check (#3636)

Closes #3636

## Summary

- Extends the **Nightly Release** workflow so that when there are no commits on `alpha` in the last 24 hours, it can optionally scan a longer retention window before skipping the build.
- Adds repository variable `NIGHTLY_RELEASE_RETENTION_CHECK_DAYS` and a `workflow_dispatch` input **Retention check days** (manual runs override the variable when set).
- Preserves existing behaviour when the retention setting is unset: only the 24-hour check applies.

This supports recovering after the nightly kill switch (`NIGHTLY_DISABLED=true`) has been off for several days: the first scheduled run after re-enable can still publish if `alpha` had commits within the configured retention period, even if none landed in the previous 24 hours.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/nightly.yml` | Two-phase change detection (24h, then optional retention); dispatch input; header docs; `change_window` job output; 90-day cap on retention | | `.github/workflows/release.yml` | Comment update only (nightly publishing is owned by `nightly.yml`) |

### Change detection order

1. **24 hours** — if `alpha` has any commits, proceed with the nightly build.
2. **Retention window** — only when step 1 finds zero commits:
   - Resolve days from `workflow_dispatch` input `retention_check_days`, else `vars.NIGHTLY_RELEASE_RETENTION_CHECK_DAYS`, else skip (same as today).
   - If commits exist within that window, proceed; otherwise skip with notice.

### Configuration (after merge)

In **Repository Settings → Secrets and variables → Actions → Variables**:

| Variable | Example | Purpose |
|----------|---------|---------|
| `NIGHTLY_RELEASE_RETENTION_CHECK_DAYS` | `7` | Days to look back on `alpha` when the 24h check is empty |

Optional: **Actions → Nightly Release → Run workflow → Retention check days** for manual overrides during testing.

## Test plan

- [ ] With `NIGHTLY_RELEASE_RETENTION_CHECK_DAYS` unset: workflow skips when `alpha` has no commits in 24h (unchanged).
- [ ] With recent commits on `alpha` (within 24h): workflow proceeds on the first check (`change_window=24h` in logs).
- [ ] With no commits in 24h but commits within retention (e.g. 3 days ago) and variable set to `7`: workflow proceeds (`change_window=retention_7d`).
- [ ] With no commits in 24h or retention window: workflow skips; skip notice mentions retention window.
- [ ] Manual dispatch with **Retention check days** set overrides the repository variable for that run.
- [ ] Retention value above 90 is clamped to 90 with a workflow warning.
- [ ] `NIGHTLY_DISABLED=true` still disables the workflow entirely (unchanged).

## Notes

- Scheduled runs use only the repository variable for retention; the dispatch input applies to `workflow_dispatch` only.
- No application or package code changes; workflow-only PR.