### PR TITLE
* Harden workflows: branch policy and `.github` sync from master

### DIFF
--- a/.github/BRANCH_POLICY.md
+++ b/.github/BRANCH_POLICY.md
@@ -2,6 +2,8 @@
 
 This repository uses a **warn-then-fail** branch policy enforced in CI ([#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610)).
 
+**Full developer documentation:** [Documents/Developers/Branch-Policy-and-Workflow-Hardening.md](../Documents/Developers/Branch-Policy-and-Workflow-Hardening.md) (architecture, rules, operations, troubleshooting).
+
 ## Product vs workflow changes
 
 | Flow | Allowed |
@@ -27,6 +29,16 @@ Downstream branches must **contain** `master` in Git history (they may still dif
 ## Automated `.github` sync
 
 Workflow **Sync .github from master** (`.github/workflows/sync-github-from-master.yml`) opens PRs that copy only `.github/` from `master` onto configured release branches.
+
+Targets include `alpha`, `canary`, `gold`, `prerelease`, `V105-LTS`, `V85-LTS`, and `V110` (see `syncGithubFromMasterTargets` in `branch-policy.json`).
+
+## Behind-master report (optional)
+
+Workflow **Branch behind master report** runs weekly (report-only, never fails). Disable with `BRANCH_BEHIND_MASTER_REPORT_DISABLED=true`.
+
+## Required checks on `master` vs release branches
+
+When enforcing policy, require **PR branch policy** on release-branch rulesets only — not on `master` — so topic PRs into `master` are not gated by this check. Details in the [developer documentation](../Documents/Developers/Branch-Policy-and-Workflow-Hardening.md#required-check-only-on-release-branches-not-topic-prs--master).
 
 | Variable | Purpose |
 |----------|---------|

--- a/.github/BRANCH_POLICY.md
+++ b/.github/BRANCH_POLICY.md
@@ -2,7 +2,7 @@
 
 This repository uses a **warn-then-fail** branch policy enforced in CI ([#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610)).
 
-**Full developer documentation:** [Documents/Developers/Branch-Policy-and-Workflow-Hardening.md](../Documents/Developers/Branch-Policy-and-Workflow-Hardening.md) (architecture, rules, operations, troubleshooting).
+**Full developer documentation:** [Documents/Developers/Contributing/BranchPolicyandWorkflowHardening.md](../Documents/Developers/Contributing/BranchPolicyandWorkflowHardening.md) (architecture, rules, operations, troubleshooting).
 
 ## Product vs workflow changes
 
@@ -38,7 +38,7 @@ Workflow **Branch behind master report** runs weekly (report-only, never fails).
 
 ## Required checks on `master` vs release branches
 
-When enforcing policy, require **PR branch policy** on release-branch rulesets only — not on `master` — so topic PRs into `master` are not gated by this check. Details in the [developer documentation](../Documents/Developers/Branch-Policy-and-Workflow-Hardening.md#required-check-only-on-release-branches-not-topic-prs--master).
+When enforcing policy, require **PR branch policy** on release-branch rulesets only — not on `master` — so topic PRs into `master` are not gated by this check. Details in the [developer documentation](../Documents/Developers/Contributing/BranchPolicyandWorkflowHardening.md#required-check-only-on-release-branches-not-topic-prs--master).
 
 | Variable | Purpose |
 |----------|---------|

--- a/.github/BRANCH_POLICY.md
+++ b/.github/BRANCH_POLICY.md
@@ -1,0 +1,46 @@
+# Branch and pull request policy
+
+This repository uses a **warn-then-fail** branch policy enforced in CI ([#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610)).
+
+## Product vs workflow changes
+
+| Flow | Allowed |
+|------|---------|
+| Topic branch → `master` | Yes (normal features and fixes) |
+| Topic branch → `alpha`, `canary`, LTS lines | Yes |
+| `master` → downstream branch | **Only** files under `.github/` |
+| `alpha` → `alpha-backup` | Yes (automated backup sync) |
+| Release line → `master` | **No** (do not merge `alpha` / `canary` / LTS into `master` via PR) |
+
+Downstream branches must **contain** `master` in Git history (they may still differ in product code). If CI reports “behind master”, merge `master` into the target branch or merge an open **Sync .github from master** PR.
+
+## Warn vs fail
+
+| Repository variable | Value | Behaviour |
+|---------------------|-------|-----------|
+| `BRANCH_POLICY_ENFORCE` | unset or `false` | Violations emit **`::warning::`**; the check **passes** |
+| `BRANCH_POLICY_ENFORCE` | `true` | Violations emit **`::error::`**; the check **fails** |
+| `BRANCH_POLICY_DISABLED` | `true` | Skips the PR policy workflow entirely |
+
+**Rollout:** leave enforce off while teams fix existing PRs, then set `BRANCH_POLICY_ENFORCE=true` and add **PR branch policy** as a required status check on protected branches.
+
+## Automated `.github` sync
+
+Workflow **Sync .github from master** (`.github/workflows/sync-github-from-master.yml`) opens PRs that copy only `.github/` from `master` onto configured release branches.
+
+| Variable | Purpose |
+|----------|---------|
+| `SYNC_GITHUB_FROM_MASTER_DISABLED` | `true` disables the sync workflow |
+| `BRANCH_POLICY_ENFORCE` | Independent; controls PR validation only |
+
+## Configuration
+
+Machine-readable rules: [branch-policy.json](branch-policy.json)
+
+Edit `downstreamBranches`, `syncGithubFromMasterTargets`, and `mustContainMasterAncestor` there when adding a new release line.
+
+## Branch names
+
+- **`canary`** (lowercase) is used by `build.yml` and `release.yml`.
+- **`Canary`** (capital C) is used by `canary.yml` only.
+- Policy treats both as downstream lines; prefer consolidating to one branch name over time.

--- a/.github/branch-policy.json
+++ b/.github/branch-policy.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Pull-request branch pairing rules for Krypton-Suite/Standard-Toolkit. See .github/BRANCH_POLICY.md.",
+  "downstreamBranches": [
+    "alpha",
+    "alpha-backup",
+    "canary",
+    "Canary",
+    "gold",
+    "prerelease",
+    "V105-LTS",
+    "V85-LTS",
+    "V110"
+  ],
+  "longLivedHeadBranches": [
+    "master",
+    "main",
+    "alpha",
+    "alpha-backup",
+    "canary",
+    "Canary",
+    "gold",
+    "prerelease",
+    "V105-LTS",
+    "V85-LTS",
+    "V110"
+  ],
+  "mustContainMasterAncestor": [
+    "alpha",
+    "canary",
+    "Canary",
+    "gold",
+    "prerelease",
+    "V105-LTS",
+    "V85-LTS",
+    "V110"
+  ],
+  "syncGithubFromMasterTargets": [
+    "alpha",
+    "canary",
+    "gold",
+    "prerelease",
+    "V105-LTS",
+    "V85-LTS",
+    "V110"
+  ],
+  "rules": [
+    {
+      "id": "master-github-downstream",
+      "description": "Workflow changes from master into release lines must touch only .github/",
+      "baseIn": "downstreamBranches",
+      "head": "master",
+      "pathsOnlyPrefix": ".github/"
+    },
+    {
+      "id": "alpha-to-alpha-backup",
+      "description": "alpha-backup is updated from alpha only",
+      "base": "alpha-backup",
+      "head": "alpha"
+    },
+    {
+      "id": "no-long-lived-to-master",
+      "description": "Do not open product PRs from another release line into master",
+      "base": "master",
+      "headIn": "longLivedHeadBranches",
+      "forbidden": true
+    }
+  ]
+}

--- a/.github/scripts/Get-BranchesBehindMaster.ps1
+++ b/.github/scripts/Get-BranchesBehindMaster.ps1
@@ -1,0 +1,105 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Report-only: lists configured branches that do not contain origin/master in their history.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PolicyPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Repository
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Repository -ne 'Krypton-Suite/Standard-Toolkit') {
+    Write-Host "Skipping behind-master report for repository '$Repository'."
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $PolicyPath)) {
+    throw "Policy file not found: $PolicyPath"
+}
+
+$policy = Get-Content -LiteralPath $PolicyPath -Raw | ConvertFrom-Json
+$branches = @($policy.mustContainMasterAncestor) | Select-Object -Unique
+
+$report = @()
+$priorEap = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+
+try {
+    $null = git fetch --no-tags --prune origin master 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host '::warning::Could not fetch origin/master for behind-master report.'
+        exit 0
+    }
+
+    $masterTip = (git rev-parse origin/master 2>$null)
+    if (-not $masterTip) {
+        Write-Host '::warning::Could not resolve origin/master.'
+        exit 0
+    }
+
+    foreach ($branch in $branches) {
+        $null = git fetch --no-tags origin "refs/heads/${branch}:refs/remotes/origin/${branch}" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            $report += [pscustomobject]@{
+                Branch  = $branch
+                Status  = 'missing'
+                Behind  = ''
+                Message = 'Branch not found on origin or fetch failed.'
+            }
+            continue
+        }
+
+        $baseTip = (git rev-parse "origin/$branch" 2>$null)
+        if (-not $baseTip) {
+            $report += [pscustomobject]@{
+                Branch  = $branch
+                Status  = 'missing'
+                Behind  = ''
+                Message = 'Could not resolve branch tip.'
+            }
+            continue
+        }
+
+        $null = git merge-base --is-ancestor $masterTip $baseTip 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $report += [pscustomobject]@{
+                Branch  = $branch
+                Status  = 'ok'
+                Behind  = '0'
+                Message = 'Contains all commits from master.'
+            }
+        } else {
+            $behind = (git rev-list --count "$baseTip..$masterTip" 2>$null)
+            if (-not $behind) { $behind = '?' }
+            $report += [pscustomobject]@{
+                Branch  = $branch
+                Status  = 'behind'
+                Behind  = [string]$behind
+                Message = "$behind commit(s) on master are not reachable from this branch."
+            }
+        }
+    }
+} finally {
+    $ErrorActionPreference = $priorEap
+}
+
+Write-Host ''
+Write-Host '=== Branches behind master (report-only) ==='
+$report | Format-Table -AutoSize Branch, Status, Behind, Message | Out-String | Write-Host
+
+foreach ($row in $report) {
+    if ($row.Status -eq 'behind') {
+        Write-Host "::warning::[behind-master-report] Branch '$($row.Branch)' is behind master: $($row.Message)"
+    } elseif ($row.Status -eq 'missing') {
+        Write-Host "::notice::[behind-master-report] Branch '$($row.Branch)': $($row.Message)"
+    }
+}
+
+$behindCount = @($report | Where-Object { $_.Status -eq 'behind' }).Count
+Write-Host "Summary: $($report.Count) branch(es) checked, $behindCount behind master."
+exit 0

--- a/.github/scripts/Invoke-BranchPolicyCheck.ps1
+++ b/.github/scripts/Invoke-BranchPolicyCheck.ps1
@@ -1,0 +1,180 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Validates pull-request base/head pairing and branch ancestry for Standard-Toolkit.
+# Called from .github/workflows/pr-branch-policy.yml
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BaseRef,
+
+    [Parameter(Mandatory = $true)]
+    [string]$HeadRef,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$ChangedFiles,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PolicyPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Enforce,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Repository
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-PolicyMessage {
+    param(
+        [ValidateSet('Warning', 'Error')]
+        [string]$Level,
+        [string]$Message
+    )
+
+    if ($Level -eq 'Error') {
+        Write-Host "::error::$Message"
+    } else {
+        Write-Host "::warning::$Message"
+    }
+}
+
+function Test-BranchInList {
+    param(
+        [string]$Branch,
+        [string[]]$List
+    )
+    return $List -contains $Branch
+}
+
+function Test-PathsUnderPrefix {
+    param(
+        [string[]]$Files,
+        [string]$Prefix
+    )
+
+    if ($Files.Count -eq 0) {
+        return $true
+    }
+
+    foreach ($file in $Files) {
+        $normalized = $file -replace '\\', '/'
+        if (-not $normalized.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Invoke-PolicyExit {
+    param(
+        [int]$ViolationCount,
+        [string]$EnforceMode
+    )
+
+    if ($ViolationCount -eq 0) {
+        Write-Host 'Branch policy check passed.'
+        exit 0
+    }
+
+    $suffix = " ($ViolationCount violation(s))"
+    if ($EnforceMode -eq 'true') {
+        Write-Host "Branch policy check failed$suffix."
+        exit 1
+    }
+
+    Write-Host "::notice::Branch policy is in warn-only mode. Set repository variable BRANCH_POLICY_ENFORCE=true to fail PRs on violations."
+    Write-Host "Branch policy reported warnings$suffix."
+    exit 0
+}
+
+if ($Repository -ne 'Krypton-Suite/Standard-Toolkit') {
+    Write-Host "Skipping branch policy for repository '$Repository'."
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $PolicyPath)) {
+    throw "Policy file not found: $PolicyPath"
+}
+
+$policy = Get-Content -LiteralPath $PolicyPath -Raw | ConvertFrom-Json
+$violations = 0
+$enforceMode = $Enforce.ToLowerInvariant()
+
+function Add-Violation {
+    param(
+        [string]$RuleId,
+        [string]$Message
+    )
+
+    $script:violations++
+    $label = if ($enforceMode -eq 'true') { 'Error' } else { 'Warning' }
+    Write-PolicyMessage -Level $label -Message "[$RuleId] $Message"
+}
+
+# --- Rule: master -> downstream must be .github only ---
+$downstream = @($policy.downstreamBranches)
+if ($HeadRef -eq 'master' -and (Test-BranchInList -Branch $BaseRef -List $downstream)) {
+    $prefix = '.github/'
+    if (-not (Test-PathsUnderPrefix -Files $ChangedFiles -Prefix $prefix)) {
+        $outside = $ChangedFiles | Where-Object {
+            $n = $_ -replace '\\', '/'
+            -not $n.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+        }
+        $sample = ($outside | Select-Object -First 5) -join ', '
+        Add-Violation -RuleId 'master-github-downstream' -Message (
+            "Pull request master -> $BaseRef must only change files under '.github/'. " +
+            "Use workflow 'Sync .github from master' or limit the PR to CI files. Outside paths (sample): $sample"
+        )
+    }
+}
+
+# --- Rule: alpha -> alpha-backup only ---
+if ($BaseRef -eq 'alpha-backup' -and $HeadRef -ne 'alpha') {
+    Add-Violation -RuleId 'alpha-to-alpha-backup' -Message (
+        "Pull requests into alpha-backup must use head branch 'alpha' (current head: '$HeadRef')."
+    )
+}
+
+# --- Rule: long-lived branch must not target master for product merges ---
+$longLived = @($policy.longLivedHeadBranches)
+if ($BaseRef -eq 'master' -and (Test-BranchInList -Branch $HeadRef -List $longLived)) {
+    Add-Violation -RuleId 'no-long-lived-to-master' -Message (
+        "Pull request $HeadRef -> master is not allowed. Merge topic branches into master, or use a .github-only sync into downstream branches."
+    )
+}
+
+# --- Ancestry: downstream bases should contain master ---
+$ancestorBranches = @($policy.mustContainMasterAncestor)
+if (Test-BranchInList -Branch $BaseRef -List $ancestorBranches) {
+    $priorEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $null = git fetch --no-tags --prune origin master "refs/heads/${BaseRef}:refs/remotes/origin/${BaseRef}" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Add-Violation -RuleId 'behind-master' -Message 'Could not fetch origin/master or the PR base branch for ancestry check.'
+        } else {
+            $masterTip = (git rev-parse origin/master 2>$null)
+            $baseTip = (git rev-parse "origin/$BaseRef" 2>$null)
+            if (-not $masterTip -or -not $baseTip) {
+                Add-Violation -RuleId 'behind-master' -Message 'Could not resolve origin/master or the PR base branch for ancestry check.'
+            } else {
+                $null = git merge-base --is-ancestor $masterTip $baseTip 2>$null
+                if ($LASTEXITCODE -ne 0) {
+                    $behind = (git rev-list --count "$baseTip..$masterTip" 2>$null)
+                    if (-not $behind) { $behind = '?' }
+                    Add-Violation -RuleId 'behind-master' -Message (
+                        "Branch '$BaseRef' does not contain all commits from master ($behind commit(s) on master are missing on the base branch). " +
+                        'Merge master into the target branch (or merge the automated .github sync PR) before merging this PR.'
+                    )
+                }
+            }
+        }
+    } finally {
+        $ErrorActionPreference = $priorEap
+    }
+}
+
+Invoke-PolicyExit -ViolationCount $violations -EnforceMode $enforceMode

--- a/.github/workflows/branch-behind-master-report.yml
+++ b/.github/workflows/branch-behind-master-report.yml
@@ -1,0 +1,48 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Report-only scheduled job: lists release branches that do not contain master in history.
+# Does not fail the workflow run. See Documents/Developers/Branch-Policy-and-Workflow-Hardening.md
+#
+# KILL-SWITCH: BRANCH_BEHIND_MASTER_REPORT_DISABLED=true
+
+name: Branch behind master report
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report kill switch
+        id: kill_switch
+        shell: bash
+        run: |
+          disabled="${{ vars.BRANCH_BEHIND_MASTER_REPORT_DISABLED }}"
+          if [ "$disabled" = "true" ]; then
+            echo "::warning:: Branch behind master report is DISABLED (BRANCH_BEHIND_MASTER_REPORT_DISABLED=true)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.kill_switch.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Report branches behind master
+        if: steps.kill_switch.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "${{ github.workspace }}/.github/scripts/Get-BranchesBehindMaster.ps1" `
+            -PolicyPath "${{ github.workspace }}/.github/branch-policy.json" `
+            -Repository "${{ github.repository }}"

--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -1,0 +1,85 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Validates pull-request base/head pairings and branch ancestry ([#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610)).
+#
+# Warn-only by default. Set repository variable BRANCH_POLICY_ENFORCE=true to fail PRs on violations.
+# Set BRANCH_POLICY_DISABLED=true to skip this workflow.
+# See .github/BRANCH_POLICY.md
+
+name: PR branch policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Branch policy kill switch
+        id: kill_switch
+        shell: bash
+        run: |
+          disabled="${{ vars.BRANCH_POLICY_DISABLED }}"
+          if [ "$disabled" = "true" ]; then
+            echo "::warning:: PR branch policy workflow is DISABLED (BRANCH_POLICY_DISABLED=true)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout (merge commit, full history for ancestry)
+        if: steps.kill_switch.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: List changed files
+        if: steps.kill_switch.outputs.enabled == 'true'
+        id: files
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const files = [];
+            for await (const response of github.paginate.iterator(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: prNumber, per_page: 100 }
+            )) {
+              for (const file of response.data) {
+                files.push(file.filename);
+              }
+            }
+            core.setOutput('paths', files.join('\n'));
+
+      - name: Run branch policy check
+        if: steps.kill_switch.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          CHANGED_FILES: ${{ steps.files.outputs.paths }}
+          POLICY_PATH: ${{ github.workspace }}/.github/branch-policy.json
+          ENFORCE: ${{ vars.BRANCH_POLICY_ENFORCE }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = @()
+          if ($env:CHANGED_FILES) {
+            $files = $env:CHANGED_FILES -split "`n" | Where-Object { $_ }
+          }
+          & "${{ github.workspace }}/.github/scripts/Invoke-BranchPolicyCheck.ps1" `
+            -BaseRef $env:PR_BASE `
+            -HeadRef $env:PR_HEAD `
+            -ChangedFiles $files `
+            -PolicyPath $env:POLICY_PATH `
+            -Enforce $(if ($env:ENFORCE) { $env:ENFORCE } else { 'false' }) `
+            -Repository $env:REPOSITORY

--- a/.github/workflows/sync-github-from-master.yml
+++ b/.github/workflows/sync-github-from-master.yml
@@ -1,0 +1,159 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Opens pull requests that copy only .github/ from master onto downstream release branches ([#3610]).
+#
+# KILL-SWITCH: SYNC_GITHUB_FROM_MASTER_DISABLED=true
+# Targets are listed in .github/branch-policy.json (syncGithubFromMasterTargets).
+# Scheduled runs use the workflow file on the default branch (master).
+
+name: Sync .github from master
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/**'
+  schedule:
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync kill switch
+        id: kill_switch
+        shell: bash
+        run: |
+          disabled="${{ vars.SYNC_GITHUB_FROM_MASTER_DISABLED }}"
+          if [ "$disabled" = "true" ]; then
+            echo "::warning:: Sync .github from master is DISABLED (SYNC_GITHUB_FROM_MASTER_DISABLED=true)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Security - Verify Repository
+        if: steps.kill_switch.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          if [ "$GITHUB_REPOSITORY" != "Krypton-Suite/Standard-Toolkit" ]; then
+            echo "::error::Invalid repository: $GITHUB_REPOSITORY"
+            exit 1
+          fi
+
+      - name: Checkout
+        if: steps.kill_switch.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Load sync targets
+        if: steps.kill_switch.outputs.enabled == 'true'
+        id: targets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $policyPath = Join-Path $env:GITHUB_WORKSPACE '.github/branch-policy.json'
+          $policy = Get-Content -LiteralPath $policyPath -Raw | ConvertFrom-Json
+          $targets = @($policy.syncGithubFromMasterTargets) -join ','
+          echo "targets=$targets" >> $env:GITHUB_OUTPUT
+
+      - name: Open sync PRs
+        if: steps.kill_switch.outputs.enabled == 'true'
+        uses: actions/github-script@v9
+        env:
+          TARGET_BRANCHES: ${{ steps.targets.outputs.targets }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { execSync } = require('child_process');
+            const { owner, repo } = context.repo;
+            const targets = (process.env.TARGET_BRANCHES || '')
+              .split(',')
+              .map((b) => b.trim())
+              .filter(Boolean);
+
+            const results = [];
+
+            for (const target of targets) {
+              try {
+                await github.rest.repos.getBranch({ owner, repo, branch: target });
+              } catch (err) {
+                if (err.status === 404) {
+                  console.log(`Skip ${target}: branch does not exist.`);
+                  continue;
+                }
+                throw err;
+              }
+
+              const syncBranch = `sync/github-from-master-${target.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+              execSync('git fetch --no-tags origin master', { stdio: 'inherit' });
+              execSync(`git fetch --no-tags origin ${target}`, { stdio: 'inherit' });
+              execSync(`git checkout -B ${syncBranch} origin/${target}`, { stdio: 'inherit' });
+              execSync('git checkout origin/master -- .github', { stdio: 'inherit' });
+
+              const status = execSync('git status --porcelain .github', { encoding: 'utf8' }).trim();
+              if (!status) {
+                console.log(`${target}: .github already matches master.`);
+                results.push({ target, action: 'noop' });
+                continue;
+              }
+
+              execSync('git config user.name "github-actions[bot]"', { stdio: 'inherit' });
+              execSync('git config user.email "github-actions[bot]@users.noreply.github.com"', { stdio: 'inherit' });
+              execSync(`git commit -m "chore(ci): sync .github from master into ${target}"`, { stdio: 'inherit' });
+              execSync(`git push --force origin HEAD:refs/heads/${syncBranch}`, { stdio: 'inherit' });
+
+              const { data: openPrs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${syncBranch}`,
+                base: target
+              });
+
+              if (openPrs.length > 0) {
+                console.log(`${target}: open PR already exists #${openPrs[0].number}`);
+                results.push({ target, action: 'existing', number: openPrs[0].number });
+                continue;
+              }
+
+              const { data: pr } = await github.rest.pulls.create({
+                owner,
+                repo,
+                title: `chore(ci): sync .github from master → ${target}`,
+                head: syncBranch,
+                base: target,
+                body: [
+                  'Automated PR: copies only `.github/` from `master` onto this branch.',
+                  '',
+                  'Part of branch policy ([#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610)).',
+                  'Do not add product code in this PR.',
+                  '',
+                  '*Triggered by Sync .github from master workflow.*'
+                ].join('\n')
+              });
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: ['chore:workflow-sync']
+                });
+              } catch (labelErr) {
+                console.warn(`Could not add label chore:workflow-sync: ${labelErr.message}`);
+              }
+
+              console.log(`${target}: created PR #${pr.number}`);
+              results.push({ target, action: 'created', number: pr.number });
+            }
+
+            return results;

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610), Harden workflows: PR branch policy (warn-then-fail via `BRANCH_POLICY_ENFORCE`), automated `.github` sync from `master`, and [branch policy documentation](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md)
 * Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,7 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
-* Implemented [#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610), Harden workflows: PR branch policy (warn-then-fail via `BRANCH_POLICY_ENFORCE`), automated `.github` sync from `master`, and [branch policy documentation](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md)
+* Implemented [#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610), Harden workflows: PR branch policy (warn-then-fail via `BRANCH_POLICY_ENFORCE`), automated `.github` sync from `master` (including `gold` and `prerelease`), weekly behind-master report workflow, [branch policy cheat sheet](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md).
 * Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing


### PR DESCRIPTION
# Harden workflows: branch policy and `.github` sync from master

Closes #3610

## Summary

This PR implements a **warn-then-fail** branch and pull request policy so workflow/CI changes can propagate from `master` to release lines without merging the full product tree, and so invalid base/head pairings are caught in CI before merge.

- **PR branch policy** workflow validates same-repo pull requests (warnings by default; optional strict mode).
- **Sync .github from master** workflow opens automated PRs that copy only `.github/` onto configured downstream branches.
- **Documentation and config** centralize rules in `.github/BRANCH_POLICY.md` and `.github/branch-policy.json`.

No product source under `Source/` is changed.

## Motivation

Release branches (`alpha`, `canary`, LTS lines, etc.) diverge in product code but should still:

1. Stay aligned with `master` in Git history (not remain “behind” `master`).
2. Receive CI/workflow updates via PRs that touch **only** `.github/`, not accidental full merges from `master`.
3. Use only **valid** source/target branch pairs (e.g. `alpha` → `alpha-backup`, not `canary` → `master` for product work).

## What changed

| Area | Files |
|------|--------|
| Policy config | `.github/branch-policy.json` |
| Maintainer docs | `.github/BRANCH_POLICY.md` |
| Validation script | `.github/scripts/Invoke-BranchPolicyCheck.ps1` | | PR checks | `.github/workflows/pr-branch-policy.yml` | | Automated sync | `.github/workflows/sync-github-from-master.yml` | | Changelog | `Documents/Changelog/Changelog.md` (V110 section) |

## Policy rules (CI)

| Rule | Behaviour |
|------|-----------|
| `master` → downstream | Changed files must be under `.github/` only | | `alpha` → `alpha-backup` | Head must be `alpha` | | Release line → `master` | Blocked (long-lived branch must not target `master`) | | Downstream PR bases | Base branch must contain all commits from `master` (ancestry check) |

Fork PRs are skipped (`head.repo` must match this repository).

## Warn-then-fail rollout

| Repository variable | Default | Effect |
|---------------------|---------|--------|
| `BRANCH_POLICY_ENFORCE` | unset / `false` | Violations are **`::warning::`**; check passes | | `BRANCH_POLICY_ENFORCE` | `true` | Violations are **`::error::`**; check fails | | `BRANCH_POLICY_DISABLED` | unset | When `true`, disables PR policy workflow | | `SYNC_GITHUB_FROM_MASTER_DISABLED` | unset | When `true`, disables sync workflow |

**Recommended after merge:**

1. Leave `BRANCH_POLICY_ENFORCE` unset and monitor **PR branch policy** warnings on open PRs.
2. Create label `chore:workflow-sync` (optional; used on automated sync PRs).
3. When noise is understood and addressed, set `BRANCH_POLICY_ENFORCE=true` and add **PR branch policy** as a required status check on protected branches.

## Sync .github from master

Targets (from `branch-policy.json`): `alpha`, `canary`, `gold`, `prerelease`, `V105-LTS`, `V85-LTS`, `V110`.

Triggers:

- Push to `master` with changes under `.github/**`
- Weekly schedule (Monday 03:30 UTC)
- Manual **workflow_dispatch**

Each target gets a PR from branch `sync/github-from-master-<target>` when `.github/` differs from `master`.

## Test plan

- [ ] Open a test PR `master` → `alpha` with a file outside `.github/` — expect **warning** (not failure) while `BRANCH_POLICY_ENFORCE` is unset.
- [ ] Open a test PR with only `.github/` changes `master` → `alpha` — expect policy check to pass (path rule).
- [ ] Set `BRANCH_POLICY_ENFORCE=true` on a test repo or after rollout — same bad PR should **fail**.
- [ ] Run **Sync .github from master** via `workflow_dispatch` on `master` — confirm sync PRs open only when `.github/` differs.
- [ ] Confirm fork PRs do not run the policy job.
- [ ] Confirm `BRANCH_POLICY_DISABLED=true` skips the policy workflow.

## Notes

- **`canary`** vs **`Canary`**: both are listed as downstream branches in policy; `build.yml` / `release.yml` use lowercase `canary`; `canary.yml` uses `Canary`. Consolidating to one branch name remains a follow-up.
- Scheduled sync and policy workflows run from the workflow definition on the default branch (`master`) once merged there.
- See [.github/BRANCH_POLICY.md](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md) for ongoing maintainer reference.