### PR TITLE
3640-V110-Fix retro button image scaling

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3640](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3640), Fixed retro themed buttons with icons
 * Implemented [#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610), Harden workflows: PR branch policy (warn-then-fail via `BRANCH_POLICY_ENFORCE`), automated `.github` sync from `master` (including `gold` and `prerelease`), weekly behind-master report workflow, [branch policy cheat sheet](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md)
 * Implemented [#3636](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3636), Improve 'Nightly' Release Workflow
 * Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -5847,11 +5847,12 @@ public class RenderStandard : RenderBase
 					|| (displayRect.Height < memento.Image.Height)
 				   )
 				{
-					var ratio = 1.0f * Math.Min(memento.Image.Width, memento.Image.Height) / Math.Max(memento.Image.Width, memento.Image.Height);
+					float ratio = Math.Min(displayRect.Width / (float)memento.Image.Width,
+						displayRect.Height / (float)memento.Image.Height);
 
 					// Resize image to fit display area
-					memento.Image = CommonHelper.ScaleImageForSizedDisplay(memento.Image, displayRect.Width * ratio,
-						displayRect.Height * ratio, false);
+					memento.Image = CommonHelper.ScaleImageForSizedDisplay(memento.Image, memento.Image.Width * ratio,
+						memento.Image.Height * ratio, false);
 				}
 
 				if (memento.Image != null)


### PR DESCRIPTION
## Summary
- Preserve aspect ratio when shrinking oversized button content images.
- Fix retro theme buttons rendering UAC icons stretched across the button face.
- Add changelog entry.


<img width="755" height="530" alt="image" src="https://github.com/user-attachments/assets/1de3675b-6db8-455c-bf83-eb88c312d502" />

