### PR TITLE
3653-V110-TestForm resizing fixes

### DIFF
--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -47,17 +47,20 @@ namespace TestForm
             this.tbFilter = new Krypton.Toolkit.KryptonTextBox();
             this.btnClearFilter = new Krypton.Toolkit.ButtonSpecAny();
             this.kryptonThemeListBox1 = new Krypton.Toolkit.KryptonThemeListBox();
+            this.rootLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.leftLayout = new System.Windows.Forms.TableLayoutPanel();
             this.btnDockTopRight = new Krypton.Toolkit.ButtonSpecAny();
             this.btnRestoreSize = new Krypton.Toolkit.ButtonSpecAny();
+            this.rootLayout.SuspendLayout();
+            this.leftLayout.SuspendLayout();
             this.SuspendLayout();
             // 
             // kbtnExit
             // 
-            this.kbtnExit.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.kbtnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.kbtnExit.Location = new System.Drawing.Point(12, 691);
-            this.kbtnExit.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnExit.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kbtnExit.Location = new System.Drawing.Point(0, 679);
+            this.kbtnExit.Margin = new System.Windows.Forms.Padding(0);
             this.kbtnExit.MinimumSize = new System.Drawing.Size(0, 30);
             this.kbtnExit.Name = "kbtnExit";
             this.kbtnExit.Size = new System.Drawing.Size(526, 30);
@@ -75,12 +78,11 @@ namespace TestForm
             // 
             // tlpMain
             // 
-            this.tlpMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.tlpMain.ColumnCount = 1;
             this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tlpMain.Location = new System.Drawing.Point(12, 51);
+            this.tlpMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpMain.Location = new System.Drawing.Point(0, 39);
+            this.tlpMain.Margin = new System.Windows.Forms.Padding(0);
             this.tlpMain.Name = "tlpMain";
             this.tlpMain.RowCount = 2;
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -90,10 +92,10 @@ namespace TestForm
             // 
             // tbFilter
             // 
-            this.tbFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.tbFilter.ButtonSpecs.Add(this.btnClearFilter);
-            this.tbFilter.Location = new System.Drawing.Point(12, 12);
+            this.tbFilter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tbFilter.Location = new System.Drawing.Point(0, 0);
+            this.tbFilter.Margin = new System.Windows.Forms.Padding(0);
             this.tbFilter.MinimumSize = new System.Drawing.Size(0, 30);
             this.tbFilter.Name = "tbFilter";
             this.tbFilter.Size = new System.Drawing.Size(526, 30);
@@ -108,14 +110,54 @@ namespace TestForm
             // 
             // kryptonThemeListBox1
             // 
-            this.kryptonThemeListBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonThemeListBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
+            this.kryptonThemeListBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonThemeListBox1.Location = new System.Drawing.Point(551, 12);
+            this.kryptonThemeListBox1.Margin = new System.Windows.Forms.Padding(0);
             this.kryptonThemeListBox1.Name = "kryptonThemeListBox1";
             this.kryptonThemeListBox1.Size = new System.Drawing.Size(313, 709);
             this.kryptonThemeListBox1.TabIndex = 17;
             this.kryptonThemeListBox1.UseKryptonScrollbars = true;
+            // 
+            // rootLayout
+            // 
+            this.rootLayout.BackColor = System.Drawing.Color.Transparent;
+            this.rootLayout.ColumnCount = 3;
+            this.rootLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.rootLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 13F));
+            this.rootLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 313F));
+            this.rootLayout.Controls.Add(this.leftLayout, 0, 0);
+            this.rootLayout.Controls.Add(this.kryptonThemeListBox1, 2, 0);
+            this.rootLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rootLayout.Location = new System.Drawing.Point(0, 0);
+            this.rootLayout.Margin = new System.Windows.Forms.Padding(0);
+            this.rootLayout.Name = "rootLayout";
+            this.rootLayout.Padding = new System.Windows.Forms.Padding(12, 12, 12, 8);
+            this.rootLayout.RowCount = 1;
+            this.rootLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.rootLayout.Size = new System.Drawing.Size(876, 729);
+            this.rootLayout.TabIndex = 18;
+            // 
+            // leftLayout
+            // 
+            this.leftLayout.BackColor = System.Drawing.Color.Transparent;
+            this.leftLayout.ColumnCount = 1;
+            this.leftLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.leftLayout.Controls.Add(this.tbFilter, 0, 0);
+            this.leftLayout.Controls.Add(this.tlpMain, 0, 2);
+            this.leftLayout.Controls.Add(this.kbtnExit, 0, 4);
+            this.leftLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.leftLayout.Location = new System.Drawing.Point(12, 12);
+            this.leftLayout.Margin = new System.Windows.Forms.Padding(0);
+            this.leftLayout.Name = "leftLayout";
+            this.leftLayout.RowCount = 5;
+            this.leftLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.leftLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 9F));
+            this.leftLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.leftLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 11F));
+            this.leftLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.leftLayout.Size = new System.Drawing.Size(526, 709);
+            this.leftLayout.TabIndex = 18;
             // 
             // btnDockTopRight
             // 
@@ -138,17 +180,16 @@ namespace TestForm
             this.ButtonSpecs.Add(this.btnDockTopRight);
             this.CancelButton = this.kbtnExit;
             this.ClientSize = new System.Drawing.Size(876, 729);
-            this.Controls.Add(this.kryptonThemeListBox1);
-            this.Controls.Add(this.tbFilter);
-            this.Controls.Add(this.tlpMain);
-            this.Controls.Add(this.kbtnExit);
+            this.Controls.Add(this.rootLayout);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.Name = "StartScreen";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Welcome";
+            this.rootLayout.ResumeLayout(false);
+            this.leftLayout.ResumeLayout(false);
+            this.leftLayout.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -159,6 +200,8 @@ namespace TestForm
         private KryptonTextBox tbFilter;
         private ButtonSpecAny btnClearFilter;
         private KryptonThemeListBox kryptonThemeListBox1;
+        private TableLayoutPanel rootLayout;
+        private TableLayoutPanel leftLayout;
         private ButtonSpecAny btnDockTopRight;
         private ButtonSpecAny btnRestoreSize;
     }

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -231,6 +231,8 @@ public partial class StartScreen : KryptonForm
         button.CommandLinkTextValues.Heading = heading;
         button.CommandLinkTextValues.Description = description;
         button.AutoSize = false;
+        button.Dock = DockStyle.Fill;
+        button.MinimumSize = new Size(0, 60);
         button.Size = new Size(_panelWidth - 10, 60);
         button.Click += (_, _) => OnCommandLinkTestButtonClick(formType);
 


### PR DESCRIPTION
Fixes #3653.

This updates the TestForm start screen layout so the theme list is owned by a fixed right column while the filter, command list, and exit button live in a flexible left column.

The previous layout used independent sibling anchors, which could leave the theme list at stale horizontal bounds during repeated resize operations on the V110 branch.
