### PR TITLE
2862-V110-VisualForm flicker fix in .NET10

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+
 * Resolved [#3640](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3640), Fixed retro themed buttons with icons
 * Implemented [#3610](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3610), Harden workflows: PR branch policy (warn-then-fail via `BRANCH_POLICY_ENFORCE`), automated `.github` sync from `master` (including `gold` and `prerelease`), weekly behind-master report workflow, [branch policy cheat sheet](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/.github/BRANCH_POLICY.md)
 * Implemented [#3636](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3636), Improve 'Nightly' Release Workflow

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -275,6 +275,11 @@ public abstract class VisualForm : Form,
                             // Remove any theme that is currently drawing chrome
                             PI.SetWindowTheme(Handle, string.Empty, string.Empty);
 
+#if NET10_0_OR_GREATER
+                            PI.Dwm.WindowSetAttribute(Handle, PI.Dwm.DWMWINDOWATTRIBUTE.NCRenderingPolicy,
+                                (int)PI.Dwm.DWMNCRENDERINGPOLICY.Disabled);
+#endif
+
                             // Call virtual method for initializing own chrome
                             WindowChromeStart();
                         }
@@ -291,6 +296,11 @@ public abstract class VisualForm : Form,
                     {
                         // Restore the application to previous theme setting
                         PI.SetWindowTheme(Handle, null, null);
+
+#if NET10_0_OR_GREATER
+                        PI.Dwm.WindowSetAttribute(Handle, PI.Dwm.DWMWINDOWATTRIBUTE.NCRenderingPolicy,
+                            (int)PI.Dwm.DWMNCRENDERINGPOLICY.UseWindowStyle);
+#endif
 
                         // Call virtual method to reverse own chrome setup
                         WindowChromeEnd();


### PR DESCRIPTION
Fixes #2862 for V110.

.NET 10 can let DWM render native non-client chrome while Krypton is drawing its own VisualForm chrome, causing visible title bar and border flicker during resize.

This changes VisualForm custom chrome activation so DWM non-client rendering is disabled while Krypton owns the frame, then restores DWM's default policy when native chrome is restored.