### PR TITLE
2862-V105-LTS-VisualForm flicker fix in .NET10

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed VisualForm resize flicker in .NET 10+
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing
 * Resolved [#3618](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3618), Canary LTS Release workflow fails

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -247,6 +247,11 @@ public abstract class VisualForm : Form,
                             // Remove any theme that is currently drawing chrome
                             PI.SetWindowTheme(Handle, string.Empty, string.Empty);
 
+#if NET10_0_OR_GREATER
+                            PI.Dwm.WindowSetAttribute(Handle, PI.Dwm.DWMWINDOWATTRIBUTE.NCRenderingPolicy,
+                                (int)PI.Dwm.DWMNCRENDERINGPOLICY.Disabled);
+#endif
+
                             // Call virtual method for initializing own chrome
                             WindowChromeStart();
                         }
@@ -263,6 +268,11 @@ public abstract class VisualForm : Form,
                     {
                         // Restore the application to previous theme setting
                         PI.SetWindowTheme(Handle, null, null);
+
+#if NET10_0_OR_GREATER
+                        PI.Dwm.WindowSetAttribute(Handle, PI.Dwm.DWMWINDOWATTRIBUTE.NCRenderingPolicy,
+                            (int)PI.Dwm.DWMNCRENDERINGPOLICY.UseWindowStyle);
+#endif
 
                         // Call virtual method to reverse own chrome setup
                         WindowChromeEnd();


### PR DESCRIPTION
## Summary

Fixes #2862.

.NET 10 can let DWM render native non-client chrome while Krypton is drawing its own VisualForm chrome, causing visible title bar and border flicker during resize.

This changes VisualForm custom chrome activation so DWM non-client rendering is disabled while Krypton owns the frame, then restores DWM's default policy when native chrome is restored.

The changelog has been updated for V105-LTS.