### PR TITLE
3658-v110-Add accessibility properties across controls

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+
 * Resolved [#3640](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3640), Fixed retro themed buttons with icons

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/General/Accessibility/UtilitiesActionControlAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/General/Accessibility/UtilitiesActionControlAccessibleObject.cs
@@ -1,0 +1,117 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), Giduac, et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Utilities;
+
+/// <summary>
+/// Provides shared accessibility behavior for utility controls with a single default action.
+/// </summary>
+/// <typeparam name="T">The owner control type.</typeparam>
+internal abstract class UtilitiesActionControlAccessibleObject<T> : Control.ControlAccessibleObject
+    where T : Control
+{
+    #region Instance Fields
+    private readonly AccessibleRole _defaultRole;
+    private readonly string _defaultAction;
+    #endregion
+
+    #region Identity
+    protected UtilitiesActionControlAccessibleObject(T owner, AccessibleRole defaultRole, string defaultAction)
+        : base(owner)
+    {
+        OwnerControl = owner;
+        _defaultRole = defaultRole;
+        _defaultAction = defaultAction;
+    }
+    #endregion
+
+    #region Protected
+    protected T OwnerControl { get; }
+
+    protected virtual string? DefaultName => null;
+
+    protected virtual string? DefaultDescription => null;
+
+    protected abstract void PerformAction();
+    #endregion
+
+    #region Public Overrides
+    public override string? Name
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(OwnerControl.AccessibleName))
+            {
+                return OwnerControl.AccessibleName;
+            }
+
+            if (!string.IsNullOrEmpty(DefaultName))
+            {
+                return DefaultName;
+            }
+
+            return base.Name ?? OwnerControl.Name;
+        }
+    }
+
+    public override string? Description
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(OwnerControl.AccessibleDescription))
+            {
+                return OwnerControl.AccessibleDescription;
+            }
+
+            return !string.IsNullOrEmpty(DefaultDescription)
+                ? DefaultDescription
+                : base.Description;
+        }
+    }
+
+    public override AccessibleRole Role => OwnerControl.AccessibleRole != AccessibleRole.Default
+        ? OwnerControl.AccessibleRole
+        : _defaultRole;
+
+    public override AccessibleStates State
+    {
+        get
+        {
+            AccessibleStates state = AccessibleStates.Focusable;
+
+            if (OwnerControl.Focused)
+            {
+                state |= AccessibleStates.Focused;
+            }
+
+            if (!OwnerControl.Visible)
+            {
+                state |= AccessibleStates.Invisible;
+            }
+
+            if (!OwnerControl.Enabled)
+            {
+                state |= AccessibleStates.Unavailable;
+            }
+
+            return state;
+        }
+    }
+
+    public override string DefaultAction => _defaultAction;
+
+    public override void DoDefaultAction()
+    {
+        if (OwnerControl.Enabled && OwnerControl.Visible)
+        {
+            PerformAction();
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton MessageBox Extended/Controls Toolkit/InternalKryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton MessageBox Extended/Controls Toolkit/InternalKryptonButton.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), Giduac, et al. 2026 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), Giduac, tobitege, et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -583,6 +583,12 @@ internal class InternalKryptonButton : VisualSimpleBase, IButtonControl, IConten
     /// Gets the default Input Method Editor (IME) mode supported by this control.
     /// </summary>
     protected override ImeMode DefaultImeMode => ImeMode.Disable;
+
+    /// <summary>
+    /// Creates a new accessibility object for this control.
+    /// </summary>
+    /// <returns>A new accessibility object for this control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new InternalKryptonButtonAccessibleObject(this);
 
     /// <summary>
     /// Raises the EnabledChanged event.

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton MessageBox Extended/General/Accessibility/InternalKryptonButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/Krypton MessageBox Extended/General/Accessibility/InternalKryptonButtonAccessibleObject.cs
@@ -1,0 +1,33 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), tobitege, et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Utilities;
+
+/// <summary>
+/// Provides accessibility information for InternalKryptonButton controls.
+/// </summary>
+internal class InternalKryptonButtonAccessibleObject : UtilitiesActionControlAccessibleObject<InternalKryptonButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the InternalKryptonButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The InternalKryptonButton control that owns this accessible object.</param>
+    public InternalKryptonButtonAccessibleObject(InternalKryptonButton owner)
+        : base(owner, AccessibleRole.PushButton, @"Press")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.Values.Text;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonCommandLinkButton/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonCommandLinkButton/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -518,6 +518,12 @@ public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
     protected override ImeMode DefaultImeMode => ImeMode.Disable;
 
     /// <summary>
+    /// Creates a new accessibility object for the control.
+    /// </summary>
+    /// <returns>A new KryptonCommandLinkButtonAccessibleObject instance for the control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonCommandLinkButtonAccessibleObject(this);
+
+    /// <summary>
     /// Raises the EnabledChanged event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonCommandLinkButton/General/Accessibility/KryptonCommandLinkButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonCommandLinkButton/General/Accessibility/KryptonCommandLinkButtonAccessibleObject.cs
@@ -1,0 +1,38 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Utilities;
+
+/// <summary>
+/// Provides accessibility information for KryptonCommandLinkButton.
+/// </summary>
+internal class KryptonCommandLinkButtonAccessibleObject : UtilitiesActionControlAccessibleObject<KryptonCommandLinkButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the KryptonCommandLinkButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonCommandLinkButton control that owns this accessible object.</param>
+    public KryptonCommandLinkButtonAccessibleObject(KryptonCommandLinkButton owner)
+        : base(owner, AccessibleRole.PushButton, @"Press")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.CommandLinkTextValues.Heading;
+
+    /// <summary>
+    /// Gets the default description of the control.
+    /// </summary>
+    protected override string? DefaultDescription => OwnerControl.CommandLinkTextValues.Description;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/Internal/InternalKryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/Internal/InternalKryptonCommandLinkButton.cs
@@ -496,6 +496,12 @@ public class InternalKryptonCommandLinkButton : VisualSimpleBase, IButtonControl
     protected override ImeMode DefaultImeMode => ImeMode.Disable;
 
     /// <summary>
+    /// Creates a new accessibility object for this control.
+    /// </summary>
+    /// <returns>A new accessibility object for this control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new InternalKryptonCommandLinkButtonAccessibleObject(this);
+
+    /// <summary>
     /// Raises the EnabledChanged event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
@@ -25,6 +25,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
     #region Instance Fields
     private VisualPopupToolTip? _visualPopupToolTip;
     private readonly ButtonSpecManagerLayout? _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private readonly ViewLayoutDocker _drawDockerInner;
     private readonly ViewDrawDocker _drawDockerOuter;
     private readonly ViewLayoutFill _layoutFill;
@@ -216,6 +217,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Create the dropdown glyph view (renderer draws an arrow or custom glyph)
         _dropDownGlyph = new ViewDrawDropDownButton(StateCommon.Content)
@@ -276,6 +278,8 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
 
             // Tell the buttons class to cleanup resources
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
         }
 
         base.Dispose(disposing);
@@ -869,6 +873,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
 
         // Update state to reflect change in enabled state
         _buttonManager?.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         PerformNeedPaint(true);
 
@@ -972,6 +977,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
             {
                 Rectangle fillRect = _layoutFill.FillRect;
                 _textBox?.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                _buttonSpecAccessibilityProxyManager?.Sync();
 
                 // In the designer, ensure the control Width reflects the full visual width
                 // (not just the inner textbox width), so the property grid reports the true size.
@@ -1066,6 +1072,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
         if (IsHandleCreated && !e.NeedLayout)
         {
             InvalidateChildren();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
@@ -184,6 +184,11 @@ public class KryptonCheckButton : KryptonButton
 
     #region Protected Overrides
     /// <summary>
+    /// Creates the accessibility object for the control.
+    /// </summary>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonCheckButtonAccessibleObject(this);
+
+    /// <summary>
     /// Raises the GotFocus event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -1019,6 +1019,12 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
     protected override ImeMode DefaultImeMode => ImeMode.Disable;
 
     /// <summary>
+    /// Creates a new accessibility object for this control.
+    /// </summary>
+    /// <returns>A new accessibility object for this control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonColorButtonAccessibleObject(this);
+
+    /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -956,6 +956,7 @@ public class KryptonComboBox : VisualControlBase,
 
     private VisualPopupToolTip? _visualPopupToolTip;
     private readonly ButtonSpecManagerLayout? _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private readonly ViewLayoutDocker _drawDockerInner;
     private readonly ViewDrawDocker _drawDockerOuter;
     private readonly ViewLayoutFill _layoutFill;
@@ -1317,6 +1318,7 @@ public class KryptonComboBox : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // We need to create and cache a device context compatible with the display
         _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
@@ -1355,6 +1357,8 @@ public class KryptonComboBox : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
         }
 
         base.Dispose(disposing);
@@ -2607,6 +2611,7 @@ public class KryptonComboBox : VisualControlBase,
 
         // Update state to reflect change in enabled state
         _buttonManager?.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         // Change in enabled state requires a layout and repaint
         PerformNeedPaint(true);
@@ -2797,6 +2802,7 @@ public class KryptonComboBox : VisualControlBase,
                     // Toggling it corrects the chopped off text and shows the item in full
                     IntegralHeight = !IntegralHeight;
                     IntegralHeight = !IntegralHeight;
+                    _buttonSpecAccessibilityProxyManager?.Sync();
                 }
             }
             catch
@@ -2856,6 +2862,7 @@ public class KryptonComboBox : VisualControlBase,
         if (!e.NeedLayout)
         {
             _comboBox.Invalidate();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else if (!DroppedDown)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -64,6 +64,7 @@ public class KryptonDateTimePicker : VisualControlBase,
     private readonly ViewDrawDateTimeText _drawText;
     private readonly ViewLayoutCenter _layoutCheckBox;
     private readonly ButtonSpecManagerDraw? _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private VisualPopupToolTip? _visualPopupToolTip;
     private KryptonContextMenuMonthCalendar? _kmc;
     private InputControlStyle _inputControlStyle;
@@ -303,6 +304,7 @@ public class KryptonDateTimePicker : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Update alignment to match current RightToLeft settings
         UpdateForRightToLeft();
@@ -321,6 +323,8 @@ public class KryptonDateTimePicker : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
         }
 
         base.Dispose(disposing);
@@ -1785,6 +1789,7 @@ public class KryptonDateTimePicker : VisualControlBase,
 
         // Update state to reflect change in enabled state
         _buttonManager?.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         // Change in enabled state requires a layout and repaint
         PerformNeedPaint(true);
@@ -1870,6 +1875,7 @@ public class KryptonDateTimePicker : VisualControlBase,
 
             // Let base class calulcate fill rectangle
             base.OnLayout(levent);
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -737,6 +737,7 @@ public class KryptonDomainUpDown : VisualControlBase,
     #region Instance Fields
     private VisualPopupToolTip? _visualPopupToolTip;
     private readonly ButtonSpecManagerLayout _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private readonly ViewLayoutDocker _drawDockerInner;
     private readonly ViewDrawDocker _drawDockerOuter;
     private readonly ViewLayoutFill _layoutFill;
@@ -909,6 +910,7 @@ public class KryptonDomainUpDown : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Add text box to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_domainUpDown);
@@ -927,6 +929,8 @@ public class KryptonDomainUpDown : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
 
             // Tell the buttons class to cleanup resources
             _subclassButtons?.Dispose();
@@ -1614,6 +1618,7 @@ public class KryptonDomainUpDown : VisualControlBase,
 
         // Update state to reflect change in enabled state
         _buttonManager.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         PerformNeedPaint(true);
 
@@ -1703,6 +1708,7 @@ public class KryptonDomainUpDown : VisualControlBase,
             {
                 Rectangle fillRect = _layoutFill.FillRect;
                 _domainUpDown.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                _buttonSpecAccessibilityProxyManager?.Sync();
             }
         }
     }
@@ -1795,6 +1801,7 @@ public class KryptonDomainUpDown : VisualControlBase,
         if (IsHandleCreated && !e.NeedLayout)
         {
             InvalidateChildren();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -646,6 +646,11 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
     protected override ImeMode DefaultImeMode => ImeMode.Disable;
 
     /// <summary>
+    /// Creates the accessibility object for the control.
+    /// </summary>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonDropButtonAccessibleObject(this);
+
+    /// <summary>
     /// Raises the EnabledChanged event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -321,6 +321,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
     private VisualPopupToolTip? _visualPopupToolTip;
     private readonly ButtonSpecManagerLayout? _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private readonly ViewLayoutDocker _drawDockerInner;
     private readonly ViewDrawDocker _drawDockerOuter;
     private readonly ViewLayoutFill _layoutFill;
@@ -524,6 +525,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Add text box to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_maskedTextBox);
@@ -542,6 +544,8 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
         }
 
         base.Dispose(disposing);
@@ -1533,6 +1537,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
         // Update state to reflect change in enabled state
         _buttonManager?.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         PerformNeedPaint(true);
 
@@ -1602,6 +1607,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
         {
             Rectangle fillRect = _layoutFill.FillRect;
             _maskedTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
     }
 
@@ -1689,6 +1695,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
         if (!e.NeedLayout)
         {
             _maskedTextBox.Invalidate();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -768,6 +768,7 @@ public class KryptonNumericUpDown : VisualControlBase,
 
     private VisualPopupToolTip? _visualPopupToolTip;
     private readonly ButtonSpecManagerLayout? _buttonManager;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private readonly ViewLayoutDocker _drawDockerInner;
     private readonly ViewDrawDocker _drawDockerOuter;
     private readonly ViewLayoutFill _layoutFill;
@@ -940,6 +941,7 @@ public class KryptonNumericUpDown : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Add text box to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_numericUpDown);
@@ -958,6 +960,8 @@ public class KryptonNumericUpDown : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
 
             // Tell the buttons class to cleanup resources
             _subclassButtons?.Dispose();
@@ -1746,6 +1750,7 @@ public class KryptonNumericUpDown : VisualControlBase,
 
         // Update state to reflect change in enabled state
         _buttonManager?.RefreshButtons();
+        _buttonSpecAccessibilityProxyManager?.Sync();
 
         PerformNeedPaint(true);
 
@@ -1835,6 +1840,7 @@ public class KryptonNumericUpDown : VisualControlBase,
             {
                 Rectangle fillRect = _layoutFill.FillRect;
                 _numericUpDown?.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                _buttonSpecAccessibilityProxyManager?.Sync();
             }
         }
     }
@@ -1928,6 +1934,7 @@ public class KryptonNumericUpDown : VisualControlBase,
         if (IsHandleCreated && !e.NeedLayout)
         {
             InvalidateChildren();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
@@ -473,6 +473,12 @@ public class KryptonRadioButton : VisualSimpleBase
 
     #region Protected
     /// <summary>
+    /// Creates a new accessibility object for this control.
+    /// </summary>
+    /// <returns>A new accessibility object for this control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonRadioButtonAccessibleObject(this);
+
+    /// <summary>
     /// Raises the DoubleClick event.
     /// </summary>
     /// <param name="e">An EventArgs containing the event data.</param>
@@ -581,6 +587,14 @@ public class KryptonRadioButton : VisualSimpleBase
 
         // No match found, let base class do standard processing
         return base.ProcessMnemonic(charCode);
+    }
+
+    internal void PerformAccessibilityClick()
+    {
+        if (CanSelect)
+        {
+            OnClick(EventArgs.Empty);
+        }
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -353,6 +353,7 @@ public class KryptonTextBox : VisualControlBase,
     private bool _showEllipsisButton;
     //private bool _isInAlphaNumericMode;
     private readonly ButtonSpecAny _editorButton;
+    private ButtonSpecAccessibilityProxyManager? _buttonSpecAccessibilityProxyManager;
     private KryptonScrollbarManager? _scrollbarManager;
     private bool? _useKryptonScrollbars;
 
@@ -534,6 +535,7 @@ public class KryptonTextBox : VisualControlBase,
         ToolTipManager.ShowToolTip += OnShowToolTip;
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
+        _buttonSpecAccessibilityProxyManager = new ButtonSpecAccessibilityProxyManager(this, ButtonSpecs, () => _buttonManager);
 
         // Create the button spec for the multiline editor button.
         _editorButton = new ButtonSpecAny
@@ -565,6 +567,8 @@ public class KryptonTextBox : VisualControlBase,
 
             // Remember to pull down the manager instance
             _buttonManager?.Destruct();
+            _buttonSpecAccessibilityProxyManager?.Dispose();
+            _buttonSpecAccessibilityProxyManager = null;
 
             _scrollbarManager?.Dispose();
             _scrollbarManager = null;
@@ -645,6 +649,8 @@ public class KryptonTextBox : VisualControlBase,
     [EditorBrowsable(EditorBrowsableState.Always)]
     [Browsable(false)]
     public TextBox TextBox => _textBox;
+
+    internal ButtonSpecManagerLayout? ButtonSpecManager => _buttonManager;
 
     /// <summary>
     /// Gets access to the contained input control.
@@ -1700,6 +1706,7 @@ public class KryptonTextBox : VisualControlBase,
             var y = Height / 2 - _textBox.Height / 2;
 
             _textBox.SetBounds(fillRect.X, y, fillRect.Width, fillRect.Height);
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
     }
 
@@ -1777,6 +1784,7 @@ public class KryptonTextBox : VisualControlBase,
         if (IsHandleCreated && !e.NeedLayout)
         {
             _textBox.Invalidate();
+            _buttonSpecAccessibilityProxyManager?.Sync();
         }
         else
         {

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/ButtonSpecAccessibilityProxyManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/ButtonSpecAccessibilityProxyManager.cs
@@ -1,0 +1,269 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Exposes hosted ButtonSpec instances as UIA-visible controls without changing their rendered button views.
+/// </summary>
+internal sealed class ButtonSpecAccessibilityProxyManager : IDisposable
+{
+    #region Classes
+    private sealed class ButtonSpecAccessibilityProxy : Control
+    {
+        #region Classes
+        private sealed class ButtonSpecAccessibilityProxyAccessibleObject : Control.ControlAccessibleObject
+        {
+            #region Instance Fields
+            private readonly ButtonSpecAccessibilityProxy _owner;
+            #endregion
+
+            #region Identity
+            public ButtonSpecAccessibilityProxyAccessibleObject(ButtonSpecAccessibilityProxy owner)
+                : base(owner)
+            {
+                _owner = owner;
+            }
+            #endregion
+
+            #region Public Overrides
+            public override string? Name => _owner.AccessibleName;
+
+            public override string? Description => _owner.AccessibleDescription;
+
+            public override AccessibleRole Role => AccessibleRole.PushButton;
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    AccessibleStates state = AccessibleStates.Focusable;
+
+                    if (!_owner.Visible)
+                    {
+                        state |= AccessibleStates.Invisible;
+                    }
+
+                    if (!_owner.Enabled)
+                    {
+                        state |= AccessibleStates.Unavailable;
+                    }
+
+                    return state;
+                }
+            }
+
+            public override string DefaultAction => @"Press";
+
+            public override void DoDefaultAction()
+            {
+                if (_owner.Enabled && _owner.Visible)
+                {
+                    _owner.ButtonSpec.PerformClick();
+                }
+            }
+            #endregion
+        }
+        #endregion
+
+        #region Instance Fields
+        private readonly ButtonSpec _buttonSpec;
+        #endregion
+
+        #region Identity
+        public ButtonSpecAccessibilityProxy(ButtonSpec buttonSpec)
+        {
+            _buttonSpec = buttonSpec;
+
+            SetStyle(ControlStyles.Selectable, false);
+            SetStyle(ControlStyles.UserPaint, true);
+            SetStyle(ControlStyles.AllPaintingInWmPaint, true);
+            SetStyle(ControlStyles.SupportsTransparentBackColor, true);
+
+            BackColor = Color.Transparent;
+            TabStop = false;
+            AccessibleRole = AccessibleRole.PushButton;
+
+            UpdateAccessibility();
+        }
+        #endregion
+
+        #region Public
+        public ButtonSpec ButtonSpec => _buttonSpec;
+
+        public void UpdateAccessibility()
+        {
+            AccessibleName = GetAccessibleName();
+            AccessibleDescription = !string.IsNullOrEmpty(_buttonSpec.ToolTipBody)
+                ? _buttonSpec.ToolTipBody
+                : null;
+        }
+        #endregion
+
+        #region Protected
+        protected override void OnClick(EventArgs e)
+        {
+            _buttonSpec.PerformClick(e);
+            base.OnClick(e);
+        }
+
+        protected override AccessibleObject CreateAccessibilityInstance() => new ButtonSpecAccessibilityProxyAccessibleObject(this);
+
+        protected override void OnPaintBackground(PaintEventArgs pevent)
+        {
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+        }
+        #endregion
+
+        #region Implementation
+        private string GetAccessibleName()
+        {
+            if (!string.IsNullOrEmpty(_buttonSpec.ToolTipTitle))
+            {
+                return _buttonSpec.ToolTipTitle;
+            }
+
+            if (!string.IsNullOrEmpty(_buttonSpec.Text))
+            {
+                return _buttonSpec.Text;
+            }
+
+            return _buttonSpec is ButtonSpecAny buttonSpecAny
+                ? buttonSpecAny.Type.ToString()
+                : _buttonSpec.GetType().Name;
+        }
+        #endregion
+    }
+    #endregion
+
+    #region Instance Fields
+    private readonly Control _owner;
+    private readonly ButtonSpecCollectionBase _buttonSpecs;
+    private readonly Func<ButtonSpecManagerBase?> _getButtonSpecManager;
+    private readonly Dictionary<ButtonSpec, ButtonSpecAccessibilityProxy> _proxies = new Dictionary<ButtonSpec, ButtonSpecAccessibilityProxy>();
+    private bool _disposed;
+    #endregion
+
+    #region Identity
+    public ButtonSpecAccessibilityProxyManager(Control owner, ButtonSpecCollectionBase buttonSpecs, Func<ButtonSpecManagerBase?> getButtonSpecManager)
+    {
+        _owner = owner;
+        _buttonSpecs = buttonSpecs;
+        _getButtonSpecManager = getButtonSpecManager;
+
+        _buttonSpecs.Inserted += OnButtonSpecInserted;
+        _buttonSpecs.Removed += OnButtonSpecRemoved;
+    }
+    #endregion
+
+    #region Public
+    public void Sync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        ButtonSpecManagerBase? buttonSpecManager = _getButtonSpecManager();
+
+        if (buttonSpecManager == null)
+        {
+            return;
+        }
+
+        ButtonSpec[] buttonSpecs = _buttonSpecs.Enumerate().Cast<ButtonSpec>().ToArray();
+
+        foreach (ButtonSpec buttonSpec in _proxies.Keys.Except(buttonSpecs).ToArray())
+        {
+            RemoveProxy(buttonSpec);
+        }
+
+        foreach (ButtonSpec buttonSpec in buttonSpecs)
+        {
+            if (!_proxies.TryGetValue(buttonSpec, out ButtonSpecAccessibilityProxy? proxy))
+            {
+                proxy = new ButtonSpecAccessibilityProxy(buttonSpec);
+                _proxies.Add(buttonSpec, proxy);
+                AddProxy(proxy);
+                proxy.BringToFront();
+            }
+
+            Rectangle rectangle = buttonSpecManager.GetButtonRectangle(buttonSpec);
+            proxy.Bounds = rectangle == Rectangle.Empty
+                ? Rectangle.Empty
+                : new Rectangle(rectangle.Location, new Size(1, 1));
+            proxy.Visible = rectangle != Rectangle.Empty && buttonSpec.GetViewEnabled();
+            proxy.Enabled = _owner.Enabled && buttonSpec.GetViewEnabled();
+            proxy.UpdateAccessibility();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _buttonSpecs.Inserted -= OnButtonSpecInserted;
+        _buttonSpecs.Removed -= OnButtonSpecRemoved;
+
+        foreach (ButtonSpec buttonSpec in _proxies.Keys.ToArray())
+        {
+            RemoveProxy(buttonSpec);
+        }
+
+        _proxies.Clear();
+    }
+    #endregion
+
+    #region Implementation
+    private void OnButtonSpecInserted(object? sender, ButtonSpecEventArgs e) => Sync();
+
+    private void OnButtonSpecRemoved(object? sender, ButtonSpecEventArgs e) => Sync();
+
+    private void RemoveProxy(ButtonSpec buttonSpec)
+    {
+        if (_proxies.TryGetValue(buttonSpec, out ButtonSpecAccessibilityProxy? proxy))
+        {
+            _proxies.Remove(buttonSpec);
+            RemoveProxyControl(proxy);
+            proxy.Dispose();
+        }
+    }
+
+    private void AddProxy(ButtonSpecAccessibilityProxy proxy)
+    {
+        if (_owner.Controls is KryptonReadOnlyControls controls)
+        {
+            controls.AddInternal(proxy);
+        }
+        else
+        {
+            _owner.Controls.Add(proxy);
+        }
+    }
+
+    private void RemoveProxyControl(ButtonSpecAccessibilityProxy proxy)
+    {
+        if (_owner.Controls is KryptonReadOnlyControls controls)
+        {
+            controls.RemoveInternal(proxy);
+        }
+        else
+        {
+            _owner.Controls.Remove(proxy);
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/InternalKryptonCommandLinkButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/InternalKryptonCommandLinkButtonAccessibleObject.cs
@@ -1,0 +1,38 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for InternalKryptonCommandLinkButton controls.
+/// </summary>
+internal class InternalKryptonCommandLinkButtonAccessibleObject : KryptonActionControlAccessibleObject<InternalKryptonCommandLinkButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the InternalKryptonCommandLinkButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The InternalKryptonCommandLinkButton control that owns this accessible object.</param>
+    public InternalKryptonCommandLinkButtonAccessibleObject(InternalKryptonCommandLinkButton owner)
+        : base(owner, AccessibleRole.PushButton, @"Press")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.CommandLinkTextValues.Heading;
+
+    /// <summary>
+    /// Gets the default description of the control.
+    /// </summary>
+    protected override string? DefaultDescription => OwnerControl.CommandLinkTextValues.Description;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonActionControlAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonActionControlAccessibleObject.cs
@@ -1,0 +1,124 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides shared accessibility behavior for Krypton controls with a single default action.
+/// </summary>
+/// <typeparam name="T">The owner control type.</typeparam>
+internal abstract class KryptonActionControlAccessibleObject<T> : Control.ControlAccessibleObject
+    where T : Control
+{
+    #region Instance Fields
+    private readonly AccessibleRole _defaultRole;
+    private readonly string _defaultAction;
+    #endregion
+
+    #region Identity
+    protected KryptonActionControlAccessibleObject(T owner, AccessibleRole defaultRole, string defaultAction)
+        : base(owner)
+    {
+        OwnerControl = owner;
+        _defaultRole = defaultRole;
+        _defaultAction = defaultAction;
+    }
+    #endregion
+
+    #region Protected
+    protected T OwnerControl { get; }
+
+    protected virtual bool IsChecked => false;
+
+    protected virtual string? DefaultName => null;
+
+    protected virtual string? DefaultDescription => null;
+
+    protected abstract void PerformAction();
+    #endregion
+
+    #region Public Overrides
+    public override string? Name
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(OwnerControl.AccessibleName))
+            {
+                return OwnerControl.AccessibleName;
+            }
+
+            if (!string.IsNullOrEmpty(DefaultName))
+            {
+                return DefaultName;
+            }
+
+            return base.Name ?? OwnerControl.Name;
+        }
+    }
+
+    public override string? Description
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(OwnerControl.AccessibleDescription))
+            {
+                return OwnerControl.AccessibleDescription;
+            }
+
+            return !string.IsNullOrEmpty(DefaultDescription)
+                ? DefaultDescription
+                : base.Description;
+        }
+    }
+
+    public override AccessibleRole Role => OwnerControl.AccessibleRole != AccessibleRole.Default
+        ? OwnerControl.AccessibleRole
+        : _defaultRole;
+
+    public override AccessibleStates State
+    {
+        get
+        {
+            AccessibleStates state = AccessibleStates.Focusable;
+
+            if (OwnerControl.Focused)
+            {
+                state |= AccessibleStates.Focused;
+            }
+
+            if (IsChecked)
+            {
+                state |= AccessibleStates.Checked;
+            }
+
+            if (!OwnerControl.Visible)
+            {
+                state |= AccessibleStates.Invisible;
+            }
+
+            if (!OwnerControl.Enabled)
+            {
+                state |= AccessibleStates.Unavailable;
+            }
+
+            return state;
+        }
+    }
+
+    public override string DefaultAction => _defaultAction;
+
+    public override void DoDefaultAction()
+    {
+        if (OwnerControl.Enabled && OwnerControl.Visible)
+        {
+            PerformAction();
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckButtonAccessibleObject.cs
@@ -1,0 +1,38 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for KryptonCheckButton controls.
+/// </summary>
+internal class KryptonCheckButtonAccessibleObject : KryptonActionControlAccessibleObject<KryptonCheckButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the KryptonCheckButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonCheckButton control that owns this accessible object.</param>
+    public KryptonCheckButtonAccessibleObject(KryptonCheckButton owner)
+        : base(owner, AccessibleRole.CheckButton, @"Toggle")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.Values.Text;
+
+    /// <summary>
+    /// Gets a value indicating whether the control is checked.
+    /// </summary>
+    protected override bool IsChecked => OwnerControl.Checked;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckedListBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckedListBoxAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -39,6 +39,11 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal ListBox (CheckedListBox inherits from ListBox) first
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible?.Name != null)
@@ -58,6 +63,11 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal ListBox first
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible?.Description != null)
@@ -77,6 +87,11 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
     {
         get
         {
+            if (_owner.AccessibleRole != AccessibleRole.Default)
+            {
+                return _owner.AccessibleRole;
+            }
+
             // Delegate to internal ListBox's role
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible != null)
@@ -129,6 +144,23 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
 
             // Fall back to base implementation
             return base.Value;
+        }
+
+        set
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _owner.Items.Count; i++)
+            {
+                if (string.Equals(_owner.ListBox.GetItemText(_owner.Items[i]), value, StringComparison.CurrentCulture))
+                {
+                    _owner.SelectedIndex = i;
+                    break;
+                }
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonColorButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonColorButtonAccessibleObject.cs
@@ -1,0 +1,33 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for KryptonColorButton controls.
+/// </summary>
+internal class KryptonColorButtonAccessibleObject : KryptonActionControlAccessibleObject<KryptonColorButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the KryptonColorButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonColorButton control that owns this accessible object.</param>
+    public KryptonColorButtonAccessibleObject(KryptonColorButton owner)
+        : base(owner, AccessibleRole.PushButton, @"Press")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.Values.Text;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonComboBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonComboBoxAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -39,6 +39,11 @@ internal class KryptonComboBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal ComboBox first
             var internalAccessible = _owner.ComboBox?.AccessibilityObject;
             if (internalAccessible?.Name != null)
@@ -58,6 +63,11 @@ internal class KryptonComboBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal ComboBox first
             var internalAccessible = _owner.ComboBox?.AccessibilityObject;
             if (internalAccessible?.Description != null)
@@ -77,6 +87,11 @@ internal class KryptonComboBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (_owner.AccessibleRole != AccessibleRole.Default)
+            {
+                return _owner.AccessibleRole;
+            }
+
             // Delegate to internal ComboBox's role
             var internalAccessible = _owner.ComboBox?.AccessibilityObject;
             if (internalAccessible != null)
@@ -129,6 +144,24 @@ internal class KryptonComboBoxAccessibleObject : Control.ControlAccessibleObject
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            int index = _owner.FindStringExact(value);
+            if (index >= 0)
+            {
+                _owner.SelectedIndex = index;
+            }
+            else if (_owner.DropDownStyle != ComboBoxStyle.DropDownList)
+            {
+                _owner.Text = value;
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonDropButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonDropButtonAccessibleObject.cs
@@ -1,0 +1,33 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for KryptonDropButton controls.
+/// </summary>
+internal class KryptonDropButtonAccessibleObject : KryptonActionControlAccessibleObject<KryptonDropButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the KryptonDropButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonDropButton control that owns this accessible object.</param>
+    public KryptonDropButtonAccessibleObject(KryptonDropButton owner)
+        : base(owner, AccessibleRole.PushButton, @"Press")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.Values.Text;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformClick();
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListBoxAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -39,6 +39,11 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal ListBox first
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible?.Name != null)
@@ -58,6 +63,11 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal ListBox first
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible?.Description != null)
@@ -77,6 +87,11 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (_owner.AccessibleRole != AccessibleRole.Default)
+            {
+                return _owner.AccessibleRole;
+            }
+
             // Delegate to internal ListBox's role
             var internalAccessible = _owner.ListBox?.AccessibilityObject;
             if (internalAccessible != null)
@@ -129,6 +144,23 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
 
             // Fall back to base implementation
             return base.Value;
+        }
+
+        set
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _owner.Items.Count; i++)
+            {
+                if (string.Equals(_owner.ListBox.GetItemText(_owner.Items[i]), value, StringComparison.CurrentCulture))
+                {
+                    _owner.SelectedIndex = i;
+                    break;
+                }
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonRadioButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonRadioButtonAccessibleObject.cs
@@ -1,0 +1,38 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for KryptonRadioButton controls.
+/// </summary>
+internal class KryptonRadioButtonAccessibleObject : KryptonActionControlAccessibleObject<KryptonRadioButton>
+{
+    /// <summary>
+    /// Initialize a new instance of the KryptonRadioButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonRadioButton control that owns this accessible object.</param>
+    public KryptonRadioButtonAccessibleObject(KryptonRadioButton owner)
+        : base(owner, AccessibleRole.RadioButton, @"Select")
+    {
+    }
+
+    /// <summary>
+    /// Gets the default name of the control.
+    /// </summary>
+    protected override string? DefaultName => OwnerControl.Values.Text;
+
+    /// <summary>
+    /// Gets a value indicating whether the control is checked.
+    /// </summary>
+    protected override bool IsChecked => OwnerControl.Checked;
+
+    /// <inheritdoc />
+    protected override void PerformAction() => OwnerControl.PerformAccessibilityClick();
+}

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -54,9 +54,9 @@ namespace TestForm
             this.rootLayout.SuspendLayout();
             this.leftLayout.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // kbtnExit
-            // 
+            //
             this.kbtnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.kbtnExit.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kbtnExit.Location = new System.Drawing.Point(0, 679);
@@ -92,6 +92,9 @@ namespace TestForm
             // 
             // tbFilter
             // 
+            this.tbFilter.AccessibleDescription = "Filters the TestForm demo button list.";
+            this.tbFilter.AccessibleName = "Filter demos";
+            this.tbFilter.AccessibleRole = System.Windows.Forms.AccessibleRole.Text;
             this.tbFilter.ButtonSpecs.Add(this.btnClearFilter);
             this.tbFilter.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tbFilter.Location = new System.Drawing.Point(0, 0);
@@ -105,6 +108,8 @@ namespace TestForm
             // 
             // btnClearFilter
             // 
+            this.btnClearFilter.ToolTipBody = "Clears the demo filter text.";
+            this.btnClearFilter.ToolTipTitle = "Clear filter";
             this.btnClearFilter.Type = Krypton.Toolkit.PaletteButtonSpecStyle.Close;
             this.btnClearFilter.UniqueName = "149f662cfafb4c229f6a7c701553bf5d";
             // 

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -230,6 +230,9 @@ public partial class StartScreen : KryptonForm
 
         button.CommandLinkTextValues.Heading = heading;
         button.CommandLinkTextValues.Description = description;
+        button.AccessibleName = heading;
+        button.AccessibleDescription = description;
+        button.AccessibleRole = AccessibleRole.PushButton;
         button.AutoSize = false;
         button.Dock = DockStyle.Fill;
         button.MinimumSize = new Size(0, 60);

--- a/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.Designer.cs
@@ -45,6 +45,9 @@
             // 
             // kchkbtnSwitchLayout
             // 
+            this.kchkbtnSwitchLayout.AccessibleDescription = "Toggles the form between right-to-left and left-to-right layout.";
+            this.kchkbtnSwitchLayout.AccessibleName = "Switch layout";
+            this.kchkbtnSwitchLayout.AccessibleRole = System.Windows.Forms.AccessibleRole.CheckButton;
             this.kchkbtnSwitchLayout.Location = new System.Drawing.Point(317, 150);
             this.kchkbtnSwitchLayout.Name = "kchkbtnSwitchLayout";
             this.kchkbtnSwitchLayout.RightToLeft = System.Windows.Forms.RightToLeft.Yes;


### PR DESCRIPTION
Implements #3658 

- Added accessible objects for custom drawn Krypton button controls so they expose names, roles, state, and default invoke actions.
- Added accessible proxy controls for editable control ButtonSpecs so embedded actions are visible as individual child buttons.
- Updated list and combo accessible objects to prefer wrapper metadata while preserving native item exposure and value behavior.
- Added TestForm metadata and the V110 changelog entry for #3658.

## Why

Custom drawn controls and painted ButtonSpecs were hard for accessibility clients to inspect or operate because the visible action was not always represented as an accessible child or invokable object.

---

Tested with [TryCUA](https://github.com/trycua/cua/#cua-driver---background-computer-use-on-macos-and-windows-with-linux-pre-release)'s (on GitHub) own cua driver which shows a dedicated, background cursor independent of yours, like magic!
And your Agent can steer it, get UAI element names for controls and/or their items and have them clicked/selected!