### PR TITLE
* KContextMenu items overflow not visible (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), KContextMenu items overflow not visible
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed VisualForm resize flicker in .NET 10+
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing

--- a/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx
+++ b/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Configurations>
+    <Platform Name="Any CPU" />
     <BuildType Name="Canary" />
     <BuildType Name="Debug" />
     <BuildType Name="Installer" />
@@ -10,9 +11,11 @@
   <Folder Name="/Solution Items/Build System/">
     <File Path="../.editorconfig" />
     <Project Path="../../Scripts/ModernBuild/ModernBuild.csproj">
-      <BuildType Solution="Canary|*" Project="Release" />
-      <BuildType Solution="Installer|*" Project="Debug" />
-      <BuildType Solution="Nightly|*" Project="Release" />
+      <BuildType Solution="Canary|Any CPU" Project="Release" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Debug" />
+      <BuildType Solution="Nightly|Any CPU" Project="Release" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
     </Project>
   </Folder>
   <Folder Name="/Solution Items/Build System/CMD Files/" />
@@ -90,21 +93,55 @@
     <File Path="../../LICENSE" />
   </Folder>
   <Folder Name="/Source/">
-    <Project Path="Krypton.Docking/Krypton.Docking 2022.csproj" />
-    <Project Path="Krypton.Navigator/Krypton.Navigator 2022.csproj" />
-    <Project Path="Krypton.Ribbon/Krypton.Ribbon 2022.csproj" />
-    <Project Path="Krypton.Toolkit/Krypton.Toolkit 2022.csproj" />
-    <Project Path="Krypton.Workspace/Krypton.Workspace 2022.csproj" />
+    <Project Path="Krypton.Docking/Krypton.Docking 2022.csproj">
+      <BuildType Solution="Canary|Any CPU" Project="Canary" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Installer" />
+      <BuildType Solution="Nightly|Any CPU" Project="Nightly" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
+    </Project>
+    <Project Path="Krypton.Navigator/Krypton.Navigator 2022.csproj">
+      <BuildType Solution="Canary|Any CPU" Project="Canary" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Installer" />
+      <BuildType Solution="Nightly|Any CPU" Project="Nightly" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
+    </Project>
+    <Project Path="Krypton.Ribbon/Krypton.Ribbon 2022.csproj">
+      <BuildType Solution="Canary|Any CPU" Project="Canary" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Installer" />
+      <BuildType Solution="Nightly|Any CPU" Project="Nightly" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
+    </Project>
+    <Project Path="Krypton.Toolkit/Krypton.Toolkit 2022.csproj">
+      <BuildType Solution="Canary|Any CPU" Project="Canary" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Installer" />
+      <BuildType Solution="Nightly|Any CPU" Project="Nightly" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
+    </Project>
+    <Project Path="Krypton.Workspace/Krypton.Workspace 2022.csproj">
+      <BuildType Solution="Canary|Any CPU" Project="Canary" />
+      <BuildType Solution="Debug|Any CPU" Project="Debug" />
+      <BuildType Solution="Installer|Any CPU" Project="Installer" />
+      <BuildType Solution="Nightly|Any CPU" Project="Nightly" />
+      <BuildType Solution="Release|Any CPU" Project="Release" />
+    </Project>
   </Folder>
   <Project Path="../TestHarnesses/ThemeSwapRepro/ThemeSwapRepro.csproj">
-    <BuildType Solution="Canary|*" Project="Release" />
-    <BuildType Solution="Installer|*" Project="Debug" />
-    <BuildType Solution="Nightly|*" Project="Release" />
+    <BuildType Solution="Canary|Any CPU" Project="Release" />
+    <BuildType Solution="Debug|Any CPU" Project="Debug" />
+    <BuildType Solution="Installer|Any CPU" Project="Debug" />
+    <BuildType Solution="Nightly|Any CPU" Project="Release" />
+    <BuildType Solution="Release|Any CPU" Project="Release" />
   </Project>
   <Project Path="TestForm/TestForm.csproj">
     <BuildDependency Project="Krypton.Navigator/Krypton.Navigator 2022.csproj" />
-    <BuildType Solution="Canary|*" Project="Debug" />
-    <BuildType Solution="Installer|*" Project="Debug" />
-    <BuildType Solution="Nightly|*" Project="Debug" />
+    <BuildType Solution="Canary|Any CPU" Project="Debug" />
+    <BuildType Solution="Debug|Any CPU" Project="Debug" />
+    <BuildType Solution="Installer|Any CPU" Project="Debug" />
+    <BuildType Solution="Nightly|Any CPU" Project="Debug" />
+    <BuildType Solution="Release|Any CPU" Project="Release" />
   </Project>
 </Solution>

--- a/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
@@ -268,5 +268,9 @@ public class AppButtonMenuProvider : IContextMenuProvider
     /// </summary>
     public NeedPaintHandler ProviderNeedPaintDelegate { get; }
 
+    /// <inheritdoc />
+    public bool ProviderOverflowScrollUseArrows =>
+        KryptonManager.Strings.ContextMenuStrings.OverflowScrollUseArrows;
+
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
@@ -1,11 +1,11 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  *  Modified: Monday 12th April, 2021 @ 18:00 GMT
  *

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuScrollButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuScrollButtonController.cs
@@ -1,12 +1,9 @@
 #region BSD License
 /*
- * 
- * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
- *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuScrollButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuScrollButtonController.cs
@@ -1,0 +1,293 @@
+#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Controller for a context menu scroll overflow button.
+/// </summary>
+internal class MenuScrollButtonController : GlobalId,
+    IMouseController,
+    IKeyController,
+    IContextMenuTarget
+{
+    #region Static Fields
+    private const int ScrollRepeatIntervalMs = 50;
+    #endregion
+
+    #region Instance Fields
+    private bool _mouseOver;
+    private System.Windows.Forms.Timer? _scrollTimer;
+    private readonly ViewDrawMenuScrollButton _scrollButton;
+    private readonly NeedPaintHandler? _needPaint;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the MenuScrollButtonController class.
+    /// </summary>
+    /// <param name="viewManager">Owning view manager instance.</param>
+    /// <param name="scrollButton">Target scroll button view element.</param>
+    /// <param name="needPaint">Delegate for notifying paint requests.</param>
+    public MenuScrollButtonController(ViewContextMenuManager viewManager,
+        ViewDrawMenuScrollButton scrollButton,
+        NeedPaintHandler? needPaint)
+    {
+        ViewManager = viewManager;
+        _scrollButton = scrollButton;
+        _needPaint = needPaint;
+    }
+    #endregion
+
+    #region ViewContextMenuManager
+    /// <summary>
+    /// Gets access to the view manager.
+    /// </summary>
+    public ViewContextMenuManager ViewManager { get; }
+
+    #endregion
+
+    #region IContextMenuTarget
+    /// <inheritdoc />
+    public bool HasSubMenu => false;
+
+    /// <inheritdoc />
+    public void ShowTarget()
+    {
+        _scrollButton.HighlightState();
+        ActivateScroll();
+        StartScrollTimer();
+    }
+
+    /// <inheritdoc />
+    public void ClearTarget()
+    {
+        StopScrollTimer();
+        _scrollButton.NormalState();
+    }
+
+    /// <inheritdoc />
+    public void ShowSubMenu()
+    {
+    }
+
+    /// <inheritdoc />
+    public void ClearSubMenu()
+    {
+    }
+
+    /// <inheritdoc />
+    public bool MatchMnemonic(char charCode) => false;
+
+    /// <inheritdoc />
+    public void MnemonicActivate() => ActivateScroll();
+
+    /// <inheritdoc />
+    public ViewBase GetActiveView() => _scrollButton;
+
+    /// <inheritdoc />
+    public Rectangle ClientRectangle => _scrollButton.ClientRectangle;
+
+    /// <inheritdoc />
+    public bool DoesStackedClientMouseDownBecomeCurrent(Point pt) => true;
+    #endregion
+
+    #region IMouseController
+    /// <inheritdoc />
+    public void MouseEnter(Control c)
+    {
+        if (!_mouseOver && _scrollButton.ItemEnabled)
+        {
+            _mouseOver = true;
+            ViewManager.SetTarget(this, false);
+        }
+    }
+
+    /// <inheritdoc />
+    public void MouseMove(Control c, Point pt)
+    {
+        if (_mouseOver && _scrollButton.ItemEnabled && _scrollTimer == null)
+        {
+            ViewManager.SetTarget(this, false);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool MouseDown(Control c, Point pt, MouseButtons button) => false;
+
+    /// <inheritdoc />
+    public void MouseUp(Control c, Point pt, MouseButtons button)
+    {
+        if (button == MouseButtons.Left && _scrollButton.ItemEnabled)
+        {
+            ActivateScroll();
+        }
+    }
+
+    /// <inheritdoc />
+    public void MouseLeave(Control c, ViewBase? next)
+    {
+        if (_mouseOver && !_scrollButton.ContainsRecurse(next))
+        {
+            _mouseOver = false;
+            ViewManager.ClearTarget(this);
+        }
+    }
+
+    /// <inheritdoc />
+    public void DoubleClick(Point pt)
+    {
+    }
+
+    /// <inheritdoc />
+    public bool IgnoreVisualFormLeftButtonDown => false;
+    #endregion
+
+    #region IKeyController
+    /// <inheritdoc />
+    public void KeyDown(Control c, KeyEventArgs e)
+    {
+        switch (e.KeyCode)
+        {
+            case Keys.Enter:
+            case Keys.Space:
+                ActivateScroll();
+                break;
+            case Keys.Up:
+                if (_scrollButton.ScrollUp)
+                {
+                    ActivateScroll();
+                }
+                else
+                {
+                    ViewManager.KeyUp();
+                }
+
+                break;
+            case Keys.Down:
+                if (_scrollButton.ScrollUp)
+                {
+                    ViewManager.KeyDown();
+                }
+                else
+                {
+                    ActivateScroll();
+                }
+
+                break;
+            case Keys.Left:
+                ViewManager.KeyLeft(false);
+                break;
+            case Keys.Right:
+                ViewManager.KeyRight();
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public void KeyPress(Control c, KeyPressEventArgs e)
+    {
+    }
+
+    /// <inheritdoc />
+    public bool KeyUp(Control c, KeyEventArgs e) => false;
+    #endregion
+
+    #region Implementation
+    private void StartScrollTimer()
+    {
+        if (!CanScrollFurther())
+        {
+            return;
+        }
+
+        StopScrollTimer();
+
+        _scrollTimer = new System.Windows.Forms.Timer
+        {
+            Interval = ScrollRepeatIntervalMs
+        };
+        _scrollTimer.Tick += OnScrollTimerTick;
+        _scrollTimer.Start();
+    }
+
+    private void StopScrollTimer()
+    {
+        if (_scrollTimer != null)
+        {
+            _scrollTimer.Stop();
+            _scrollTimer.Tick -= OnScrollTimerTick;
+            _scrollTimer.Dispose();
+            _scrollTimer = null;
+        }
+    }
+
+    private void OnScrollTimerTick(object? sender, EventArgs e)
+    {
+        if (!CanScrollFurther())
+        {
+            StopScrollTimer();
+            return;
+        }
+
+        ActivateScroll();
+    }
+
+    private bool CanScrollFurther()
+    {
+        ViewLayoutContextMenuOverflowColumn? column = _scrollButton.OverflowColumn;
+        if (column == null)
+        {
+            return false;
+        }
+
+        return _scrollButton.ScrollUp ? column.HasMoreAbove : column.HasMoreBelow(null);
+    }
+
+    private void ActivateScroll()
+    {
+        ViewLayoutContextMenuOverflowColumn? column = _scrollButton.OverflowColumn;
+        if (column == null)
+        {
+            return;
+        }
+
+        if (_scrollButton.ScrollUp)
+        {
+            if (!column.HasMoreAbove)
+            {
+                StopScrollTimer();
+                return;
+            }
+        }
+        else if (!column.HasMoreBelow(null))
+        {
+            StopScrollTimer();
+            return;
+        }
+
+        column.Scroll(_scrollButton.ScrollUp);
+        _needPaint?.Invoke(this, new NeedLayoutEventArgs(true));
+
+        // Items can scroll under the cursor; keep the overflow button active while hovered
+        if (_mouseOver)
+        {
+            ViewManager.SetTarget(this, false);
+        }
+
+        if (!CanScrollFurther())
+        {
+            StopScrollTimer();
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -1,11 +1,11 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -77,6 +77,8 @@ public class KryptonContextMenu : Component,
         LocalCustomPalette = null;
         PaletteMode = PaletteMode.Global;
         Images = new ContextMenuImages(needPaintDelegate);
+        // Note: The PaletteRedirect used here will automatically scale context menu item padding
+        // when touchscreen support is enabled (see PaletteRedirect.GetMetricPadding for details)
         _redirector = new PaletteRedirect(null);
         _redirectorImages = new PaletteRedirectContextMenu(_redirector, Images);
         Enabled = true;
@@ -210,7 +212,7 @@ public class KryptonContextMenu : Component,
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Gets or sets whether overflow scroll rows use arrow glyphs instead of text labels.
+    /// Gets or sets whether overflow scroll rows use arrow glyphs instead of Scroll Up/Scroll Down text.
     /// When null, <see cref="KryptonContextMenuStrings.OverflowScrollUseArrows"/> is used.
     /// </summary>
     [Category(@"Appearance")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -27,6 +27,7 @@ public class KryptonContextMenu : Component,
 {
     #region Instance Fields
     private bool _disposed;
+    private bool? _overflowScrollUseArrows;
     private readonly PaletteRedirectContextMenu _redirectorImages;
     private readonly PaletteRedirect _redirector;
 
@@ -207,6 +208,31 @@ public class KryptonContextMenu : Component,
     [DefaultValue(true)]
     [Bindable(true)]
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether overflow scroll rows use arrow glyphs instead of text labels.
+    /// When null, <see cref="KryptonContextMenuStrings.OverflowScrollUseArrows"/> is used.
+    /// </summary>
+    [Category(@"Appearance")]
+    [Description(@"When set, overflow scroll rows show arrow glyphs instead of text labels. When null, uses global KryptonContextMenuStrings.OverflowScrollUseArrows.")]
+    [DefaultValue(null)]
+    [Bindable(true)]
+    public bool? OverflowScrollUseArrows
+    {
+        get => _overflowScrollUseArrows;
+        set => _overflowScrollUseArrows = value;
+    }
+
+    private bool ShouldSerializeOverflowScrollUseArrows() => _overflowScrollUseArrows.HasValue;
+
+    /// <summary>Resets <see cref="OverflowScrollUseArrows"/> to the global default.</summary>
+    public void ResetOverflowScrollUseArrows() => _overflowScrollUseArrows = null;
+
+    /// <summary>
+    /// Gets the effective overflow scroll arrow setting for this menu.
+    /// </summary>
+    internal bool GetEffectiveOverflowScrollUseArrows() =>
+        _overflowScrollUseArrows ?? KryptonManager.Strings.ContextMenuStrings.OverflowScrollUseArrows;
 
     /// <summary>
     /// Gets or sets the palette to be applied.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -23,7 +23,7 @@ public class VisualContextMenu : VisualPopup
     private readonly ContextMenuProvider _provider;
     private ViewDrawDocker _drawDocker;
     private readonly ViewLayoutStack _viewColumns;
-    private readonly List<ViewLayoutContextMenuOverflowColumn> _overflowColumns = new List<ViewLayoutContextMenuOverflowColumn>();
+    private readonly List<ViewLayoutContextMenuOverflowColumn> _overflowColumns = [];
 
     #endregion
 
@@ -566,7 +566,7 @@ public class VisualContextMenu : VisualPopup
 
     private void WrapOverflowTargets(ViewBase columnRoot, ViewContextMenuManager contextMenuManager)
     {
-        var piles = EnumerateMenuItemPiles(columnRoot).ToList();
+        var piles = EnumerateMenuItemPiles(columnRoot);
         var wrapped = false;
 
         foreach (ViewLayoutMenuItemsPile pile in piles)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -23,6 +23,7 @@ public class VisualContextMenu : VisualPopup
     private readonly ContextMenuProvider _provider;
     private ViewDrawDocker _drawDocker;
     private readonly ViewLayoutStack _viewColumns;
+    private readonly List<ViewLayoutContextMenuOverflowColumn> _overflowColumns = new List<ViewLayoutContextMenuOverflowColumn>();
 
     #endregion
 
@@ -183,6 +184,7 @@ public class VisualContextMenu : VisualPopup
         bool constrain)
     {
         // Find the preferred size of the context menu if it could be any size it likes
+        ClearOverflowHeight();
         Size preferredSize = CalculatePreferredSize();
 
         // Get the working area of the monitor that most of the screen rectangle is inside
@@ -190,6 +192,13 @@ public class VisualContextMenu : VisualPopup
 
         if (constrain)
         {
+            var maxHeight = Math.Min(workingArea.Height, preferredSize.Height);
+            if (preferredSize.Height > maxHeight)
+            {
+                ApplyOverflowHeight(maxHeight);
+                preferredSize = CalculatePreferredSize();
+            }
+
             // Limit size of context menu to the working area
             preferredSize.Width = Math.Min(workingArea.Width, preferredSize.Width);
             preferredSize.Height = Math.Min(workingArea.Height, preferredSize.Height);
@@ -380,6 +389,20 @@ public class VisualContextMenu : VisualPopup
     }
 
     /// <summary>
+    /// Raises the MouseWheel event.
+    /// </summary>
+    /// <param name="e">A MouseEventArgs that contains the event data.</param>
+    protected override void OnMouseWheel(MouseEventArgs e)
+    {
+        if (ScrollMenuByWheel(e.Delta))
+        {
+            return;
+        }
+
+        base.OnMouseWheel(e);
+    }
+
+    /// <summary>
     /// Raises the Layout event.
     /// </summary>
     /// <param name="levent">An EventArgs that contains the event data.</param>
@@ -424,6 +447,8 @@ public class VisualContextMenu : VisualPopup
     {
         // Ask the top level collection to generate the child view elements
         items.GenerateView(_provider, this, _viewColumns, true, true, NeedPaintDelegate);
+
+        WrapColumnsForOverflow();
 
         // Create the control panel canvas
         var mainBackground = new ViewDrawCanvas(_provider.ProviderStateCommon.ControlInner.Back,
@@ -520,6 +545,117 @@ public class VisualContextMenu : VisualPopup
 
         // Kill this pop-up window
         Dispose();
+    }
+
+    private void WrapColumnsForOverflow()
+    {
+        _overflowColumns.Clear();
+
+        if (ViewManager is not ViewContextMenuManager contextMenuManager)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _viewColumns.Count; i++)
+        {
+            WrapOverflowTargets(_viewColumns[i], contextMenuManager);
+        }
+
+        contextMenuManager.OverflowColumns = _overflowColumns;
+    }
+
+    private void WrapOverflowTargets(ViewBase columnRoot, ViewContextMenuManager contextMenuManager)
+    {
+        var piles = EnumerateMenuItemPiles(columnRoot).ToList();
+        var wrapped = false;
+
+        foreach (ViewLayoutMenuItemsPile pile in piles)
+        {
+            WrapItemStack(pile.ItemStack, contextMenuManager);
+            wrapped = true;
+        }
+
+        if (!wrapped && columnRoot is ViewLayoutStack { Horizontal: false } column)
+        {
+            WrapItemStack(column, contextMenuManager);
+        }
+    }
+
+    private static IEnumerable<ViewLayoutMenuItemsPile> EnumerateMenuItemPiles(ViewBase root)
+    {
+        if (root is ViewLayoutMenuItemsPile pile)
+        {
+            yield return pile;
+            yield break;
+        }
+
+        if (root is ViewLayoutStack stack)
+        {
+            foreach (ViewBase child in stack)
+            {
+                foreach (ViewLayoutMenuItemsPile childPile in EnumerateMenuItemPiles(child))
+                {
+                    yield return childPile;
+                }
+            }
+        }
+    }
+
+    private void WrapItemStack(ViewLayoutStack itemStack, ViewContextMenuManager contextMenuManager)
+    {
+        if (itemStack.Count == 0)
+        {
+            return;
+        }
+
+        var overflowColumn = new ViewLayoutContextMenuOverflowColumn(_provider, contextMenuManager,
+            NeedPaintDelegate);
+        overflowColumn.Adopt(itemStack);
+        itemStack.Add(overflowColumn);
+        _overflowColumns.Add(overflowColumn);
+    }
+
+    private void ApplyOverflowHeight(int maxMenuHeight)
+    {
+        using var context = new ViewLayoutContext(ViewManager, this, this, Renderer);
+        var columnsHeight = _viewColumns.GetPreferredSize(context).Height;
+        var rootHeight = ViewManager!.Root!.GetPreferredSize(context).Height;
+        var chromeHeight = Math.Max(0, rootHeight - columnsHeight);
+        var contentHeight = Math.Max(1, maxMenuHeight - chromeHeight);
+
+        foreach (ViewLayoutContextMenuOverflowColumn column in _overflowColumns)
+        {
+            column.SetMaxContentHeight(contentHeight, context);
+        }
+    }
+
+    private void ClearOverflowHeight()
+    {
+        foreach (ViewLayoutContextMenuOverflowColumn column in _overflowColumns)
+        {
+            column.ClearMaxContentHeight();
+        }
+    }
+
+    private bool ScrollMenuByWheel(int delta)
+    {
+        if (delta == 0 || _overflowColumns.Count == 0)
+        {
+            return false;
+        }
+
+        var scrolled = false;
+        foreach (ViewLayoutContextMenuOverflowColumn column in _overflowColumns)
+        {
+            scrolled |= column.ScrollByWheel(delta);
+        }
+
+        if (scrolled)
+        {
+            PerformNeedPaint(true);
+        }
+
+        return scrolled;
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -389,6 +389,28 @@ public class VisualContextMenu : VisualPopup
     }
 
     /// <summary>
+    /// Processes Windows messages.
+    /// </summary>
+    /// <param name="m">The Windows Message to process.</param>
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == PI.WM_.MOUSEWHEEL)
+        {
+            var screenPt = new Point(PI.LOWORD((int)m.LParam), PI.HIWORD((int)m.LParam));
+            if (ClientRectangle.Contains(PointToClient(screenPt)))
+            {
+                var delta = (short)PI.HIWORD((int)m.WParam);
+                if (ScrollMenuByWheel(delta))
+                {
+                    return;
+                }
+            }
+        }
+
+        base.WndProc(ref m);
+    }
+
+    /// <summary>
     /// Raises the MouseWheel event.
     /// </summary>
     /// <param name="e">A MouseEventArgs that contains the event data.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
@@ -444,6 +444,8 @@ public class VisualPopupManager : IMessageFilter
                 case PI.WM_.MOUSEMOVE:
                 case PI.WM_.NCMOUSEMOVE:
                     return ProcessMouseMove(ref m);
+                case PI.WM_.MOUSEWHEEL:
+                    return ProcessMouseWheel(ref m);
                 case PI.WM_.LBUTTONDOWN:
                 case PI.WM_.RBUTTONDOWN:
                 case PI.WM_.MBUTTONDOWN:
@@ -603,6 +605,28 @@ public class VisualPopupManager : IMessageFilter
         }
 
         return processed;
+    }
+
+    private bool ProcessMouseWheel(ref Message m)
+    {
+        if (CurrentPopup is not VisualContextMenu contextMenu)
+        {
+            return false;
+        }
+
+        var screenPt = new Point(PI.LOWORD((int)m.LParam), PI.HIWORD((int)m.LParam));
+        if (!contextMenu.ClientRectangle.Contains(contextMenu.PointToClient(screenPt)))
+        {
+            return false;
+        }
+
+        if (m.HWnd == contextMenu.Handle)
+        {
+            return false;
+        }
+
+        PI.SendMessage(contextMenu.Handle, m.Msg, m.WParam, m.LParam);
+        return true;
     }
 
     private bool ProcessMouseMove(ref Message m)

--- a/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
@@ -71,6 +71,7 @@ public class ContextMenuProvider : IContextMenuProvider
         ProviderNeedPaintDelegate = needPaintDelegate;
         ProviderShowHorz = provider.ProviderShowHorz;
         ProviderShowVert = provider.ProviderShowVert;
+        ProviderOverflowScrollUseArrows = provider.ProviderOverflowScrollUseArrows;
     }
 
     /// <summary>
@@ -112,6 +113,7 @@ public class ContextMenuProvider : IContextMenuProvider
         ProviderRedirector = redirector;
         ProviderNeedPaintDelegate = needPaintDelegate;
         ProviderCanCloseMenu = true;
+        ProviderOverflowScrollUseArrows = contextMenu.GetEffectiveOverflowScrollUseArrows();
     }
 
     /// <summary>
@@ -160,6 +162,7 @@ public class ContextMenuProvider : IContextMenuProvider
         ProviderPaletteMode = paletteMode;
         ProviderRedirector = redirector;
         ProviderNeedPaintDelegate = needPaintDelegate;
+        ProviderOverflowScrollUseArrows = KryptonManager.Strings.ContextMenuStrings.OverflowScrollUseArrows;
     }
     #endregion
 
@@ -321,6 +324,9 @@ public class ContextMenuProvider : IContextMenuProvider
     /// Gets a delegate used to indicate a repaint is required.
     /// </summary>
     public NeedPaintHandler ProviderNeedPaintDelegate { get; }
+
+    /// <inheritdoc />
+    public bool ProviderOverflowScrollUseArrows { get; }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -4,7 +4,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Gidua, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Gidua, Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  */
 #endregion
 
@@ -59,6 +59,48 @@ public interface IContentValues
     /// </summary>
     /// <returns>String value.</returns>
     string GetLongText();
+
+    /// <summary>
+    /// Gets the overlay image.
+    /// </summary>
+    /// <param name="state">The state for which the overlay image is needed.</param>
+    /// <returns>Overlay image value, or null if no overlay image is set.</returns>
+    Image? GetOverlayImage(PaletteState state);
+
+    /// <summary>
+    /// Gets the overlay image color that should be transparent.
+    /// </summary>
+    /// <param name="state">The state for which the overlay image is needed.</param>
+    /// <returns>Color value.</returns>
+    Color GetOverlayImageTransparentColor(PaletteState state);
+
+    /// <summary>
+    /// Gets the position of the overlay image relative to the main image.
+    /// </summary>
+    /// <param name="state">The state for which the overlay position is needed.</param>
+    /// <returns>Overlay image position.</returns>
+    OverlayImagePosition GetOverlayImagePosition(PaletteState state);
+
+    /// <summary>
+    /// Gets the scaling mode for the overlay image.
+    /// </summary>
+    /// <param name="state">The state for which the overlay scale mode is needed.</param>
+    /// <returns>Overlay image scale mode.</returns>
+    OverlayImageScaleMode GetOverlayImageScaleMode(PaletteState state);
+
+    /// <summary>
+    /// Gets the scale factor for the overlay image (used when scale mode is Percentage or ProportionalToMain).
+    /// </summary>
+    /// <param name="state">The state for which the overlay scale factor is needed.</param>
+    /// <returns>Scale factor (0.0 to 2.0).</returns>
+    float GetOverlayImageScaleFactor(PaletteState state);
+
+    /// <summary>
+    /// Gets the fixed size for the overlay image (used when scale mode is FixedSize).
+    /// </summary>
+    /// <param name="state">The state for which the overlay fixed size is needed.</param>
+    /// <returns>Fixed size for the overlay image.</returns>
+    Size GetOverlayImageFixedSize(PaletteState state);
 }
 #endregion
 
@@ -324,7 +366,7 @@ public interface IContextMenuProvider
     NeedPaintHandler ProviderNeedPaintDelegate { get; }
 
     /// <summary>
-    /// Gets a value indicating whether overflow scroll rows use arrow glyphs instead of text labels.
+    /// Gets a value indicating whether overflow scroll rows use arrow glyphs instead of Scroll Up/Scroll Down text.
     /// </summary>
     bool ProviderOverflowScrollUseArrows { get; }
 }
@@ -1085,6 +1127,114 @@ public enum ButtonCheckState
 }
 #endregion
 
+#region Enum BadgePosition
+
+/// <summary>
+/// Specifies the position of a badge on a button.
+/// </summary>
+public enum BadgePosition
+{
+    /// <summary>
+    /// Specifies the badge is positioned in the top-right corner.
+    /// </summary>
+    TopRight,
+
+    /// <summary>
+    /// Specifies the badge is positioned in the top-left corner.
+    /// </summary>
+    TopLeft,
+
+    /// <summary>
+    /// Specifies the badge is positioned in the bottom-right corner.
+    /// </summary>
+    BottomRight,
+
+    /// <summary>
+    /// Specifies the badge is positioned in the bottom-left corner.
+    /// </summary>
+    BottomLeft
+}
+
+#endregion
+
+#region Enum BadgeShape
+
+/// <summary>
+/// Specifies the shape of a badge.
+/// </summary>
+public enum BadgeShape
+{
+    /// <summary>
+    /// Specifies a circular badge.
+    /// </summary>
+    Circle,
+
+    /// <summary>
+    /// Specifies a square badge.
+    /// </summary>
+    Square,
+
+    /// <summary>
+    /// Specifies a rounded rectangle badge.
+    /// </summary>
+    RoundedRectangle,
+
+    /// <summary>
+    /// Specifies a capsule (pill-shaped) badge with fully rounded ends.
+    /// </summary>
+    Capsule
+}
+
+#endregion
+
+#region Enum BadgeAnimation
+
+/// <summary>
+/// Specifies the animation type for a badge.
+/// </summary>
+public enum BadgeAnimation
+{
+    /// <summary>
+    /// No animation.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Fade in and out animation.
+    /// </summary>
+    FadeInOut,
+
+    /// <summary>
+    /// Pulsing animation (scale and opacity).
+    /// </summary>
+    Pulse
+}
+
+#endregion
+
+#region Enum BadgeBevelType
+/// <summary>
+/// Specifies the type of bevel effect for badge borders.
+/// </summary>
+public enum BadgeBevelType
+{
+    /// <summary>
+    /// No bevel effect.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Raised bevel effect (light top/left edges, dark bottom/right edges).
+    /// </summary>
+    Raised,
+
+    /// <summary>
+    /// Inset/embedded bevel effect (dark top/left edges, light bottom/right edges).
+    /// </summary>
+    Inset
+}
+#endregion
+
 #region Enum RelativeEdgeAlign
 /// <summary>
 /// Specifies a relative edge alignment position.
@@ -1782,7 +1932,22 @@ public enum CheckedSelectionMode
     /// <summary>
     /// Only one item can be selected.
     /// </summary>
-    One = 1
+    One = 1,
+
+    /// <summary>
+    /// Multiple items can be selected with simple click selection.
+    /// </summary>
+    MultiSimple = 2,
+
+    /// <summary>
+    /// Multiple items can be selected with extended selection (Ctrl/Shift keys).
+    /// </summary>
+    MultiExtended = 3,
+
+    /// <summary>
+    /// Only one item can be checked at a time (radio button behavior).
+    /// </summary>
+    Radio = 4
 }
 #endregion
 
@@ -2111,226 +2276,6 @@ public enum KryptonMessageBoxResult
 
 #endregion
 
-#region Toast Definitions
-
-#region Enum KryptonToastNotificationIcon
-
-[TypeConverter(typeof(KryptonToastNotificationIconConverter))]
-public enum KryptonToastNotificationIcon
-{
-    /// <summary>Specify no icon.</summary>
-    None = 0,
-
-    /// <summary>Specify a hand icon.</summary>
-    Hand = 1,
-
-    /// <summary>Specify the system hand icon.</summary>
-    SystemHand = MessageBoxIcon.Hand,
-
-    /// <summary>Specify a question icon.</summary>
-    Question = 2,
-
-    /// <summary>Specify the system question icon.</summary>
-    SystemQuestion = MessageBoxIcon.Question,
-
-    /// <summary>Specify an exclamation icon.</summary>
-    Exclamation = 3,
-
-    /// <summary>Specify the system exclamation icon.</summary>
-    SystemExclamation = MessageBoxIcon.Exclamation,
-
-    /// <summary>Specify an asterisk icon.</summary>
-    Asterisk = 4,
-
-    /// <summary>Specify the system asterisk icon.</summary>
-    SystemAsterisk = MessageBoxIcon.Asterisk,
-
-    /// <summary>Specify a stop icon.</summary>
-    Stop = 5,
-
-    /// <summary>Specify the system stop icon.</summary>
-    SystemStop = MessageBoxIcon.Stop,
-
-    /// <summary>Specify a error icon.</summary>
-    Error = 6,
-
-    /// <summary>Specify the system error icon.</summary>
-    SystemError = MessageBoxIcon.Error,
-
-    /// <summary>Specify a warning icon.</summary>
-    Warning = 7,
-
-    /// <summary>Specify the system warning icon.</summary>
-    SystemWarning = MessageBoxIcon.Warning,
-
-    /// <summary>Specify an information icon.</summary>
-    Information = 8,
-
-    /// <summary>Specify the system information icon.</summary>
-    SystemInformation = MessageBoxIcon.Information,
-
-    /// <summary>Specify a UAC shield icon.</summary>
-    Shield = 9,
-
-    /// <summary>Specify a Windows logo icon.</summary>
-    WindowsLogo = 10,
-
-    /// <summary>Specify your application icon.</summary>
-    Application = 11,
-
-    /// <summary>Specify the default system application icon. See <see cref="SystemIcons.Application"/>.</summary>
-    SystemApplication = 12,
-
-    /// <summary>Specify an ok icon.</summary>
-    Ok = 13,
-
-    /// <summary>Specify a custom icon.</summary>
-    Custom = 14
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationContentAreaType
-
-public enum KryptonToastNotificationContentAreaType
-{
-    RichTextBox = 0,
-    MultiLineTextBox = 1,
-    WrapLinkLabel = 2,
-    WrapLabel = 3
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationInputAreaType
-
-public enum KryptonToastNotificationInputAreaType
-{
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonComboBox"/> user input.</summary>
-    ComboBox = 0,
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonDateTimePicker"/> user input.</summary>
-    DateTime = 1,
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonDomainUpDown"/> user input.</summary>
-    DomainUpDown = 2,
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonNumericUpDown"/> user input.</summary>
-    NumericUpDown = 3,
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonMaskedTextBox"/> user input.</summary>
-    MaskedTextBox = 4,
-    /// <summary>A <see cref="KryptonToastNotification"/> with a <see cref="KryptonTextBox"/> user input.</summary>
-    TextBox = 5
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationActionButton
-
-public enum KryptonToastNotificationActionButton
-{
-    Button1 = 0,
-    Button2 = 1
-    //Button3 = 2
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationActionType
-
-public enum KryptonToastNotificationActionType
-{
-    Default = 0,
-    Dismiss = 1,
-    LaunchProcess = 2,
-    Open = 3
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationDismissButtonLocation
-
-public enum KryptonToastNotificationDismissButtonLocation
-{
-    Left = 0,
-    Right = 1
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationAlignment
-
-public enum KryptonToastNotificationAlignment
-{
-    LeftToRight = 0,
-    RightToLeft = 1
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationResponseType
-
-public enum KryptonToastNotificationResponseType
-{
-    /// <summary>Returns a <see cref="bool"/> result.</summary>
-    Bool = 0,
-    /// <summary>Returns a <see cref="CheckBoxState"/> result.</summary>
-    CheckedState = 1,
-    /// <summary>Returns what ever value is selected in the <see cref="KryptonComboBox"/>.</summary>
-    ComboBox = 2,
-    /// <summary>Returns a <see cref="System.DateTime"/> result.</summary>
-    DateTime = 3,
-    /// <summary>Returns a <see cref="System.Windows.Forms.DialogResult"/> result.</summary>
-    DialogResult = 4,
-    /// <summary>Returns a time-out result.</summary>
-    Timeout = 5,
-    /// <summary>Returns a <see cref="string"/> result.</summary>
-    String = 6
-}
-
-#endregion
-
-#region Enum KryptonToastNotificationType
-
-public enum KryptonToastNotificationType
-{
-    Basic = 0,
-    BasicWithProgressBar = 1,
-    UserInput = 2,
-    UserInputWithProgressBar = 3
-}
-
-#endregion
-
-#region KryptonToastNotificationResult
-
-/// <summary>
-/// Options for the <see cref="KryptonToastNotification"/>.
-/// </summary>
-public enum KryptonToastNotificationResult
-{
-    None = DialogResult.None,
-    Ok = DialogResult.OK,
-    Cancel = DialogResult.Cancel,
-    Abort = DialogResult.Abort,
-    Retry = DialogResult.Retry,
-    Ignore = DialogResult.Ignore,
-    Yes = DialogResult.Yes,
-    No = DialogResult.No,
-    Close = 8,
-    Help = 9,
-#if NET8_0_OR_GREATER
-        TryAgain = DialogResult.TryAgain,
-        Continue = DialogResult.Continue,
-#else
-    TryAgain = 10,
-    Continue = 11,
-#endif
-    TimeOut = 12,
-    DoNotShowAgain = 13
-}
-
-#endregion
-
-#endregion
-
 #region Enum ToolkitSupportType
 
 /// <summary>
@@ -2355,46 +2300,6 @@ public enum ToolkitSupportType
     /// </summary>
     LongTermSupport = 3
 }
-
-#endregion
-
-#region AboutBox Definitions
-
-#region Enum AboutToolkitPage
-
-internal enum AboutToolkitPage
-{
-    GeneralInformation = 0,
-    Discord = 1,
-    DeveloperInformation = 2,
-    Versions = 3
-}
-
-#endregion
-
-#region Enum AboutBoxFileInformationPage
-
-public enum AboutBoxFileInformationPage
-{
-    Application = 0,
-    Assemblies = 1,
-    AssemblyDetails = 2
-}
-
-#endregion
-
-#region Enum AboutBoxPage
-
-public enum AboutBoxPage
-{
-    GeneralInformation = 0,
-    Description = 1,
-    FileInformation = 2,
-    Theme = 3,
-    ToolkitInformation = 4
-}
-
-#endregion
 
 #endregion
 
@@ -4428,6 +4333,61 @@ public enum IconSelectionStrategy
 
 #endregion
 
+#region Enum Error Provider Icon Types
+
+/// <summary>
+/// Defines the icon types supported by the error provider border helper.
+/// </summary>
+public enum ErrorProviderIconType
+{
+    /// <summary>
+    /// Error icon type (red border).
+    /// </summary>
+    Error = 0,
+
+    /// <summary>
+    /// Warning icon type (yellow/orange border).
+    /// </summary>
+    Warning = 1,
+
+    /// <summary>
+    /// Information icon type (blue border).
+    /// </summary>
+    Information = 2
+}
+
+#endregion
+
+#region Enum File System Root Mode
+
+/// <summary>
+/// Specifies the root display mode for the file system tree view.
+/// </summary>
+public enum FileSystemRootMode
+{
+    /// <summary>
+    /// Displays Desktop as root with special folders (Computer, Network, Recycle Bin, etc.) and drives, similar to Windows Explorer.
+    /// </summary>
+    Desktop,
+
+    /// <summary>
+    /// Displays Computer as root with all drives.
+    /// </summary>
+    Computer,
+
+    /// <summary>
+    /// Displays all drives directly as root nodes.
+    /// </summary>
+    Drives,
+
+    /// <summary>
+    /// Uses the custom RootPath property to determine the root directory.
+    /// </summary>
+    CustomPath
+}
+
+#endregion
+
 #region IFocusLostMenuItem
 /// <summary>
 /// This interface can be implemented by any (derived) control or component that needs focus handling via the FocusLostMenuHelper.
@@ -4451,4 +4411,108 @@ public interface IFocusLostMenuItem
     /// </summary>
     void ProcessItem();
 }
+#endregion
+
+#region Enum OverlayImagePosition
+/// <summary>
+/// Specifies the position of an overlay image relative to the main image.
+/// </summary>
+public enum OverlayImagePosition
+{
+    /// <summary>
+    /// Specifies the overlay image is positioned at the top-left corner.
+    /// </summary>
+    TopLeft,
+
+    /// <summary>
+    /// Specifies the overlay image is positioned at the top-right corner.
+    /// </summary>
+    TopRight,
+
+    /// <summary>
+    /// Specifies the overlay image is positioned at the bottom-left corner.
+    /// </summary>
+    BottomLeft,
+
+    /// <summary>
+    /// Specifies the overlay image is positioned at the bottom-right corner.
+    /// </summary>
+    BottomRight
+}
+#endregion
+
+#region Enum OverlayImageScaleMode
+/// <summary>
+/// Specifies how an overlay image should be scaled relative to the main image.
+/// </summary>
+public enum OverlayImageScaleMode
+{
+    /// <summary>
+    /// Use the actual size of the overlay image without scaling.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Scale the overlay image as a percentage of the main image size.
+    /// </summary>
+    Percentage,
+
+    /// <summary>
+    /// Scale the overlay image to a fixed size.
+    /// </summary>
+    FixedSize,
+
+    /// <summary>
+    /// Scale the overlay image proportionally to maintain aspect ratio, using the smaller dimension of the main image as reference.
+    /// </summary>
+    ProportionalToMain
+}
+#endregion
+
+#region Enum ScrollbarManagerMode
+
+/// <summary>
+/// Specifies the integration mode for the scrollbar manager.
+/// </summary>
+public enum ScrollbarManagerMode
+{
+    /// <summary>
+    /// Container mode - for controls like Panel, GroupBox that use AutoScroll.
+    /// </summary>
+    Container,
+
+    /// <summary>
+    /// Native wrapper mode - for controls like TextBox, RichTextBox with native scrollbars.
+    /// </summary>
+    NativeWrapper,
+
+    /// <summary>
+    /// Custom mode - for controls with custom scrolling logic.
+    /// </summary>
+    Custom
+}
+
+#endregion
+
+#region Enum KryptonTaskbarProgressState
+
+/// <summary>Specifies the state of the taskbar progress indicator when <see cref="KryptonProgressBar.UseTaskbarProgress"/> is enabled.</summary>
+public enum KryptonTaskbarProgressState
+{
+    /// <summary>No progress indicator is shown. Equivalent to <c>TBPF_NOPROGRESS</c>.</summary>
+    NoProgress = 0,
+
+    /// <summary>A pulsing green indicator is shown without a specific value. Equivalent to <c>TBPF_INDETERMINATE</c>.</summary>
+    Indeterminate = 1,
+
+    /// <summary>A green progress indicator shows the current completion amount. Equivalent to <c>TBPF_NORMAL</c>.</summary>
+    Normal = 2,
+
+    /// <summary>A red progress indicator shows that an error has occurred. Equivalent to <c>TBPF_ERROR</c>.</summary>
+    Error = 4,
+
+    /// <summary>A yellow progress indicator shows that the operation has been paused. Equivalent to <c>TBPF_PAUSED</c>.</summary>
+    Paused = 8
+}
+
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -322,6 +322,11 @@ public interface IContextMenuProvider
     /// Gets a delegate used to indicate a repaint is required.
     /// </summary>
     NeedPaintHandler ProviderNeedPaintDelegate { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether overflow scroll rows use arrow glyphs instead of text labels.
+    /// </summary>
+    bool ProviderOverflowScrollUseArrows { get; }
 }
 #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonGlobalToolkitStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonGlobalToolkitStrings.cs
@@ -184,6 +184,11 @@ public class KryptonGlobalToolkitStrings : GlobalId
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public static KryptonScrollBarStrings KryptonScrollBarStrings { get; } = new KryptonScrollBarStrings();
 
+    /// <summary>Gets the context menu strings.</summary>
+    /// <value>The context menu strings.</value>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public static KryptonContextMenuStrings KryptonContextMenuStrings { get; } = new KryptonContextMenuStrings();
+
     /// <summary>Gets the toast notification strings.</summary>
     /// <value>The toast notification strings.</value>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -530,6 +535,17 @@ public class KryptonGlobalToolkitStrings : GlobalId
     private bool ShouldSerializeScrollBarStrings() => !KryptonScrollBarStrings.IsDefault;
     private void ResetScrollBarStrings() => KryptonScrollBarStrings.Reset();
 
+    /// <summary>Gets the context menu strings.</summary>
+    /// <value>The context menu strings.</value>
+    [Category(@"Visuals")]
+    [Description(@"Collection of context menu strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public KryptonContextMenuStrings ContextMenuStrings => KryptonContextMenuStrings;
+    private bool ShouldSerializeContextMenuStrings() => !KryptonContextMenuStrings.IsDefault;
+    private void ResetContextMenuStrings() => KryptonContextMenuStrings.Reset();
+
     /// <summary>Gets the data grid view strings.</summary>
     /// <value>The data grid view strings.</value>
     [Category(@"Visuals")]
@@ -706,7 +722,8 @@ public class KryptonGlobalToolkitStrings : GlobalId
                                ShouldSerializePaletteImageEffectStrings() ||
                                ShouldSerializePaletteImageStyleStrings() || ShouldSerializePaletteModeStrings() ||
                                ShouldSerializePaletteTextTrimStrings() || ShouldSerializePlacementModeStrings() ||
-                               ShouldSerializeScrollBarStrings() || ShouldSerializeSeparatorStyleStrings() ||
+                               ShouldSerializeScrollBarStrings() || ShouldSerializeContextMenuStrings() ||
+                               ShouldSerializeSeparatorStyleStrings() ||
                                ShouldSerializeToastNotificationIconStrings() ||
                                ShouldSerializeTabBorderStyleStrings() || ShouldSerializeTabStyleStrings() ||
                                ShouldSerializeToastNotificationStrings() || ShouldSerializeToolBarStrings() ||
@@ -744,6 +761,7 @@ public class KryptonGlobalToolkitStrings : GlobalId
         ResetPaletteTextTrimStrings();
         ResetPlacementModeStrings();
         ResetScrollBarStrings();
+        ResetContextMenuStrings();
         ResetSeparatorStyleStrings();
         ResetTabBorderStyleStrings();
         ResetTabStyleStrings();

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonGlobalToolkitStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonGlobalToolkitStrings.cs
@@ -1,8 +1,8 @@
-﻿#region BSD License
+#region BSD License
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2023 - 2026. All rights reserved. 
  *  
  */
 #endregion
@@ -45,6 +45,11 @@ public class KryptonGlobalToolkitStrings : GlobalId
     /// <value>The grid view style strings.</value>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public static DataGridViewStyleStrings DataGridViewStyles { get; } = new DataGridViewStyleStrings();
+
+    /// <summary>Gets the file system list view strings.</summary>
+    /// <value>The file system list view strings.</value>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public static KryptonFileSystemListViewStrings KryptonFileSystemListViewStrings { get; } = new KryptonFileSystemListViewStrings();
 
     /// <summary>Gets the style strings.</summary>
     /// <value>The style strings.</value>
@@ -163,6 +168,11 @@ public class KryptonGlobalToolkitStrings : GlobalId
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public static KryptonAboutBoxBasicApplicationInformationStrings KryptonAboutBoxBasicApplicationInformationStrings { get; } = new KryptonAboutBoxBasicApplicationInformationStrings();
 
+    /// <summary>Gets the bug reporting dialog strings.</summary>
+    /// <value>The bug reporting dialog strings.</value>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public static KryptonBugReportingDialogStrings KryptonBugReportingDialogStrings { get; } = new KryptonBugReportingDialogStrings();
+
     /// <summary>Gets the about box strings.</summary>
     /// <value>The about box strings.</value>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -178,6 +188,9 @@ public class KryptonGlobalToolkitStrings : GlobalId
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public static KryptonMiscellaneousThemeStrings KryptonMiscellaneousThemeStrings { get; } =
         new KryptonMiscellaneousThemeStrings();
+
+    public static KryptonPrintPreviewDialogStrings KryptonPrintPreviewDialogStrings { get; } =
+        new KryptonPrintPreviewDialogStrings();
 
     /// <summary>Gets the scroll bar strings.</summary>
     /// <value>The scroll bar strings.</value>
@@ -219,6 +232,11 @@ public class KryptonGlobalToolkitStrings : GlobalId
     /// <value>The win32 system menu strings.</value>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public static SystemMenuStrings Win32SystemMenuStrings { get; } = new SystemMenuStrings();
+
+    /// <summary>Gets the form title bar strings.</summary>
+    /// <value>The form title bar strings.</value>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public static FormTitleBarStrings FormTitleBarStrings { get; } = new FormTitleBarStrings();
 
     #endregion
 
@@ -334,6 +352,17 @@ public class KryptonGlobalToolkitStrings : GlobalId
     private bool ShouldSerializeGeneralStrings() => !GeneralToolkitStrings.IsDefault;
     private void ResetGeneralStrings() => GeneralToolkitStrings.Reset();
 
+    [Category(@"Visuals")]
+    [Description(@"Collection of file system list view strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public KryptonFileSystemListViewStrings FileSystemListViewStrings => KryptonFileSystemListViewStrings;
+
+    private bool ShouldSerializeFileSystemListViewStrings() => !KryptonFileSystemListViewStrings.IsDefault;
+
+    private void ResetFileSystemListViewStrings() => KryptonFileSystemListViewStrings.Reset();
+
     /// <summary>Gets the integrated toolbar button strings.</summary>
     /// <value>The integrated toolbar button strings.</value>
     [Category(@"Visuals")]
@@ -344,6 +373,19 @@ public class KryptonGlobalToolkitStrings : GlobalId
     public IntegratedToolBarStrings ToolBarStrings => IntegratedToolBarStrings;
     private bool ShouldSerializeToolBarStrings() => !IntegratedToolBarStrings.IsDefault;
     private void ResetToolBarStrings() => IntegratedToolBarStrings.Reset();
+
+    /// <summary>Gets the form title bar strings.</summary>
+    /// <value>The form title bar strings.</value>
+    [Category(@"Visuals")]
+    [Description(@"Collection of form title bar strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public FormTitleBarStrings TitleBarStrings => FormTitleBarStrings;
+
+    private bool ShouldSerializeTitleBarStrings() => !FormTitleBarStrings.IsDefault;
+
+    private void ResetTitleBarStrings() => FormTitleBarStrings.Reset();
 
     /// <summary>Gets the link behavior style strings.</summary>
     /// <value>The link behavior style strings.</value>
@@ -491,6 +533,20 @@ public class KryptonGlobalToolkitStrings : GlobalId
     private bool ShouldSerializeAboutBoxBasicStrings() => !KryptonAboutBoxBasicApplicationInformationStrings.IsDefault;
     private void ResetAboutBoxBasicStrings() => KryptonAboutBoxBasicApplicationInformationStrings.Reset();
 
+    /// <summary>Gets the krypton bug reporting dialog strings.</summary>
+    /// <value>The krypton bug reporting dialog strings.</value>
+    [Category(@"Visuals")]
+    [Description(@"Collection of bug reporting dialog strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public KryptonBugReportingDialogStrings BugReportingDialogStrings => KryptonBugReportingDialogStrings;
+
+    private bool ShouldSerializeBugReportingDialogStrings() => !KryptonBugReportingDialogStrings.IsDefault;
+
+    /// <summary>Resets the krypton bug reporting dialog strings.</summary>
+    private void ResetBugReportingDialogStrings() => KryptonBugReportingDialogStrings.Reset();
+
     /// <summary>Gets the krypton about box strings.</summary>
     /// <value>The krypton about box strings.</value>
     [Category(@"Visuals")]
@@ -512,6 +568,17 @@ public class KryptonGlobalToolkitStrings : GlobalId
     public KryptonExceptionDialogStrings ExceptionDialogStrings => KryptonExceptionDialogStrings;
     private bool ShouldSerializeExceptionDialogStrings() => !KryptonExceptionDialogStrings.IsDefault;
     private void ResetExceptionDialogStrings() => KryptonExceptionDialogStrings.Reset();
+
+    /// <summary>Gets the krypton print preview dialog strings.</summary>
+    /// <value>The krypton print preview dialog strings.</value>
+    [Category(@"Visuals")]
+    [Description(@"Collection of print preview dialog strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public KryptonPrintPreviewDialogStrings PrintPreviewDialogStrings => KryptonPrintPreviewDialogStrings;
+    private bool ShouldSerializePrintPreviewDialogStrings() => !KryptonPrintPreviewDialogStrings.IsDefault;
+    private void ResetMiscellaneousPrintPreviewDialogStrings() => KryptonPrintPreviewDialogStrings.Reset();
 
     /// <summary>Gets the krypton miscellaneous theme strings.</summary>
     /// <value>The krypton miscellaneous theme strings.</value>
@@ -706,11 +773,13 @@ public class KryptonGlobalToolkitStrings : GlobalId
     [EditorBrowsable(EditorBrowsableState.Never)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsDefault => !(ShouldSerializeAboutBoxBasicStrings() || ShouldSerializeAboutBoxStrings() ||
-                               ShouldSerializeExceptionDialogStrings() ||
+                               ShouldSerializeBugReportingDialogStrings() ||
+                               ShouldSerializeExceptionDialogStrings() || ShouldSerializePrintPreviewDialogStrings() ||
                                ShouldSerializeBackStyleStrings() || ShouldSerializeBorderStyleStrings() ||
                                ShouldSerializeButtonOrientationStrings() ||
                                ShouldSerializeButtonSpecStyleStrings() || ShouldSerializeButtonStyleStrings() ||
                                ShouldSerializeColorStrings() || ShouldSerializeCustomStrings() ||
+                               ShouldSerializeFileSystemListViewStrings() ||
                                ShouldSerializeGeneralRibbonStrings() || ShouldSerializeGeneralStrings() ||
                                ShouldSerializeGridStyleStrings() || ShouldSerializeGridViewStyleStrings() ||
                                ShouldSerializeHeaderGroupCollapsedTargetStrings() ||
@@ -727,14 +796,16 @@ public class KryptonGlobalToolkitStrings : GlobalId
                                ShouldSerializeToastNotificationIconStrings() ||
                                ShouldSerializeTabBorderStyleStrings() || ShouldSerializeTabStyleStrings() ||
                                ShouldSerializeToastNotificationStrings() || ShouldSerializeToolBarStrings() ||
-                               ShouldSerializeSplashScreenStringsStrings() || ShouldSerializeMiscellaneousStrings() || 
-                               ShouldSerializeMessageBoxStringsStrings() || ShouldSerializeSystemMenuStrings());
+                               ShouldSerializeSplashScreenStringsStrings() || ShouldSerializeMiscellaneousStrings() ||
+                               ShouldSerializeMessageBoxStringsStrings() || ShouldSerializeSystemMenuStrings() ||
+                               ShouldSerializeTitleBarStrings());
 
     /// <summary>Resets this instance.</summary>
     public void Reset()
     {
         ResetAboutBoxBasicStrings();
         ResetAboutBoxStrings();
+        ResetBugReportingDialogStrings();
         ResetExceptionDialogStrings();
         ResetBackStyleStrings();
         ResetBorderStyleStrings();
@@ -743,6 +814,8 @@ public class KryptonGlobalToolkitStrings : GlobalId
         ResetButtonStyleStrings();
         ResetColorStrings();
         ResetCustomStrings();
+        ResetFileSystemListViewStrings();
+        ResetMiscellaneousPrintPreviewDialogStrings();
         ResetGeneralRibbonStrings();
         ResetGeneralStrings();
         ResetGridStyleStrings();
@@ -773,6 +846,7 @@ public class KryptonGlobalToolkitStrings : GlobalId
         ResetMessageBoxStrings();
         ResetSearchBoxStrings();
         ResetSystemMenuStrings();
+        ResetTitleBarStrings();
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonContextMenuStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonContextMenuStrings.cs
@@ -1,0 +1,108 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>Exposes the set of <see cref="KryptonContextMenu"/> strings used within Krypton and that are localizable.</summary>
+[TypeConverter(typeof(ExpandableObjectConverter))]
+public class KryptonContextMenuStrings : GlobalId
+{
+    #region Static Strings
+
+    private const string DEFAULT_OVERFLOW_SCROLL_UP = @"Scroll Up";
+    private const string DEFAULT_OVERFLOW_SCROLL_DOWN = @"Scroll Down";
+    private const string DEFAULT_OVERFLOW_SCROLL_UP_ARROW = "\u25B2";
+    private const string DEFAULT_OVERFLOW_SCROLL_DOWN_ARROW = "\u25BC";
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>Initializes a new instance of the <see cref="KryptonContextMenuStrings" /> class.</summary>
+    public KryptonContextMenuStrings()
+    {
+        Reset();
+    }
+
+    public override string ToString() => !IsDefault ? "Modified" : string.Empty;
+
+    #endregion
+
+    #region Public
+
+    /// <summary>Gets a value indicating whether this instance is default.</summary>
+    [Browsable(false)]
+    public bool IsDefault => OverflowScrollUp.Equals(DEFAULT_OVERFLOW_SCROLL_UP) &&
+                             OverflowScrollDown.Equals(DEFAULT_OVERFLOW_SCROLL_DOWN) &&
+                             !OverflowScrollUseArrows &&
+                             OverflowScrollUpArrow.Equals(DEFAULT_OVERFLOW_SCROLL_UP_ARROW) &&
+                             OverflowScrollDownArrow.Equals(DEFAULT_OVERFLOW_SCROLL_DOWN_ARROW);
+
+    /// <summary>Resets this instance.</summary>
+    public void Reset()
+    {
+        OverflowScrollUp = DEFAULT_OVERFLOW_SCROLL_UP;
+        OverflowScrollDown = DEFAULT_OVERFLOW_SCROLL_DOWN;
+        OverflowScrollUseArrows = false;
+        OverflowScrollUpArrow = DEFAULT_OVERFLOW_SCROLL_UP_ARROW;
+        OverflowScrollDownArrow = DEFAULT_OVERFLOW_SCROLL_DOWN_ARROW;
+    }
+
+    /// <summary>Gets or sets the overflow scroll up row label when <see cref="OverflowScrollUseArrows"/> is false.</summary>
+    [Category(@"Visuals")]
+    [Description(@"The overflow scroll up row label when OverflowScrollUseArrows is false.")]
+    [DefaultValue(DEFAULT_OVERFLOW_SCROLL_UP)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string OverflowScrollUp { get; set; }
+
+    /// <summary>Gets or sets the overflow scroll down row label when <see cref="OverflowScrollUseArrows"/> is false.</summary>
+    [Category(@"Visuals")]
+    [Description(@"The overflow scroll down row label when OverflowScrollUseArrows is false.")]
+    [DefaultValue(DEFAULT_OVERFLOW_SCROLL_DOWN)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string OverflowScrollDown { get; set; }
+
+    /// <summary>Gets or sets whether overflow scroll rows use arrow glyphs instead of text labels.</summary>
+    [Category(@"Visuals")]
+    [Description(@"When true, overflow scroll rows show arrow glyphs instead of OverflowScrollUp/OverflowScrollDown text.")]
+    [DefaultValue(false)]
+    [RefreshProperties(RefreshProperties.All)]
+    public bool OverflowScrollUseArrows { get; set; }
+
+    /// <summary>Gets or sets the glyph shown on the overflow scroll up row when <see cref="OverflowScrollUseArrows"/> is true.</summary>
+    [Category(@"Visuals")]
+    [Description(@"The glyph shown on the overflow scroll up row when OverflowScrollUseArrows is true.")]
+    [DefaultValue(DEFAULT_OVERFLOW_SCROLL_UP_ARROW)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string OverflowScrollUpArrow { get; set; }
+
+    /// <summary>Gets or sets the glyph shown on the overflow scroll down row when <see cref="OverflowScrollUseArrows"/> is true.</summary>
+    [Category(@"Visuals")]
+    [Description(@"The glyph shown on the overflow scroll down row when OverflowScrollUseArrows is true.")]
+    [DefaultValue(DEFAULT_OVERFLOW_SCROLL_DOWN_ARROW)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string OverflowScrollDownArrow { get; set; }
+
+    #endregion
+
+    #region Internal
+
+    /// <summary>
+    /// Gets the label for an overflow scroll row.
+    /// </summary>
+    /// <param name="scrollUp">True for scroll up; otherwise scroll down.</param>
+    /// <param name="useArrows">True to use arrow glyphs; otherwise use text labels.</param>
+    /// <returns>Display text for the overflow scroll row.</returns>
+    internal string GetOverflowScrollText(bool scrollUp, bool useArrows) =>
+        useArrows
+            ? scrollUp ? OverflowScrollUpArrow : OverflowScrollDownArrow
+            : scrollUp ? OverflowScrollUp : OverflowScrollDown;
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonContextMenuStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonContextMenuStrings.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonScrollBarStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonScrollBarStrings.cs
@@ -2,7 +2,7 @@
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2023 - 2026. All rights reserved. 
  *  
  */
 #endregion
@@ -19,9 +19,13 @@ public class KryptonScrollBarStrings : GlobalId
     private const string DEFAULT_SCROLL_BAR_PAGE_UP = @"Page Up";
     private const string DEFAULT_SCROLL_BAR_PAGE_LEFT = @"Page Left";
     private const string DEFAULT_SCROLL_BAR_PAGE_RIGHT = @"Page Right";
-    private const string DEFAULT_SCROLL_BAR_SCROLL_DOWN = @"Scoll Down";
+    private const string DEFAULT_SCROLL_BAR_SCROLL_DOWN = @"Scroll Down";
     private const string DEFAULT_SCROLL_BAR_SCROLL_HERE = @"Scroll Here";
     private const string DEFAULT_SCROLL_BAR_SCROLL_UP = @"Scroll Up";
+    private const string DEFAULT_SCROLL_BAR_TOP = @"Top";
+    private const string DEFAULT_SCROLL_BAR_BOTTOM = @"Bottom";
+    private const string DEFAULT_SCROLL_BAR_LEFT = @"Left";
+    private const string DEFAULT_SCROLL_BAR_RIGHT = @"Right";
     private const string DEFAULT_SCROLL_BAR_SCROLL_RIGHT = @"Scroll Right";
     private const string DEFAULT_SCROLL_BAR_SCROLL_LEFT = @"Scroll Left";
 
@@ -52,7 +56,11 @@ public class KryptonScrollBarStrings : GlobalId
                              ScrollHere.Equals(DEFAULT_SCROLL_BAR_SCROLL_HERE) &&
                              ScrollUp.Equals(DEFAULT_SCROLL_BAR_SCROLL_UP) &&
                              ScrollLeft.Equals(DEFAULT_SCROLL_BAR_SCROLL_LEFT) &&
-                             ScrollRight.Equals(DEFAULT_SCROLL_BAR_SCROLL_RIGHT);
+                             ScrollRight.Equals(DEFAULT_SCROLL_BAR_SCROLL_RIGHT) &&
+                             Top.Equals(DEFAULT_SCROLL_BAR_TOP) &&
+                             Bottom.Equals(DEFAULT_SCROLL_BAR_BOTTOM) &&
+                             Left.Equals(DEFAULT_SCROLL_BAR_LEFT) &&
+                             Right.Equals(DEFAULT_SCROLL_BAR_RIGHT);
 
     /// <summary>Resets this instance.</summary>
     public void Reset()
@@ -74,6 +82,14 @@ public class KryptonScrollBarStrings : GlobalId
         ScrollLeft = DEFAULT_SCROLL_BAR_SCROLL_LEFT;
 
         ScrollRight = DEFAULT_SCROLL_BAR_SCROLL_RIGHT;
+
+        Top = DEFAULT_SCROLL_BAR_TOP;
+
+        Bottom = DEFAULT_SCROLL_BAR_BOTTOM;
+
+        Right = DEFAULT_SCROLL_BAR_RIGHT;
+
+        Left = DEFAULT_SCROLL_BAR_LEFT;
     }
 
     /// <summary>Gets or sets the scrollbar page down string.</summary>
@@ -138,6 +154,30 @@ public class KryptonScrollBarStrings : GlobalId
     [DefaultValue(DEFAULT_SCROLL_BAR_SCROLL_LEFT)]
     [RefreshProperties(RefreshProperties.All)]
     public string ScrollLeft { get; set; }
+
+    [Category(@"Visuals")]
+    [Description(@"The scrollbar top string.")]
+    [DefaultValue(DEFAULT_SCROLL_BAR_TOP)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string Top { get; set; }
+
+    [Category(@"Visuals")]
+    [Description(@"The scrollbar bottom string.")]
+    [DefaultValue(DEFAULT_SCROLL_BAR_BOTTOM)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string Bottom { get; set; }
+
+    [Category(@"Visuals")]
+    [Description(@"The scrollbar left string.")]
+    [DefaultValue(DEFAULT_SCROLL_BAR_LEFT)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string Left { get; set; }
+
+    [Category(@"Visuals")]
+    [Description(@"The scrollbar right string.")]
+    [DefaultValue(DEFAULT_SCROLL_BAR_RIGHT)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string Right { get; set; }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ToolkitStringValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ToolkitStringValues.cs
@@ -394,6 +394,20 @@ public class ToolkitStringValues : Storage /*GlobalId*/
     /// <summary>Resets the krypton scroll bar strings.</summary>
     public void ResetKryptonScrollBarStrings() => ScrollBarStrings.Reset();
 
+    /// <summary>Gets the context menu strings.</summary>
+    /// <value>The context menu strings.</value>
+    [Category(@"Visuals")]
+    [Description(@"Collection of context menu strings.")]
+    [MergableProperty(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    [Localizable(true)]
+    public KryptonContextMenuStrings KryptonContextMenuStrings => ContextMenuStrings;
+
+    private bool ShouldSerializeKryptonContextMenuStrings() => !ContextMenuStrings.IsDefault;
+
+    /// <summary>Resets the context menu strings.</summary>
+    public void ResetKryptonContextMenuStrings() => ContextMenuStrings.Reset();
+
     /// <summary>Gets the krypton toast notification strings.</summary>
     /// <value>The krypton toast notification strings.</value>
     [Category(@"Visuals")]
@@ -521,6 +535,10 @@ public class ToolkitStringValues : Storage /*GlobalId*/
     /// <value>The scroll bar strings.</value>
     public static KryptonScrollBarStrings ScrollBarStrings { get; } = new();
 
+    /// <summary>Gets the context menu strings.</summary>
+    /// <value>The context menu strings.</value>
+    public static KryptonContextMenuStrings ContextMenuStrings { get; } = new();
+
     public static KryptonToastNotificationStrings ToastNotificationStrings { get; } = new();
 
     #endregion
@@ -565,6 +583,7 @@ public class ToolkitStringValues : Storage /*GlobalId*/
                                         ShouldSerializeTabBorderStyleStrings() ||
                                         ShouldSerializeTabStyleStrings() ||
                                         ShouldSerializeKryptonScrollBarStrings() ||
+                                        ShouldSerializeKryptonContextMenuStrings() ||
                                         ShouldSerializeKryptonToastNotificationStrings());
 
     #endregion
@@ -657,6 +676,8 @@ public class ToolkitStringValues : Storage /*GlobalId*/
         ResetTabStyleStrings();
 
         ResetKryptonScrollBarStrings();
+
+        ResetKryptonContextMenuStrings();
 
         ResetKryptonToastNotificationStrings();
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ToolkitStringValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ToolkitStringValues.cs
@@ -2,7 +2,7 @@
 /*
  *  
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2023 - 2026. All rights reserved. 
  *  
  */
 #endregion
@@ -553,7 +553,7 @@ public class ToolkitStringValues : Storage /*GlobalId*/
 
     /// <summary>Converts to string.</summary>
     /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
-    public override string ToString() => !IsDefault ? "Modified" : GlobalStaticValues.DEFAULT_EMPTY_STRING;
+    public override string ToString() => !IsDefault ? "Modified" : GlobalStaticVariables.DEFAULT_EMPTY_STRING;
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -576,17 +576,16 @@ public class ViewContextMenuManager : ViewManager
 
     private IContextMenuTarget? FindDownTarget(TargetList targets, IContextMenuTarget current)
     {
+        if (TryFindOverflowVerticalTarget(current, targets, scrollDown: true, out IContextMenuTarget? overflowTarget))
+        {
+            return overflowTarget;
+        }
+
         // Find the next item below the current one
         IContextMenuTarget? newTarget = FindDownTarget(targets, current.ClientRectangle);
 
-        // If nothing found, try scrolling an overflow column before wrapping
-        if (newTarget == null && TryOverflowScrollDown(current, targets, out newTarget))
-        {
-            return newTarget;
-        }
-
         // If nothing found, then we must be at the bottom of the display
-        if (newTarget == null)
+        if (newTarget == null && OverflowColumns.Count == 0)
         {
             // Convert item rectangle to be above the client area
             Rectangle currentRect = current.ClientRectangle;
@@ -645,17 +644,16 @@ public class ViewContextMenuManager : ViewManager
 
     private IContextMenuTarget? FindUpTarget(TargetList targets, IContextMenuTarget current)
     {
+        if (TryFindOverflowVerticalTarget(current, targets, scrollDown: false, out IContextMenuTarget? overflowTarget))
+        {
+            return overflowTarget;
+        }
+
         // Find the next item above the current one
         IContextMenuTarget? newTarget = FindUpTarget(targets, current.ClientRectangle);
 
-        // If nothing found, try scrolling an overflow column before wrapping
-        if (newTarget == null && TryOverflowScrollUp(current, targets, out newTarget))
-        {
-            return newTarget;
-        }
-
         // If nothing found, then we must be at the top of the display
-        if (newTarget == null)
+        if (newTarget == null && OverflowColumns.Count == 0)
         {
             // Convert item rectangle to be below the client area
             Rectangle currentRect = current.ClientRectangle;
@@ -859,14 +857,29 @@ public class ViewContextMenuManager : ViewManager
     /// Scroll all overflow columns in the requested direction.
     /// </summary>
     /// <param name="scrollUp">True to scroll up; otherwise scroll down.</param>
-    public void ScrollOverflow(bool scrollUp)
+    /// <returns>True if any column scrolled.</returns>
+    public bool ScrollOverflow(bool scrollUp)
     {
+        var scrolled = false;
         foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
         {
-            column.Scroll(scrollUp);
+            scrolled |= column.Scroll(scrollUp);
         }
 
-        RequestOverflowLayout();
+        if (scrolled)
+        {
+            PerformOverflowNeedPaint();
+        }
+
+        return scrolled;
+    }
+
+    private void PerformOverflowNeedPaint()
+    {
+        if (AlignControl is VisualPopup popup)
+        {
+            popup.PerformNeedPaint(true);
+        }
     }
 
     private void EnsureOverflowTargetVisible()
@@ -886,63 +899,98 @@ public class ViewContextMenuManager : ViewManager
         {
             if (column.ContainsTarget(_target))
             {
-                column.EnsureVisible(_target.GetActiveView(), context);
+                ViewBase activeView = _target.GetActiveView();
+                if (!column.IsItemVisible(activeView, context))
+                {
+                    column.EnsureVisible(activeView, context);
+                }
             }
         }
     }
 
-    private bool TryOverflowScrollDown(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
+    private bool TryFindOverflowVerticalTarget(IContextMenuTarget current, TargetList targets, bool scrollDown,
+        out IContextMenuTarget? newTarget)
     {
+        newTarget = null;
+
         foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
         {
-            if (!column.ContainsTarget(current) || !column.HasMoreBelow(null))
+            if (!column.ContainsTarget(current))
             {
                 continue;
             }
 
-            column.Scroll(false);
-            RequestOverflowLayout();
-            TargetList refreshed = ConstructKeyboardTargets(Root);
-            newTarget = FindDownTarget(refreshed, current.ClientRectangle);
-            if (newTarget != null)
-            {
-                return true;
-            }
-        }
-
-        newTarget = null;
-        return false;
-    }
-
-    private bool TryOverflowScrollUp(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
-    {
-        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
-        {
-            if (!column.ContainsTarget(current) || !column.HasMoreAbove)
+            var index = column.GetItemIndex(current.GetActiveView());
+            if (index < 0)
             {
                 continue;
             }
 
-            column.Scroll(true);
-            RequestOverflowLayout();
-            TargetList refreshed = ConstructKeyboardTargets(Root);
-            newTarget = FindUpTarget(refreshed, current.ClientRectangle);
-            if (newTarget != null)
+            if (scrollDown)
+            {
+                if (index < column.GetLastVisibleIndex(null))
+                {
+                    newTarget = FindTargetForItemIndex(column, index + 1, targets);
+                    return true;
+                }
+
+                if (!column.HasMoreBelow(null))
+                {
+                    return true;
+                }
+
+                if (column.Scroll(false))
+                {
+                    PerformOverflowNeedPaint();
+                }
+
+                TargetList refreshed = ConstructKeyboardTargets(Root);
+                newTarget = FindTargetForItemIndex(column, index + 1, refreshed);
+                return true;
+            }
+
+            if (index > column.TopIndex)
+            {
+                newTarget = FindTargetForItemIndex(column, index - 1, targets);
+                return true;
+            }
+
+            if (!column.HasMoreAbove)
             {
                 return true;
             }
+
+            if (column.Scroll(true))
+            {
+                PerformOverflowNeedPaint();
+            }
+
+            TargetList refreshedUp = ConstructKeyboardTargets(Root);
+            newTarget = FindTargetForItemIndex(column, index - 1, refreshedUp);
+            return true;
         }
 
-        newTarget = null;
         return false;
     }
 
-    private void RequestOverflowLayout()
+    private static IContextMenuTarget? FindTargetForItemIndex(ViewLayoutContextMenuOverflowColumn column, int index,
+        TargetList targets)
     {
-        if (AlignControl is VisualPopup popup)
+        ViewBase? itemView = column.GetItemView(index);
+        if (itemView == null)
         {
-            popup.PerformNeedPaint(true);
+            return null;
         }
+
+        foreach (IContextMenuTarget target in targets)
+        {
+            if (target.GetActiveView() == itemView)
+            {
+                return target;
+            }
+        }
+
+        return null;
     }
 
     private void OnDelayTimerExpire(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -27,11 +27,11 @@ public class ViewContextMenuManager : ViewManager
     private System.Windows.Forms.Timer? _itemDelayTimer;
     #endregion
 
-    #region OverflowColumns
+    #region Public
     /// <summary>
-    /// Gets or sets overflow columns used when the menu height is constrained.
+    /// Gets and sets the overflow columns used for scroll item display.
     /// </summary>
-    internal List<ViewLayoutContextMenuOverflowColumn> OverflowColumns { get; set; } = new List<ViewLayoutContextMenuOverflowColumn>();
+    internal List<ViewLayoutContextMenuOverflowColumn> OverflowColumns { get; set; } = [];
     #endregion
 
     #region Identity
@@ -115,7 +115,7 @@ public class ViewContextMenuManager : ViewManager
                 }
 
                 _target.ShowTarget();
-                EnsureOverflowTargetVisible(_target);
+                EnsureOverflowTargetVisible();
             }
         }
     }
@@ -154,6 +154,7 @@ public class ViewContextMenuManager : ViewManager
 
         // Tell new target to draw as highlighted and start delay timer
         _target?.ShowTarget();
+        EnsureOverflowTargetVisible();
     }
 
     /// <summary>
@@ -206,10 +207,8 @@ public class ViewContextMenuManager : ViewManager
         // Find the next appropriate target
         IContextMenuTarget? newTarget = _target == null ? FindBottomLeftTarget(targets) : FindUpTarget(targets, _target);
 
-        if (newTarget == null && _target != null && TryOverflowScrollUp(_target, targets, out newTarget))
-        {
-        }
-        else if ((newTarget != null) && (newTarget != _target))
+        // If we found a new target, then make it the current target
+        if ((newTarget != null) && (newTarget != _target))
         {
             SetTarget(newTarget, false);
         }
@@ -225,10 +224,8 @@ public class ViewContextMenuManager : ViewManager
         // Find the next appropriate target
         IContextMenuTarget? newTarget = _target == null ? FindTopLeftTarget(targets) : FindDownTarget(targets, _target);
 
-        if (newTarget == null && _target != null && TryOverflowScrollDown(_target, targets, out newTarget))
-        {
-        }
-        else if ((newTarget != null) && (newTarget != _target))
+        // If we found a new target, then make it the current target
+        if ((newTarget != null) && (newTarget != _target))
         {
             SetTarget(newTarget, false);
         }
@@ -582,6 +579,12 @@ public class ViewContextMenuManager : ViewManager
         // Find the next item below the current one
         IContextMenuTarget? newTarget = FindDownTarget(targets, current.ClientRectangle);
 
+        // If nothing found, try scrolling an overflow column before wrapping
+        if (newTarget == null && TryOverflowScrollDown(current, targets, out newTarget))
+        {
+            return newTarget;
+        }
+
         // If nothing found, then we must be at the bottom of the display
         if (newTarget == null)
         {
@@ -644,6 +647,12 @@ public class ViewContextMenuManager : ViewManager
     {
         // Find the next item above the current one
         IContextMenuTarget? newTarget = FindUpTarget(targets, current.ClientRectangle);
+
+        // If nothing found, try scrolling an overflow column before wrapping
+        if (newTarget == null && TryOverflowScrollUp(current, targets, out newTarget))
+        {
+            return newTarget;
+        }
 
         // If nothing found, then we must be at the top of the display
         if (newTarget == null)
@@ -846,6 +855,96 @@ public class ViewContextMenuManager : ViewManager
         return distance;
     }
 
+    /// <summary>
+    /// Scroll all overflow columns in the requested direction.
+    /// </summary>
+    /// <param name="scrollUp">True to scroll up; otherwise scroll down.</param>
+    public void ScrollOverflow(bool scrollUp)
+    {
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            column.Scroll(scrollUp);
+        }
+
+        RequestOverflowLayout();
+    }
+
+    private void EnsureOverflowTargetVisible()
+    {
+        if (_target == null || OverflowColumns.Count == 0)
+        {
+            return;
+        }
+
+        if (AlignControl is not VisualPopup popup)
+        {
+            return;
+        }
+
+        using var context = new ViewLayoutContext(this, AlignControl, AlignControl, popup.Renderer);
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (column.ContainsTarget(_target))
+            {
+                column.EnsureVisible(_target.GetActiveView(), context);
+            }
+        }
+    }
+
+    private bool TryOverflowScrollDown(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
+    {
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (!column.ContainsTarget(current) || !column.HasMoreBelow(null))
+            {
+                continue;
+            }
+
+            column.Scroll(false);
+            RequestOverflowLayout();
+            TargetList refreshed = ConstructKeyboardTargets(Root);
+            newTarget = FindDownTarget(refreshed, current.ClientRectangle);
+            if (newTarget != null)
+            {
+                return true;
+            }
+        }
+
+        newTarget = null;
+        return false;
+    }
+
+    private bool TryOverflowScrollUp(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
+    {
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (!column.ContainsTarget(current) || !column.HasMoreAbove)
+            {
+                continue;
+            }
+
+            column.Scroll(true);
+            RequestOverflowLayout();
+            TargetList refreshed = ConstructKeyboardTargets(Root);
+            newTarget = FindUpTarget(refreshed, current.ClientRectangle);
+            if (newTarget != null)
+            {
+                return true;
+            }
+        }
+
+        newTarget = null;
+        return false;
+    }
+
+    private void RequestOverflowLayout()
+    {
+        if (AlignControl is VisualPopup popup)
+        {
+            popup.PerformNeedPaint(true);
+        }
+    }
+
     private void OnDelayTimerExpire(object? sender, EventArgs e)
     {
         if (_itemDelayTimer != null)
@@ -873,108 +972,6 @@ public class ViewContextMenuManager : ViewManager
                 }
             }
         }
-    }
-
-    private IRenderer? GetMenuRenderer() => Control is VisualPopup popup ? popup.Renderer : null;
-
-    private void EnsureOverflowTargetVisible(IContextMenuTarget target)
-    {
-        if (OverflowColumns.Count == 0)
-        {
-            return;
-        }
-
-        IRenderer? renderer = GetMenuRenderer();
-        if (renderer == null)
-        {
-            return;
-        }
-
-        ViewBase view = target.GetActiveView();
-        using var context = new ViewLayoutContext(this, Control, AlignControl, renderer);
-        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
-        {
-            if (column.ContainsView(view))
-            {
-                column.EnsureVisible(view, context);
-                Layout(renderer);
-                return;
-            }
-        }
-    }
-
-    private bool TryOverflowScrollUp(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
-    {
-        newTarget = null;
-        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
-        {
-            if (!column.ContainsTarget(current))
-            {
-                continue;
-            }
-
-            if (column.HasMoreAbove)
-            {
-                column.Scroll(true);
-                IRenderer? renderer = GetMenuRenderer();
-                if (renderer != null)
-                {
-                    Layout(renderer);
-                }
-
-                EnsureOverflowTargetVisible(current);
-                newTarget = current;
-                return true;
-            }
-
-            foreach (IContextMenuTarget target in targets)
-            {
-                if (target.GetActiveView() is ViewDrawMenuScrollButton { ScrollUp: true })
-                {
-                    newTarget = target;
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private bool TryOverflowScrollDown(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
-    {
-        newTarget = null;
-        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
-        {
-            if (!column.ContainsTarget(current))
-            {
-                continue;
-            }
-
-            if (column.HasMoreBelow(null))
-            {
-                column.Scroll(false);
-                IRenderer? renderer = GetMenuRenderer();
-                if (renderer != null)
-                {
-                    Layout(renderer);
-                }
-
-                EnsureOverflowTargetVisible(current);
-                newTarget = current;
-                return true;
-            }
-
-            foreach (IContextMenuTarget target in targets)
-            {
-                if (target.GetActiveView() is ViewDrawMenuScrollButton { ScrollUp: false })
-                {
-                    newTarget = target;
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -27,6 +27,13 @@ public class ViewContextMenuManager : ViewManager
     private System.Windows.Forms.Timer? _itemDelayTimer;
     #endregion
 
+    #region OverflowColumns
+    /// <summary>
+    /// Gets or sets overflow columns used when the menu height is constrained.
+    /// </summary>
+    internal List<ViewLayoutContextMenuOverflowColumn> OverflowColumns { get; set; } = new List<ViewLayoutContextMenuOverflowColumn>();
+    #endregion
+
     #region Identity
     /// <summary>
     /// Initialize a new instance of the ViewContextMenuManager class.
@@ -108,6 +115,7 @@ public class ViewContextMenuManager : ViewManager
                 }
 
                 _target.ShowTarget();
+                EnsureOverflowTargetVisible(_target);
             }
         }
     }
@@ -198,8 +206,10 @@ public class ViewContextMenuManager : ViewManager
         // Find the next appropriate target
         IContextMenuTarget? newTarget = _target == null ? FindBottomLeftTarget(targets) : FindUpTarget(targets, _target);
 
-        // If we found a new target, then make it the current target
-        if ((newTarget != null) && (newTarget != _target))
+        if (newTarget == null && _target != null && TryOverflowScrollUp(_target, targets, out newTarget))
+        {
+        }
+        else if ((newTarget != null) && (newTarget != _target))
         {
             SetTarget(newTarget, false);
         }
@@ -215,8 +225,10 @@ public class ViewContextMenuManager : ViewManager
         // Find the next appropriate target
         IContextMenuTarget? newTarget = _target == null ? FindTopLeftTarget(targets) : FindDownTarget(targets, _target);
 
-        // If we found a new target, then make it the current target
-        if ((newTarget != null) && (newTarget != _target))
+        if (newTarget == null && _target != null && TryOverflowScrollDown(_target, targets, out newTarget))
+        {
+        }
+        else if ((newTarget != null) && (newTarget != _target))
         {
             SetTarget(newTarget, false);
         }
@@ -861,6 +873,108 @@ public class ViewContextMenuManager : ViewManager
                 }
             }
         }
+    }
+
+    private IRenderer? GetMenuRenderer() => Control is VisualPopup popup ? popup.Renderer : null;
+
+    private void EnsureOverflowTargetVisible(IContextMenuTarget target)
+    {
+        if (OverflowColumns.Count == 0)
+        {
+            return;
+        }
+
+        IRenderer? renderer = GetMenuRenderer();
+        if (renderer == null)
+        {
+            return;
+        }
+
+        ViewBase view = target.GetActiveView();
+        using var context = new ViewLayoutContext(this, Control, AlignControl, renderer);
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (column.ContainsView(view))
+            {
+                column.EnsureVisible(view, context);
+                Layout(renderer);
+                return;
+            }
+        }
+    }
+
+    private bool TryOverflowScrollUp(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
+    {
+        newTarget = null;
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (!column.ContainsTarget(current))
+            {
+                continue;
+            }
+
+            if (column.HasMoreAbove)
+            {
+                column.Scroll(true);
+                IRenderer? renderer = GetMenuRenderer();
+                if (renderer != null)
+                {
+                    Layout(renderer);
+                }
+
+                EnsureOverflowTargetVisible(current);
+                newTarget = current;
+                return true;
+            }
+
+            foreach (IContextMenuTarget target in targets)
+            {
+                if (target.GetActiveView() is ViewDrawMenuScrollButton { ScrollUp: true })
+                {
+                    newTarget = target;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryOverflowScrollDown(IContextMenuTarget current, TargetList targets, out IContextMenuTarget? newTarget)
+    {
+        newTarget = null;
+        foreach (ViewLayoutContextMenuOverflowColumn column in OverflowColumns)
+        {
+            if (!column.ContainsTarget(current))
+            {
+                continue;
+            }
+
+            if (column.HasMoreBelow(null))
+            {
+                column.Scroll(false);
+                IRenderer? renderer = GetMenuRenderer();
+                if (renderer != null)
+                {
+                    Layout(renderer);
+                }
+
+                EnsureOverflowTargetVisible(current);
+                newTarget = current;
+                return true;
+            }
+
+            foreach (IContextMenuTarget target in targets)
+            {
+                if (target.GetActiveView() is ViewDrawMenuScrollButton { ScrollUp: false })
+                {
+                    newTarget = target;
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -66,6 +66,36 @@ public class ViewControl : Control
 
         // Remember incoming references
         _rootControl = rootControl;
+
+        // Create delegate so child elements can request a repaint
+        NeedPaintDelegate = OnNeedPaint;
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the ViewControl class.
+    /// </summary>
+    /// <param name="rootPopup">Top level visual popup.</param>
+    public ViewControl([DisallowNull] VisualPopup rootPopup)
+    {
+        Debug.Assert(rootPopup != null);
+
+        // We use double buffering to reduce drawing flicker
+        SetStyle(ControlStyles.OptimizedDoubleBuffer |
+                 ControlStyles.AllPaintingInWmPaint |
+                 ControlStyles.UserPaint, true);
+
+        // We need to repaint entire control whenever resized
+        SetStyle(ControlStyles.ResizeRedraw, true);
+
+        // We are not selectable
+        SetStyle(ControlStyles.Selectable, false);
+
+        // Default
+        TransparentBackground = false;
+        InDesignMode = false;
+
+        // Remember incoming references
+        _rootPopup = rootPopup;
 
         // Create delegate so child elements can request a repaint
         NeedPaintDelegate = OnNeedPaint;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuScrollButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuScrollButton.cs
@@ -1,0 +1,129 @@
+#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Draw element for a context menu scroll overflow button.
+/// </summary>
+internal class ViewDrawMenuScrollButton : ViewDrawCanvas
+{
+    #region Instance Fields
+    private readonly IContextMenuProvider _provider;
+    private readonly PaletteContent _contentPalette;
+    private readonly ViewDrawContent _drawContent;
+    private readonly bool _scrollUp;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the ViewDrawMenuScrollButton class.
+    /// </summary>
+    /// <param name="provider">Provider of context menu information.</param>
+    /// <param name="scrollUp">True for scroll up; otherwise scroll down.</param>
+    public ViewDrawMenuScrollButton(IContextMenuProvider provider, bool scrollUp)
+        : base(provider.ProviderStateNormal.ItemHighlight.Back,
+            provider.ProviderStateNormal.ItemHighlight.Border,
+            provider.ProviderStateNormal.ItemHighlight,
+            PaletteMetricPadding.ContextMenuItemHighlight,
+            VisualOrientation.Top)
+    {
+        _provider = provider;
+        _scrollUp = scrollUp;
+
+        var text = KryptonManager.Strings.ContextMenuStrings.GetOverflowScrollText(scrollUp,
+            provider.ProviderOverflowScrollUseArrows);
+
+        _contentPalette = new PaletteContent(provider.ProviderStateNormal.ItemTextStandard);
+        _contentPalette.ShortText.TextH = PaletteRelativeAlign.Center;
+
+        _drawContent = new ViewDrawContent(_contentPalette,
+            new FixedContentValue(text, string.Empty, null, GlobalStaticValues.EMPTY_COLOR),
+            VisualOrientation.Top);
+
+        var docker = new ViewLayoutDocker();
+        docker.Add(_drawContent, ViewDockStyle.Fill);
+        Add(docker);
+
+        var controller = new MenuScrollButtonController(provider.ProviderViewManager, this,
+            provider.ProviderNeedPaintDelegate);
+        KeyController = controller;
+        MouseController = controller;
+    }
+
+    /// <summary>
+    /// Obtains the String representation of this instance.
+    /// </summary>
+    /// <returns>User readable name of the instance.</returns>
+    public override string ToString() =>
+        $"ViewDrawMenuScrollButton:{Id}";
+
+    #endregion
+
+    #region ScrollUp
+    /// <summary>
+    /// Gets a value indicating if this is the scroll up button.
+    /// </summary>
+    public bool ScrollUp => _scrollUp;
+
+    #endregion
+
+    #region OverflowColumn
+    /// <summary>
+    /// Gets and sets the overflow column that owns this scroll button.
+    /// </summary>
+    public ViewLayoutContextMenuOverflowColumn? OverflowColumn { get; set; }
+
+    #endregion
+
+    #region ItemEnabled
+    /// <summary>
+    /// Gets the enabled state of the scroll button.
+    /// </summary>
+    public bool ItemEnabled => _provider.ProviderEnabled;
+
+    #endregion
+
+    #region HighlightState
+    /// <summary>
+    /// Update view to reflect the highlighted state.
+    /// </summary>
+    public void HighlightState()
+    {
+        if (ItemEnabled)
+        {
+            ElementState = PaletteState.Tracking;
+            SetPalettes(_provider.ProviderStateHighlight.ItemHighlight.Back,
+                _provider.ProviderStateHighlight.ItemHighlight.Border);
+        }
+        else
+        {
+            ElementState = PaletteState.Disabled;
+            SetPalettes(_provider.ProviderStateDisabled.ItemHighlight.Back,
+                _provider.ProviderStateDisabled.ItemHighlight.Border);
+            _contentPalette.SetInherit(_provider.ProviderStateDisabled.ItemTextStandard);
+        }
+    }
+
+    /// <summary>
+    /// Update view to reflect the normal state.
+    /// </summary>
+    public void NormalState()
+    {
+        ElementState = PaletteState.Normal;
+        SetPalettes(_provider.ProviderStateNormal.ItemHighlight.Back,
+            _provider.ProviderStateNormal.ItemHighlight.Border);
+        _contentPalette.SetInherit(_provider.ProviderStateNormal.ItemTextStandard);
+    }
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuScrollButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuScrollButton.cs
@@ -1,12 +1,9 @@
 #region BSD License
 /*
- * 
- * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
- *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -47,7 +44,7 @@ internal class ViewDrawMenuScrollButton : ViewDrawCanvas
         _contentPalette.ShortText.TextH = PaletteRelativeAlign.Center;
 
         _drawContent = new ViewDrawContent(_contentPalette,
-            new FixedContentValue(text, string.Empty, null, GlobalStaticValues.EMPTY_COLOR),
+            new FixedContentValue(text, string.Empty, null, GlobalStaticVariables.EMPTY_COLOR),
             VisualOrientation.Top);
 
         var docker = new ViewLayoutDocker();

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
@@ -1,12 +1,9 @@
 #region BSD License
 /*
- * 
- * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
- *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -18,7 +15,7 @@ namespace Krypton.Toolkit;
 internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
 {
     #region Instance Fields
-    private readonly List<ViewBase> _allItems = new List<ViewBase>();
+    private readonly List<ViewBase> _allItems = [];
     private readonly IContextMenuProvider _provider;
     private readonly ViewContextMenuManager _viewManager;
     private readonly NeedPaintHandler _needPaint;
@@ -128,6 +125,7 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
 
         var lineCount = scrollLines < 0 ? 1 : scrollLines;
         var scrollUp = delta > 0;
+        var startIndex = _topIndex;
 
         for (var i = 0; i < lineCount; i++)
         {
@@ -151,7 +149,7 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
             }
         }
 
-        if (scrollUp || HasMoreBelow(null))
+        if (startIndex != _topIndex)
         {
             Rebuild(null);
             return true;

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
@@ -1,0 +1,378 @@
+#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Lays out a context menu column with scroll up/down overflow items when content exceeds available height.
+/// </summary>
+internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
+{
+    #region Instance Fields
+    private readonly List<ViewBase> _allItems = new List<ViewBase>();
+    private readonly IContextMenuProvider _provider;
+    private readonly ViewContextMenuManager _viewManager;
+    private readonly NeedPaintHandler _needPaint;
+    private ViewDrawMenuScrollButton? _scrollUp;
+    private ViewDrawMenuScrollButton? _scrollDown;
+    private int _topIndex;
+    private int _maxContentHeight = int.MaxValue;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the ViewLayoutContextMenuOverflowColumn class.
+    /// </summary>
+    /// <param name="provider">Provider of context menu information.</param>
+    /// <param name="viewManager">Owning view manager.</param>
+    /// <param name="needPaint">Delegate for notifying paint requests.</param>
+    public ViewLayoutContextMenuOverflowColumn(IContextMenuProvider provider,
+        ViewContextMenuManager viewManager,
+        NeedPaintHandler needPaint)
+        : base(false)
+    {
+        _provider = provider;
+        _viewManager = viewManager;
+        _needPaint = needPaint;
+    }
+
+    /// <summary>
+    /// Obtains the String representation of this instance.
+    /// </summary>
+    /// <returns>User readable name of the instance.</returns>
+    public override string ToString() =>
+        $"ViewLayoutContextMenuOverflowColumn:{Id}";
+
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// Takes ownership of the views from an existing column stack.
+    /// </summary>
+    /// <param name="column">Source column to adopt.</param>
+    public void Adopt(ViewLayoutStack column)
+    {
+        while (column.Count > 0)
+        {
+            ViewBase child = column[0];
+            column.RemoveAt(0);
+            _allItems.Add(child);
+        }
+
+        Rebuild(null);
+    }
+
+    /// <summary>
+    /// Sets the maximum height available for column content and rebuilds visible items.
+    /// </summary>
+    /// <param name="maxContentHeight">Maximum height in pixels.</param>
+    /// <param name="context">Optional layout context for measurement.</param>
+    public void SetMaxContentHeight(int maxContentHeight, ViewLayoutContext? context)
+    {
+        _maxContentHeight = Math.Max(1, maxContentHeight);
+        Rebuild(context);
+    }
+
+    /// <summary>
+    /// Removes overflow limits and shows all items.
+    /// </summary>
+    public void ClearMaxContentHeight() => SetMaxContentHeight(int.MaxValue, null);
+
+    /// <summary>
+    /// Scrolls the column up or down by one item.
+    /// </summary>
+    /// <param name="scrollUp">True to scroll up; otherwise scroll down.</param>
+    public void Scroll(bool scrollUp)
+    {
+        if (scrollUp)
+        {
+            if (_topIndex > 0)
+            {
+                _topIndex--;
+                Rebuild(null);
+            }
+        }
+        else if (GetLastVisibleIndex(null) < _allItems.Count - 1)
+        {
+            _topIndex++;
+            Rebuild(null);
+        }
+    }
+
+    /// <summary>
+    /// Scrolls the column using the mouse wheel.
+    /// </summary>
+    /// <param name="delta">Mouse wheel delta.</param>
+    /// <returns>True if scrolling was applied.</returns>
+    public bool ScrollByWheel(int delta)
+    {
+        if (!IsOverflowActive(null))
+        {
+            return false;
+        }
+
+        var scrollLines = SystemInformation.MouseWheelScrollLines;
+        if (scrollLines == 0)
+        {
+            return false;
+        }
+
+        var lineCount = scrollLines < 0 ? 1 : scrollLines;
+        var scrollUp = delta > 0;
+
+        for (var i = 0; i < lineCount; i++)
+        {
+            if (scrollUp)
+            {
+                if (_topIndex == 0)
+                {
+                    break;
+                }
+
+                _topIndex--;
+            }
+            else
+            {
+                if (!HasMoreBelow(null))
+                {
+                    break;
+                }
+
+                _topIndex++;
+            }
+        }
+
+        if (scrollUp || HasMoreBelow(null))
+        {
+            Rebuild(null);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether more items exist below the visible range.
+    /// </summary>
+    /// <param name="context">Optional layout context for measurement.</param>
+    /// <returns>True if more items can be scrolled into view.</returns>
+    public bool HasMoreBelow(ViewLayoutContext? context) =>
+        GetLastVisibleIndex(context) < _allItems.Count - 1;
+
+    /// <summary>
+    /// Gets a value indicating whether items exist above the visible range.
+    /// </summary>
+    public bool HasMoreAbove => _topIndex > 0;
+
+    /// <summary>
+    /// Ensures the provided view is within the visible range.
+    /// </summary>
+    /// <param name="view">View to bring into view.</param>
+    /// <param name="context">Layout context for measurement.</param>
+    public void EnsureVisible(ViewBase view, ViewLayoutContext context)
+    {
+        var index = _allItems.IndexOf(view);
+        if (index < 0)
+        {
+            return;
+        }
+
+        if (index < _topIndex)
+        {
+            _topIndex = index;
+            Rebuild(context);
+            return;
+        }
+
+        var lastVisible = GetLastVisibleIndex(context);
+        if (index > lastVisible)
+        {
+            _topIndex = index;
+            while (_topIndex > 0 && GetLastVisibleIndex(context) < index)
+            {
+                _topIndex--;
+            }
+
+            Rebuild(context);
+        }
+    }
+
+    /// <summary>
+    /// Determines if the view belongs to this column.
+    /// </summary>
+    /// <param name="view">View to test.</param>
+    /// <returns>True if owned by this column.</returns>
+    public bool ContainsView(ViewBase view) => _allItems.Contains(view);
+
+    /// <summary>
+    /// Determines if the target belongs to this column.
+    /// </summary>
+    /// <param name="target">Target to test.</param>
+    /// <returns>True if owned by this column.</returns>
+    public bool ContainsTarget(IContextMenuTarget target)
+    {
+        ViewBase active = target.GetActiveView();
+        return ContainsView(active);
+    }
+    #endregion
+
+    #region Layout
+    /// <inheritdoc />
+    public override Size GetPreferredSize(ViewLayoutContext context)
+    {
+        Rebuild(context);
+        return base.GetPreferredSize(context);
+    }
+    #endregion
+
+    #region Implementation
+    private void Rebuild(ViewLayoutContext? context)
+    {
+        Clear();
+
+        if (_allItems.Count == 0)
+        {
+            return;
+        }
+
+        if (!IsOverflowActive(context))
+        {
+            _topIndex = 0;
+            foreach (ViewBase item in _allItems)
+            {
+                Add(item);
+            }
+
+            return;
+        }
+
+        var scrollHeight = GetScrollButtonHeight(context);
+        var used = 0;
+
+        if (_topIndex > 0)
+        {
+            Add(GetScrollUpButton());
+            used += scrollHeight;
+        }
+
+        var index = _topIndex;
+        var lastAdded = _topIndex - 1;
+
+        while (index < _allItems.Count)
+        {
+            var itemHeight = MeasureItemHeight(_allItems[index], context);
+            var reserveScrollDown = index < _allItems.Count - 1 ? scrollHeight : 0;
+
+            if (used + itemHeight + reserveScrollDown > _maxContentHeight)
+            {
+                break;
+            }
+
+            Add(_allItems[index]);
+            used += itemHeight;
+            lastAdded = index;
+            index++;
+        }
+
+        if (lastAdded < _allItems.Count - 1)
+        {
+            Add(GetScrollDownButton());
+        }
+    }
+
+    private bool IsOverflowActive(ViewLayoutContext? context)
+    {
+        if (_maxContentHeight == int.MaxValue)
+        {
+            return false;
+        }
+
+        var total = 0;
+        foreach (ViewBase item in _allItems)
+        {
+            total += MeasureItemHeight(item, context);
+        }
+
+        var scrollHeight = GetScrollButtonHeight(context);
+        return total + (scrollHeight * 2) > _maxContentHeight;
+    }
+
+    private int GetLastVisibleIndex(ViewLayoutContext? context)
+    {
+        if (!IsOverflowActive(context))
+        {
+            return _allItems.Count - 1;
+        }
+
+        var scrollHeight = GetScrollButtonHeight(context);
+        var used = _topIndex > 0 ? scrollHeight : 0;
+        var index = _topIndex;
+        var lastVisible = _topIndex - 1;
+
+        while (index < _allItems.Count)
+        {
+            var itemHeight = MeasureItemHeight(_allItems[index], context);
+            var reserveScrollDown = index < _allItems.Count - 1 ? scrollHeight : 0;
+
+            if (used + itemHeight + reserveScrollDown > _maxContentHeight)
+            {
+                break;
+            }
+
+            used += itemHeight;
+            lastVisible = index;
+            index++;
+        }
+
+        return lastVisible;
+    }
+
+    private static int MeasureItemHeight(ViewBase item, ViewLayoutContext? context)
+    {
+        if (context == null)
+        {
+            return item.ClientHeight > 0 ? item.ClientHeight : SystemInformation.MenuHeight;
+        }
+
+        return item.GetPreferredSize(context).Height;
+    }
+
+    private int GetScrollButtonHeight(ViewLayoutContext? context) =>
+        MeasureItemHeight(GetScrollUpButton(), context);
+
+    private ViewDrawMenuScrollButton GetScrollUpButton()
+    {
+        if (_scrollUp == null)
+        {
+            _scrollUp = new ViewDrawMenuScrollButton(_provider, true)
+            {
+                OverflowColumn = this
+            };
+        }
+
+        return _scrollUp;
+    }
+
+    private ViewDrawMenuScrollButton GetScrollDownButton()
+    {
+        if (_scrollDown == null)
+        {
+            _scrollDown = new ViewDrawMenuScrollButton(_provider, false)
+            {
+                OverflowColumn = this
+            };
+        }
+
+        return _scrollDown;
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContextMenuOverflowColumn.cs
@@ -88,21 +88,29 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
     /// Scrolls the column up or down by one item.
     /// </summary>
     /// <param name="scrollUp">True to scroll up; otherwise scroll down.</param>
-    public void Scroll(bool scrollUp)
+    /// <returns>True if the visible range changed.</returns>
+    public bool Scroll(bool scrollUp)
     {
         if (scrollUp)
         {
-            if (_topIndex > 0)
+            if (_topIndex <= 0)
             {
-                _topIndex--;
-                Rebuild(null);
+                return false;
             }
-        }
-        else if (GetLastVisibleIndex(null) < _allItems.Count - 1)
-        {
-            _topIndex++;
+
+            _topIndex--;
             Rebuild(null);
+            return true;
         }
+
+        if (GetLastVisibleIndexCore(null) >= _allItems.Count - 1)
+        {
+            return false;
+        }
+
+        _topIndex++;
+        Rebuild(null);
+        return true;
     }
 
     /// <summary>
@@ -123,9 +131,9 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
             return false;
         }
 
+        var startTopIndex = _topIndex;
         var lineCount = scrollLines < 0 ? 1 : scrollLines;
         var scrollUp = delta > 0;
-        var startIndex = _topIndex;
 
         for (var i = 0; i < lineCount; i++)
         {
@@ -149,7 +157,7 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
             }
         }
 
-        if (startIndex != _topIndex)
+        if (_topIndex != startTopIndex)
         {
             Rebuild(null);
             return true;
@@ -159,12 +167,19 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
     }
 
     /// <summary>
+    /// Gets the index of the last menu item visible in the column.
+    /// </summary>
+    /// <param name="context">Optional layout context for measurement.</param>
+    /// <returns>Last visible item index.</returns>
+    public int GetLastVisibleIndex(ViewLayoutContext? context) => GetLastVisibleIndexCore(context);
+
+    /// <summary>
     /// Gets a value indicating whether more items exist below the visible range.
     /// </summary>
     /// <param name="context">Optional layout context for measurement.</param>
     /// <returns>True if more items can be scrolled into view.</returns>
     public bool HasMoreBelow(ViewLayoutContext? context) =>
-        GetLastVisibleIndex(context) < _allItems.Count - 1;
+        GetLastVisibleIndexCore(context) < _allItems.Count - 1;
 
     /// <summary>
     /// Gets a value indicating whether items exist above the visible range.
@@ -191,7 +206,7 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
             return;
         }
 
-        var lastVisible = GetLastVisibleIndex(context);
+        var lastVisible = GetLastVisibleIndexCore(context);
         if (index > lastVisible)
         {
             _topIndex = index;
@@ -220,6 +235,43 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
     {
         ViewBase active = target.GetActiveView();
         return ContainsView(active);
+    }
+
+    /// <summary>
+    /// Gets the index of a menu item view within the column.
+    /// </summary>
+    /// <param name="view">View to locate.</param>
+    /// <returns>Item index, or -1 if not found.</returns>
+    public int GetItemIndex(ViewBase view) => _allItems.IndexOf(view);
+
+    /// <summary>
+    /// Gets the view for a menu item at the specified index.
+    /// </summary>
+    /// <param name="index">Item index.</param>
+    /// <returns>Item view, or null if out of range.</returns>
+    public ViewBase? GetItemView(int index) =>
+        index >= 0 && index < _allItems.Count ? _allItems[index] : null;
+
+    /// <summary>
+    /// Gets the index of the first visible menu item.
+    /// </summary>
+    public int TopIndex => _topIndex;
+
+    /// <summary>
+    /// Determines if a menu item is within the currently visible range.
+    /// </summary>
+    /// <param name="view">View to test.</param>
+    /// <param name="context">Optional layout context for measurement.</param>
+    /// <returns>True if the item is visible without scrolling.</returns>
+    public bool IsItemVisible(ViewBase view, ViewLayoutContext? context)
+    {
+        var index = GetItemIndex(view);
+        if (index < 0)
+        {
+            return true;
+        }
+
+        return index >= _topIndex && index <= GetLastVisibleIndexCore(context);
     }
     #endregion
 
@@ -304,7 +356,7 @@ internal class ViewLayoutContextMenuOverflowColumn : ViewLayoutStack
         return total + (scrollHeight * 2) > _maxContentHeight;
     }
 
-    private int GetLastVisibleIndex(ViewLayoutContext? context)
+    private int GetLastVisibleIndexCore(ViewLayoutContext? context)
     {
         if (!IsOverflowActive(context))
         {

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -26,6 +26,17 @@ public class ViewLayoutControl : ViewLeaf
     public ViewLayoutControl(VisualControl rootControl,
         ViewBase viewChild)
         : this(new ViewControl(rootControl), rootControl, viewChild)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the ViewLayoutControl class.
+    /// </summary>
+    /// <param name="rootPopup">Top level visual popup.</param>
+    /// <param name="viewChild">View used to size and position the child control.</param>
+    public ViewLayoutControl(VisualPopup rootPopup,
+        ViewBase viewChild)
+        : this(new ViewControl(rootPopup), rootPopup, viewChild)
     {
     }
 
@@ -66,6 +77,45 @@ public class ViewLayoutControl : ViewLeaf
 
         // Add our new control to the provided parent collection
         CommonHelper.AddControlToParent(rootControl!, ChildControl);
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the ViewLayoutControl class.
+    /// </summary>
+    /// <param name="viewControl">View control to use as child.</param>
+    /// <param name="rootPopup">Top level visual popup.</param>
+    /// <param name="viewChild">View used to size and position the child control.</param>
+    public ViewLayoutControl([DisallowNull] ViewControl viewControl,
+        [DisallowNull] VisualPopup rootPopup,
+        [DisallowNull] ViewBase viewChild)
+    {
+        Debug.Assert(viewControl != null);
+        Debug.Assert(rootPopup != null);
+        Debug.Assert(viewChild != null);
+
+        // Default values
+        LayoutOffset = Point.Empty;
+
+        // Remember the view
+        ChildView = viewChild;
+
+        // Ensure the child is hooked into the hierarchy of elements
+        ChildView!.Parent = this;
+
+        // Create the view control instance
+        ChildControl = viewControl;
+
+        // Back reference hookup
+        ChildControl!.ViewLayoutControl = this;
+
+        // Start off invisible until first laid out
+        ChildControl.Visible = false;
+
+        // Ensure that all view elements inside here use our control
+        OwningControl = ChildControl;
+
+        // Add our new control to the provided parent collection
+        CommonHelper.AddControlToParent(rootPopup!, ChildControl);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -96,6 +96,87 @@ public class ViewLayoutScrollViewport : ViewLayoutDocker
         {
             InDesignMode = rootControl!.InDesignMode
         };
+
+        // Create the scrollbar and matching border edge
+        ScrollbarV = new ViewDrawScrollBar(true);
+        ScrollbarH = new ViewDrawScrollBar(false);
+        BorderEdgeV = new ViewDrawBorderEdge(paletteBorderEdge, System.Windows.Forms.Orientation.Vertical);
+        BorderEdgeH = new ViewDrawBorderEdge(paletteBorderEdge, System.Windows.Forms.Orientation.Horizontal);
+
+        // Hook into scroll position changes
+        ScrollbarV.ScrollChanged += OnScrollVChanged;
+        ScrollbarH.ScrollChanged += OnScrollHChanged;
+
+        // Add with appropriate docking style
+        Add(ViewControl, ViewDockStyle.Fill);
+        Add(BorderEdgeV, ViewDockStyle.Right);
+        Add(BorderEdgeH, ViewDockStyle.Bottom);
+        Add(ScrollbarV, ViewDockStyle.Right);
+        Add(ScrollbarH, ViewDockStyle.Bottom);
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the ViewLayoutScrollViewport class.
+    /// </summary>
+    /// <param name="rootPopup">Top level visual popup.</param>
+    /// <param name="viewportFiller">View element to place inside viewport.</param>
+    /// <param name="paletteBorderEdge">Palette for use with the border edge.</param>
+    /// <param name="paletteMetrics">Palette source for metrics.</param>
+    /// <param name="metricPadding">Metric used to get view padding.</param>
+    /// <param name="metricOvers">Metric used to get overposition.</param>
+    /// <param name="orientation">Orientation for the viewport children.</param>
+    /// <param name="alignment">Alignment of the children within the viewport.</param>
+    /// <param name="animateChange">Animate changes in the viewport.</param>
+    /// <param name="vertical">Is the viewport vertical.</param>
+    /// <param name="needPaintDelegate">Delegate for notifying paint requests.</param>
+    public ViewLayoutScrollViewport([DisallowNull] VisualPopup rootPopup,
+        [DisallowNull] ViewBase viewportFiller,
+        PaletteBorderEdge paletteBorderEdge,
+        IPaletteMetric? paletteMetrics,
+        PaletteMetricPadding metricPadding,
+        PaletteMetricInt metricOvers,
+        VisualOrientation orientation,
+        RelativePositionAlign alignment,
+        bool animateChange,
+        bool vertical,
+        [DisallowNull] NeedPaintHandler needPaintDelegate)
+    {
+        Debug.Assert(rootPopup != null);
+        Debug.Assert(viewportFiller != null);
+        Debug.Assert(needPaintDelegate != null);
+
+        // We need a way to notify changes in layout
+        _needPaintDelegate = needPaintDelegate;
+
+        // By default we are showing the contained viewport in vertical scrolling
+        _viewportVertical = vertical;
+
+        // Our initial visual orientation should match the parameter
+        Orientation = orientation;
+
+        // Create the child viewport
+        Viewport = new ViewLayoutViewport(paletteMetrics!, metricPadding,
+            metricOvers, ViewportOrientation(_viewportVertical),
+            alignment, animateChange)
+        {
+
+            // Default to same alignment for both directions
+            CounterAlignment = alignment,
+
+            // We always want the viewport to fill any remainder space
+            FillSpace = true
+        };
+
+        // Put the provided element inside the viewport
+        Viewport.Add(viewportFiller!);
+
+        // Hook into animation step events
+        Viewport.AnimateStep += OnAnimateStep;
+
+        // To prevent the contents of the viewport from being able to draw outside
+        // the viewport (such as having child controls) we use a ViewLayoutControl
+        // that uses a child control to restrict the drawing region.
+        ViewControl = new ViewLayoutControl(rootPopup!, Viewport);
 
         // Create the scrollbar and matching border edge
         ScrollbarV = new ViewDrawScrollBar(true);

--- a/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.Designer.cs
@@ -1,0 +1,313 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac et al. 2024 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class Bug3661KryptonContextMenuOverflowDemo
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
+            this.lblInstruction = new Krypton.Toolkit.KryptonWrapLabel();
+            this.lblSectionConfig = new Krypton.Toolkit.KryptonLabel();
+            this.klblItemCount = new Krypton.Toolkit.KryptonLabel();
+            this.knumItemCount = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kchkOverflowArrows = new Krypton.Toolkit.KryptonCheckBox();
+            this.lblSectionProgrammatic = new Krypton.Toolkit.KryptonLabel();
+            this.kbtnShowMouse = new Krypton.Toolkit.KryptonButton();
+            this.kbtnShowScreenTop = new Krypton.Toolkit.KryptonButton();
+            this.kbtnShowScreenCenter = new Krypton.Toolkit.KryptonButton();
+            this.kbtnShowScreenBottom = new Krypton.Toolkit.KryptonButton();
+            this.kbtnKeyboardOpen = new Krypton.Toolkit.KryptonButton();
+            this.lblSectionAttached = new Krypton.Toolkit.KryptonLabel();
+            this.kbtnLongList = new Krypton.Toolkit.KryptonButton();
+            this.kbtnMixedList = new Krypton.Toolkit.KryptonButton();
+            this.klblStatus = new Krypton.Toolkit.KryptonLabel();
+            this.lblSectionAnchor = new Krypton.Toolkit.KryptonLabel();
+            this.kbtnAnchorTarget = new Krypton.Toolkit.KryptonButton();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
+            this.kryptonPanelMain.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // kryptonPanelMain
+            // 
+            this.kryptonPanelMain.AutoScroll = true;
+            this.kryptonPanelMain.Controls.Add(this.kbtnAnchorTarget);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionAnchor);
+            this.kryptonPanelMain.Controls.Add(this.klblStatus);
+            this.kryptonPanelMain.Controls.Add(this.kbtnMixedList);
+            this.kryptonPanelMain.Controls.Add(this.kbtnLongList);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionAttached);
+            this.kryptonPanelMain.Controls.Add(this.kbtnKeyboardOpen);
+            this.kryptonPanelMain.Controls.Add(this.kbtnShowScreenBottom);
+            this.kryptonPanelMain.Controls.Add(this.kbtnShowScreenCenter);
+            this.kryptonPanelMain.Controls.Add(this.kbtnShowScreenTop);
+            this.kryptonPanelMain.Controls.Add(this.kbtnShowMouse);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionProgrammatic);
+            this.kryptonPanelMain.Controls.Add(this.kchkOverflowArrows);
+            this.kryptonPanelMain.Controls.Add(this.knumItemCount);
+            this.kryptonPanelMain.Controls.Add(this.klblItemCount);
+            this.kryptonPanelMain.Controls.Add(this.lblSectionConfig);
+            this.kryptonPanelMain.Controls.Add(this.lblInstruction);
+            this.kryptonPanelMain.Controls.Add(this.kryptonThemeComboBox1);
+            this.kryptonPanelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanelMain.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanelMain.Name = "kryptonPanelMain";
+            this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
+            this.kryptonPanelMain.Size = new System.Drawing.Size(684, 561);
+            this.kryptonPanelMain.TabIndex = 0;
+            // 
+            // kryptonThemeComboBox1
+            // 
+            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Global;
+            this.kryptonThemeComboBox1.DropDownWidth = 220;
+            this.kryptonThemeComboBox1.IntegralHeight = false;
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(15, 15);
+            this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(220, 22);
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kryptonThemeComboBox1.TabIndex = 0;
+            // 
+            // lblInstruction
+            // 
+            this.lblInstruction.AutoSize = false;
+            this.lblInstruction.Location = new System.Drawing.Point(15, 48);
+            this.lblInstruction.Name = "lblInstruction";
+            this.lblInstruction.Size = new System.Drawing.Size(640, 130);
+            this.lblInstruction.Text = "Issue #3661: When a KryptonContextMenu has more items than fit on screen, Scroll Up " +
+    "and Scroll Down rows appear instead of clipping. Verify: (1) hover a scroll row — " +
+    "the list should advance while the pointer stays on the row; (2) mouse wheel over the " +
+    "menu; (3) arrow keys past the first/last visible item; (4) keyboard-open places focus " +
+    "on the first item. Use \"Near bottom of screen\" or shrink the window height to force overflow.";
+            // 
+            // lblSectionConfig
+            // 
+            this.lblSectionConfig.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionConfig.Location = new System.Drawing.Point(15, 188);
+            this.lblSectionConfig.Name = "lblSectionConfig";
+            this.lblSectionConfig.Size = new System.Drawing.Size(200, 27);
+            this.lblSectionConfig.TabIndex = 2;
+            this.lblSectionConfig.Values.Text = "Configuration";
+            // 
+            // klblItemCount
+            // 
+            this.klblItemCount.Location = new System.Drawing.Point(15, 220);
+            this.klblItemCount.Name = "klblItemCount";
+            this.klblItemCount.Size = new System.Drawing.Size(140, 20);
+            this.klblItemCount.TabIndex = 3;
+            this.klblItemCount.Values.Text = "Menu item count: 65";
+            // 
+            // knumItemCount
+            // 
+            this.knumItemCount.Location = new System.Drawing.Point(200, 220);
+            this.knumItemCount.Maximum = new decimal(new int[] {
+            150,
+            0,
+            0,
+            0});
+            this.knumItemCount.Minimum = new decimal(new int[] {
+            15,
+            0,
+            0,
+            0});
+            this.knumItemCount.Name = "knumItemCount";
+            this.knumItemCount.Size = new System.Drawing.Size(80, 22);
+            this.knumItemCount.TabIndex = 4;
+            this.knumItemCount.Value = new decimal(new int[] {
+            65,
+            0,
+            0,
+            0});
+            // 
+            // kchkOverflowArrows
+            // 
+            this.kchkOverflowArrows.Location = new System.Drawing.Point(300, 220);
+            this.kchkOverflowArrows.Name = "kchkOverflowArrows";
+            this.kchkOverflowArrows.Size = new System.Drawing.Size(220, 20);
+            this.kchkOverflowArrows.TabIndex = 5;
+            this.kchkOverflowArrows.Values.Text = "Overflow rows use arrows";
+            // 
+            // lblSectionProgrammatic
+            // 
+            this.lblSectionProgrammatic.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionProgrammatic.Location = new System.Drawing.Point(15, 258);
+            this.lblSectionProgrammatic.Name = "lblSectionProgrammatic";
+            this.lblSectionProgrammatic.Size = new System.Drawing.Size(280, 27);
+            this.lblSectionProgrammatic.TabIndex = 6;
+            this.lblSectionProgrammatic.Values.Text = "Programmatic placement (long list)";
+            // 
+            // kbtnShowMouse
+            // 
+            this.kbtnShowMouse.Location = new System.Drawing.Point(15, 292);
+            this.kbtnShowMouse.Name = "kbtnShowMouse";
+            this.kbtnShowMouse.Size = new System.Drawing.Size(200, 28);
+            this.kbtnShowMouse.TabIndex = 7;
+            this.kbtnShowMouse.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowMouse.Values.Text = "Show below anchor button";
+            this.kbtnShowMouse.Click += new System.EventHandler(this.kbtnShowMouse_Click);
+            // 
+            // kbtnShowScreenTop
+            // 
+            this.kbtnShowScreenTop.Location = new System.Drawing.Point(225, 292);
+            this.kbtnShowScreenTop.Name = "kbtnShowScreenTop";
+            this.kbtnShowScreenTop.Size = new System.Drawing.Size(200, 28);
+            this.kbtnShowScreenTop.TabIndex = 8;
+            this.kbtnShowScreenTop.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenTop.Values.Text = "Near top of screen";
+            this.kbtnShowScreenTop.Click += new System.EventHandler(this.kbtnShowScreenTop_Click);
+            // 
+            // kbtnShowScreenCenter
+            // 
+            this.kbtnShowScreenCenter.Location = new System.Drawing.Point(435, 292);
+            this.kbtnShowScreenCenter.Name = "kbtnShowScreenCenter";
+            this.kbtnShowScreenCenter.Size = new System.Drawing.Size(200, 28);
+            this.kbtnShowScreenCenter.TabIndex = 9;
+            this.kbtnShowScreenCenter.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenCenter.Values.Text = "Screen center";
+            this.kbtnShowScreenCenter.Click += new System.EventHandler(this.kbtnShowScreenCenter_Click);
+            // 
+            // kbtnShowScreenBottom
+            // 
+            this.kbtnShowScreenBottom.Location = new System.Drawing.Point(15, 328);
+            this.kbtnShowScreenBottom.Name = "kbtnShowScreenBottom";
+            this.kbtnShowScreenBottom.Size = new System.Drawing.Size(200, 28);
+            this.kbtnShowScreenBottom.TabIndex = 10;
+            this.kbtnShowScreenBottom.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenBottom.Values.Text = "Near bottom of screen";
+            this.kbtnShowScreenBottom.Click += new System.EventHandler(this.kbtnShowScreenBottom_Click);
+            // 
+            // kbtnKeyboardOpen
+            // 
+            this.kbtnKeyboardOpen.Location = new System.Drawing.Point(225, 328);
+            this.kbtnKeyboardOpen.Name = "kbtnKeyboardOpen";
+            this.kbtnKeyboardOpen.Size = new System.Drawing.Size(200, 28);
+            this.kbtnKeyboardOpen.TabIndex = 11;
+            this.kbtnKeyboardOpen.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnKeyboardOpen.Values.Text = "Keyboard-activated open";
+            this.kbtnKeyboardOpen.Click += new System.EventHandler(this.kbtnKeyboardOpen_Click);
+            // 
+            // lblSectionAttached
+            // 
+            this.lblSectionAttached.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionAttached.Location = new System.Drawing.Point(15, 368);
+            this.lblSectionAttached.Name = "lblSectionAttached";
+            this.lblSectionAttached.Size = new System.Drawing.Size(320, 27);
+            this.lblSectionAttached.TabIndex = 12;
+            this.lblSectionAttached.Values.Text = "Attached menus (right-click)";
+            // 
+            // kbtnLongList
+            // 
+            this.kbtnLongList.Location = new System.Drawing.Point(15, 402);
+            this.kbtnLongList.Name = "kbtnLongList";
+            this.kbtnLongList.Size = new System.Drawing.Size(280, 32);
+            this.kbtnLongList.TabIndex = 13;
+            this.kbtnLongList.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnLongList.Values.Text = "Long list — right-click here";
+            // 
+            // kbtnMixedList
+            // 
+            this.kbtnMixedList.Location = new System.Drawing.Point(310, 402);
+            this.kbtnMixedList.Name = "kbtnMixedList";
+            this.kbtnMixedList.Size = new System.Drawing.Size(325, 32);
+            this.kbtnMixedList.TabIndex = 14;
+            this.kbtnMixedList.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnMixedList.Values.Text = "Mixed headings / separators / extras — right-click";
+            // 
+            // klblStatus
+            // 
+            this.klblStatus.Location = new System.Drawing.Point(15, 448);
+            this.klblStatus.Name = "klblStatus";
+            this.klblStatus.Size = new System.Drawing.Size(620, 40);
+            this.klblStatus.TabIndex = 15;
+            this.klblStatus.Values.Text = "Status: open a menu to begin.";
+            // 
+            // lblSectionAnchor
+            // 
+            this.lblSectionAnchor.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
+            this.lblSectionAnchor.Location = new System.Drawing.Point(15, 498);
+            this.lblSectionAnchor.Name = "lblSectionAnchor";
+            this.lblSectionAnchor.Size = new System.Drawing.Size(200, 27);
+            this.lblSectionAnchor.TabIndex = 16;
+            this.lblSectionAnchor.Values.Text = "Anchor for placement";
+            // 
+            // kbtnAnchorTarget
+            // 
+            this.kbtnAnchorTarget.Location = new System.Drawing.Point(15, 532);
+            this.kbtnAnchorTarget.Name = "kbtnAnchorTarget";
+            this.kbtnAnchorTarget.Size = new System.Drawing.Size(240, 28);
+            this.kbtnAnchorTarget.TabIndex = 17;
+            this.kbtnAnchorTarget.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnAnchorTarget.Values.Text = "Anchor button (also has long list menu)";
+            // 
+            // Bug3661KryptonContextMenuOverflowDemo
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(684, 561);
+            this.Controls.Add(this.kryptonPanelMain);
+            this.Name = "Bug3661KryptonContextMenuOverflowDemo";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Issue #3661: KryptonContextMenu Overflow Demo";
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).EndInit();
+            this.kryptonPanelMain.ResumeLayout(false);
+            this.kryptonPanelMain.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanelMain;
+        private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
+        private Krypton.Toolkit.KryptonWrapLabel lblInstruction;
+        private Krypton.Toolkit.KryptonLabel lblSectionConfig;
+        private Krypton.Toolkit.KryptonLabel klblItemCount;
+        private Krypton.Toolkit.KryptonNumericUpDown knumItemCount;
+        private Krypton.Toolkit.KryptonCheckBox kchkOverflowArrows;
+        private Krypton.Toolkit.KryptonLabel lblSectionProgrammatic;
+        private Krypton.Toolkit.KryptonButton kbtnShowMouse;
+        private Krypton.Toolkit.KryptonButton kbtnShowScreenTop;
+        private Krypton.Toolkit.KryptonButton kbtnShowScreenCenter;
+        private Krypton.Toolkit.KryptonButton kbtnShowScreenBottom;
+        private Krypton.Toolkit.KryptonButton kbtnKeyboardOpen;
+        private Krypton.Toolkit.KryptonLabel lblSectionAttached;
+        private Krypton.Toolkit.KryptonButton kbtnLongList;
+        private Krypton.Toolkit.KryptonButton kbtnMixedList;
+        private Krypton.Toolkit.KryptonLabel klblStatus;
+        private Krypton.Toolkit.KryptonLabel lblSectionAnchor;
+        private Krypton.Toolkit.KryptonButton kbtnAnchorTarget;
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.Designer.cs
@@ -11,30 +11,20 @@ namespace TestForm
 {
     partial class Bug3661KryptonContextMenuOverflowDemo
     {
-        /// <summary>
-        /// Required designer variable.
-        /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                components?.Dispose();
             }
+
             base.Dispose(disposing);
         }
 
         #region Windows Form Designer generated code
 
-        /// <summary>
-        /// Required method for Designer support - do not modify
-        /// the contents of this method with the code editor.
-        /// </summary>
         private void InitializeComponent()
         {
             this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
@@ -54,15 +44,15 @@ namespace TestForm
             this.kbtnLongList = new Krypton.Toolkit.KryptonButton();
             this.kbtnMixedList = new Krypton.Toolkit.KryptonButton();
             this.klblStatus = new Krypton.Toolkit.KryptonLabel();
-            this.lblSectionAnchor = new Krypton.Toolkit.KryptonLabel();
             this.kbtnAnchorTarget = new Krypton.Toolkit.KryptonButton();
+            this.lblSectionAnchor = new Krypton.Toolkit.KryptonLabel();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
             this.kryptonPanelMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanelMain
-            // 
+            //
             this.kryptonPanelMain.AutoScroll = true;
             this.kryptonPanelMain.Controls.Add(this.kbtnAnchorTarget);
             this.kryptonPanelMain.Controls.Add(this.lblSectionAnchor);
@@ -88,9 +78,9 @@ namespace TestForm
             this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
             this.kryptonPanelMain.Size = new System.Drawing.Size(684, 561);
             this.kryptonPanelMain.TabIndex = 0;
-            // 
+            //
             // kryptonThemeComboBox1
-            // 
+            //
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Global;
             this.kryptonThemeComboBox1.DropDownWidth = 220;
             this.kryptonThemeComboBox1.IntegralHeight = false;
@@ -99,9 +89,9 @@ namespace TestForm
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(220, 22);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 0;
-            // 
+            //
             // lblInstruction
-            // 
+            //
             this.lblInstruction.AutoSize = false;
             this.lblInstruction.Location = new System.Drawing.Point(15, 48);
             this.lblInstruction.Name = "lblInstruction";
@@ -111,168 +101,148 @@ namespace TestForm
     "the list should advance while the pointer stays on the row; (2) mouse wheel over the " +
     "menu; (3) arrow keys past the first/last visible item; (4) keyboard-open places focus " +
     "on the first item. Use \"Near bottom of screen\" or shrink the window height to force overflow.";
-            // 
+            //
             // lblSectionConfig
-            // 
+            //
             this.lblSectionConfig.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
             this.lblSectionConfig.Location = new System.Drawing.Point(15, 188);
             this.lblSectionConfig.Name = "lblSectionConfig";
             this.lblSectionConfig.Size = new System.Drawing.Size(200, 27);
             this.lblSectionConfig.TabIndex = 2;
             this.lblSectionConfig.Values.Text = "Configuration";
-            // 
+            //
             // klblItemCount
-            // 
-            this.klblItemCount.Location = new System.Drawing.Point(15, 220);
+            //
+            this.klblItemCount.Location = new System.Drawing.Point(15, 222);
             this.klblItemCount.Name = "klblItemCount";
             this.klblItemCount.Size = new System.Drawing.Size(140, 20);
             this.klblItemCount.TabIndex = 3;
             this.klblItemCount.Values.Text = "Menu item count: 65";
-            // 
+            //
             // knumItemCount
-            // 
+            //
             this.knumItemCount.Location = new System.Drawing.Point(200, 220);
-            this.knumItemCount.Maximum = new decimal(new int[] {
-            150,
-            0,
-            0,
-            0});
-            this.knumItemCount.Minimum = new decimal(new int[] {
-            15,
-            0,
-            0,
-            0});
+            this.knumItemCount.Maximum = new decimal(new int[] { 150, 0, 0, 0 });
+            this.knumItemCount.Minimum = new decimal(new int[] { 15, 0, 0, 0 });
             this.knumItemCount.Name = "knumItemCount";
             this.knumItemCount.Size = new System.Drawing.Size(80, 22);
             this.knumItemCount.TabIndex = 4;
-            this.knumItemCount.Value = new decimal(new int[] {
-            65,
-            0,
-            0,
-            0});
-            // 
+            this.knumItemCount.Value = new decimal(new int[] { 65, 0, 0, 0 });
+            //
             // kchkOverflowArrows
-            // 
+            //
             this.kchkOverflowArrows.Location = new System.Drawing.Point(300, 220);
             this.kchkOverflowArrows.Name = "kchkOverflowArrows";
             this.kchkOverflowArrows.Size = new System.Drawing.Size(220, 20);
             this.kchkOverflowArrows.TabIndex = 5;
             this.kchkOverflowArrows.Values.Text = "Overflow rows use arrows";
-            // 
+            //
             // lblSectionProgrammatic
-            // 
+            //
             this.lblSectionProgrammatic.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
             this.lblSectionProgrammatic.Location = new System.Drawing.Point(15, 258);
             this.lblSectionProgrammatic.Name = "lblSectionProgrammatic";
             this.lblSectionProgrammatic.Size = new System.Drawing.Size(280, 27);
-            this.lblSectionProgrammatic.TabIndex = 6;
+            this.lblSectionProgrammatic.TabIndex = 5;
             this.lblSectionProgrammatic.Values.Text = "Programmatic placement (long list)";
-            // 
+            //
             // kbtnShowMouse
-            // 
+            //
             this.kbtnShowMouse.Location = new System.Drawing.Point(15, 292);
             this.kbtnShowMouse.Name = "kbtnShowMouse";
             this.kbtnShowMouse.Size = new System.Drawing.Size(200, 28);
-            this.kbtnShowMouse.TabIndex = 7;
-            this.kbtnShowMouse.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowMouse.TabIndex = 6;
             this.kbtnShowMouse.Values.Text = "Show below anchor button";
             this.kbtnShowMouse.Click += new System.EventHandler(this.kbtnShowMouse_Click);
-            // 
+            //
             // kbtnShowScreenTop
-            // 
+            //
             this.kbtnShowScreenTop.Location = new System.Drawing.Point(225, 292);
             this.kbtnShowScreenTop.Name = "kbtnShowScreenTop";
             this.kbtnShowScreenTop.Size = new System.Drawing.Size(200, 28);
-            this.kbtnShowScreenTop.TabIndex = 8;
-            this.kbtnShowScreenTop.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenTop.TabIndex = 7;
             this.kbtnShowScreenTop.Values.Text = "Near top of screen";
             this.kbtnShowScreenTop.Click += new System.EventHandler(this.kbtnShowScreenTop_Click);
-            // 
+            //
             // kbtnShowScreenCenter
-            // 
+            //
             this.kbtnShowScreenCenter.Location = new System.Drawing.Point(435, 292);
             this.kbtnShowScreenCenter.Name = "kbtnShowScreenCenter";
             this.kbtnShowScreenCenter.Size = new System.Drawing.Size(200, 28);
-            this.kbtnShowScreenCenter.TabIndex = 9;
-            this.kbtnShowScreenCenter.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenCenter.TabIndex = 8;
             this.kbtnShowScreenCenter.Values.Text = "Screen center";
             this.kbtnShowScreenCenter.Click += new System.EventHandler(this.kbtnShowScreenCenter_Click);
-            // 
+            //
             // kbtnShowScreenBottom
-            // 
+            //
             this.kbtnShowScreenBottom.Location = new System.Drawing.Point(15, 328);
             this.kbtnShowScreenBottom.Name = "kbtnShowScreenBottom";
             this.kbtnShowScreenBottom.Size = new System.Drawing.Size(200, 28);
-            this.kbtnShowScreenBottom.TabIndex = 10;
-            this.kbtnShowScreenBottom.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowScreenBottom.TabIndex = 9;
             this.kbtnShowScreenBottom.Values.Text = "Near bottom of screen";
             this.kbtnShowScreenBottom.Click += new System.EventHandler(this.kbtnShowScreenBottom_Click);
-            // 
+            //
             // kbtnKeyboardOpen
-            // 
+            //
             this.kbtnKeyboardOpen.Location = new System.Drawing.Point(225, 328);
             this.kbtnKeyboardOpen.Name = "kbtnKeyboardOpen";
             this.kbtnKeyboardOpen.Size = new System.Drawing.Size(200, 28);
-            this.kbtnKeyboardOpen.TabIndex = 11;
-            this.kbtnKeyboardOpen.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnKeyboardOpen.TabIndex = 10;
             this.kbtnKeyboardOpen.Values.Text = "Keyboard-activated open";
             this.kbtnKeyboardOpen.Click += new System.EventHandler(this.kbtnKeyboardOpen_Click);
-            // 
+            //
             // lblSectionAttached
-            // 
+            //
             this.lblSectionAttached.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
             this.lblSectionAttached.Location = new System.Drawing.Point(15, 368);
             this.lblSectionAttached.Name = "lblSectionAttached";
             this.lblSectionAttached.Size = new System.Drawing.Size(320, 27);
-            this.lblSectionAttached.TabIndex = 12;
+            this.lblSectionAttached.TabIndex = 11;
             this.lblSectionAttached.Values.Text = "Attached menus (right-click)";
-            // 
+            //
             // kbtnLongList
-            // 
+            //
             this.kbtnLongList.Location = new System.Drawing.Point(15, 402);
             this.kbtnLongList.Name = "kbtnLongList";
             this.kbtnLongList.Size = new System.Drawing.Size(280, 32);
-            this.kbtnLongList.TabIndex = 13;
-            this.kbtnLongList.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnLongList.TabIndex = 12;
             this.kbtnLongList.Values.Text = "Long list — right-click here";
-            // 
+            //
             // kbtnMixedList
-            // 
+            //
             this.kbtnMixedList.Location = new System.Drawing.Point(310, 402);
             this.kbtnMixedList.Name = "kbtnMixedList";
             this.kbtnMixedList.Size = new System.Drawing.Size(325, 32);
-            this.kbtnMixedList.TabIndex = 14;
-            this.kbtnMixedList.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnMixedList.TabIndex = 13;
             this.kbtnMixedList.Values.Text = "Mixed headings / separators / extras — right-click";
-            // 
+            //
             // klblStatus
-            // 
+            //
             this.klblStatus.Location = new System.Drawing.Point(15, 448);
             this.klblStatus.Name = "klblStatus";
             this.klblStatus.Size = new System.Drawing.Size(620, 40);
-            this.klblStatus.TabIndex = 15;
+            this.klblStatus.TabIndex = 14;
             this.klblStatus.Values.Text = "Status: open a menu to begin.";
-            // 
+            //
             // lblSectionAnchor
-            // 
+            //
             this.lblSectionAnchor.LabelStyle = Krypton.Toolkit.LabelStyle.TitlePanel;
             this.lblSectionAnchor.Location = new System.Drawing.Point(15, 498);
             this.lblSectionAnchor.Name = "lblSectionAnchor";
             this.lblSectionAnchor.Size = new System.Drawing.Size(200, 27);
-            this.lblSectionAnchor.TabIndex = 16;
+            this.lblSectionAnchor.TabIndex = 15;
             this.lblSectionAnchor.Values.Text = "Anchor for placement";
-            // 
+            //
             // kbtnAnchorTarget
-            // 
+            //
             this.kbtnAnchorTarget.Location = new System.Drawing.Point(15, 532);
             this.kbtnAnchorTarget.Name = "kbtnAnchorTarget";
             this.kbtnAnchorTarget.Size = new System.Drawing.Size(240, 28);
-            this.kbtnAnchorTarget.TabIndex = 17;
-            this.kbtnAnchorTarget.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnAnchorTarget.TabIndex = 16;
             this.kbtnAnchorTarget.Values.Text = "Anchor button (also has long list menu)";
-            // 
+            //
             // Bug3661KryptonContextMenuOverflowDemo
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(684, 561);
@@ -285,7 +255,6 @@ namespace TestForm
             this.kryptonPanelMain.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3661KryptonContextMenuOverflowDemo.cs
@@ -1,0 +1,181 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac et al. 2024 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Comprehensive demo for Issue #3661: KryptonContextMenu overflow when item list exceeds screen height.
+/// </summary>
+public partial class Bug3661KryptonContextMenuOverflowDemo : KryptonForm
+{
+    private KryptonContextMenu _longListMenu;
+    private KryptonContextMenu _mixedListMenu;
+
+    public Bug3661KryptonContextMenuOverflowDemo()
+    {
+        InitializeComponent();
+        _longListMenu = CreateLongListMenu();
+        _mixedListMenu = CreateMixedListMenu();
+        kbtnLongList.KryptonContextMenu = _longListMenu;
+        kbtnMixedList.KryptonContextMenu = _mixedListMenu;
+        kbtnAnchorTarget.KryptonContextMenu = _longListMenu;
+        HookMenuEvents(_longListMenu);
+        HookMenuEvents(_mixedListMenu);
+        knumItemCount.ValueChanged += OnItemCountChanged;
+        kchkOverflowArrows.CheckedChanged += OnOverflowArrowsChanged;
+        UpdateItemCountLabel();
+    }
+
+    private void OnOverflowArrowsChanged(object? sender, EventArgs e)
+    {
+        _longListMenu.OverflowScrollUseArrows = kchkOverflowArrows.Checked;
+        _mixedListMenu.OverflowScrollUseArrows = kchkOverflowArrows.Checked;
+    }
+
+    private void OnItemCountChanged(object? sender, EventArgs e)
+    {
+        _longListMenu = CreateLongListMenu();
+        _mixedListMenu = CreateMixedListMenu();
+        kbtnLongList.KryptonContextMenu = _longListMenu;
+        kbtnMixedList.KryptonContextMenu = _mixedListMenu;
+        kbtnAnchorTarget.KryptonContextMenu = _longListMenu;
+        HookMenuEvents(_longListMenu);
+        HookMenuEvents(_mixedListMenu);
+        UpdateItemCountLabel();
+    }
+
+    private void UpdateItemCountLabel()
+    {
+        var count = (int)knumItemCount.Value;
+        klblItemCount.Values.Text = $"Menu item count: {count}";
+    }
+
+    private void kbtnShowMouse_Click(object? sender, EventArgs e) =>
+        ShowMenu(kbtnAnchorTarget, false);
+
+    private void kbtnShowScreenTop_Click(object? sender, EventArgs e) =>
+        ShowMenuAtScreen(new Point(80, 40), false);
+
+    private void kbtnShowScreenCenter_Click(object? sender, EventArgs e)
+    {
+        var area = Screen.PrimaryScreen?.WorkingArea ?? Screen.GetWorkingArea(this);
+        var pt = new Point(area.Left + (area.Width / 2), area.Top + (area.Height / 2));
+        ShowMenuAtScreen(pt, false);
+    }
+
+    private void kbtnShowScreenBottom_Click(object? sender, EventArgs e)
+    {
+        var area = Screen.PrimaryScreen?.WorkingArea ?? Screen.GetWorkingArea(this);
+        var pt = new Point(area.Left + 80, area.Bottom - 8);
+        ShowMenuAtScreen(pt, true);
+    }
+
+    private void kbtnKeyboardOpen_Click(object? sender, EventArgs e) =>
+        ShowMenu(kbtnAnchorTarget, true);
+
+    private void ShowMenu(Control target, bool keyboardActivated)
+    {
+        var screenPt = target.PointToScreen(new Point(target.Width / 2, target.Height));
+        _longListMenu.Show(target, new Rectangle(screenPt, Size.Empty), KryptonContextMenuPositionH.Left,
+            KryptonContextMenuPositionV.Below, keyboardActivated, true);
+    }
+
+    private void ShowMenuAtScreen(Point screenPt, bool alignAbove)
+    {
+        _longListMenu.Show(kbtnAnchorTarget, new Rectangle(screenPt, Size.Empty),
+            KryptonContextMenuPositionH.Left,
+            alignAbove ? KryptonContextMenuPositionV.Above : KryptonContextMenuPositionV.Below,
+            false, true);
+    }
+
+    private KryptonContextMenu CreateLongListMenu()
+    {
+        var menu = new KryptonContextMenu
+        {
+            OverflowScrollUseArrows = kchkOverflowArrows.Checked
+        };
+        var items = new KryptonContextMenuItems();
+        menu.Items.Add(items);
+
+        var count = (int)knumItemCount.Value;
+        for (var i = 1; i <= count; i++)
+        {
+            var item = new KryptonContextMenuItem($"Long list item {i}")
+            {
+                CommandParameter = i
+            };
+            item.Click += OnMenuItemClick;
+            items.Items.Add(item);
+        }
+
+        return menu;
+    }
+
+    private KryptonContextMenu CreateMixedListMenu()
+    {
+        var menu = new KryptonContextMenu
+        {
+            OverflowScrollUseArrows = kchkOverflowArrows.Checked
+        };
+        var items = new KryptonContextMenuItems();
+        menu.Items.Add(items);
+
+        items.Items.Add(new KryptonContextMenuHeading("Mixed content"));
+
+        var count = Math.Max(12, (int)knumItemCount.Value / 2);
+        for (var i = 1; i <= count; i++)
+        {
+            if (i > 1 && (i % 8) == 1)
+            {
+                items.Items.Add(new KryptonContextMenuSeparator());
+            }
+
+            if (i == 5)
+            {
+                items.Items.Add(new KryptonContextMenuCheckBox("Sample check box"));
+            }
+
+            if (i == 10)
+            {
+                items.Items.Add(new KryptonContextMenuRadioButton("Radio option A"));
+                items.Items.Add(new KryptonContextMenuRadioButton("Radio option B"));
+            }
+
+            var item = new KryptonContextMenuItem($"Mixed item {i}")
+            {
+                ExtraText = i % 3 == 0 ? "Extra text column" : string.Empty,
+                CommandParameter = $"mixed-{i}"
+            };
+            item.Click += OnMenuItemClick;
+            items.Items.Add(item);
+        }
+
+        return menu;
+    }
+
+    private void HookMenuEvents(KryptonContextMenu menu)
+    {
+        menu.Opened += OnMenuOpened;
+        menu.Closed += OnMenuClosed;
+    }
+
+    private void OnMenuOpened(object? sender, EventArgs e) =>
+        klblStatus.Values.Text = "Menu opened — hover Scroll Up/Down, use wheel, or arrow keys";
+
+    private void OnMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) =>
+        klblStatus.Values.Text = $"Menu closed ({e.CloseReason})";
+
+    private void OnMenuItemClick(object? sender, EventArgs e)
+    {
+        if (sender is KryptonContextMenuItem item)
+        {
+            klblStatus.Values.Text = $"Clicked: {item.Text} (param: {item.CommandParameter})";
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/ButtonsTest.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -16,6 +16,13 @@ public partial class ButtonsTest : KryptonForm
         InitializeComponent();
         kcbColorScheme.SelectedItem = "OfficeThemes";
         kcbSortMode.Enabled = false;
+
+        // #1673 sample: progress bar in the shared UAC drop-down context menu
+        kryptonContextMenuItems1.Items.Insert(0, new KryptonContextMenuProgressBar
+        {
+            MinimumWidth = 200,
+            Value = 42
+        });
     }
 
     private void kcbtnDropDown_SelectedColorChanged(object sender, ColorEventArgs e)

--- a/Source/Krypton Components/TestForm/StartScreen.OptionalProjectDemos.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.OptionalProjectDemos.cs
@@ -1,0 +1,80 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+public partial class StartScreen
+{
+    private void AddOptionalProjectButtons()
+    {
+        CreateButton<ButtonBadgeTest>("Badge Test", "Comprehensive badge functionality demonstration for KryptonButton and KryptonCheckButton.");
+        CreateButton<ButtonTextTrackingExample>("Button Text Tracking", "Demonstrates alternate text color for tracking (hover) state on KryptonButton, KryptonCheckButton, KryptonColorButton and other controls (Issue #1326). Improves readability in dark themes.");
+        CreateButton<KryptonColorButtonDemo>("KryptonColorButton Custom Colours", "Comprehensive demo of KryptonColorButton custom colours (Issue #776): CustomColors, MaxCustomColors, and visibility. Only 10 colours, or custom + theme + standard, or cap display count.");
+        CreateButton<KryptonComboBoxUserControlDemo>("KryptonComboBoxUserControl", "Demo for Issue #3443: a ComboBox-style control whose drop-down hosts any UserControl. Shows tree-picker, grid-picker and a plain (non-contract) UserControl scenario.");
+        CreateButton<KryptonTreeComboBoxDemo>("KryptonTreeComboBox", "Demo for Issue #3444: ComboBox-style control with a grouped tree drop-down (leaf/full path, breadcrumb, and parent-node selection).");
+        CreateButton<KryptonCheckedListComboBoxDemo>("KryptonCheckedListComboBox", "Multi-select combo (#3445) with KryptonCheckedListBox drop-down: items + DataSource/DisplayMember/ValueMember demo and live summary.");
+        CreateButton<BorderlessFormDemo>("Borderless Form Demo", "Demo for Issue #2922: Borderless KryptonForm without system title bar flicker on startup. Form should appear directly in borderless state.");
+        CreateButton<Bug2914Test>("Bug 2914 Test", "Tests the fix for 2914.");
+        CreateButton<Bug2984SeparatorTest>("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.");
+        CreateButton<Bug3025KryptonLabelAutoSizeDemo>("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.");
+        CreateButton<Bug3342KryptonTextBoxResizeFlickerDemo>("Bug 3342 Multiline TextBox Flicker", "Demo for issue #3342: multiline KryptonTextBox text flicker while resizing. Includes manual resize steps and an automated stress-resize toggle.");
+        CreateButton<Bug3382CueHintLinesDemo>("Bug 3382 CueHint line artifacts", "Demo for issue #3382: KryptonTextBox CueHint with TextH Near and mixed cue/content fonts — verify no stray top/left lines; cue remains vertically centered.");
+        CreateButton<Bug3383KryptonButtonStateTrackingRoundingDemo>("Bug 3383 KryptonButton hover rounding vs OverrideFocus", "Demo for issue #3383: large StateCommon rounding with different StateTracking rounding and OverrideFocus rounding — Tab to focus, then hover (left repro vs right matched control). Corner fill and stroke should align after the palette merge fix.");
+        CreateButton<Bug3451KryptonHeaderGroupPanelDemo>("Bug 3451 HeaderGroup panel parenting", "Demo for issue #3451: add child controls to KryptonHeaderGroup, KryptonGroup, and KryptonGroupBox via the internal Panel at design time. Open in the WinForms Designer and drag controls into each content area; verify no ReadOnly controls collection error.");
+        CreateButton<KryptonToolTipTest>("KryptonToolTip", "Component wrapper (#3380): themed VisualPopupToolTip on arbitrary WinForms / Krypton controls via extender props or SetToolTip.");
+        CreateButton<Bug3283ThemeComboBoxProgrammaticTest>("Bug 3283 ThemeComboBox programmatic", "Issue #3283: KryptonThemeComboBox must apply the global palette when SelectedIndex is set in code. Buttons cycle or jump the index; status lines show selection vs KryptonManager.CurrentGlobalPaletteMode. Optional: add a fresh combo with index set before its handle exists.");
+        CreateButton<Bug2935MdiMultiMonitorDemo>("Bug 2935 MDI multi-monitor", "Demo for issue #2935: maximized MDI child form border drawn on the correct monitor. Move the MDI parent to a second monitor, open and maximize a child; the border should stay on the same monitor.");
+        CreateButton<Bug3013TestForm>("Bug 3013 Test", "Tests the fix for 3013.");
+        CreateButton<BugReportingDialogTest>("BugReportingTool", "Easily report bugs with this tool.");
+        CreateButton<CodeEditorTest>("Code Editor", "Native code editor with syntax highlighting, line numbering, code folding, and auto-completion.");
+        CreateButton<CountdownButtonTest>("Countdown Button", "Comprehensive demonstration of KryptonCountdownButton features with customizable duration, format, and enable-at-zero options.");
+        CreateButton<KryptonCommandButtonSpecDemo>("KryptonCommand ButtonSpec", "Issue #1133: KryptonCommand.CommandType drives integrated toolbar and help ButtonSpecs with palette-aware images. Click toolbar and help buttons; change theme to verify refresh.");
+        CreateButton<ControlStylesForm>("Control Styles", string.Empty);
+        CreateButton<KryptonDateTimePickerMonthCalendarDemo>("DateTimePicker Month Calendar Background", "Comprehensive demo of KryptonDateTimePicker month calendar custom background (Issue #1827): CalendarBackColor, theme default, presets (dark/light), and pick-a-color to style the drop-down calendar.");
+        CreateButton<DockingRedockDemo>("Docking Redock Demo", "Demo for Issue #2933: undock (Float) then redock; no floating window left behind.");
+        CreateButton<FontAwesomeTest>("Font Awesome Test", string.Empty);
+        CreateButton<FloatingToolbarsDemo>("Floating Toolbars Demo", "Comprehensive demonstration of KryptonFloatingToolbars features including drag-and-drop floating/docking, programmatic control, animation, window styles, docking preview indicators, custom themes, state persistence, and multi-monitor support.");
+        CreateButton<FlowLayoutPanelTest>("FlowLayoutPanel", "Test KryptonFlowLayoutPanel with dynamic control layout and flow directions.");
+        CreateButton<FileSystemWatcherTest>("FileSystemWatcher", "Monitor file system changes with Krypton integration.");
+        CreateButton<ErrorProviderTest>("ErrorProvider", string.Empty);
+        CreateButton<FileCheckSumDemo>("File checksum (Compute && Verify)", "Compute or verify file hashes (MD5, SHA-1, SHA-256, SHA-384, SHA-512, RIPEMD-160) using the Krypton checksum dialogs.");
+        CreateButton<HelpProviderTest>("HelpProvider", "Test KryptonHelpProvider functionality");
+        CreateButton<NotifyIconTest>("NotifyIcon", "Comprehensive demonstration of KryptonNotifyIcon with all events, balloon tips, and context menu support.");
+        CreateButton<OAuth2Demo>("OAuth2 PKCE Demo", "Comprehensive OAuth2 with PKCE demo. Sign in with Azure AD, Google, or GitHub using embedded WebView2 or system browser. Configure client ID, redirect URI, and scopes.");
+        CreateButton<QRCodeDemo>("QR Code (KryptonQRCode)", "Native QR code generation without external packages: live preview, ECC levels, module size, colors, quiet zone, Save PNG, clipboard, and static GenerateBitmap API.");
+        CreateButton<ScrollBarTest>("ScrollBar", "Comprehensive demonstration of KryptonHScrollBar and KryptonVScrollBar controls with basic usage, scrolling content, synchronization, theming, programmatic control, and event logging.");
+        CreateButton<ScrollbarManagerTest>("Scrollbar Manager", "Comprehensive demonstration of KryptonScrollbarManager with container mode, native wrapper mode, dynamic content, and integration examples.");
+        CreateButton<RTLControlsTest>("RTL Compliance Tests", "Test the Krypton.Toolkit controls for compliance.");
+        CreateButton<TaskbarOverlayIconTest>("Taskbar Overlay Icon Test", "Comprehensive demonstration of taskbar overlay icons on KryptonForm with configurable icons, descriptions, and interactive examples.");
+        CreateButton<TaskbarThumbnailButtonsDemo>("Taskbar Thumbnail Buttons", "Demo of taskbar thumbnail toolbar buttons (Play, Pause, Next, Stop) in the taskbar preview. Hover the taskbar button to see them.");
+        CreateButton<TaskbarProgressBarDemo>("Taskbar Progress Bar Demo", "Comprehensive demo of KryptonProgressBar taskbar synchronisation (Issue #2890). Covers enable/disable toggle, simulated download, manual slider, all ProgressBarStyles, all KryptonTaskbarProgressState overrides (Normal/Error/Paused/Indeterminate/NoProgress), and Min/Max range.");
+        CreateButton<TooltipTimeoutTest>("Tooltip Extended/Infinite Timeout", "Comprehensive demo of extended and infinite tooltip timeout (Issue #3075). Krypton tooltips support AutoPopDelay > 5000ms and 0 (infinite) on all Windows versions.");
+        CreateButton<TouchscreenHighDpiDemo>("Touchscreen + High DPI Demo", "Comprehensive demonstration of touchscreen support with per-monitor high DPI scaling (Issue #2844).");
+        CreateButton<KryptonFormTitleBarDemo>("Title Bar Menu", "Demonstrates titlebar menu.");
+        CreateButton<Bug3343RichTextBoxEditLossDemo>("Bug 3343 RichTextBox mouse leave", "Issue #3343: type in KryptonRichTextBox, move the mouse out without changing focus; text and TextLength must not reset. Includes KryptonTextBox for comparison.");
+        CreateButton<RTLFormBorderTest>("RTL Layout Test", "Test for RTL compliance");
+        CreateButton<WorkspaceTest>("WorkspaceTest", string.Empty);
+        CreateButton<DropDownArrowsDemo>("Drop-Down Arrows Demo", "Comprehensive demonstration of drop-down arrows: smaller size and DPI awareness (Issue #2129). Shows KryptonButton, KryptonDropButton, KryptonComboBox, KryptonDateTimePicker, KryptonColorButton, and KryptonNumericUpDown. Move window between monitors to verify DPI scaling.");
+        CreateButton<BindingNavigatorDemo>("KryptonBindingNavigator Demo", "Comprehensive example of KryptonBindingNavigator with data binding");
+        CreateButton<JumpListTest>("Jump List Test", "Comprehensive demonstration of jump lists on KryptonForm with user tasks, custom categories, known categories, and interactive examples.");
+        CreateButton<ProgressBarTriStateTest>("ProgressBar Tri-State", string.Empty);
+        CreateButton<OverlayImageTest>("Overlay Image Test", "Comprehensive demonstration of overlay images on KryptonButton and KryptonLabel with configurable positions and scaling modes.");
+        CreateButton<RibbonNotificationBarDemo>("Ribbon Notification Bar", "Comprehensive demonstration of the Krypton Ribbon Notification Bar feature with all customization options.");
+        CreateButton<RibbonMergerDemo>("Ribbon Merger Demo", "Demonstrates UserControl hosting and ribbon merging for plugin architectures");
+        CreateButton<RibbonDetachableTest>("Detachable Ribbons", "Demonstrates detachable ribbons feature - allows ribbon to be moved to a floating window (Issue #595)");
+        CreateButton<TextSuggestionDemo>("TextSuggestion", string.Empty);
+        CreateButton<TouchscreenSupportTest>("Touchscreen Support Test", "Comprehensive demonstration of touchscreen support with real-time scale factor adjustment.");
+        CreateButton<ControlboxTouchscreenDemo>("Controlbox && Context Menu Touchscreen", "Demonstration of touchscreen support for controlbox buttons (minimize, maximize, close) and KryptonContextMenu items (Issue #2925).");
+        CreateButton<TimerTest>("Timer", "Test KryptonTimer with interval configuration and event tracking.");
+        CreateButton<TabbedMdiDemo>("Tabbed MDI Demo (Issue #1746)", "KryptonTabbedMdiManager: MDI child windows displayed as tab pages instead of overlapping windows.");
+        CreateButton<RibbonMdiDemo>("Ribbon MDI Demo (Issue #2921)", "Comprehensive demo for Issue #2921: Ribbon + MDI. Verifies no double ribbon tabs when opening/closing maximized MDI children; close/minimize/maximize and QAT click areas aligned with visuals.");
+        CreateButton<Bug3203QATLocationHiddenFormTest>("Ribbon QATLocation=Hidden does not hide QAT when FormBorderStyle=None (Issue #3203)", string.Empty);
+        CreateButton<Bug3183SmallSquareRenderedNextToClose>("Small Square Rendered Next to Close Button (Issue #3183)", string.Empty);
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -10,8 +10,6 @@
 using System.Reflection;
 using System.Windows.Forms;
 
-using Krypton.Toolkit.Utilities;
-
 namespace TestForm;
 
 public partial class StartScreen : KryptonForm
@@ -59,71 +57,24 @@ public partial class StartScreen : KryptonForm
     {
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
-        CreateButton<ButtonBadgeTest>("Badge Test", "Comprehensive badge functionality demonstration for KryptonButton and KryptonCheckButton.");
-        CreateButton<ButtonTextTrackingExample>("Button Text Tracking", "Demonstrates alternate text color for tracking (hover) state on KryptonButton, KryptonCheckButton, KryptonColorButton and other controls (Issue #1326). Improves readability in dark themes.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
-        CreateButton<KryptonColorButtonDemo>("KryptonColorButton Custom Colours", "Comprehensive demo of KryptonColorButton custom colours (Issue #776): CustomColors, MaxCustomColors, and visibility. Only 10 colours, or custom + theme + standard, or cap display count.");
-        CreateButton<KryptonComboBoxUserControlDemo>("KryptonComboBoxUserControl", "Demo for Issue #3443: a ComboBox-style control whose drop-down hosts any UserControl. Shows tree-picker, grid-picker and a plain (non-contract) UserControl scenario.");
-        CreateButton<KryptonTreeComboBoxDemo>("KryptonTreeComboBox", "Demo for Issue #3444: ComboBox-style control with a grouped tree drop-down (leaf/full path, breadcrumb, and parent-node selection).");
-        CreateButton<KryptonCheckedListComboBoxDemo>("KryptonCheckedListComboBox", "Multi-select combo (#3445) with KryptonCheckedListBox drop-down: items + DataSource/DisplayMember/ValueMember demo and live summary.");
-        CreateButton<BorderlessFormDemo>("Borderless Form Demo", "Demo for Issue #2922: Borderless KryptonForm without system title bar flicker on startup. Form should appear directly in borderless state.");
-        CreateButton<Bug2914Test>("Bug 2914 Test", "Tests the fix for 2914.");
-        CreateButton<Bug2984SeparatorTest>("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.");
-        CreateButton<Bug3025KryptonLabelAutoSizeDemo>("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.");
-        CreateButton<Bug3342KryptonTextBoxResizeFlickerDemo>("Bug 3342 Multiline TextBox Flicker", "Demo for issue #3342: multiline KryptonTextBox text flicker while resizing. Includes manual resize steps and an automated stress-resize toggle.");
         CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox/KryptonMaskedTextBox, including ImageStates.ImageNormal without the Image property.");
-        CreateButton<Bug3382CueHintLinesDemo>("Bug 3382 CueHint line artifacts", "Demo for issue #3382: KryptonTextBox CueHint with TextH Near and mixed cue/content fonts — verify no stray top/left lines; cue remains vertically centered.");
-        CreateButton<Bug3383KryptonButtonStateTrackingRoundingDemo>("Bug 3383 KryptonButton hover rounding vs OverrideFocus", "Demo for issue #3383: large StateCommon rounding with different StateTracking rounding and OverrideFocus rounding — Tab to focus, then hover (left repro vs right matched control). Corner fill and stroke should align after the palette merge fix.");
-        CreateButton<Bug3451KryptonHeaderGroupPanelDemo>("Bug 3451 HeaderGroup panel parenting", "Demo for issue #3451: add child controls to KryptonHeaderGroup, KryptonGroup, and KryptonGroupBox via the internal Panel at design time. Open in the WinForms Designer and drag controls into each content area; verify no ReadOnly controls collection error.");
         CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu with more items than fit on screen shows Scroll Up/Scroll Down rows, mouse-wheel scrolling, and keyboard navigation past visible items. Long list, mixed content, programmatic placement, and keyboard-open scenarios.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
-        CreateButton<KryptonToolTipTest>("KryptonToolTip", "Component wrapper (#3380): themed VisualPopupToolTip on arbitrary WinForms / Krypton controls via extender props or SetToolTip.");
-        CreateButton<Bug3283ThemeComboBoxProgrammaticTest>("Bug 3283 ThemeComboBox programmatic", "Issue #3283: KryptonThemeComboBox must apply the global palette when SelectedIndex is set in code. Buttons cycle or jump the index; status lines show selection vs KryptonManager.CurrentGlobalPaletteMode. Optional: add a fresh combo with index set before its handle exists.");
-        CreateButton<Bug2935MdiMultiMonitorDemo>("Bug 2935 MDI multi-monitor", "Demo for issue #2935: maximized MDI child form border drawn on the correct monitor. Move the MDI parent to a second monitor, open and maximize a child; the border should stay on the same monitor.");
-        CreateButton<Bug3013TestForm>("Bug 3013 Test", "Tests the fix for 3013.");
-        CreateButton<BugReportingDialogTest>("BugReportingTool", "Easily report bugs with this tool.");
-        CreateButton<CodeEditorTest>("Code Editor", "Native code editor with syntax highlighting, line numbering, code folding, and auto-completion.");
-        CreateButton<CountdownButtonTest>("Countdown Button", "Comprehensive demonstration of KryptonCountdownButton features with customizable duration, format, and enable-at-zero options.");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
-        CreateButton<KryptonCommandButtonSpecDemo>("KryptonCommand ButtonSpec", "Issue #1133: KryptonCommand.CommandType drives integrated toolbar and help ButtonSpecs with palette-aware images. Click toolbar and help buttons; change theme to verify refresh.");
-        CreateButton<ControlStylesForm>("Control Styles", string.Empty);
-        CreateButton<KryptonDateTimePickerMonthCalendarDemo>("DateTimePicker Month Calendar Background", "Comprehensive demo of KryptonDateTimePicker month calendar custom background (Issue #1827): CalendarBackColor, theme default, presets (dark/light), and pick-a-color to style the drop-down calendar.");
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);
         CreateButton<DockingConfigSaveLoadTest>("Docking Config Save/Load Test", "Test SaveConfigToArray and LoadConfigFromArray");
-        CreateButton<DockingRedockDemo>("Docking Redock Demo", "Demo for Issue #2933: undock (Float) then redock; no floating window left behind.");
-        CreateButton<FontAwesomeTest>("Font Awesome Test", string.Empty);
         CreateButton<FloatingWindowTest>("Floating Window Test", "Comprehensive test for floating window bug fix (Issue #2721)");
-        CreateButton<FloatingToolbarsDemo>("Floating Toolbars Demo", "Comprehensive demonstration of KryptonFloatingToolbars features including drag-and-drop floating/docking, programmatic control, animation, window styles, docking preview indicators, custom themes, state persistence, and multi-monitor support.");
-        CreateButton<FlowLayoutPanelTest>("FlowLayoutPanel", "Test KryptonFlowLayoutPanel with dynamic control layout and flow directions.");
-        CreateButton<FileSystemWatcherTest>("FileSystemWatcher", "Monitor file system changes with Krypton integration.");
-        CreateButton<ErrorProviderTest>("ErrorProvider", string.Empty);
-        CreateButton<FileCheckSumDemo>("File checksum (Compute && Verify)", "Compute or verify file hashes (MD5, SHA-1, SHA-256, SHA-384, SHA-512, RIPEMD-160) using the Krypton checksum dialogs.");
         CreateButton<FormBorderTest>("FormBorder Test", string.Empty);
         CreateButton<HeaderExamples>("Header Examples", string.Empty);
-        CreateButton<HelpProviderTest>("HelpProvider", "Test KryptonHelpProvider functionality");
         CreateButton<MenuToolBarStatusStripTest>("Menu/Tool/Status Strips", string.Empty);
-        CreateButton<NotifyIconTest>("NotifyIcon", "Comprehensive demonstration of KryptonNotifyIcon with all events, balloon tips, and context menu support.");
-        CreateButton<OAuth2Demo>("OAuth2 PKCE Demo", "Comprehensive OAuth2 with PKCE demo. Sign in with Azure AD, Google, or GitHub using embedded WebView2 or system browser. Configure client ID, redirect URI, and scopes.");
-        CreateButton<QRCodeDemo>("QR Code (KryptonQRCode)", "Native QR code generation without external packages: live preview, ECC levels, module size, colors, quiet zone, Save PNG, clipboard, and static GenerateBitmap API.");
         CreateButton<ProgressBarTest>("ProgressBar", "Checkout if progress has been made.");
-        CreateButton<ScrollBarTest>("ScrollBar", "Comprehensive demonstration of KryptonHScrollBar and KryptonVScrollBar controls with basic usage, scrolling content, synchronization, theming, programmatic control, and event logging.");
-        CreateButton<ScrollbarManagerTest>("Scrollbar Manager", "Comprehensive demonstration of KryptonScrollbarManager with container mode, native wrapper mode, dynamic content, and integration examples.");
         CreateButton<RibbonNavigatorWorkspaceTest>("Ribbon / Navigator / Workspace", string.Empty);
-        CreateButton<RTLControlsTest>("RTL Compliance Tests", "Test the Krypton.Toolkit controls for compliance.");
         CreateButton<SplashScreenExample>("Splash Screen", string.Empty);
-        CreateButton<TaskbarOverlayIconTest>("Taskbar Overlay Icon Test", "Comprehensive demonstration of taskbar overlay icons on KryptonForm with configurable icons, descriptions, and interactive examples.");
-        CreateButton<TaskbarThumbnailButtonsDemo>("Taskbar Thumbnail Buttons", "Demo of taskbar thumbnail toolbar buttons (Play, Pause, Next, Stop) in the taskbar preview. Hover the taskbar button to see them.");
-        CreateButton<TaskbarProgressBarDemo>("Taskbar Progress Bar Demo", "Comprehensive demo of KryptonProgressBar taskbar synchronisation (Issue #2890). Covers enable/disable toggle, simulated download, manual slider, all ProgressBarStyles, all KryptonTaskbarProgressState overrides (Normal/Error/Paused/Indeterminate/NoProgress), and Min/Max range.");
         CreateButton<ThemeControlExamples>("Theme Controls", string.Empty);
-        CreateButton<TooltipTimeoutTest>("Tooltip Extended/Infinite Timeout", "Comprehensive demo of extended and infinite tooltip timeout (Issue #3075). Krypton tooltips support AutoPopDelay > 5000ms and 0 (infinite) on all Windows versions.");
         CreateButton<KryptonTextBoxValidatingTest>("TextBox Validating Test", "Tests fix for Validating event duplication bug #2801");
-        CreateButton<TouchscreenHighDpiDemo>("Touchscreen + High DPI Demo", "Comprehensive demonstration of touchscreen support with per-monitor high DPI scaling (Issue #2844).");
-        CreateButton<KryptonFormTitleBarDemo>("Title Bar Menu", "Demonstrates titlebar menu.");
         CreateButton<RichTextBoxFormattingTest>("RichTextBox Formatting Test", "Tests fix for RichTextBox formatting preservation when palette changes (Issue #2832)");
-        CreateButton<Bug3343RichTextBoxEditLossDemo>("Bug 3343 RichTextBox mouse leave", "Issue #3343: type in KryptonRichTextBox, move the mouse out without changing focus; text and TextLength must not reset. Includes KryptonTextBox for comparison.");
-        CreateButton<RTLFormBorderTest>("RTL Layout Test", "Test for RTL compliance");
         CreateButton<ToastNotificationTestChoice>("Toast", "For breakfast....?");
-        CreateButton<WorkspaceTest>("WorkspaceTest", string.Empty);
         CreateButton<BlurExampleForm>("Blur Example", string.Empty);
         CreateButton<VisualControlsTest>("Visual Controls", string.Empty);
         CreateButton<BasicEmojiViewerForm>("EmojiViewer Basic", string.Empty);
@@ -131,41 +82,29 @@ public partial class StartScreen : KryptonForm
         CreateButton<BreadCrumbTest>("BreadCrumb", "Follow the breadcrumbs and find the treasure...");
         CreateButton<CalendarTest>("Calendar", string.Empty);
         CreateButton<ComboBoxDateTimePickerConsistencyDemo>("ComboBox/DateTimePicker Consistency", "Comprehensive demonstration of KComboBox and KDateTimePicker consistency fix (Issue #1651). Shows drop-down buttons stretching to full height and centered text.");
-        CreateButton<DropDownArrowsDemo>("Drop-Down Arrows Demo", "Comprehensive demonstration of drop-down arrows: smaller size and DPI awareness (Issue #2129). Shows KryptonButton, KryptonDropButton, KryptonComboBox, KryptonDateTimePicker, KryptonColorButton, and KryptonNumericUpDown. Move window between monitors to verify DPI scaling.");
         CreateButton<ControlsTest>("Controls Test", string.Empty);
         CreateButton<DataGridViewDemo>("KryptonDataGridView Demo", string.Empty);
-        CreateButton<BindingNavigatorDemo>("KryptonBindingNavigator Demo", "Comprehensive example of KryptonBindingNavigator with data binding");
         CreateButton<KryptonDialogExamples>("Krypton Dialog tests", "Tests the various types of dialogs.");
         CreateButton<FadeFormTest>("FadeForm", string.Empty);
         CreateButton<GroupBoxTest>("GroupBox", string.Empty);
         CreateButton<InputBoxTest>("InputBox", string.Empty);
-        CreateButton<JumpListTest>("Jump List Test", "Comprehensive demonstration of jump lists on KryptonForm with user tasks, custom categories, known categories, and interactive examples.");
         CreateButton<KryptonFolderBrowserDialogDemo>("Folder Browser Dialog", "Comprehensive demo of KryptonFolderBrowserDialog: configure Title, Icon, SelectedPath, RootFolder, and InitialDirectory, compare with the standard dialog, and try preset scenarios.");
         CreateButton<MessageBoxTest>("MessageBox", string.Empty);
         CreateButton<Main>("Old Style Main: Fullscreen", string.Empty);
-        CreateButton<ProgressBarTriStateTest>("ProgressBar Tri-State", string.Empty);
-        CreateButton<OverlayImageTest>("Overlay Image Test", "Comprehensive demonstration of overlay images on KryptonButton and KryptonLabel with configurable positions and scaling modes.");
         CreateButton<PropertyGridTest>("PropertyGridTest", string.Empty);
         CreateButton<RibbonTest>("Ribbon", string.Empty);
-        CreateButton<RibbonNotificationBarDemo>("Ribbon Notification Bar", "Comprehensive demonstration of the Krypton Ribbon Notification Bar feature with all customization options.");
-        CreateButton<RibbonMergerDemo>("Ribbon Merger Demo", "Demonstrates UserControl hosting and ribbon merging for plugin architectures");
-        CreateButton<RibbonDetachableTest>("Detachable Ribbons", "Demonstrates detachable ribbons feature - allows ribbon to be moved to a floating window (Issue #595)");
         CreateButton<TextBoxEventTest>("TextBox", string.Empty);
-        CreateButton<TextSuggestionDemo>("TextSuggestion", string.Empty);
         CreateButton<TreeViewExample>("TreeView", string.Empty);
-        CreateButton<TouchscreenSupportTest>("Touchscreen Support Test", "Comprehensive demonstration of touchscreen support with real-time scale factor adjustment.");
-        CreateButton<ControlboxTouchscreenDemo>("Controlbox && Context Menu Touchscreen", "Demonstration of touchscreen support for controlbox buttons (minimize, maximize, close) and KryptonContextMenu items (Issue #2925).");
-        CreateButton<TimerTest>("Timer", "Test KryptonTimer with interval configuration and event tracking.");
         CreateButton<PanelForm>("Panel Form", string.Empty);
         CreateButton<PaletteViewerForm>("Palette Viewer", string.Empty);
         CreateButton<PoweredByButtonExample>("Powered By Button", string.Empty);
         CreateButton<KryptonTaskDialogDemoForm>("Krypton Task Dialog Demo", string.Empty);
         CreateButton<MdiWindow>("Krypton MDI Window", "KryptonForm MDI Container with both KForm and WForm children");
-        CreateButton<TabbedMdiDemo>("Tabbed MDI Demo (Issue #1746)", "KryptonTabbedMdiManager: MDI child windows displayed as tab pages instead of overlapping windows.");
-        CreateButton<RibbonMdiDemo>("Ribbon MDI Demo (Issue #2921)", "Comprehensive demo for Issue #2921: Ribbon + MDI. Verifies no double ribbon tabs when opening/closing maximized MDI children; close/minimize/maximize and QAT click areas aligned with visuals.");
-        CreateButton<Bug3203QATLocationHiddenFormTest>("Ribbon QATLocation=Hidden does not hide QAT when FormBorderStyle=None (Issue #3203)", string.Empty);
-        CreateButton<Bug3183SmallSquareRenderedNextToClose>("Small Square Rendered Next to Close Button (Issue #3183)", string.Empty);
-	}
+
+#if HAS_OPTIONAL_TEST_PROJECTS
+        AddOptionalProjectButtons();
+#endif
+    }
 
     private void OnFormClosing(object? sender, FormClosingEventArgs e)
     {

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -58,6 +58,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
+        CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu overflow scroll rows, wheel, keyboard navigation, optional arrow labels, and programmatic placement.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
         CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox, KryptonMaskedTextBox, and KryptonForm (ImageStates.ImageNormal without Image).");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -2,13 +2,15 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
  *
  */
 #endregion
 
 using System.Reflection;
 using System.Windows.Forms;
+
+using Krypton.Toolkit.Utilities;
 
 namespace TestForm;
 
@@ -17,9 +19,9 @@ public partial class StartScreen : KryptonForm
     private readonly List<KryptonCommandLinkButton> _buttons;
     private readonly IComparer<KryptonCommandLinkButton> _headingComparer;
     private readonly Timer _filterTimer;
-    private int _panelWidth;
-    private Size _sizeAtStartup;
-    private RegistryAccess _registryAccess;
+    private readonly int _panelWidth;
+    private readonly Size _sizeAtStartup;
+    private readonly RegistryAccess _registryAccess;
     private bool _dockTopRight;
 
     public StartScreen()
@@ -27,14 +29,14 @@ public partial class StartScreen : KryptonForm
         InitializeComponent();
 
         // Init & basic settings
-        _registryAccess = new();
+        _registryAccess = new RegistryAccess();
         _dockTopRight = false;
         _buttons = [];
         _headingComparer = new ButtonHeadingComparer();
         _panelWidth = tlpMain.Width;
-        _filterTimer = new();
+        _filterTimer = new Timer();
         _sizeAtStartup = new Size(902, 633);
-
+        
         this.Size = _sizeAtStartup;
         this.FormClosing += OnFormClosing;
 
@@ -57,22 +59,69 @@ public partial class StartScreen : KryptonForm
     {
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
+        CreateButton<ButtonBadgeTest>("Badge Test", "Comprehensive badge functionality demonstration for KryptonButton and KryptonCheckButton.");
+        CreateButton<ButtonTextTrackingExample>("Button Text Tracking", "Demonstrates alternate text color for tracking (hover) state on KryptonButton, KryptonCheckButton, KryptonColorButton and other controls (Issue #1326). Improves readability in dark themes.");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
-        CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu overflow scroll rows, wheel, keyboard navigation, optional arrow labels, and programmatic placement.");
+        CreateButton<KryptonColorButtonDemo>("KryptonColorButton Custom Colours", "Comprehensive demo of KryptonColorButton custom colours (Issue #776): CustomColors, MaxCustomColors, and visibility. Only 10 colours, or custom + theme + standard, or cap display count.");
+        CreateButton<KryptonComboBoxUserControlDemo>("KryptonComboBoxUserControl", "Demo for Issue #3443: a ComboBox-style control whose drop-down hosts any UserControl. Shows tree-picker, grid-picker and a plain (non-contract) UserControl scenario.");
+        CreateButton<KryptonTreeComboBoxDemo>("KryptonTreeComboBox", "Demo for Issue #3444: ComboBox-style control with a grouped tree drop-down (leaf/full path, breadcrumb, and parent-node selection).");
+        CreateButton<KryptonCheckedListComboBoxDemo>("KryptonCheckedListComboBox", "Multi-select combo (#3445) with KryptonCheckedListBox drop-down: items + DataSource/DisplayMember/ValueMember demo and live summary.");
+        CreateButton<BorderlessFormDemo>("Borderless Form Demo", "Demo for Issue #2922: Borderless KryptonForm without system title bar flicker on startup. Form should appear directly in borderless state.");
+        CreateButton<Bug2914Test>("Bug 2914 Test", "Tests the fix for 2914.");
+        CreateButton<Bug2984SeparatorTest>("Bug 2984 Separator Test", "Demo for Issue #2984: NullReferenceException in ViewDrawSeparator.RenderBefore. Exercises KryptonNavigator (Outlook), KryptonSplitContainer, and KryptonSeparator. Swap themes to verify no crash.");
+        CreateButton<Bug3025KryptonLabelAutoSizeDemo>("Bug 3025 KryptonLabel AutoSize Demo", "Demo for Issue #3025: KryptonLabel with AutoSize now resizes to fit text when placed in the Designer (click-drag). Shows AutoSize on/off, LabelStyles, short/long text, and text + image.");
+        CreateButton<Bug3342KryptonTextBoxResizeFlickerDemo>("Bug 3342 Multiline TextBox Flicker", "Demo for issue #3342: multiline KryptonTextBox text flicker while resizing. Includes manual resize steps and an automated stress-resize toggle.");
+        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox/KryptonMaskedTextBox, including ImageStates.ImageNormal without the Image property.");
+        CreateButton<Bug3382CueHintLinesDemo>("Bug 3382 CueHint line artifacts", "Demo for issue #3382: KryptonTextBox CueHint with TextH Near and mixed cue/content fonts — verify no stray top/left lines; cue remains vertically centered.");
+        CreateButton<Bug3383KryptonButtonStateTrackingRoundingDemo>("Bug 3383 KryptonButton hover rounding vs OverrideFocus", "Demo for issue #3383: large StateCommon rounding with different StateTracking rounding and OverrideFocus rounding — Tab to focus, then hover (left repro vs right matched control). Corner fill and stroke should align after the palette merge fix.");
+        CreateButton<Bug3451KryptonHeaderGroupPanelDemo>("Bug 3451 HeaderGroup panel parenting", "Demo for issue #3451: add child controls to KryptonHeaderGroup, KryptonGroup, and KryptonGroupBox via the internal Panel at design time. Open in the WinForms Designer and drag controls into each content area; verify no ReadOnly controls collection error.");
+        CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu with more items than fit on screen shows Scroll Up/Scroll Down rows, mouse-wheel scrolling, and keyboard navigation past visible items. Long list, mixed content, programmatic placement, and keyboard-open scenarios.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");
-        CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox, KryptonMaskedTextBox, and KryptonForm (ImageStates.ImageNormal without Image).");
+        CreateButton<KryptonToolTipTest>("KryptonToolTip", "Component wrapper (#3380): themed VisualPopupToolTip on arbitrary WinForms / Krypton controls via extender props or SetToolTip.");
+        CreateButton<Bug3283ThemeComboBoxProgrammaticTest>("Bug 3283 ThemeComboBox programmatic", "Issue #3283: KryptonThemeComboBox must apply the global palette when SelectedIndex is set in code. Buttons cycle or jump the index; status lines show selection vs KryptonManager.CurrentGlobalPaletteMode. Optional: add a fresh combo with index set before its handle exists.");
+        CreateButton<Bug2935MdiMultiMonitorDemo>("Bug 2935 MDI multi-monitor", "Demo for issue #2935: maximized MDI child form border drawn on the correct monitor. Move the MDI parent to a second monitor, open and maximize a child; the border should stay on the same monitor.");
+        CreateButton<Bug3013TestForm>("Bug 3013 Test", "Tests the fix for 3013.");
+        CreateButton<BugReportingDialogTest>("BugReportingTool", "Easily report bugs with this tool.");
+        CreateButton<CodeEditorTest>("Code Editor", "Native code editor with syntax highlighting, line numbering, code folding, and auto-completion.");
+        CreateButton<CountdownButtonTest>("Countdown Button", "Comprehensive demonstration of KryptonCountdownButton features with customizable duration, format, and enable-at-zero options.");
         CreateButton<CommandLinkButtons>("CommandLink Buttons", "No comment");
+        CreateButton<KryptonCommandButtonSpecDemo>("KryptonCommand ButtonSpec", "Issue #1133: KryptonCommand.CommandType drives integrated toolbar and help ButtonSpecs with palette-aware images. Click toolbar and help buttons; change theme to verify refresh.");
         CreateButton<ControlStylesForm>("Control Styles", string.Empty);
+        CreateButton<KryptonDateTimePickerMonthCalendarDemo>("DateTimePicker Month Calendar Background", "Comprehensive demo of KryptonDateTimePicker month calendar custom background (Issue #1827): CalendarBackColor, theme default, presets (dark/light), and pick-a-color to style the drop-down calendar.");
         CreateButton<DateTimeExample>("DateTime Example", string.Empty);
         CreateButton<DockingConfigSaveLoadTest>("Docking Config Save/Load Test", "Test SaveConfigToArray and LoadConfigFromArray");
+        CreateButton<DockingRedockDemo>("Docking Redock Demo", "Demo for Issue #2933: undock (Float) then redock; no floating window left behind.");
+        CreateButton<FontAwesomeTest>("Font Awesome Test", string.Empty);
+        CreateButton<FloatingWindowTest>("Floating Window Test", "Comprehensive test for floating window bug fix (Issue #2721)");
+        CreateButton<FloatingToolbarsDemo>("Floating Toolbars Demo", "Comprehensive demonstration of KryptonFloatingToolbars features including drag-and-drop floating/docking, programmatic control, animation, window styles, docking preview indicators, custom themes, state persistence, and multi-monitor support.");
+        CreateButton<FlowLayoutPanelTest>("FlowLayoutPanel", "Test KryptonFlowLayoutPanel with dynamic control layout and flow directions.");
+        CreateButton<FileSystemWatcherTest>("FileSystemWatcher", "Monitor file system changes with Krypton integration.");
+        CreateButton<ErrorProviderTest>("ErrorProvider", string.Empty);
+        CreateButton<FileCheckSumDemo>("File checksum (Compute && Verify)", "Compute or verify file hashes (MD5, SHA-1, SHA-256, SHA-384, SHA-512, RIPEMD-160) using the Krypton checksum dialogs.");
         CreateButton<FormBorderTest>("FormBorder Test", string.Empty);
         CreateButton<HeaderExamples>("Header Examples", string.Empty);
+        CreateButton<HelpProviderTest>("HelpProvider", "Test KryptonHelpProvider functionality");
         CreateButton<MenuToolBarStatusStripTest>("Menu/Tool/Status Strips", string.Empty);
+        CreateButton<NotifyIconTest>("NotifyIcon", "Comprehensive demonstration of KryptonNotifyIcon with all events, balloon tips, and context menu support.");
+        CreateButton<OAuth2Demo>("OAuth2 PKCE Demo", "Comprehensive OAuth2 with PKCE demo. Sign in with Azure AD, Google, or GitHub using embedded WebView2 or system browser. Configure client ID, redirect URI, and scopes.");
+        CreateButton<QRCodeDemo>("QR Code (KryptonQRCode)", "Native QR code generation without external packages: live preview, ECC levels, module size, colors, quiet zone, Save PNG, clipboard, and static GenerateBitmap API.");
         CreateButton<ProgressBarTest>("ProgressBar", "Checkout if progress has been made.");
+        CreateButton<ScrollBarTest>("ScrollBar", "Comprehensive demonstration of KryptonHScrollBar and KryptonVScrollBar controls with basic usage, scrolling content, synchronization, theming, programmatic control, and event logging.");
+        CreateButton<ScrollbarManagerTest>("Scrollbar Manager", "Comprehensive demonstration of KryptonScrollbarManager with container mode, native wrapper mode, dynamic content, and integration examples.");
         CreateButton<RibbonNavigatorWorkspaceTest>("Ribbon / Navigator / Workspace", string.Empty);
-        CreateButton<FloatingWindowTest>("Floating Window Test", "Comprehensive test for floating window bug fix (Issue #2721)");
+        CreateButton<RTLControlsTest>("RTL Compliance Tests", "Test the Krypton.Toolkit controls for compliance.");
         CreateButton<SplashScreenExample>("Splash Screen", string.Empty);
+        CreateButton<TaskbarOverlayIconTest>("Taskbar Overlay Icon Test", "Comprehensive demonstration of taskbar overlay icons on KryptonForm with configurable icons, descriptions, and interactive examples.");
+        CreateButton<TaskbarThumbnailButtonsDemo>("Taskbar Thumbnail Buttons", "Demo of taskbar thumbnail toolbar buttons (Play, Pause, Next, Stop) in the taskbar preview. Hover the taskbar button to see them.");
+        CreateButton<TaskbarProgressBarDemo>("Taskbar Progress Bar Demo", "Comprehensive demo of KryptonProgressBar taskbar synchronisation (Issue #2890). Covers enable/disable toggle, simulated download, manual slider, all ProgressBarStyles, all KryptonTaskbarProgressState overrides (Normal/Error/Paused/Indeterminate/NoProgress), and Min/Max range.");
         CreateButton<ThemeControlExamples>("Theme Controls", string.Empty);
+        CreateButton<TooltipTimeoutTest>("Tooltip Extended/Infinite Timeout", "Comprehensive demo of extended and infinite tooltip timeout (Issue #3075). Krypton tooltips support AutoPopDelay > 5000ms and 0 (infinite) on all Windows versions.");
+        CreateButton<KryptonTextBoxValidatingTest>("TextBox Validating Test", "Tests fix for Validating event duplication bug #2801");
+        CreateButton<TouchscreenHighDpiDemo>("Touchscreen + High DPI Demo", "Comprehensive demonstration of touchscreen support with per-monitor high DPI scaling (Issue #2844).");
+        CreateButton<KryptonFormTitleBarDemo>("Title Bar Menu", "Demonstrates titlebar menu.");
+        CreateButton<RichTextBoxFormattingTest>("RichTextBox Formatting Test", "Tests fix for RichTextBox formatting preservation when palette changes (Issue #2832)");
+        CreateButton<Bug3343RichTextBoxEditLossDemo>("Bug 3343 RichTextBox mouse leave", "Issue #3343: type in KryptonRichTextBox, move the mouse out without changing focus; text and TextLength must not reset. Includes KryptonTextBox for comparison.");
+        CreateButton<RTLFormBorderTest>("RTL Layout Test", "Test for RTL compliance");
         CreateButton<ToastNotificationTestChoice>("Toast", "For breakfast....?");
         CreateButton<WorkspaceTest>("WorkspaceTest", string.Empty);
         CreateButton<BlurExampleForm>("Blur Example", string.Empty);
@@ -82,26 +131,41 @@ public partial class StartScreen : KryptonForm
         CreateButton<BreadCrumbTest>("BreadCrumb", "Follow the breadcrumbs and find the treasure...");
         CreateButton<CalendarTest>("Calendar", string.Empty);
         CreateButton<ComboBoxDateTimePickerConsistencyDemo>("ComboBox/DateTimePicker Consistency", "Comprehensive demonstration of KComboBox and KDateTimePicker consistency fix (Issue #1651). Shows drop-down buttons stretching to full height and centered text.");
+        CreateButton<DropDownArrowsDemo>("Drop-Down Arrows Demo", "Comprehensive demonstration of drop-down arrows: smaller size and DPI awareness (Issue #2129). Shows KryptonButton, KryptonDropButton, KryptonComboBox, KryptonDateTimePicker, KryptonColorButton, and KryptonNumericUpDown. Move window between monitors to verify DPI scaling.");
         CreateButton<ControlsTest>("Controls Test", string.Empty);
         CreateButton<DataGridViewDemo>("KryptonDataGridView Demo", string.Empty);
+        CreateButton<BindingNavigatorDemo>("KryptonBindingNavigator Demo", "Comprehensive example of KryptonBindingNavigator with data binding");
+        CreateButton<KryptonDialogExamples>("Krypton Dialog tests", "Tests the various types of dialogs.");
         CreateButton<FadeFormTest>("FadeForm", string.Empty);
         CreateButton<GroupBoxTest>("GroupBox", string.Empty);
         CreateButton<InputBoxTest>("InputBox", string.Empty);
+        CreateButton<JumpListTest>("Jump List Test", "Comprehensive demonstration of jump lists on KryptonForm with user tasks, custom categories, known categories, and interactive examples.");
         CreateButton<KryptonFolderBrowserDialogDemo>("Folder Browser Dialog", "Comprehensive demo of KryptonFolderBrowserDialog: configure Title, Icon, SelectedPath, RootFolder, and InitialDirectory, compare with the standard dialog, and try preset scenarios.");
         CreateButton<MessageBoxTest>("MessageBox", string.Empty);
         CreateButton<Main>("Old Style Main: Fullscreen", string.Empty);
+        CreateButton<ProgressBarTriStateTest>("ProgressBar Tri-State", string.Empty);
+        CreateButton<OverlayImageTest>("Overlay Image Test", "Comprehensive demonstration of overlay images on KryptonButton and KryptonLabel with configurable positions and scaling modes.");
         CreateButton<PropertyGridTest>("PropertyGridTest", string.Empty);
         CreateButton<RibbonTest>("Ribbon", string.Empty);
+        CreateButton<RibbonNotificationBarDemo>("Ribbon Notification Bar", "Comprehensive demonstration of the Krypton Ribbon Notification Bar feature with all customization options.");
+        CreateButton<RibbonMergerDemo>("Ribbon Merger Demo", "Demonstrates UserControl hosting and ribbon merging for plugin architectures");
+        CreateButton<RibbonDetachableTest>("Detachable Ribbons", "Demonstrates detachable ribbons feature - allows ribbon to be moved to a floating window (Issue #595)");
         CreateButton<TextBoxEventTest>("TextBox", string.Empty);
-        CreateButton<KryptonTextBoxValidatingTest>("TextBox Validating Test", "Tests fix for Validating event duplication bug #2801");
-        CreateButton<RichTextBoxFormattingTest>("RichTextBox Formatting Test", "Tests fix for RichTextBox formatting preservation when palette changes (Issue #2832)");
+        CreateButton<TextSuggestionDemo>("TextSuggestion", string.Empty);
         CreateButton<TreeViewExample>("TreeView", string.Empty);
+        CreateButton<TouchscreenSupportTest>("Touchscreen Support Test", "Comprehensive demonstration of touchscreen support with real-time scale factor adjustment.");
+        CreateButton<ControlboxTouchscreenDemo>("Controlbox && Context Menu Touchscreen", "Demonstration of touchscreen support for controlbox buttons (minimize, maximize, close) and KryptonContextMenu items (Issue #2925).");
+        CreateButton<TimerTest>("Timer", "Test KryptonTimer with interval configuration and event tracking.");
         CreateButton<PanelForm>("Panel Form", string.Empty);
         CreateButton<PaletteViewerForm>("Palette Viewer", string.Empty);
         CreateButton<PoweredByButtonExample>("Powered By Button", string.Empty);
         CreateButton<KryptonTaskDialogDemoForm>("Krypton Task Dialog Demo", string.Empty);
         CreateButton<MdiWindow>("Krypton MDI Window", "KryptonForm MDI Container with both KForm and WForm children");
-    }
+        CreateButton<TabbedMdiDemo>("Tabbed MDI Demo (Issue #1746)", "KryptonTabbedMdiManager: MDI child windows displayed as tab pages instead of overlapping windows.");
+        CreateButton<RibbonMdiDemo>("Ribbon MDI Demo (Issue #2921)", "Comprehensive demo for Issue #2921: Ribbon + MDI. Verifies no double ribbon tabs when opening/closing maximized MDI children; close/minimize/maximize and QAT click areas aligned with visuals.");
+        CreateButton<Bug3203QATLocationHiddenFormTest>("Ribbon QATLocation=Hidden does not hide QAT when FormBorderStyle=None (Issue #3203)", string.Empty);
+        CreateButton<Bug3183SmallSquareRenderedNextToClose>("Small Square Rendered Next to Close Button (Issue #3183)", string.Empty);
+	}
 
     private void OnFormClosing(object? sender, FormClosingEventArgs e)
     {
@@ -110,7 +174,7 @@ public partial class StartScreen : KryptonForm
 
     private bool IsFormDockedTopRight()
     {
-        return this.Top == 0
+        return this.Top == 0 
             && this.Left == Screen.FromControl(this).Bounds.Width - this.Size.Width;
     }
 
@@ -159,17 +223,22 @@ public partial class StartScreen : KryptonForm
     {
         KryptonCommandLinkButton button = new();
         Type formType = typeof(TForm);
-        
+
         if (!typeof(Form).IsAssignableFrom(formType))
         {
             throw new InvalidCastException("Parameter formType is not of type Form or derived from Form.");
         }
 
-        button.CommandLinkTextValues.Heading         = heading;
-        button.CommandLinkTextValues.Description     = description;
-        button.AutoSize                              = false;
-        button.Size                                  = new Size(_panelWidth - 10, 60);
-        button.Click                                 += (_, _) => OnCommandLinkTestButtonClick(formType);
+        button.CommandLinkTextValues.Heading = heading;
+        button.CommandLinkTextValues.Description = description;
+        button.AccessibleName = heading;
+        button.AccessibleDescription = description;
+        button.AccessibleRole = AccessibleRole.PushButton;
+        button.AutoSize = false;
+        button.Dock = DockStyle.Fill;
+        button.MinimumSize = new Size(0, 60);
+        button.Size = new Size(_panelWidth - 10, 60);
+        button.Click += (_, _) => OnCommandLinkTestButtonClick(formType);
 
         if (image is not null)
         {
@@ -312,7 +381,7 @@ public partial class StartScreen : KryptonForm
                 string headingX = x.CommandLinkTextValues.Heading.ToLower(CultureInfo.InvariantCulture);
                 string headingY = y.CommandLinkTextValues.Heading.ToLower(CultureInfo.InvariantCulture);
 
-                return headingX.CompareTo(headingY);
+                return string.Compare(headingX, headingY, StringComparison.Ordinal);
             }
             else
             {

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -2,11 +2,14 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <!-- Jump list COM (CustomDestinationList) requires matching process architecture. Target x64 on 64-bit Windows to avoid REGDB_E_CLASSNOTREG. -->
+    <PlatformTarget>x64</PlatformTarget>
     <Nullable>enable</Nullable>
     <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
     <WarningLevel>8</WarningLevel>
     <AnalysisLevel>latest</AnalysisLevel>
     <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
     <ApplicationVisualStyles>true</ApplicationVisualStyles>
@@ -15,34 +18,39 @@
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
   </PropertyGroup>
 
-  <Choose>
-    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-      <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
-
-        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
   <ItemGroup>
     <ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Navigator.Utilities\Krypton.Navigator.Utilities.csproj" />
     <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
     <ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj" />
     <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj" />
     <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
   </ItemGroup>
+
+  <!-- WebView2: prefer Lib/WebView2 (matches Krypton.Toolkit.Utilities), fallback to NuGet when DLLs missing -->
+  <PropertyGroup>
+    <WebView2LibPath>$(MSBuildThisFileDirectory)..\Krypton.Toolkit.Utilities\Lib\WebView2</WebView2LibPath>
+    <WebView2CoreDll>$(WebView2LibPath)\Microsoft.Web.WebView2.Core.dll</WebView2CoreDll>
+    <WebView2WinFormsDll>$(WebView2LibPath)\Microsoft.Web.WebView2.WinForms.dll</WebView2WinFormsDll>
+  </PropertyGroup>
+  <ItemGroup Condition="Exists('$(WebView2CoreDll)') And Exists('$(WebView2WinFormsDll)')">
+    <Reference Include="Microsoft.Web.WebView2.Core">
+      <HintPath>$(WebView2CoreDll)</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.WebView2.WinForms">
+      <HintPath>$(WebView2WinFormsDll)</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(WebView2CoreDll)') Or !Exists('$(WebView2WinFormsDll)')">
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3800.47" />
+  </ItemGroup>
+  <PropertyGroup Condition="Exists('$(WebView2CoreDll)') And Exists('$(WebView2WinFormsDll)')">
+    <DefineConstants>$(DefineConstants);WEBVIEW2_AVAILABLE</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Update="KryptonTaskDialogDemo\DemoDialogs\KryptonTaskDialogDemoForm.ProgressBar1.cs">
@@ -67,17 +75,38 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="Bug3382CueHintLinesDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Bug3382CueHintLinesDemo.Designer.cs">
+      <DependentUpon>Bug3382CueHintLinesDemo.cs</DependentUpon>
+    </Compile>
     <Compile Update="Bug3381KryptonButtonRoundedTextCenteringDemo.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Update="Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs">
       <DependentUpon>Bug3381KryptonButtonRoundedTextCenteringDemo.cs</DependentUpon>
     </Compile>
+    <Compile Update="Bug3383KryptonButtonStateTrackingRoundingDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Bug3383KryptonButtonStateTrackingRoundingDemo.Designer.cs">
+      <DependentUpon>Bug3383KryptonButtonStateTrackingRoundingDemo.cs</DependentUpon>
+    </Compile>
     <Compile Update="Bug3661KryptonContextMenuOverflowDemo.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Update="Bug3661KryptonContextMenuOverflowDemo.Designer.cs">
       <DependentUpon>Bug3661KryptonContextMenuOverflowDemo.cs</DependentUpon>
+    </Compile>
+    <Compile Update="KryptonComboBoxUserControlDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="KryptonTreeComboBoxDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="KryptonCheckedListComboBoxDemo.cs">
+      <SubType>Form</SubType>
     </Compile>
   </ItemGroup>
 
@@ -116,8 +145,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.4" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="Cyotek.Windows.Forms.ColorPicker" Version="2.0.0-beta.7" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -72,6 +72,12 @@
     </Compile>
     <Compile Update="Bug3381KryptonButtonRoundedTextCenteringDemo.Designer.cs">
       <DependentUpon>Bug3381KryptonButtonRoundedTextCenteringDemo.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Bug3661KryptonContextMenuOverflowDemo.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Bug3661KryptonContextMenuOverflowDemo.Designer.cs">
+      <DependentUpon>Bug3661KryptonContextMenuOverflowDemo.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -18,15 +18,59 @@
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
   </PropertyGroup>
 
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' == 'true'">net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all' And '$(ExcludeVs2019UnsupportedTargetFrameworks)' != 'true' And '$(ExcludeVs2022UnsupportedTargetFrameworks)' != 'true'">net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <_NavigatorUtilitiesProject>$(MSBuildThisFileDirectory)..\Krypton.Navigator.Utilities\Krypton.Navigator.Utilities.csproj</_NavigatorUtilitiesProject>
+    <_ToolkitUtilitiesProject>$(MSBuildThisFileDirectory)..\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj</_ToolkitUtilitiesProject>
+    <_JumpListProject>$(MSBuildThisFileDirectory)..\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj</_JumpListProject>
+    <HasOptionalTestProjects>false</HasOptionalTestProjects>
+    <HasOptionalTestProjects Condition="Exists('$(_NavigatorUtilitiesProject)') And Exists('$(_ToolkitUtilitiesProject)') And Exists('$(_JumpListProject)')">true</HasOptionalTestProjects>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(HasOptionalTestProjects)' == 'true'">
+    <DefineConstants>$(DefineConstants);HAS_OPTIONAL_TEST_PROJECTS</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />
-    <ProjectReference Include="..\Krypton.Navigator.Utilities\Krypton.Navigator.Utilities.csproj" />
     <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
     <ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
-    <ProjectReference Include="..\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj" />
     <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-    <ProjectReference Include="..\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj" />
     <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(_NavigatorUtilitiesProject)')">
+    <ProjectReference Include="$(_NavigatorUtilitiesProject)" />
+  </ItemGroup>
+  <ItemGroup Condition="Exists('$(_JumpListProject)')">
+    <ProjectReference Include="$(_JumpListProject)" />
+  </ItemGroup>
+  <ItemGroup Condition="Exists('$(_ToolkitUtilitiesProject)')">
+    <ProjectReference Include="$(_ToolkitUtilitiesProject)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(HasOptionalTestProjects)' == 'true'">
+    <Compile Include="StartScreen.OptionalProjectDemos.cs" />
   </ItemGroup>
 
   <!-- WebView2: prefer Lib/WebView2 (matches Krypton.Toolkit.Utilities), fallback to NuGet when DLLs missing -->


### PR DESCRIPTION
# PR: Fix `KryptonContextMenu` overflow when items exceed screen height

**Issue:** [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661) — `KryptonContextMenu` items beyond screen height are clipped; keyboard selection can move off-screen; no way to scroll the list.

**Branch:** `V105-LTS-3661-bug-kcontextmenu-items-overflow-not-visible`

---

## Summary

When a `KryptonContextMenu` is shown with `constrain: true` and its natural height exceeds the monitor working area, the menu now caps column height and shows **Scroll Up** / **Scroll Down** overflow rows (classic menu behaviour) instead of clipping items. Users can scroll via hover (with repeat), mouse wheel, click, and keyboard. Overflow labels are localizable through a new **`KryptonContextMenuStrings`** collection, with optional arrow glyphs instead of text.

---

## Problem

Long context menus were laid out at full height, then positioned/clipped against the working area. Items below the visible region were unreachable. Arrow-key navigation could highlight items that were not visible. There was no scroll affordance comparable to legacy WinForms overflow menus or the scrollbar context-menu entries on `KryptonScrollBar`.

Typical menus built with `KryptonContextMenuItems` place item views inside `ViewLayoutMenuItemsPile.ItemStack`; the initial overflow wrapper only targeted direct `ViewLayoutStack` children on the column root, so overflow logic never activated for standard menu structures.

---

## Solution

1. **`ViewLayoutContextMenuOverflowColumn`** — Owns all item views for a column, tracks `_topIndex`, and rebuilds the visible slice plus optional scroll rows when height is constrained.
2. **`ViewDrawMenuScrollButton`** + **`MenuScrollButtonController`** — Overflow row UI and input (hover auto-scroll with timer, wheel, keys, click).
3. **`VisualContextMenu`** — On show with `constrain`, computes available content height, applies overflow to every `ViewLayoutMenuItemsPile` (and plain vertical stacks), reclculates preferred size, then positions the popup.
4. **`ViewContextMenuManager`** — Keyboard navigation scrolls overflow columns at edges before wrapping; ensures targets stay visible.
5. **`KryptonContextMenuStrings`** — Dedicated localizable strings for overflow labels and optional arrow glyphs (separate from `KryptonScrollBarStrings`).
6. **`KryptonContextMenu.OverflowScrollUseArrows`** — Per-menu nullable override of the global arrow/text choice.

Scroll overflow uses **menu rows**, not an embedded scrollbar viewport (the previous `ViewLayoutScrollViewport` approach was removed from `VisualContextMenu`).

---

## Key files

| Area | Files |
|------|--------|
| Overflow layout | `ViewLayoutContextMenuOverflowColumn.cs` | | Scroll row UI | `ViewDrawMenuScrollButton.cs`, `MenuScrollButtonController.cs` | | Menu show / wrap | `VisualContextMenu.cs` | | Keyboard / wheel | `ViewContextMenuManager.cs` | | Strings | `KryptonContextMenuStrings.cs`, `KryptonGlobalToolkitStrings.cs`, `ToolkitStringValues.cs` | | API | `KryptonContextMenu.cs`, `ContextMenuProvider.cs`, `Definitions.cs` (`IContextMenuProvider`) | | Ribbon provider | `AppButtonMenuProvider.cs` (uses global `ContextMenuStrings`) | | Popup hosting | `ViewControl.cs`, `ViewLayoutControl.cs`, `ViewLayoutScrollViewport.cs` (popup ctor retained for other uses) | | Demo | `Bug3661KryptonContextMenuOverflowDemo.cs`, `StartScreen.cs`, `TestForm.csproj` |

---

## API / localization

### `KryptonManager.Strings.ContextMenuStrings`

| Property | Default | Purpose |
|----------|---------|---------|
| `OverflowScrollUp` | `Scroll Up` | Text label when arrows disabled | | `OverflowScrollDown` | `Scroll Down` | Text label when arrows disabled | | `OverflowScrollUseArrows` | `false` | Global default: use arrow glyphs | | `OverflowScrollUpArrow` | `▲` | Up-row glyph | | `OverflowScrollDownArrow` | `▼` | Down-row glyph |

### `KryptonContextMenu`

| Property | Purpose |
|----------|---------|
| `OverflowScrollUseArrows` (`bool?`) | Per-menu override; `null` inherits global `ContextMenuStrings.OverflowScrollUseArrows` |

Example:

```csharp
KryptonManager.Strings.ContextMenuStrings.OverflowScrollUseArrows = true;

var menu = new KryptonContextMenu
{
    OverflowScrollUseArrows = true // optional per-menu override
};
```

---

## TestForm demo

**Start screen → Bug 3661 Context Menu Overflow**

- Configurable item count (15–150)
- Long list and mixed-content menus (headings, separators, check/radio, extra text)
- Programmatic placement (anchor, top/center/bottom of screen, keyboard-open)
- **Overflow rows use arrows** checkbox (per-menu `OverflowScrollUseArrows`)

Temporary overflow repro was removed from **Buttons Test**.

---

## Test plan

- [ ] Build `Krypton.Toolkit` and `TestForm` (e.g. `-f net481` or `-f net11.0-windows`).
- [ ] Open **Bug 3661 Context Menu Overflow**; right-click **Long list** with default item count — confirm **Scroll Up** / **Scroll Down** appear when the menu is taller than the screen.
- [ ] Use **Near bottom of screen** — overflow rows should appear; hover a scroll row and confirm the list advances while the pointer stays on the row.
- [ ] Mouse wheel over the open menu scrolls the list.
- [ ] Arrow keys: from the first visible item, Up shows scroll-up behaviour; from the last visible item, Down shows scroll-down behaviour; highlighted item stays in view.
- [ ] Enable **Overflow rows use arrows**; reopen menu — rows show ▲ / ▼ (or customized glyphs).
- [ ] Change `ContextMenuStrings.OverflowScrollUp` / `OverflowScrollDown`; reopen menu — labels update.
- [ ] Right-click attached menu on a control (`KryptonButton` with `KryptonContextMenu`) — same overflow behaviour as programmatic `Show(..., constrain: true)`.
- [ ] Mixed-content menu scrolls correctly with non-item rows (separators, headings).
- [ ] Smoke-test a short menu (few items) — no scroll rows, no layout regression.
- [ ] Change theme via demo combo — scroll rows and items still render correctly.

---

## Breaking changes

None expected. New types and properties are additive. `KryptonScrollBarStrings` is unchanged for scrollbar context menus; overflow strings live only on `KryptonContextMenuStrings`.

---

## Changelog

`Documents/Changelog/Changelog.md` (V110 Nightly):

* Resolves [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), KContextMenu items overflow not visible