### PR TITLE
#3667-V110-Fix WebView2 palette recursion

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonWebView2/Controls Toolkit/KryptonWebView2.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonWebView2/Controls Toolkit/KryptonWebView2.cs
@@ -924,24 +924,17 @@ public class KryptonWebView2 : WebView2Base
 
     private void SetControlBackColor(Color color)
     {
-        var property = typeof(Control).GetProperty(nameof(BackColor), BindingFlags.Public | BindingFlags.Instance);
-        property?.SetValue(this, color);
+        base.BackColor = color;
     }
 
     private void SetControlForeColor(Color color)
     {
-        var property = typeof(Control).GetProperty(nameof(ForeColor), BindingFlags.Public | BindingFlags.Instance);
-        property?.SetValue(this, color);
+        base.ForeColor = color;
     }
 
     private void SetBaseDefaultBackgroundColor(Color color)
     {
-        var baseType = GetType().BaseType;
-        if (baseType != null)
-        {
-            var property = baseType.GetProperty("DefaultBackgroundColor", BindingFlags.Public | BindingFlags.Instance);
-            property?.SetValue(this, color);
-        }
+        base.DefaultBackgroundColor = color;
     }
 
     private async Task ApplyAppearanceAfterInitializationAsync(Task initializationTask)


### PR DESCRIPTION
Fixes #3667.

This fixes the WebView2 startup crash when the real WebView2 implementation is compiled into Krypton.Toolkit.Utilities.

The palette color application now writes through the base WebView2 properties directly, avoiding recursive calls through KryptonWebView2's palette-backed property setters.