### PR TITLE
3670-V110-appbutton-color-registration

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3670](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3670), Fixed AppButton color registration in several themes
 * Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -2236,6 +2236,8 @@ public abstract class PaletteBase : Component
     {
         for (var owner = GetType(); owner != null; owner = owner.BaseType)
         {
+            System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(owner.TypeHandle);
+
             var key = (owner, enumType, index);
 
             if (_colorLut.ContainsKey(key))

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -30,6 +30,24 @@ public abstract class PaletteOffice2007Base : PaletteBase
         }
         _defaultsRegistered = true;
 
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(255, 213,  77));
@@ -48,6 +66,22 @@ public abstract class PaletteOffice2007Base : PaletteBase
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(255, 196,  68));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(158, 130,  85));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(254, 218, 144));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
     }
 
     #region Padding

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -256,6 +256,24 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         }
         _defaultsRegistered = true;
 
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
@@ -274,6 +292,22 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(150, 200, 225));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(148, 197,  220));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(160, 205, 240));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
     }
 
     #region Padding

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -235,6 +235,24 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         }
         _defaultsRegistered = true;
 
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));
@@ -253,6 +271,22 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(118, 130, 160));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(136, 150, 185));
         RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(174, 192, 236));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
     }
 
     #region Padding

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -246,6 +246,24 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         }
         _defaultsRegistered = true;
 
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -241,6 +241,24 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
         }
         _defaultsRegistered = true;
 
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));


### PR DESCRIPTION
Fixes #3670

Palette color lookup can run before an abstract palette base static constructor has seeded the shared color registry. This forces palette owner static constructors before lookup and fills missing `AppButton` color registrations in affected Office 2007 and Office 2010 theme bases.
