### PR TITLE
3679-v110-Palette color fixes (Treeview)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3679](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3679), fixed the TreeViewExample custom palette crash when property grid data cell states request short text colors.
 * Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -1,11 +1,11 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -5464,6 +5464,8 @@ public class KryptonCustomPaletteBase : PaletteBase
             case PaletteState.Disabled:
                 return grid.StateDisabled.DataCell.Back;
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:
+            case PaletteState.FocusOverride:
                 return grid.StateNormal.DataCell.Back;
             case PaletteState.CheckedNormal:
                 return grid.StateSelected.DataCell.Back;
@@ -5523,6 +5525,8 @@ public class KryptonCustomPaletteBase : PaletteBase
             case PaletteState.Disabled:
                 return grid.StateDisabled.DataCell.Border;
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:
+            case PaletteState.FocusOverride:
                 return grid.StateNormal.DataCell.Border;
             case PaletteState.CheckedNormal:
                 return grid.StateSelected.DataCell.Border;
@@ -5583,6 +5587,8 @@ public class KryptonCustomPaletteBase : PaletteBase
             case PaletteState.Disabled:
                 return grid.StateDisabled.DataCell.Content;
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:
+            case PaletteState.FocusOverride:
                 return grid.StateNormal.DataCell.Content;
             case PaletteState.CheckedNormal:
                 return grid.StateSelected.DataCell.Content;


### PR DESCRIPTION
Fixes #3679.

Updates custom palette grid data-cell state handling so TreeViewExample can open when its KryptonPropertyGrid receives ContextNormal or FocusOverride palette states.
