### PR TITLE
3678-V110-Fix .NET 4.x resource dependencies

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3678](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3678), fixed net4x TestForm runtime deployment for preserialized resource dependencies used by generated resources.
 * Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+

--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
@@ -22,8 +22,12 @@
 	        AfterTargets="ResolveAssemblyReferences"
 	        BeforeTargets="_GenerateSuggestedBindingRedirectsCache"
 	        Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(GenerateBindingRedirectsOutputType)' == 'true' And '$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true'">
+		<ItemGroup>
+			<_KryptonSreCopyLocalDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions'" />
+		</ItemGroup>
 		<PropertyGroup>
-			<_KryptonSreDllPath Condition="'$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll</_KryptonSreDllPath>
+			<_KryptonSreDllPath Condition="'@(_KryptonSreCopyLocalDll)' != ''">@(_KryptonSreCopyLocalDll->'%(FullPath)')</_KryptonSreDllPath>
+			<_KryptonSreDllPath Condition="'$(_KryptonSreDllPath)' == '' And '$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll</_KryptonSreDllPath>
 			<_KryptonSreDllPath Condition="'$(_KryptonSreDllPath)' == '' And '$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll</_KryptonSreDllPath>
 		</PropertyGroup>
 		<GetAssemblyIdentity AssemblyFiles="$(_KryptonSreDllPath)"

--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
@@ -35,9 +35,18 @@
 
 	<Target Name="KryptonCopyPreserializedResourceDependenciesToOutput"
 	        AfterTargets="Build"
-	        Condition="'$(GenerateResourceUsePreserializedResources)' == 'true' And '$(DesignTimeBuild)' != 'true' And '$(_KryptonSreDllPath)' != ''">
+	        Condition="'$(GenerateResourceUsePreserializedResources)' == 'true' And '$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
-			<_KryptonResourceRuntimeDll Include="$(_KryptonSreDllPath)" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Formats.Nrbf'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Memory'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Buffers'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Runtime.CompilerServices.Unsafe'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Collections.Immutable'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Reflection.Metadata'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Numerics.Vectors'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'Microsoft.Bcl.HashCode'" />
+			<_KryptonResourceRuntimeDll Include="$(_KryptonSreDllPath)" Condition="'$(_KryptonSreDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonNrbfDllPath)" Condition="'$(_KryptonNrbfDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonMemoryDllPath)" Condition="'$(_KryptonMemoryDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonBuffersDllPath)" Condition="'$(_KryptonBuffersDllPath)' != ''" />


### PR DESCRIPTION
Fixes #3678.

Copies the resolved preserialized-resource runtime dependency set for net4x TestForm output and derives the System.Resources.Extensions binding redirect from the resolved copy-local assembly.
