### PR TITLE
3682-V110-Fix scrolling in themed KryptonDataGridview

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), fixed detached themed `KryptonDataGridView` scrollbars so mouse clicks, page jumps, and thumb dragging route to the native grid scrolling path.
 * Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Implemented [#804](https://github.com/Krypton-Suite/Standard-Toolkit/issues/804), `KryptonDataGridView` external corner rounding via `StateNormal.Border.Rounding` (and `StateDisabled.Border`, same as other Krypton controls; `-1` inherits/disables). Clips the data area, paints a rounded outer border, draws rounded backgrounds/borders on outer corner cells, and detaches native scrollbars to themed `Krypton` scrollbars in the gutter while rounding is active. `PaletteDataGridViewAll` exposes `Border` in the designer (replacing `PaletteBorder` visibility).
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed flicker in VisualForm resizing for .net 10+

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -3472,11 +3472,6 @@ public class KryptonDataGridView : DataGridView
             return;
         }
 
-        if (e.Type == ScrollEventType.EndScroll)
-        {
-            return;
-        }
-
         if (!TryGetNativeDataGridScrollBar(horizontal, out ScrollBar? nativeScrollBar)
             || nativeScrollBar == null
             || !nativeScrollBar.IsHandleCreated)
@@ -3492,9 +3487,14 @@ public class KryptonDataGridView : DataGridView
             int newValue = Math.Max(nativeScrollBar.Minimum, Math.Min(scrollableMaximum, e.NewValue));
             IntPtr nativeScrollBarHandle = nativeScrollBar.Handle;
             int message = horizontal ? (int)PI.WM_.HSCROLL : (int)PI.WM_.VSCROLL;
-            int scrollRequest = e.Type == ScrollEventType.ThumbTrack
-                ? (int)PI.SB_.THUMBTRACK
-                : (int)PI.SB_.THUMBPOSITION;
+            int scrollRequest = GetDetachedScrollRequest(horizontal, e.Type);
+
+            if (ShouldSetDetachedScrollPosition(e.Type))
+            {
+                PI.SB_ scrollBar = horizontal ? PI.SB_.HORZ : PI.SB_.VERT;
+                PI.SetScrollPos(Handle, scrollBar, newValue, true);
+                PI.SetScrollPos(nativeScrollBarHandle, PI.SB_.CTL, newValue, true);
+            }
 
             // DataGridView scrolls via WM_*SCROLL routed to its child scroll bar handle.
             PI.SendMessage(Handle, message,
@@ -3507,6 +3507,44 @@ public class KryptonDataGridView : DataGridView
         finally
         {
             _suppressRoundingScrollSync = false;
+        }
+    }
+
+    private static int GetDetachedScrollRequest(bool horizontal, ScrollEventType type)
+    {
+        switch (type)
+        {
+            case ScrollEventType.SmallDecrement:
+                return horizontal ? (int)PI.SB_.LINELEFT : (int)PI.SB_.LINEUP;
+            case ScrollEventType.SmallIncrement:
+                return horizontal ? (int)PI.SB_.LINERIGHT : (int)PI.SB_.LINEDOWN;
+            case ScrollEventType.LargeDecrement:
+                return horizontal ? (int)PI.SB_.PAGELEFT : (int)PI.SB_.PAGEUP;
+            case ScrollEventType.LargeIncrement:
+                return horizontal ? (int)PI.SB_.PAGERIGHT : (int)PI.SB_.PAGEDOWN;
+            case ScrollEventType.First:
+                return horizontal ? (int)PI.SB_.LEFT : (int)PI.SB_.TOP;
+            case ScrollEventType.Last:
+                return horizontal ? (int)PI.SB_.RIGHT : (int)PI.SB_.BOTTOM;
+            case ScrollEventType.ThumbTrack:
+                return (int)PI.SB_.THUMBTRACK;
+            case ScrollEventType.ThumbPosition:
+            case ScrollEventType.EndScroll:
+            default:
+                return (int)PI.SB_.THUMBPOSITION;
+        }
+    }
+
+    private static bool ShouldSetDetachedScrollPosition(ScrollEventType type)
+    {
+        switch (type)
+        {
+            case ScrollEventType.ThumbTrack:
+            case ScrollEventType.ThumbPosition:
+            case ScrollEventType.EndScroll:
+                return true;
+            default:
+                return false;
         }
     }
 


### PR DESCRIPTION
Fixes #3682.

Routes detached `KryptonDataGridView` scrollbar input through the matching native scroll commands and preserves thumb tracking/release positions.
