### PR TITLE
3698-master-Fix master TestForm CI SDK/TFM mismatch

### DIFF
--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -86,7 +86,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Restore TestForm
-        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all
+        run: dotnet restore "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release -p:TFMs=all -p:ExcludeNet11=true
 
       - name: Validate TestForm linked resources
         shell: pwsh
@@ -137,7 +137,7 @@ jobs:
           }
 
       - name: Build TestForm
-        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -m:1 -p:BuildInParallel=false
+        run: dotnet build "Source/Krypton Components/TestForm/TestForm.csproj" -p:Configuration=Release --no-restore -p:TFMs=all -p:ExcludeNet11=true -m:1 -p:BuildInParallel=false
 
       - name: Save NuGet cache
         if: success() && github.event_name != 'pull_request'

--- a/Source/Krypton Components/Directory.Build.props
+++ b/Source/Krypton Components/Directory.Build.props
@@ -59,6 +59,10 @@
 		</Otherwise>
 	</Choose>
 
+	<PropertyGroup Condition="'$(ExcludeNet11)' == 'true' And '$(TFMs)' == 'all'">
+		<TargetFrameworks>net472;net48;net481;net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
+	</PropertyGroup>
+
 	<!--Sets up the language version.-->
 	<!--https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#configure-multiple-projects-->
 	<PropertyGroup>


### PR DESCRIPTION
Fixes #3698.

The stable TestForm CI job pins SDK 10.0.x, so it now restores and builds the stable TFM set through net10.0-windows instead of including net11.0-windows.
