### PR TITLE
Show detailed exception info in bug dialog

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,11 +45,12 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3719](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3719), Information exposure through transmitted data
 * Resolved [#3670](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3670), Fixed AppButton color registration in several themes
-* Resolved [#3678](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3678), fixed net4x TestForm runtime deployment for preserialized resource dependencies used by generated resources.
-* Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), fixed detached themed `KryptonDataGridView` scrollbars so mouse clicks, page jumps, and thumb dragging route to the native grid scrolling path.
-* Resolved [#3679](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3679), fixed the TreeViewExample custom palette crash when property grid data cell states request short text colors.
-* Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
+* Resolved [#3678](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3678), Fixed net4x TestForm runtime deployment for preserialized resource dependencies used by generated resources.
+* Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), Fixed detached themed `KryptonDataGridView` scrollbars so mouse clicks, page jumps, and thumb dragging route to the native grid scrolling path.
+* Resolved [#3679](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3679), Fixed the TreeViewExample custom palette crash when property grid data cell states request short text colors.
+* Implemented [#3658](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3658), Add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Resolveed [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), KContextMenu items overflow not visible
 * Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), Fixed detached themed `KryptonDataGridView` scrollbars so mouse clicks, page jumps, and thumb dragging route to the native grid scrolling path.
 * Resolved [#3679](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3679), Fixed the TreeViewExample custom palette crash when property grid data cell states request short text colors.

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonBugReportingDialog/Controls Visuals/VisualBugReportingDialogForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonBugReportingDialog/Controls Visuals/VisualBugReportingDialogForm.cs
@@ -568,7 +568,9 @@ public partial class VisualBugReportingDialogForm : KryptonForm
         {
             sb.AppendLine("Exception Details:");
             sb.AppendLine("-----------------");
-            sb.AppendLine(FormatExceptionDetails(_exception));
+            sb.AppendLine($"Exception Type: {_exception.GetType().Name}");
+            sb.AppendLine($"Message: {_exception.Message}");
+            sb.AppendLine($"Stack Trace: {_exception.StackTrace}");
             sb.AppendLine();
         }
 


### PR DESCRIPTION
Update VisualBugReportingDialogForm to append explicit exception details (type, message, stack trace) instead of the previous FormatExceptionDetails call. Also tidy up Documents/Changelog/Changelog.md entries (reordered and capitalization fixes) to reflect the new release notes.