### PR TITLE
Drain TreeView select update batches to fix blanking

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3720](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3720), `KryptonTreeView` freezes blank after programmatic `SelectedNode = null` then re-select (drain leaked selection `BeginUpdate`/`EndUpdate` batches from #3282/#3498)
 * Resolved [#3670](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3670), Fixed AppButton color registration in several themes
 * Resolved [#3678](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3678), fixed net4x TestForm runtime deployment for preserialized resource dependencies used by generated resources.
 * Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), fixed detached themed `KryptonDataGridView` scrollbars so mouse clicks, page jumps, and thumb dragging route to the native grid scrolling path.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2509,9 +2509,7 @@ public class KryptonTreeView : VisualControlBase,
         if (e.Cancel && !_isRecreating)
         {
             _pendingMultiSelectToggle = null;
-
-            _selectUpdateCount--;
-            _treeView.EndUpdate();
+            EndSelectUpdateBatches();
         }
     }
 
@@ -2536,13 +2534,23 @@ public class KryptonTreeView : VisualControlBase,
         }
         finally
         {
-            if (!_isRecreating && _selectUpdateCount > 0)
-            {
-                _selectUpdateCount--;
-                _treeView.EndUpdate();
-            }
-
+            EndSelectUpdateBatches();
             _pendingMultiSelectToggle = null;
+        }
+    }
+
+    /// <summary>
+    /// Pairs every outstanding <see cref="TreeView.BeginUpdate"/> from selection batching with
+    /// <see cref="TreeView.EndUpdate"/>. Programmatic deselect-to-null can leave an extra
+    /// <c>BeforeSelect</c> without a matching <c>AfterSelect</c>; draining here avoids a stuck
+    /// <c>WM_SETREDRAW(FALSE)</c> that blanks the control (#3720).
+    /// </summary>
+    private void EndSelectUpdateBatches()
+    {
+        while (!_isRecreating && _selectUpdateCount > 0)
+        {
+            _selectUpdateCount--;
+            _treeView.EndUpdate();
         }
     }
 


### PR DESCRIPTION
Add EndSelectUpdateBatches helper to KryptonTreeView to ensure every programmatic selection BeginUpdate is paired with EndUpdate, preventing a stuck WM_SETREDRAW(FALSE) that left the control blank after SelectedNode = null (fixes #3720). Replace inline decrement logic with the new method and update changelog entry describing the fix.