### PR TITLE
3714-V105-LTS-Improve accessibility of controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,14 @@
 - Projects use `global using` like in GlobalDeclarations.cs, do not add new usings in other files
 - Before adding new variables check for existing ones
 - No variable aliasing
+- New files must use only the current Standard Toolkit BSD header. Do not add the original ComponentFactory BSD header unless the file is derived from original ComponentFactory source.
 
 ## C# Rules
 - Surgical edits: preserve structure, identifiers, and existing comments; avoid adding defensive checks unless asked
 - No unneeded `try/catch` blocks if there's no catch handling
 - Idioms: use null-propagation and object/collection initializers where consistent
+- Fix compiler, analyzer, and IDE warnings in new or modified code before handing work back
+- Prefer switch expressions for simple value/type dispatch that only returns a value; keep switch statements for complex control flow or side effects
 - Compatibility: ensure changes build for `net472` and C# 7.3
 - WinForms: `UseWindowsForms=true`; prefer designer-friendly patterns and keep partial classes tidy
 - WinForms designer: keep object declarations at file bottom; initialize in `*.Designer.cs` `InitializeComponent()`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3714](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3714), Add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Resolved [#3690](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3690), Fix VS 2019 build targeting so VS 2019 uses only .NET Framework 4.x projects while VS2022/Current scripts refresh restore assets for modern target frameworks.
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed VisualForm resize flicker in .NET 10+
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -243,6 +243,12 @@ public class KryptonRibbon : VisualSimple,
 
         base.Dispose(disposing);
     }
+
+    /// <summary>
+    /// Creates the accessibility object for the ribbon.
+    /// </summary>
+    /// <returns>A new KryptonRibbonAccessibleObject instance.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonRibbonAccessibleObject(this);
     #endregion
 
     #region Public Hidden Properties

--- a/Source/Krypton Components/Krypton.Ribbon/General/Accessibility/KryptonRibbonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/Accessibility/KryptonRibbonAccessibleObject.cs
@@ -1,0 +1,626 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Ribbon;
+
+internal class KryptonRibbonAccessibleObject : Control.ControlAccessibleObject
+{
+    #region Instance Fields
+    private readonly KryptonRibbon _ribbon;
+    #endregion
+
+    #region Identity
+    public KryptonRibbonAccessibleObject(KryptonRibbon owner)
+        : base(owner)
+    {
+        _ribbon = owner;
+    }
+    #endregion
+
+    #region Public Overrides
+    public override string? Name => !string.IsNullOrEmpty(_ribbon.AccessibleName)
+        ? _ribbon.AccessibleName
+        : base.Name ?? _ribbon.Name;
+
+    public override AccessibleRole Role => _ribbon.AccessibleRole != AccessibleRole.Default
+        ? _ribbon.AccessibleRole
+        : AccessibleRole.ToolBar;
+
+    public override AccessibleStates State
+    {
+        get
+        {
+            AccessibleStates state = AccessibleStates.None;
+
+            if (!_ribbon.Visible)
+            {
+                state |= AccessibleStates.Invisible;
+            }
+
+            if (!_ribbon.Enabled)
+            {
+                state |= AccessibleStates.Unavailable;
+            }
+
+            return state;
+        }
+    }
+
+    public override Rectangle Bounds => _ribbon.RectangleToScreen(_ribbon.ClientRectangle);
+
+    public override int GetChildCount() => GetChildren().Count;
+
+    public override AccessibleObject? GetChild(int index)
+    {
+        List<AccessibleObject> children = GetChildren();
+
+        return index >= 0 && index < children.Count
+            ? children[index]
+            : null;
+    }
+
+    public override AccessibleObject? HitTest(int x, int y)
+    {
+        foreach (AccessibleObject child in GetChildren())
+        {
+            if (child.Bounds.Contains(x, y))
+            {
+                AccessibleObject? nested = child.HitTest(x, y);
+
+                return nested ?? child;
+            }
+        }
+
+        return Bounds.Contains(x, y) ? this : null;
+    }
+    #endregion
+
+    #region Implementation
+    private List<AccessibleObject> GetChildren()
+    {
+        var children = new List<AccessibleObject>();
+
+        foreach (IQuickAccessToolbarButton qatButton in _ribbon.QATButtons)
+        {
+            if (qatButton.GetVisible())
+            {
+                children.Add(new RibbonQATButtonAccessibleObject(this, _ribbon, qatButton));
+            }
+        }
+
+        foreach (KryptonRibbonTab tab in _ribbon.RibbonTabs)
+        {
+            if (tab.Visible)
+            {
+                children.Add(new RibbonTabAccessibleObject(this, _ribbon, tab));
+            }
+        }
+
+        if (_ribbon.SelectedTab != null)
+        {
+            foreach (KryptonRibbonGroup group in _ribbon.SelectedTab.Groups)
+            {
+                if (group.Visible)
+                {
+                    children.Add(new RibbonGroupAccessibleObject(this, _ribbon, group));
+                }
+            }
+        }
+
+        return children;
+    }
+
+    private static string? SiteName(Component? component) => component?.Site?.Name;
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (string? value in values)
+        {
+            string? normalized = Normalize(value);
+
+            if (!string.IsNullOrEmpty(normalized))
+            {
+                return normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value!.Trim();
+    }
+
+    private static string? CombineText(string? line1, string? line2)
+    {
+        string? first = Normalize(line1);
+        string? second = Normalize(line2);
+
+        if (!string.IsNullOrEmpty(first) && !string.IsNullOrEmpty(second))
+        {
+            return $@"{first} {second}";
+        }
+
+        return first ?? second;
+    }
+
+    private static string? ToolTipName(ToolTipValues? toolTipValues) => toolTipValues == null
+        ? null
+        : FirstNonEmpty(toolTipValues.Heading, toolTipValues.Description);
+
+    private static string? ToolTipDescription(ToolTipValues? toolTipValues) => toolTipValues == null
+        ? null
+        : FirstNonEmpty(toolTipValues.Description, toolTipValues.Heading);
+
+    private static string? ButtonName(KryptonRibbonGroupButton button) =>
+        FirstNonEmpty(
+            CombineText(button.KryptonCommand?.TextLine1, button.KryptonCommand?.TextLine2),
+            button.KryptonCommand?.Text,
+            CombineText(button.TextLine1, button.TextLine2),
+            ToolTipName(button.ToolTipValues),
+            button.KeyTip,
+            SiteName(button),
+            button.GetType().Name);
+
+    private static string? CheckBoxName(KryptonRibbonGroupCheckBox checkBox) =>
+        FirstNonEmpty(
+            CombineText(checkBox.KryptonCommand?.TextLine1, checkBox.KryptonCommand?.TextLine2),
+            checkBox.KryptonCommand?.Text,
+            CombineText(checkBox.TextLine1, checkBox.TextLine2),
+            ToolTipName(checkBox.ToolTipValues),
+            checkBox.KeyTip,
+            SiteName(checkBox),
+            checkBox.GetType().Name);
+
+    private static string? GroupName(KryptonRibbonGroup group) =>
+        FirstNonEmpty(
+            CombineText(group.TextLine1, group.TextLine2),
+            group.KeyTipGroup,
+            SiteName(group),
+            group.GetType().Name);
+
+    private static string? TabName(KryptonRibbonTab tab) =>
+        FirstNonEmpty(tab.Text, tab.KeyTip, SiteName(tab), tab.GetType().Name);
+
+    private static string? QATName(IQuickAccessToolbarButton qatButton) =>
+        FirstNonEmpty(
+            qatButton.GetText(),
+            qatButton.GetToolTipTitle(),
+            qatButton.GetToolTipBody(),
+            SiteName(qatButton as Component),
+            qatButton.GetType().Name);
+
+    private static string? CustomControlName(KryptonRibbonGroupCustomControl customControl)
+    {
+        Control? control = customControl.CustomControl;
+
+        return FirstNonEmpty(
+            control?.AccessibleName,
+            control?.Text,
+            control?.Name,
+            ToolTipName(customControl.ToolTipValues),
+            customControl.KeyTip,
+            SiteName(customControl),
+            customControl.GetType().Name);
+    }
+
+    private static string? ItemName(KryptonRibbonGroupItem item) => item switch
+    {
+        KryptonRibbonGroupButton button => ButtonName(button),
+        KryptonRibbonGroupCheckBox checkBox => CheckBoxName(checkBox),
+        KryptonRibbonGroupCustomControl customControl => CustomControlName(customControl),
+        _ => FirstNonEmpty(ToolTipName(item.ToolTipValues), SiteName(item), item.GetType().Name)
+    };
+
+    private static string? ItemDescription(KryptonRibbonGroupItem item) => ToolTipDescription(item.ToolTipValues);
+
+    private static Rectangle ViewBounds(KryptonRibbon ribbon, ViewBase? view)
+    {
+        return view != null && view.ClientRectangle != Rectangle.Empty
+            ? ribbon.RectangleToScreen(view.ClientRectangle)
+            : Rectangle.Empty;
+    }
+
+    private static Rectangle BoundsOrOwner(KryptonRibbon ribbon, ViewBase? view)
+    {
+        Rectangle bounds = ViewBounds(ribbon, view);
+
+        return !bounds.IsEmpty ? bounds : ribbon.RectangleToScreen(ribbon.ClientRectangle);
+    }
+
+    private static ViewBase? FindQATView(KryptonRibbon ribbon, IQuickAccessToolbarButton qatButton)
+    {
+        ViewBase? root = ribbon.ViewRibbonManager?.Root;
+
+        return root == null ? null : FindQATView(root, qatButton);
+    }
+
+    private static ViewBase? FindQATView(ViewBase view, IQuickAccessToolbarButton qatButton)
+    {
+        if (view is ViewDrawRibbonQATButton qatView && ReferenceEquals(qatView.QATButton, qatButton))
+        {
+            return qatView;
+        }
+
+        foreach (ViewBase? child in view)
+        {
+            if (child == null)
+            {
+                continue;
+            }
+
+            ViewBase? found = FindQATView(child, qatButton);
+
+            if (found != null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static ViewBase? ItemView(KryptonRibbonGroupItem item) => item switch
+    {
+        KryptonRibbonGroupButton button => button.ButtonView,
+        KryptonRibbonGroupCheckBox checkBox => checkBox.CheckBoxView,
+        KryptonRibbonGroupCustomControl customControl => customControl.CustomControlView,
+        _ => null
+    };
+
+    private static bool ItemEnabled(KryptonRibbonGroupItem item) => item switch
+    {
+        KryptonRibbonGroupButton button => button.KryptonCommand?.Enabled ?? button.Enabled,
+        KryptonRibbonGroupCheckBox checkBox => checkBox.KryptonCommand?.Enabled ?? checkBox.Enabled,
+        KryptonRibbonGroupCustomControl customControl => customControl.Enabled && (customControl.CustomControl?.Enabled ?? true),
+        _ => true
+    };
+
+    private static CheckState ItemCheckState(KryptonRibbonGroupItem item) => item switch
+    {
+        KryptonRibbonGroupButton { ButtonType: GroupButtonType.Check } button =>
+            (button.KryptonCommand?.Checked ?? button.Checked) ? CheckState.Checked : CheckState.Unchecked,
+        KryptonRibbonGroupCheckBox checkBox => checkBox.KryptonCommand?.CheckState ?? checkBox.CheckState,
+        _ => CheckState.Unchecked
+    };
+
+    private static IEnumerable<KryptonRibbonGroupItem> ChildItems(KryptonRibbonGroup group)
+    {
+        foreach (KryptonRibbonGroupContainer container in group.Items)
+        {
+            foreach (KryptonRibbonGroupItem item in ChildItems(container))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private static IEnumerable<KryptonRibbonGroupItem> ChildItems(KryptonRibbonGroupContainer container)
+    {
+        foreach (Component component in container.GetChildComponents())
+        {
+            if (component is KryptonRibbonGroupContainer childContainer)
+            {
+                foreach (KryptonRibbonGroupItem item in ChildItems(childContainer))
+                {
+                    yield return item;
+                }
+            }
+            else if (component is KryptonRibbonGroupItem item)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private abstract class RibbonChildAccessibleObject : AccessibleObject
+    {
+        private readonly AccessibleObject _parent;
+
+        protected RibbonChildAccessibleObject(AccessibleObject parent, KryptonRibbon ribbon)
+        {
+            _parent = parent;
+            Ribbon = ribbon;
+        }
+
+        protected KryptonRibbon Ribbon { get; }
+
+        public override AccessibleObject? Parent => _parent;
+
+        public override int GetChildCount() => 0;
+
+        public override AccessibleObject? GetChild(int index) => null;
+
+        public override AccessibleObject? HitTest(int x, int y) => Bounds.Contains(x, y) ? this : null;
+    }
+
+    private sealed class RibbonTabAccessibleObject : RibbonChildAccessibleObject
+    {
+        private readonly KryptonRibbonTab _tab;
+
+        public RibbonTabAccessibleObject(AccessibleObject parent, KryptonRibbon ribbon, KryptonRibbonTab tab)
+            : base(parent, ribbon)
+        {
+            _tab = tab;
+        }
+
+        public override string? Name => TabName(_tab);
+
+        public override string DefaultAction => @"Select";
+
+        public override AccessibleRole Role => AccessibleRole.PageTab;
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.Focusable | AccessibleStates.Selectable;
+
+                if (!_tab.Visible)
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                if (Ribbon.SelectedTab == _tab)
+                {
+                    state |= AccessibleStates.Selected;
+                }
+
+                if (!Ribbon.Enabled)
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds => BoundsOrOwner(Ribbon, _tab.TabView);
+
+        public override void DoDefaultAction() => Select(AccessibleSelection.TakeSelection);
+
+        public override void Select(AccessibleSelection flags)
+        {
+            if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
+            {
+                Ribbon.SelectedTab = _tab;
+            }
+        }
+    }
+
+    private sealed class RibbonGroupAccessibleObject : RibbonChildAccessibleObject
+    {
+        private readonly KryptonRibbonGroup _group;
+
+        public RibbonGroupAccessibleObject(AccessibleObject parent, KryptonRibbon ribbon, KryptonRibbonGroup group)
+            : base(parent, ribbon)
+        {
+            _group = group;
+        }
+
+        public override string? Name => GroupName(_group);
+
+        public override AccessibleRole Role => AccessibleRole.Grouping;
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.None;
+
+                if (!_group.Visible || Ribbon.SelectedTab != _group.RibbonTab)
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                if (!Ribbon.Enabled)
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds => BoundsOrOwner(Ribbon, _group.GroupView);
+
+        public override int GetChildCount() => GetChildren().Count;
+
+        public override AccessibleObject? GetChild(int index)
+        {
+            List<AccessibleObject> children = GetChildren();
+
+            return index >= 0 && index < children.Count
+                ? children[index]
+                : null;
+        }
+
+        public override AccessibleObject? HitTest(int x, int y)
+        {
+            foreach (AccessibleObject child in GetChildren())
+            {
+                if (child.Bounds.Contains(x, y))
+                {
+                    AccessibleObject? nested = child.HitTest(x, y);
+
+                    return nested ?? child;
+                }
+            }
+
+            return Bounds.Contains(x, y) ? this : null;
+        }
+
+        private List<AccessibleObject> GetChildren()
+        {
+            var children = new List<AccessibleObject>();
+
+            foreach (KryptonRibbonGroupItem item in ChildItems(_group))
+            {
+                if (item.Visible)
+                {
+                    children.Add(new RibbonGroupItemAccessibleObject(this, Ribbon, item));
+                }
+            }
+
+            return children;
+        }
+    }
+
+    private sealed class RibbonGroupItemAccessibleObject : RibbonChildAccessibleObject
+    {
+        private readonly KryptonRibbonGroupItem _item;
+
+        public RibbonGroupItemAccessibleObject(AccessibleObject parent, KryptonRibbon ribbon, KryptonRibbonGroupItem item)
+            : base(parent, ribbon)
+        {
+            _item = item;
+        }
+
+        public override string? Name => ItemName(_item);
+
+        public override string? Description => ItemDescription(_item);
+
+        public override string DefaultAction => _item is KryptonRibbonGroupCustomControl ? @"Focus" : @"Press";
+
+        public override AccessibleRole Role => _item switch
+        {
+            KryptonRibbonGroupCheckBox _ => AccessibleRole.CheckButton,
+            KryptonRibbonGroupButton button => button.ButtonType == GroupButtonType.Check ? AccessibleRole.CheckButton : AccessibleRole.PushButton,
+            KryptonRibbonGroupCustomControl customControl => customControl.CustomControl?.AccessibilityObject.Role ?? AccessibleRole.Client,
+            _ => AccessibleRole.PushButton
+        };
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.Focusable;
+
+                if (!_item.Visible || _item.RibbonTab?.Ribbon?.SelectedTab != _item.RibbonTab)
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                if (!Ribbon.Enabled || !ItemEnabled(_item))
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                state |= ItemCheckState(_item) switch
+                {
+                    CheckState.Checked => AccessibleStates.Checked,
+                    CheckState.Indeterminate => AccessibleStates.Indeterminate,
+                    _ => 0
+                };
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds
+        {
+            get
+            {
+                if (_item is KryptonRibbonGroupCustomControl customControl
+                    && customControl.CustomControl != null
+                    && customControl.CustomControl.Visible)
+                {
+                    return customControl.CustomControl.RectangleToScreen(customControl.CustomControl.ClientRectangle);
+                }
+
+                return BoundsOrOwner(Ribbon, ItemView(_item));
+            }
+        }
+
+        public override void DoDefaultAction()
+        {
+            if (!ItemEnabled(_item))
+            {
+                return;
+            }
+
+            if (_item is KryptonRibbonGroupButton button)
+            {
+                if (button.ButtonType is GroupButtonType.DropDown or GroupButtonType.Split)
+                {
+                    button.PerformDropDown();
+                }
+                else
+                {
+                    button.PerformClick();
+                }
+            }
+            else if (_item is KryptonRibbonGroupCheckBox checkBox)
+            {
+                checkBox.PerformClick();
+            }
+            else if (_item is KryptonRibbonGroupCustomControl customControl
+                && customControl.CustomControl?.CanFocus == true)
+            {
+                customControl.CustomControl.Focus();
+            }
+        }
+    }
+
+    private sealed class RibbonQATButtonAccessibleObject : RibbonChildAccessibleObject
+    {
+        private readonly IQuickAccessToolbarButton _qatButton;
+
+        public RibbonQATButtonAccessibleObject(AccessibleObject parent, KryptonRibbon ribbon, IQuickAccessToolbarButton qatButton)
+            : base(parent, ribbon)
+        {
+            _qatButton = qatButton;
+        }
+
+        public override string? Name => QATName(_qatButton);
+
+        public override string? Description => FirstNonEmpty(_qatButton.GetToolTipBody(), _qatButton.GetToolTipTitle());
+
+        public override string DefaultAction => @"Press";
+
+        public override AccessibleRole Role => AccessibleRole.PushButton;
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.Focusable;
+
+                if (!_qatButton.GetVisible())
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                if (!Ribbon.Enabled || !_qatButton.GetEnabled())
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds => BoundsOrOwner(Ribbon, FindQATView(Ribbon, _qatButton));
+
+        public override void DoDefaultAction()
+        {
+            if (Ribbon.Enabled && _qatButton.GetEnabled() && _qatButton.GetVisible())
+            {
+                _qatButton.PerformClick();
+            }
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -820,6 +820,7 @@ public class KryptonCheckedListBox : VisualControlBase,
 
             return (IEnumerator)_miGetEnumerator?.Invoke(InnerArray, [stateMask, anyBit])!;
         }
+
         #endregion
 
         #region Private
@@ -937,15 +938,47 @@ public class KryptonCheckedListBox : VisualControlBase,
             var selectedIndex = SelectedIndex;
             if ((selectedIndex >= 0) && (selectedIndex < Items.Count))
             {
-                if (!_killNextSelect && ((selectedIndex == _lastSelected) || _kryptonCheckedListBox.CheckOnClick))
+                if (!_killNextSelect)
                 {
-                    CheckState checkedState = _kryptonCheckedListBox.GetItemCheckState(selectedIndex);
-                    CheckState newCheckValue = (checkedState != CheckState.Unchecked) ? CheckState.Unchecked : CheckState.Checked;
-                    var ice = new ItemCheckEventArgs(selectedIndex, newCheckValue, checkedState);
-                    _kryptonCheckedListBox.SetItemCheckState(selectedIndex, ice.NewValue);
+                    Action<int>? selectAction = _kryptonCheckedListBox.SelectionMode switch
+                    {
+                        CheckedSelectionMode.MultiSimple or CheckedSelectionMode.MultiExtended => ToggleItemCheckState,
+                        CheckedSelectionMode.Radio => CheckRadioItem,
+                        _ when (selectedIndex == _lastSelected) || _kryptonCheckedListBox.CheckOnClick => ToggleItemCheckState,
+                        _ => null
+                    };
+
+                    selectAction?.Invoke(selectedIndex);
                 }
+
                 _lastSelected = selectedIndex;
                 Invalidate();
+            }
+
+            void ToggleItemCheckState(int itemIndex)
+            {
+                CheckState checkedState = _kryptonCheckedListBox.GetItemCheckState(itemIndex);
+                CheckState newCheckValue = (checkedState != CheckState.Unchecked) ? CheckState.Unchecked : CheckState.Checked;
+                var ice = new ItemCheckEventArgs(itemIndex, newCheckValue, checkedState);
+                _kryptonCheckedListBox.SetItemCheckState(itemIndex, ice.NewValue);
+            }
+
+            void CheckRadioItem(int itemIndex)
+            {
+                for (int i = 0; i < _kryptonCheckedListBox.Items.Count; i++)
+                {
+                    if (i != itemIndex && _kryptonCheckedListBox.GetItemCheckState(i) != CheckState.Unchecked)
+                    {
+                        _kryptonCheckedListBox.SetItemCheckState(i, CheckState.Unchecked);
+                    }
+                }
+
+                CheckState checkedState = _kryptonCheckedListBox.GetItemCheckState(itemIndex);
+                if (checkedState == CheckState.Unchecked)
+                {
+                    var ice = new ItemCheckEventArgs(itemIndex, CheckState.Checked, checkedState);
+                    _kryptonCheckedListBox.SetItemCheckState(itemIndex, ice.NewValue);
+                }
             }
         }
         #endregion
@@ -976,6 +1009,7 @@ public class KryptonCheckedListBox : VisualControlBase,
     private ButtonStyle _style;
     private readonly IntPtr _screenDC;
     private int _lastSelectedIndex;
+    private CheckedSelectionMode _currentSelectionMode = CheckedSelectionMode.One;
     private bool _mouseOver;
     private bool _alwaysActive;
     private bool _forcedLayout;
@@ -1471,17 +1505,31 @@ public class KryptonCheckedListBox : VisualControlBase,
     /// Gets or sets the selection mode of the KryptonCheckedListBox control.
     /// </summary>
     [Category(@"Behavior")]
-    [Description(@"Indicates if the checked list box is to be single-select or not selectable. (Multi## not supported)")]
+    [Description(@"Indicates if the checked list box is to be single-select, multi-select or not selectable.")]
     [DefaultValue(CheckedSelectionMode.One)]
     public virtual CheckedSelectionMode SelectionMode
     {
-        get => _listBox.SelectionMode == System.Windows.Forms.SelectionMode.One
-            ? CheckedSelectionMode.One
-            : CheckedSelectionMode.None;
+        get => _listBox.SelectionMode switch
+        {
+            System.Windows.Forms.SelectionMode.One => _currentSelectionMode == CheckedSelectionMode.Radio ? CheckedSelectionMode.Radio : CheckedSelectionMode.One,
+            System.Windows.Forms.SelectionMode.MultiSimple => CheckedSelectionMode.MultiSimple,
+            System.Windows.Forms.SelectionMode.MultiExtended => CheckedSelectionMode.MultiExtended,
+            _ => CheckedSelectionMode.None
+        };
 
-        set => _listBox.SelectionMode = (value == CheckedSelectionMode.One)
-            ? System.Windows.Forms.SelectionMode.One
-            : System.Windows.Forms.SelectionMode.None;
+        set
+        {
+            _currentSelectionMode = value;
+
+            _listBox.SelectionMode = value switch
+            {
+                CheckedSelectionMode.One => System.Windows.Forms.SelectionMode.One,
+                CheckedSelectionMode.MultiSimple => System.Windows.Forms.SelectionMode.MultiSimple,
+                CheckedSelectionMode.MultiExtended => System.Windows.Forms.SelectionMode.MultiExtended,
+                CheckedSelectionMode.Radio => System.Windows.Forms.SelectionMode.One,
+                _ => System.Windows.Forms.SelectionMode.None
+            };
+        }
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -715,6 +715,12 @@ public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
     /// </summary>
     protected virtual ViewDrawCommandLinkButton ViewDrawButton => _drawCommandLinkButton;
 
+    /// <summary>
+    /// Creates a new accessibility object for the control.
+    /// </summary>
+    /// <returns>A new KryptonCommandLinkButtonAccessibleObject instance for the control.</returns>
+    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonCommandLinkButtonAccessibleObject(this);
+
     #endregion
 
     #region Implementation
@@ -740,4 +746,5 @@ public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
     }
 
     #endregion
+
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -949,6 +949,32 @@ public class KryptonDomainUpDown : VisualControlBase,
     [Browsable(false)]
     public DomainUpDown DomainUpDown => _domainUpDown;
 
+    /// <inheritdoc />
+    [DefaultValue(null)]
+    [Localizable(true)]
+    public new string? AccessibleName
+    {
+        get => base.AccessibleName;
+        set
+        {
+            base.AccessibleName = value;
+            DomainUpDown.AccessibleName = value;
+        }
+    }
+
+    /// <inheritdoc />
+    [DefaultValue(null)]
+    [Localizable(true)]
+    public new string? AccessibleDescription
+    {
+        get => base.AccessibleDescription;
+        set
+        {
+            base.AccessibleDescription = value;
+            DomainUpDown.AccessibleDescription = value;
+        }
+    }
+
     /// <summary>
     /// Gets access to the contained input control.
     /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -682,12 +682,6 @@ public class KryptonLinkWrapLabel : LinkLabel
 
         return base.ProcessCmdKey(ref msg, keyData);
     }
-
-    /// <summary>
-    /// Creates the accessibility object for the KryptonLinkWrapLabel control.
-    /// </summary>
-    /// <returns>A new KryptonLinkWrapLabelAccessibleObject instance for the control.</returns>
-    protected override AccessibleObject CreateAccessibilityInstance() => new KryptonLinkWrapLabelAccessibleObject(this);
 
     /// <summary>
     /// Processes a mnemonic character.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -978,6 +978,32 @@ public class KryptonNumericUpDown : VisualControlBase,
     [Browsable(false)]
     public NumericUpDown NumericUpDown => _numericUpDown;
 
+    /// <inheritdoc />
+    [DefaultValue(null)]
+    [Localizable(true)]
+    public new string? AccessibleName
+    {
+        get => base.AccessibleName;
+        set
+        {
+            base.AccessibleName = value;
+            NumericUpDown.AccessibleName = value;
+        }
+    }
+
+    /// <inheritdoc />
+    [DefaultValue(null)]
+    [Localizable(true)]
+    public new string? AccessibleDescription
+    {
+        get => base.AccessibleDescription;
+        set
+        {
+            base.AccessibleDescription = value;
+            NumericUpDown.AccessibleDescription = value;
+        }
+    }
+
     /// <summary>
     /// Gets access to the contained input control.
     /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckedListBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCheckedListBoxAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -158,12 +158,14 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
     {
         // Delegate to internal ListBox's children
         var internalAccessible = _owner.ListBox?.AccessibilityObject;
-        if (internalAccessible != null)
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
         {
             return internalAccessible.GetChild(index);
         }
 
-        return base.GetChild(index);
+        return index >= 0 && index < _owner.Items.Count
+            ? new KryptonCheckedListBoxItemAccessibleObject(this, _owner, index)
+            : null;
     }
 
     /// <summary>
@@ -174,12 +176,27 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
     {
         // Delegate to internal ListBox's child count
         var internalAccessible = _owner.ListBox?.AccessibilityObject;
-        if (internalAccessible != null)
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
         {
             return internalAccessible.GetChildCount();
         }
 
-        return base.GetChildCount();
+        return _owner.Items.Count;
+    }
+
+    /// <summary>
+    /// Retrieves the currently selected child.
+    /// </summary>
+    /// <returns>The selected child accessible object.</returns>
+    public override AccessibleObject? GetSelected()
+    {
+        var internalAccessible = _owner.ListBox?.AccessibilityObject;
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
+        {
+            return internalAccessible.GetSelected();
+        }
+
+        return _owner.SelectedIndex >= 0 ? GetChild(_owner.SelectedIndex) : null;
     }
 
     /// <summary>
@@ -215,6 +232,138 @@ internal class KryptonCheckedListBoxAccessibleObject : Control.ControlAccessible
         {
             base.Select(flags);
         }
+    }
+    #endregion
+
+    #region Implementation
+    private static bool HasNativeItemChildren(AccessibleObject accessibleObject)
+    {
+        for (int i = 0; i < accessibleObject.GetChildCount(); i++)
+        {
+            AccessibleObject? child = accessibleObject.GetChild(i);
+            if (child?.Role == AccessibleRole.CheckButton || child?.Role == AccessibleRole.ListItem)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class KryptonCheckedListBoxItemAccessibleObject : AccessibleObject
+    {
+        private readonly AccessibleObject _parent;
+        private readonly KryptonCheckedListBox _owner;
+        private readonly int _index;
+
+        public KryptonCheckedListBoxItemAccessibleObject(AccessibleObject parent, KryptonCheckedListBox owner, int index)
+        {
+            _parent = parent;
+            _owner = owner;
+            _index = index;
+        }
+
+        public override AccessibleObject? Parent => _parent;
+
+        public override string? Name => _owner.ListBox.GetItemText(_owner.Items[_index]);
+
+        public override AccessibleRole Role => AccessibleRole.CheckButton;
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.Focusable | AccessibleStates.Selectable;
+
+                if (_owner.GetSelected(_index))
+                {
+                    state |= AccessibleStates.Selected;
+                }
+
+                if (_owner.ListBox.Focused && _owner.SelectedIndex == _index)
+                {
+                    state |= AccessibleStates.Focused;
+                }
+
+                state |= _owner.GetItemCheckState(_index) switch
+                {
+                    CheckState.Checked => AccessibleStates.Checked,
+                    CheckState.Indeterminate => AccessibleStates.Indeterminate,
+                    _ => 0
+                };
+
+                if (!_owner.Enabled)
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                Rectangle bounds = _owner.GetItemRectangle(_index);
+                if (bounds.IsEmpty)
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds => _owner.ListBox.RectangleToScreen(_owner.GetItemRectangle(_index));
+
+        public override string DefaultAction => @"Toggle";
+
+        public override void DoDefaultAction()
+        {
+            if (!_owner.Enabled || _owner.SelectionMode == CheckedSelectionMode.None)
+            {
+                return;
+            }
+
+            _owner.SelectedIndex = _index;
+
+            if (_owner.SelectionMode == CheckedSelectionMode.Radio)
+            {
+                for (int i = 0; i < _owner.Items.Count; i++)
+                {
+                    if (i != _index && _owner.GetItemCheckState(i) != CheckState.Unchecked)
+                    {
+                        _owner.SetItemCheckState(i, CheckState.Unchecked);
+                    }
+                }
+
+                if (_owner.GetItemCheckState(_index) == CheckState.Unchecked)
+                {
+                    _owner.SetItemCheckState(_index, CheckState.Checked);
+                }
+
+                return;
+            }
+
+            CheckState current = _owner.GetItemCheckState(_index);
+            _owner.SetItemCheckState(_index, current == CheckState.Unchecked ? CheckState.Checked : CheckState.Unchecked);
+        }
+
+        public override void Select(AccessibleSelection flags)
+        {
+            if (_owner.SelectionMode == CheckedSelectionMode.None)
+            {
+                return;
+            }
+
+            if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
+            {
+                _owner.SelectedIndex = _index;
+            }
+            else if ((flags & AccessibleSelection.AddSelection) == AccessibleSelection.AddSelection)
+            {
+                _owner.SetSelected(_index, true);
+            }
+            else if ((flags & AccessibleSelection.RemoveSelection) == AccessibleSelection.RemoveSelection)
+            {
+                _owner.SetSelected(_index, false);
+            }
+        }
+
+        public override int GetChildCount() => 0;
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCommandLinkButtonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonCommandLinkButtonAccessibleObject.cs
@@ -1,0 +1,104 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides accessibility information for KryptonCommandLinkButton.
+/// </summary>
+internal class KryptonCommandLinkButtonAccessibleObject : Control.ControlAccessibleObject
+{
+    #region Instance Fields
+    private readonly KryptonCommandLinkButton _owner;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the KryptonCommandLinkButtonAccessibleObject class.
+    /// </summary>
+    /// <param name="owner">The KryptonCommandLinkButton control that owns this accessible object.</param>
+    public KryptonCommandLinkButtonAccessibleObject(KryptonCommandLinkButton owner)
+        : base(owner)
+    {
+        _owner = owner;
+    }
+    #endregion
+
+    #region Public Overrides
+    /// <summary>
+    /// Gets the accessible name of the control.
+    /// </summary>
+    public override string? Name
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
+            return FirstNonEmpty(_owner.CommandLinkTextValues?.Heading, _owner.Text, _owner.Name);
+        }
+
+        set => _owner.AccessibleName = value;
+    }
+
+    /// <summary>
+    /// Gets the accessible description of the control.
+    /// </summary>
+    public override string? Description
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
+            return FirstNonEmpty(_owner.CommandLinkTextValues?.Description, base.Description);
+        }
+    }
+
+    /// <summary>
+    /// Gets the accessible role of the control.
+    /// </summary>
+    public override AccessibleRole Role => AccessibleRole.PushButton;
+
+    /// <summary>
+    /// Gets the default action for the control.
+    /// </summary>
+    public override string DefaultAction => @"Press";
+
+    /// <summary>
+    /// Performs the default action associated with this accessible object.
+    /// </summary>
+    public override void DoDefaultAction()
+    {
+        if (_owner.Enabled)
+        {
+            _owner.PerformClick();
+        }
+    }
+    #endregion
+
+    #region Implementation
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (string? value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonDomainUpDownAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonDomainUpDownAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -39,11 +39,17 @@ internal class KryptonDomainUpDownAccessibleObject : Control.ControlAccessibleOb
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal DomainUpDown first
             var internalAccessible = _owner.DomainUpDown?.AccessibilityObject;
-            if (internalAccessible?.Name != null)
+            string? name = internalAccessible?.Name;
+            if (!string.IsNullOrEmpty(name))
             {
-                return internalAccessible.Name;
+                return name;
             }
 
             // Fall back to base implementation
@@ -58,11 +64,17 @@ internal class KryptonDomainUpDownAccessibleObject : Control.ControlAccessibleOb
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal DomainUpDown first
             var internalAccessible = _owner.DomainUpDown?.AccessibilityObject;
-            if (internalAccessible?.Description != null)
+            string? description = internalAccessible?.Description;
+            if (!string.IsNullOrEmpty(description))
             {
-                return internalAccessible.Description;
+                return description;
             }
 
             // Fall back to base implementation
@@ -129,6 +141,25 @@ internal class KryptonDomainUpDownAccessibleObject : Control.ControlAccessibleOb
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _owner.Items.Count; i++)
+            {
+                if (string.Equals(Convert.ToString(_owner.Items[i]), value, StringComparison.CurrentCulture))
+                {
+                    _owner.SelectedIndex = i;
+                    return;
+                }
+            }
+
+            _owner.Text = value;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListBoxAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -158,12 +158,14 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
     {
         // Delegate to internal ListBox's children
         var internalAccessible = _owner.ListBox?.AccessibilityObject;
-        if (internalAccessible != null)
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
         {
             return internalAccessible.GetChild(index);
         }
 
-        return base.GetChild(index);
+        return index >= 0 && index < _owner.Items.Count
+            ? new KryptonListBoxItemAccessibleObject(this, _owner, index)
+            : null;
     }
 
     /// <summary>
@@ -174,12 +176,27 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
     {
         // Delegate to internal ListBox's child count
         var internalAccessible = _owner.ListBox?.AccessibilityObject;
-        if (internalAccessible != null)
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
         {
             return internalAccessible.GetChildCount();
         }
 
-        return base.GetChildCount();
+        return _owner.Items.Count;
+    }
+
+    /// <summary>
+    /// Retrieves the currently selected child.
+    /// </summary>
+    /// <returns>The selected child accessible object.</returns>
+    public override AccessibleObject? GetSelected()
+    {
+        var internalAccessible = _owner.ListBox?.AccessibilityObject;
+        if (internalAccessible != null && HasNativeItemChildren(internalAccessible))
+        {
+            return internalAccessible.GetSelected();
+        }
+
+        return _owner.SelectedIndex >= 0 ? GetChild(_owner.SelectedIndex) : null;
     }
 
     /// <summary>
@@ -215,6 +232,102 @@ internal class KryptonListBoxAccessibleObject : Control.ControlAccessibleObject
         {
             base.Select(flags);
         }
+    }
+    #endregion
+
+    #region Implementation
+    private static bool HasNativeItemChildren(AccessibleObject accessibleObject)
+    {
+        for (int i = 0; i < accessibleObject.GetChildCount(); i++)
+        {
+            AccessibleObject? child = accessibleObject.GetChild(i);
+            if (child?.Role == AccessibleRole.ListItem)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class KryptonListBoxItemAccessibleObject : AccessibleObject
+    {
+        private readonly AccessibleObject _parent;
+        private readonly KryptonListBox _owner;
+        private readonly int _index;
+
+        public KryptonListBoxItemAccessibleObject(AccessibleObject parent, KryptonListBox owner, int index)
+        {
+            _parent = parent;
+            _owner = owner;
+            _index = index;
+        }
+
+        public override AccessibleObject? Parent => _parent;
+
+        public override string? Name => _owner.ListBox.GetItemText(_owner.Items[_index]);
+
+        public override AccessibleRole Role => AccessibleRole.ListItem;
+
+        public override AccessibleStates State
+        {
+            get
+            {
+                AccessibleStates state = AccessibleStates.Focusable | AccessibleStates.Selectable;
+
+                if (_owner.GetSelected(_index))
+                {
+                    state |= AccessibleStates.Selected;
+                }
+
+                if (_owner.ListBox.Focused && _owner.SelectedIndex == _index)
+                {
+                    state |= AccessibleStates.Focused;
+                }
+
+                if (!_owner.Enabled)
+                {
+                    state |= AccessibleStates.Unavailable;
+                }
+
+                Rectangle bounds = _owner.GetItemRectangle(_index);
+                if (bounds.IsEmpty)
+                {
+                    state |= AccessibleStates.Invisible;
+                }
+
+                return state;
+            }
+        }
+
+        public override Rectangle Bounds => _owner.ListBox.RectangleToScreen(_owner.GetItemRectangle(_index));
+
+        public override string DefaultAction => @"Select";
+
+        public override void DoDefaultAction() => Select(AccessibleSelection.TakeSelection);
+
+        public override void Select(AccessibleSelection flags)
+        {
+            if (_owner.SelectionMode == SelectionMode.None)
+            {
+                return;
+            }
+
+            if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
+            {
+                _owner.SelectedIndex = _index;
+            }
+            else if ((flags & AccessibleSelection.AddSelection) == AccessibleSelection.AddSelection)
+            {
+                _owner.SetSelected(_index, true);
+            }
+            else if ((flags & AccessibleSelection.RemoveSelection) == AccessibleSelection.RemoveSelection)
+            {
+                _owner.SetSelected(_index, false);
+            }
+        }
+
+        public override int GetChildCount() => 0;
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListViewAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonListViewAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -156,14 +156,7 @@ internal class KryptonListViewAccessibleObject : Control.ControlAccessibleObject
     /// <returns>An AccessibleObject that represents the child accessible object corresponding to the specified index.</returns>
     public override AccessibleObject? GetChild(int index)
     {
-        // Delegate to internal ListView's children
-        var internalAccessible = _owner.ListView?.AccessibilityObject;
-        if (internalAccessible != null)
-        {
-            return internalAccessible.GetChild(index);
-        }
-
-        return base.GetChild(index);
+        return null;
     }
 
     /// <summary>
@@ -172,14 +165,7 @@ internal class KryptonListViewAccessibleObject : Control.ControlAccessibleObject
     /// <returns>The number of children belonging to an accessible object.</returns>
     public override int GetChildCount()
     {
-        // Delegate to internal ListView's child count
-        var internalAccessible = _owner.ListView?.AccessibilityObject;
-        if (internalAccessible != null)
-        {
-            return internalAccessible.GetChildCount();
-        }
-
-        return base.GetChildCount();
+        return 0;
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonMaskedTextBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonMaskedTextBoxAccessibleObject.cs
@@ -1,8 +1,8 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -39,11 +39,17 @@ internal class KryptonMaskedTextBoxAccessibleObject : Control.ControlAccessibleO
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal MaskedTextBox first
             var internalAccessible = _owner.MaskedTextBox?.AccessibilityObject;
-            if (internalAccessible?.Name != null)
+            string? name = internalAccessible?.Name;
+            if (!string.IsNullOrEmpty(name))
             {
-                return internalAccessible.Name;
+                return name;
             }
 
             // Fall back to base implementation
@@ -58,11 +64,17 @@ internal class KryptonMaskedTextBoxAccessibleObject : Control.ControlAccessibleO
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal MaskedTextBox first
             var internalAccessible = _owner.MaskedTextBox?.AccessibilityObject;
-            if (internalAccessible?.Description != null)
+            string? description = internalAccessible?.Description;
+            if (!string.IsNullOrEmpty(description))
             {
-                return internalAccessible.Description;
+                return description;
             }
 
             // Fall back to base implementation
@@ -129,6 +141,20 @@ internal class KryptonMaskedTextBoxAccessibleObject : Control.ControlAccessibleO
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            string text = value ?? string.Empty;
+
+            if (_owner.MaskedTextBox != null)
+            {
+                _owner.MaskedTextBox.Text = text;
+            }
+            else
+            {
+                _owner.Text = text;
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonNumericUpDownAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonNumericUpDownAccessibleObject.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -39,11 +39,17 @@ internal class KryptonNumericUpDownAccessibleObject : Control.ControlAccessibleO
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal NumericUpDown first
             var internalAccessible = _owner.NumericUpDown?.AccessibilityObject;
-            if (internalAccessible?.Name != null)
+            string? name = internalAccessible?.Name;
+            if (!string.IsNullOrEmpty(name))
             {
-                return internalAccessible.Name;
+                return name;
             }
 
             // Fall back to base implementation
@@ -58,11 +64,17 @@ internal class KryptonNumericUpDownAccessibleObject : Control.ControlAccessibleO
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal NumericUpDown first
             var internalAccessible = _owner.NumericUpDown?.AccessibilityObject;
-            if (internalAccessible?.Description != null)
+            string? description = internalAccessible?.Description;
+            if (!string.IsNullOrEmpty(description))
             {
-                return internalAccessible.Description;
+                return description;
             }
 
             // Fall back to base implementation
@@ -129,6 +141,23 @@ internal class KryptonNumericUpDownAccessibleObject : Control.ControlAccessibleO
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            if (decimal.TryParse(value, out decimal result))
+            {
+                if (result < _owner.Minimum)
+                {
+                    result = _owner.Minimum;
+                }
+                else if (result > _owner.Maximum)
+                {
+                    result = _owner.Maximum;
+                }
+
+                _owner.Value = result;
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonRichTextBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonRichTextBoxAccessibleObject.cs
@@ -1,8 +1,8 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -39,11 +39,17 @@ internal class KryptonRichTextBoxAccessibleObject : Control.ControlAccessibleObj
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal RichTextBox first
             var internalAccessible = _owner.RichTextBox?.AccessibilityObject;
-            if (internalAccessible?.Name != null)
+            string? name = internalAccessible?.Name;
+            if (!string.IsNullOrEmpty(name))
             {
-                return internalAccessible.Name;
+                return name;
             }
 
             // Fall back to base implementation
@@ -58,11 +64,17 @@ internal class KryptonRichTextBoxAccessibleObject : Control.ControlAccessibleObj
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal RichTextBox first
             var internalAccessible = _owner.RichTextBox?.AccessibilityObject;
-            if (internalAccessible?.Description != null)
+            string? description = internalAccessible?.Description;
+            if (!string.IsNullOrEmpty(description))
             {
-                return internalAccessible.Description;
+                return description;
             }
 
             // Fall back to base implementation
@@ -129,6 +141,20 @@ internal class KryptonRichTextBoxAccessibleObject : Control.ControlAccessibleObj
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            string text = value ?? string.Empty;
+
+            if (_owner.RichTextBox != null)
+            {
+                _owner.RichTextBox.Text = text;
+            }
+            else
+            {
+                _owner.Text = text;
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonTextBoxAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Accessibility/KryptonTextBoxAccessibleObject.cs
@@ -1,8 +1,8 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2026 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -39,11 +39,17 @@ internal class KryptonTextBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleName))
+            {
+                return _owner.AccessibleName;
+            }
+
             // Try to get name from internal TextBox first
             var internalAccessible = _owner.TextBox?.AccessibilityObject;
-            if (internalAccessible?.Name != null)
+            string? name = internalAccessible?.Name;
+            if (!string.IsNullOrEmpty(name))
             {
-                return internalAccessible.Name;
+                return name;
             }
 
             // Fall back to base implementation
@@ -58,11 +64,17 @@ internal class KryptonTextBoxAccessibleObject : Control.ControlAccessibleObject
     {
         get
         {
+            if (!string.IsNullOrEmpty(_owner.AccessibleDescription))
+            {
+                return _owner.AccessibleDescription;
+            }
+
             // Try to get description from internal TextBox first
             var internalAccessible = _owner.TextBox?.AccessibilityObject;
-            if (internalAccessible?.Description != null)
+            string? description = internalAccessible?.Description;
+            if (!string.IsNullOrEmpty(description))
             {
-                return internalAccessible.Description;
+                return description;
             }
 
             // Fall back to base implementation
@@ -129,6 +141,20 @@ internal class KryptonTextBoxAccessibleObject : Control.ControlAccessibleObject
 
             // Fall back to control's text
             return _owner.Text;
+        }
+
+        set
+        {
+            string text = value ?? string.Empty;
+
+            if (_owner.TextBox != null)
+            {
+                _owner.TextBox.Text = text;
+            }
+            else
+            {
+                _owner.Text = text;
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -1777,7 +1777,22 @@ public enum CheckedSelectionMode
     /// <summary>
     /// Only one item can be selected.
     /// </summary>
-    One = 1
+    One = 1,
+
+    /// <summary>
+    /// Multiple items can be selected with simple click selection.
+    /// </summary>
+    MultiSimple = 2,
+
+    /// <summary>
+    /// Multiple items can be selected with extended selection (Ctrl/Shift keys).
+    /// </summary>
+    MultiExtended = 3,
+
+    /// <summary>
+    /// Only one item can be checked at a time (radio button behavior).
+    /// </summary>
+    Radio = 4
 }
 #endregion
 

--- a/Source/Krypton Components/TestForm/AccessibilityTest.cs
+++ b/Source/Krypton Components/TestForm/AccessibilityTest.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), et al. 2024 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), tobitege, et al. 2024 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -521,6 +521,7 @@ public partial class AccessibilityTest : KryptonForm
         {
             var accessible = control.AccessibilityObject;
             result.AccessibleObjectCreated = accessible != null;
+            var errors = new List<string>();
 
             if (accessible != null)
             {
@@ -542,7 +543,19 @@ public partial class AccessibilityTest : KryptonForm
                     result.NavigationWorks = false;
                 }
 
-                result.Success = true;
+                if (!string.IsNullOrEmpty(control.AccessibleName) && string.IsNullOrEmpty(result.Name))
+                {
+                    errors.Add($"AccessibleName '{control.AccessibleName}' is not exposed.");
+                }
+
+                if (control.AccessibleRole != AccessibleRole.Default
+                    && result.Role != control.AccessibleRole.ToString())
+                {
+                    errors.Add($"AccessibleRole '{control.AccessibleRole}' is not exposed.");
+                }
+
+                result.Success = errors.Count == 0;
+                result.ErrorMessage = string.Join("; ", errors);
             }
             else
             {

--- a/Source/TestHarnesses/RibbonAccessibilityProbe/Program.cs
+++ b/Source/TestHarnesses/RibbonAccessibilityProbe/Program.cs
@@ -1,0 +1,216 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using Krypton.Ribbon;
+using Krypton.Toolkit;
+
+namespace RibbonAccessibilityProbe
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static int Main(string[] args)
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+
+            if (args.Any(arg => string.Equals(arg, "--show", StringComparison.OrdinalIgnoreCase)))
+            {
+                Application.Run(new ProbeForm());
+                return 0;
+            }
+
+            try
+            {
+                RunAssertions();
+                Console.WriteLine(@"Ribbon accessibility probe passed.");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return 1;
+            }
+        }
+
+        private static void RunAssertions()
+        {
+            using (var form = new ProbeForm())
+            {
+                form.Show();
+                Application.DoEvents();
+                form.Ribbon.PerformLayout();
+                Application.DoEvents();
+
+                AccessibleObject ribbonAccessible = form.Ribbon.AccessibilityObject;
+
+                AccessibleObject homeTab = RequireDescendant(ribbonAccessible, @"Home");
+                Require(homeTab.Role == AccessibleRole.PageTab, @"Home tab should expose PageTab role.");
+
+                AccessibleObject group = RequireDescendant(ribbonAccessible, @"Clipboard");
+                Require(group.Role == AccessibleRole.Grouping, @"Clipboard group should expose Grouping role.");
+
+                AccessibleObject pasteButton = RequireDescendant(ribbonAccessible, @"Paste Special");
+                Require(pasteButton.Role == AccessibleRole.PushButton, @"Paste button should expose PushButton role.");
+                pasteButton.DoDefaultAction();
+                Require(form.PasteClicks == 1, @"Paste button default action should invoke Click.");
+
+                AccessibleObject boldCheckBox = RequireDescendant(ribbonAccessible, @"Bold");
+                Require(boldCheckBox.Role == AccessibleRole.CheckButton, @"Bold checkbox should expose CheckButton role.");
+                Require((boldCheckBox.State & AccessibleStates.Checked) == 0, @"Bold checkbox should start unchecked.");
+                boldCheckBox.DoDefaultAction();
+                Require(form.BoldCheckBox.Checked, @"Bold checkbox default action should toggle Checked.");
+                Require((boldCheckBox.State & AccessibleStates.Checked) == AccessibleStates.Checked, @"Bold checkbox state should expose Checked after toggle.");
+
+                AccessibleObject qatButton = RequireDescendant(ribbonAccessible, @"Quick Paste");
+                qatButton.DoDefaultAction();
+                Require(form.QatClicks == 1, @"QAT default action should invoke Click.");
+
+                AccessibleObject customHost = RequireDescendant(ribbonAccessible, @"Search box");
+                Require(!string.IsNullOrWhiteSpace(customHost.Name), @"Custom control host should expose a stable name.");
+            }
+        }
+
+        private static AccessibleObject RequireDescendant(AccessibleObject root, string name)
+        {
+            AccessibleObject? found = Descendants(root).FirstOrDefault(child => string.Equals(child.Name, name, StringComparison.Ordinal));
+
+            if (found == null)
+            {
+                throw new InvalidOperationException($@"Could not find accessible descendant named '{name}'.");
+            }
+
+            return found;
+        }
+
+        private static IEnumerable<AccessibleObject> Descendants(AccessibleObject root)
+        {
+            int childCount = root.GetChildCount();
+
+            for (int i = 0; i < childCount; i++)
+            {
+                AccessibleObject? child = root.GetChild(i);
+
+                if (child == null)
+                {
+                    continue;
+                }
+
+                yield return child;
+
+                foreach (AccessibleObject descendant in Descendants(child))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+
+        private static void Require(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+
+    internal sealed class ProbeForm : Form
+    {
+        private readonly KryptonRibbonGroupButton _pasteButton;
+        private readonly KryptonRibbonQATButton _qatButton;
+
+        public ProbeForm()
+        {
+            Text = @"Ribbon Accessibility Probe";
+            Name = @"RibbonAccessibilityProbeForm";
+            Size = new Size(900, 400);
+
+            Ribbon = new KryptonRibbon
+            {
+                Name = @"probeRibbon",
+                Dock = DockStyle.Top
+            };
+
+            var homeTab = new KryptonRibbonTab
+            {
+                Text = @"Home",
+                KeyTip = @"H"
+            };
+
+            var clipboardGroup = new KryptonRibbonGroup
+            {
+                TextLine1 = @"Clipboard",
+                KeyTipGroup = @"C"
+            };
+
+            var triple = new KryptonRibbonGroupTriple();
+
+            _pasteButton = new KryptonRibbonGroupButton
+            {
+                TextLine1 = @"Paste",
+                TextLine2 = @"Special",
+                KeyTip = @"P"
+            };
+            _pasteButton.Click += OnPasteClick;
+
+            BoldCheckBox = new KryptonRibbonGroupCheckBox
+            {
+                TextLine1 = @"Bold",
+                KeyTip = @"B"
+            };
+
+            var customTextBox = new TextBox
+            {
+                Name = @"searchBox",
+                AccessibleName = @"Search box",
+                Text = @"Search"
+            };
+
+            var customHost = new KryptonRibbonGroupCustomControl
+            {
+                CustomControl = customTextBox,
+                KeyTip = @"S"
+            };
+
+            triple.Items!.Add(_pasteButton);
+            triple.Items.Add(BoldCheckBox);
+            triple.Items.Add(customHost);
+            clipboardGroup.Items.Add(triple);
+            homeTab.Groups.Add(clipboardGroup);
+            Ribbon.RibbonTabs.Add(homeTab);
+            Ribbon.SelectedTab = homeTab;
+
+            _qatButton = new KryptonRibbonQATButton
+            {
+                Text = @"Quick Paste"
+            };
+            _qatButton.Click += OnQatClick;
+            Ribbon.QATButtons.Add(_qatButton);
+
+            Controls.Add(Ribbon);
+        }
+
+        public KryptonRibbon Ribbon { get; }
+
+        public KryptonRibbonGroupCheckBox BoldCheckBox { get; }
+
+        public int PasteClicks { get; private set; }
+
+        public int QatClicks { get; private set; }
+
+        private void OnPasteClick(object? sender, EventArgs e) => PasteClicks++;
+
+        private void OnQatClick(object? sender, EventArgs e) => QatClicks++;
+    }
+}

--- a/Source/TestHarnesses/RibbonAccessibilityProbe/RibbonAccessibilityProbe.csproj
+++ b/Source/TestHarnesses/RibbonAccessibilityProbe/RibbonAccessibilityProbe.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <AssemblyName>RibbonAccessibilityProbe</AssemblyName>
+    <RootNamespace>RibbonAccessibilityProbe</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
+    <ProjectReference Include="..\..\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Implements #3714 for V105-LTS.

It gives `KryptonRibbon` a toolkit-owned accessibility tree so automation tools can discover and invoke ribbon tabs, groups, group buttons, check boxes, QAT items, and hosted custom controls by meaningful names instead of seeing only a generic ribbon container.

It also improves the wrapped-control accessibility providers that automation clients target in `AccessibilityTest`: text-like wrappers now forward names and values to the inner WinForms controls more consistently, list-like wrappers expose item children when the native inner provider does not surface them, and `KryptonListView` avoids duplicating item children already exposed by the native provider.

## Task List

- [x] Implement Ribbon-related accessibility for `KryptonRibbon`, tabs, groups, buttons, check boxes, QAT items, and hosted custom controls.
- [x] Review `KryptonRichTextBox` outer-to-inner provider behavior so automation clients do not get a misleading set-value surface.
- [x] Review text input controls such as `KryptonTextBox` and `KryptonMaskedTextBox` where configured accessible names are not consistently exposed on the targetable element.
- [x] Review `KryptonCheckedListBox` item roles and checked-state reporting.
  Added fallback item accessible objects when the wrapped WinForms provider does not expose real item children. These item objects report stable names, selection state, default toggle behavior, and checked/indeterminate states through the existing `AccessibleObject` surface. A deeper UIA TogglePattern provider is intentionally left out because it would require a larger provider rewrite.
- [x] Review list selection state reporting where selected items are not clearly reflected in the UIA tree.
  Added fallback item children and `GetSelected()` support for `KryptonListBox`, while leaving `KryptonListView` on the native item provider to avoid duplicate UIA rows. This keeps automation-visible list items available without replacing the inner WinForms provider wholesale.
- [x] Tighten `AccessibilityTest` so configured accessible names and states are verified instead of passing with empty exposed names.
