### PR TITLE
3698-V100-Fix CI build error

### DIFF
--- a/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
+++ b/Source/Krypton Components/Krypton.Standard.Toolkit/Krypton.Standard.Toolkit.csproj
@@ -123,7 +123,7 @@
 	
 		Target Framework Mapping:
 		- .NET Framework TFMs (net472, net48, net481): Use the TFM as-is in package paths
-		- .NET 8+ Windows TFMs (net8.0-windows, net9.0-windows, net10.0-windows): Map to netX.0-windows7.0 format
+		- .NET 8+ Windows TFMs (net8.0-windows, net9.0-windows, net10.0-windows, net11.0-windows): Map to netX.0-windows7.0 format
 		  This mapping is required because NuGet packages use a specific version string format for .NET Core/5+ Windows TFMs
 		  Example: net10.0-windows -> net10.0-windows7.0 in the package lib folder
 	
@@ -139,6 +139,7 @@
 			<_LibFolderName Condition="'$(TargetFramework)' == 'net8.0-windows'">net8.0-windows7.0</_LibFolderName>
 			<_LibFolderName Condition="'$(TargetFramework)' == 'net9.0-windows'">net9.0-windows7.0</_LibFolderName>
 			<_LibFolderName Condition="'$(TargetFramework)' == 'net10.0-windows'">net10.0-windows7.0</_LibFolderName>
+			<_LibFolderName Condition="'$(TargetFramework)' == 'net11.0-windows'">net11.0-windows7.0</_LibFolderName>
 			<!-- For .NET Framework TFMs, use the TFM as-is -->
 			<_LibFolderName Condition="'$(_LibFolderName)' == ''">$(TargetFramework)</_LibFolderName>
 		</PropertyGroup>


### PR DESCRIPTION
Followup fix for #3698.

The aggregate Krypton.Standard.Toolkit package maps Windows TFMs to NuGet lib folder names with a windows7.0 platform version. net11.0-windows was added to the supported TFMs but not to that mapping, so CI generated lib/net11.0-windows paths and NuGet rejected them with NU1012.

This adds the net11.0-windows mapping to net11.0-windows7.0.