### PR TITLE
3682-V105-LTS-Fix KDGridView column resizing

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), Fixed KryptonDataGridView column resize flicker
 * Resolved [#3690](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3690), Fix VS 2019 build targeting so VS 2019 uses only .NET Framework 4.x projects while VS2022/Current scripts refresh restore assets for modern target frameworks.
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed VisualForm resize flicker in .NET 10+
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1241,7 +1241,7 @@ public class KryptonDataGridView : DataGridView
         // the painting to fail.
         if ((_cellDown.X == -1) || (_cellDown.Y == -1))
         {
-            DoubleBuffered = false;
+            base.DoubleBuffered = false;
         }
 
         base.OnCellMouseDown(e);
@@ -1266,9 +1266,9 @@ public class KryptonDataGridView : DataGridView
         _cellDown = _nullCell;
 
         // Put back double buffered if it was turned off in the OnCellMouseDown
-        if (!DoubleBuffered)
+        if (!base.DoubleBuffered)
         {
-            DoubleBuffered = true;
+            base.DoubleBuffered = true;
         }
 
         base.OnCellMouseUp(e);


### PR DESCRIPTION
Fixes #3682 for V105-LTS

This fixes KryptonDataGridView column resize flicker on V105-LTS by bypassing the public DoubleBuffered setter for the temporary resize-feedback toggle.
The public setter invalidates the whole grid, while the resize path only needs to change the underlying DataGridView double buffering state so the native resize feedback can draw correctly.