### PR TITLE
3736-v110-High DPI scaling followup fixes

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3736](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3736), Fixed high-dpi scaling causing magenta image borders
 * Implemented [#3718](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3718), Use 'switch' expression
 * Resolved [#3720](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3720), `KryptonTreeView` freezes blank after programmatic `SelectedNode = null` then re-select (drain leaked selection `BeginUpdate`/`EndUpdate` batches from #3282/#3498)
 * Resolved [#3719](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3719), Information exposure through transmitted data

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -5732,9 +5732,11 @@ public class RenderStandard : RenderBase
 					float ratio = Math.Min(displayRect.Width / (float)memento.Image.Width,
 						displayRect.Height / (float)memento.Image.Height);
 
+					bool avoidPurple = memento.ImageTransparentColor != GlobalStaticVariables.EMPTY_COLOR;
+
 					// Resize image to fit display area
 					memento.Image = CommonHelper.ScaleImageForSizedDisplay(memento.Image, memento.Image.Width * ratio,
-						memento.Image.Height * ratio, false);
+						memento.Image.Height * ratio, avoidPurple);
 				}
 
 				if (memento.Image != null)

--- a/Source/Krypton Components/TestForm/TouchscreenHighDpiDemo.cs
+++ b/Source/Krypton Components/TestForm/TouchscreenHighDpiDemo.cs
@@ -25,6 +25,7 @@ public partial class TouchscreenHighDpiDemo : KryptonForm
 {
     private Timer _dpiMonitorTimer;
     private bool _updatingFromEvent;
+    private readonly Dictionary<Control, Rectangle> _baselineBounds = new();
 
     public TouchscreenHighDpiDemo()
     {
@@ -47,6 +48,8 @@ public partial class TouchscreenHighDpiDemo : KryptonForm
 
         // Setup demo controls
         SetupDemoControls();
+
+        grpSettings.Panel.AutoScroll = true;
 
         // Setup event handlers
         chkEnableTouchscreen.CheckedChanged += ChkEnableTouchscreen_CheckedChanged;
@@ -376,12 +379,78 @@ public partial class TouchscreenHighDpiDemo : KryptonForm
             trackFontScaleFactor.Enabled = fontScalingEnabled;
             lblFontScaleFactor.Enabled = touchscreenEnabled;
             lblFontScaleValue.Enabled = touchscreenEnabled;
+
+            ApplyScaledDemoLayout(settings);
         }
         finally
         {
             _updatingFromEvent = false;
         }
     }
+
+    private void ApplyScaledDemoLayout(TouchscreenSettingValues settings)
+    {
+        CaptureBaselineBounds(grpControls.Panel);
+        CaptureBaselineBounds(grpSettings.Panel);
+
+        float scaleFactor = 1f;
+        if (settings.TouchscreenModeEnabled)
+        {
+            scaleFactor = settings.ControlScaleFactor;
+            if (settings.FontScalingEnabled)
+            {
+                scaleFactor = Math.Max(scaleFactor, settings.FontScaleFactor);
+            }
+        }
+
+        scaleFactor = Math.Max(1f, scaleFactor);
+
+        grpControls.Panel.SuspendLayout();
+        grpSettings.Panel.SuspendLayout();
+
+        try
+        {
+            foreach (KeyValuePair<Control, Rectangle> entry in _baselineBounds)
+            {
+                Control control = entry.Key;
+                if (control.IsDisposed || control.Dock == DockStyle.Fill)
+                {
+                    continue;
+                }
+
+                Rectangle bounds = entry.Value;
+                control.Bounds = new Rectangle(
+                    ScaleLayoutValue(bounds.X, scaleFactor),
+                    ScaleLayoutValue(bounds.Y, scaleFactor),
+                    ScaleLayoutSize(bounds.Width, scaleFactor),
+                    ScaleLayoutSize(bounds.Height, scaleFactor));
+            }
+        }
+        finally
+        {
+            grpSettings.Panel.ResumeLayout(true);
+            grpControls.Panel.ResumeLayout(true);
+        }
+    }
+
+    private void CaptureBaselineBounds(Control parent)
+    {
+        foreach (Control child in parent.Controls)
+        {
+            if (child.Dock != DockStyle.Fill && !_baselineBounds.ContainsKey(child))
+            {
+                _baselineBounds.Add(child, child.Bounds);
+            }
+
+            CaptureBaselineBounds(child);
+        }
+    }
+
+    private static int ScaleLayoutValue(int value, float scaleFactor) =>
+        Math.Max(0, (int)Math.Round(value * scaleFactor));
+
+    private static int ScaleLayoutSize(int value, float scaleFactor) =>
+        Math.Max(1, (int)Math.Round(value * scaleFactor));
 
     private void UpdateStatus()
     {


### PR DESCRIPTION
Fixes #3736 , but also follow-up for #2844 to address DPI/touchscreen scaling regressions.

- Preserve purple-safe image scaling when color-keyed button images are resized to fit.
- Scale the touchscreen high-DPI demo layout so the 50% preset shows enlarged fonts without clipping the controls.