### PR TITLE
* Use glyphs for dropdown arrows (V105)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,7 +47,8 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
-* Resolveed [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), Fixed KContextMenu items overflow not visible
+* Implemented [#3663](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3663), Use glyphs for dropdown arrows. Drop-down arrows use cached bitmap glyphs instead of anti-aliased vector paths; Unicode triangles (e.g. ▼) are the default, with pixel-aligned polygon glyphs available via `KryptonManager.DropDownArrowRenderMode` / `GlobalDropDownArrowRenderMode`; two-tone arrows composite separate fill and outline glyph layers with configurable style via `DropDownArrowGlyphStyle` / `GlobalDropDownArrowGlyphStyle` (`Flat`, `Bevel`, `Emboss`); colours use `TextButtonNormal` + `InputDropDownNormal2` (disabled: `InputDropDownDisabled1` / `2`); `ButtonValues.DropDownArrowColor` overrides when set; default base size is 14 logical pixels at 96 DPI (`DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi`), with DPI scaling via `DropDownArrowBaseSize` on each paint and layout pass; `KryptonScrollBar`, `KryptonHScrollBar`, and `KryptonVScrollBar` arrow buttons use the same glyph renderer
+* Resolved [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), Fixed KContextMenu items overflow not visible
 * Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), Fixed KryptonDataGridView column resize flicker
 * Implemented [#3714](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3714), Add accessibility support for custom drawn Krypton controls and editable control ButtonSpecs.
 * Resolved [#3690](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3690), Fix VS 2019 build targeting so VS 2019 uses only .NET Framework 4.x projects while VS2022/Current scripts refresh restore assets for modern target frameworks.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -9,26 +9,24 @@
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// This class is used  within advanved columns that make use of embedded controls.
+/// This class is used  within advanced columns that make use of embedded controls.
 /// </summary>
 [ToolboxItem(false)]
 internal class KryptonDataGridViewCellIndicatorImage : IDisposable
 {
     #region Fields
     // Cell indicator image
-    private Image? _image = null;
+    private Image? _image;
     // Size of the image which is always square
-    private int _size;
+    private readonly int _size;
     // Datagridview the column belongs to.
     private KryptonDataGridView? _dataGridView;
     // State of disposal
     private bool _disposed = false;
 
     // type and state of the image
-    private PaletteRibbonGalleryButton _paletteRibbonGalleryButton = PaletteRibbonGalleryButton.Down;
-    private PaletteState _paletteState = PaletteState.Normal;
-    // Cache of pre-rendered dropdown glyphs by size (square)
-    private readonly Dictionary<int, Image> _sizeToImageCache = new Dictionary<int, Image>();
+    private readonly PaletteRibbonGalleryButton _paletteRibbonGalleryButton = PaletteRibbonGalleryButton.Down;
+    private readonly PaletteState _paletteState = PaletteState.Normal;
     #endregion Fields
 
     #region Identity
@@ -68,7 +66,6 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
                 if (_dataGridView is not null)
                 {
                     _dataGridView.PaletteChanged += OnDataGridViewPaletteChanged;
-                    _sizeToImageCache.Clear();
                     UpdateCellIndicatorImage(false);
                 }
             }
@@ -153,7 +150,6 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
             }
         }
         ResizeCellIndicatorImage();
-        _sizeToImageCache.Clear();
     }
 
     /// <summary>
@@ -168,7 +164,7 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
     }
 
     /// <summary>
-    /// Returns a cached dropdown glyph bitmap for the requested square size. Renders once per size/palette.
+    /// Returns a cached crisp dropdown glyph for the requested square size.
     /// For use by non-selected, non-highlighted, non-editing cells.
     /// </summary>
     /// <param name="size">Desired square size in pixels.</param>
@@ -180,32 +176,34 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
             return null;
         }
 
-        if (_sizeToImageCache.TryGetValue(size, out var cached))
-        {
-            return cached;
-        }
-
         if (_dataGridView is null || _dataGridView.Renderer is null)
         {
-            return _image; // fallback to palette-provided image
+            return _image;
         }
 
-        // Create transparent bitmap and ask renderer to draw vector glyph
-        var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        using (var g = Graphics.FromImage(bmp))
+        PaletteBase palette = _dataGridView.GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(palette, _paletteState);
+
+        int maxSize = Math.Max(size, 1);
+        float dpiY = 96f;
+        if (_dataGridView?.IsHandleCreated == true)
         {
-            var rc = new RenderContext(_dataGridView, g, new Rectangle(0, 0, size, size), _dataGridView.Renderer);
-            // Match the editing control by using an input-control button palette content
-            var triple = new PaletteTripleToPalette(_dataGridView.Redirector,
-                PaletteBackStyle.ButtonStandalone,
-                PaletteBorderStyle.ButtonStandalone,
-                PaletteContentStyle.ButtonStandalone);
-            triple.SetStyles(ButtonStyle.InputControl);
-            _dataGridView.Renderer.RenderGlyph.DrawInputControlDropDownGlyph(rc, new Rectangle(0, 0, size, size), triple.PaletteContent!, PaletteState.Normal);
+            using var g = _dataGridView.CreateGraphics();
+            dpiY = g.DpiY;
         }
 
-        _sizeToImageCache[size] = bmp;
-        return bmp;
+        int glyphSize = DropDownArrowGlyphMetrics.ResolvePixelSize(
+            dpiY,
+            new Rectangle(0, 0, maxSize, maxSize),
+            _dataGridView,
+            _paletteState);
+
+        if (glyphSize <= 0)
+        {
+            return _image;
+        }
+
+        return DropDownArrowGlyphCache.GetOrCreate(glyphSize, outline, fill, DropDownArrowGlyphDirection.Down);
     }
     #endregion Private
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -28,6 +28,8 @@ public sealed class KryptonManager : Component
     private static bool _globalUseThemeFormChromeBorderWidth = true;
     private static bool _globalShowAdministratorSuffix = true;
     internal static bool _globalUseKryptonFileDialogs = true;
+    private static DropDownArrowRenderMode _globalDropDownArrowRenderMode = DropDownArrowRenderMode.Unicode;
+    private static DropDownArrowGlyphStyle _globalDropDownArrowGlyphStyle = DropDownArrowGlyphStyle.Bevel;
     private static Font? _baseFont;
 
     // Initialize the default modes
@@ -149,6 +151,20 @@ public sealed class KryptonManager : Component
     [Category(@"Property Changed")]
     [Description(@"Occurs when the value of the GlobalUseThemeFormChromeBorderWidth property is changed.")]
     public static event EventHandler? GlobalUseThemeFormChromeBorderWidthChanged;
+
+    /// <summary>
+    /// Occurs when the drop-down arrow render mode changes.
+    /// </summary>
+    [Category(@"Property Changed")]
+    [Description(@"Occurs when the value of the GlobalDropDownArrowRenderMode property is changed.")]
+    public static event EventHandler? GlobalDropDownArrowRenderModeChanged;
+
+    /// <summary>
+    /// Occurs when the value of the GlobalDropDownArrowGlyphStyle property is changed.
+    /// </summary>
+    [Category(@"Property Changed")]
+    [Description(@"Occurs when the value of the GlobalDropDownArrowGlyphStyle property is changed.")]
+    public static event EventHandler? GlobalDropDownArrowGlyphStyleChanged;
     #endregion
 
     #region Identity
@@ -217,6 +233,8 @@ public sealed class KryptonManager : Component
                                ShouldSerializeToolkitStrings() ||
                                ShouldSerializeUseKryptonFileDialogs() ||
                                ShouldSerializeBaseFont() ||
+                               ShouldSerializeGlobalDropDownArrowRenderMode() ||
+                               ShouldSerializeGlobalDropDownArrowGlyphStyle() ||
                                ShouldSerializeGlobalPaletteMode());
 
     /// <summary>
@@ -233,6 +251,8 @@ public sealed class KryptonManager : Component
         ResetUseKryptonFileDialogs();
         ResetBaseFont();
         ResetGlobalPaletteMode();
+        ResetGlobalDropDownArrowRenderMode();
+        ResetGlobalDropDownArrowGlyphStyle();
     }
 
     /// <summary>
@@ -419,6 +439,34 @@ public sealed class KryptonManager : Component
     }
     private bool ShouldSerializeShowAdministratorSuffix() => !UseAdministratorSuffix;
     private void ResetShowAdministratorSuffix() => UseAdministratorSuffix = true;
+
+    /// <summary>
+    /// Gets or sets how drop-down arrow glyphs are rendered across Krypton controls.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"How drop-down arrow glyphs are rendered: Unicode characters (default) or pixel-aligned polygons.")]
+    [DefaultValue(DropDownArrowRenderMode.Unicode)]
+    public DropDownArrowRenderMode GlobalDropDownArrowRenderMode
+    {
+        get => DropDownArrowRenderMode;
+        set => DropDownArrowRenderMode = value;
+    }
+    private bool ShouldSerializeGlobalDropDownArrowRenderMode() => GlobalDropDownArrowRenderMode != DropDownArrowRenderMode.Unicode;
+    private void ResetGlobalDropDownArrowRenderMode() => GlobalDropDownArrowRenderMode = DropDownArrowRenderMode.Unicode;
+
+    /// <summary>
+    /// Gets or sets how two-tone drop-down arrow glyphs are composited (flat, bevel, or emboss).
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"How two-tone drop-down arrow glyphs are composited: Flat, Bevel (raised), or Emboss (inset).")]
+    [DefaultValue(DropDownArrowGlyphStyle.Bevel)]
+    public DropDownArrowGlyphStyle GlobalDropDownArrowGlyphStyle
+    {
+        get => DropDownArrowGlyphStyle;
+        set => DropDownArrowGlyphStyle = value;
+    }
+    private bool ShouldSerializeGlobalDropDownArrowGlyphStyle() => GlobalDropDownArrowGlyphStyle != DropDownArrowGlyphStyle.Bevel;
+    private void ResetGlobalDropDownArrowGlyphStyle() => GlobalDropDownArrowGlyphStyle = DropDownArrowGlyphStyle.Bevel;
 
     #endregion
 
@@ -1126,6 +1174,10 @@ public sealed class KryptonManager : Component
 
     private static void OnGlobalUseThemeFormChromeBorderWidthChanged(EventArgs e) => GlobalUseThemeFormChromeBorderWidthChanged?.Invoke(null, e);
 
+    private static void OnGlobalDropDownArrowRenderModeChanged(EventArgs e) => GlobalDropDownArrowRenderModeChanged?.Invoke(null, e);
+
+    private static void OnGlobalDropDownArrowGlyphStyleChanged(EventArgs e) => GlobalDropDownArrowGlyphStyleChanged?.Invoke(null, e);
+
     private static void OnGlobalPaletteChanged(EventArgs e)
     {
         UpdateToolStripManager();
@@ -1229,4 +1281,45 @@ public sealed class KryptonManager : Component
 
     #endregion
 
+    #region Static DropDownArrowRenderMode
+    /// <summary>
+    /// Gets and sets how drop-down arrow glyphs are rendered across Krypton controls.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public static DropDownArrowRenderMode DropDownArrowRenderMode
+    {
+        get => _globalDropDownArrowRenderMode;
+
+        set
+        {
+            if (_globalDropDownArrowRenderMode != value)
+            {
+                _globalDropDownArrowRenderMode = value;
+                DropDownArrowGlyphCache.Clear();
+                OnGlobalDropDownArrowRenderModeChanged(EventArgs.Empty);
+            }
+        }
+    }
+    #endregion
+
+    #region Static DropDownArrowGlyphStyle
+    /// <summary>
+    /// Gets and sets how two-tone drop-down arrow glyphs are composited across Krypton controls.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public static DropDownArrowGlyphStyle DropDownArrowGlyphStyle
+    {
+        get => _globalDropDownArrowGlyphStyle;
+
+        set
+        {
+            if (_globalDropDownArrowGlyphStyle != value)
+            {
+                _globalDropDownArrowGlyphStyle = value;
+                DropDownArrowGlyphCache.Clear();
+                OnGlobalDropDownArrowGlyphStyleChanged(EventArgs.Empty);
+            }
+        }
+    }
+    #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -900,11 +900,15 @@ public abstract class VisualControlBase : Control,
         if (attach)
         {
             KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
+            KryptonManager.GlobalDropDownArrowRenderModeChanged += OnGlobalDropDownArrowSettingsChanged;
+            KryptonManager.GlobalDropDownArrowGlyphStyleChanged += OnGlobalDropDownArrowSettingsChanged;
             SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
         }
         else
         {
             KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
+            KryptonManager.GlobalDropDownArrowRenderModeChanged -= OnGlobalDropDownArrowSettingsChanged;
+            KryptonManager.GlobalDropDownArrowGlyphStyleChanged -= OnGlobalDropDownArrowSettingsChanged;
             SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
         }
     }
@@ -1509,6 +1513,20 @@ public abstract class VisualControlBase : Control,
 
         base.OnHandleCreated(e);
     }
+
+    /// <summary>
+    /// Occurs when global drop-down arrow glyph settings have been changed.
+    /// </summary>
+    /// <param name="sender">Source of the event.</param>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected virtual void OnGlobalDropDownArrowSettingsChanged(object? sender, EventArgs e)
+    {
+        if (IsHandleCreated)
+        {
+            OnNeedPaint(LocalCustomPalette, new NeedLayoutEventArgs(false));
+        }
+    }
+
     #endregion
 
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/KryptonScrollBarRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/KryptonScrollBarRenderer.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2017 - 2026. All rights reserved.
+ *
  */
 #endregion
 
@@ -132,6 +132,11 @@ internal static class KryptonScrollBarRenderer
          * | |-----------------------------------------| |
          * |                                             |
          * ----------------------------------------------- (15,17)
+         *
+         * The 15x17 diagram describes the source arrow bitmap only.
+         * Track and thumb rectangles are supplied by the controls and can
+         * be larger at high DPI, so those paint paths must fill rect, not a
+         * fixed 15px interior.
          */
 
         // hot state
@@ -189,7 +194,9 @@ internal static class KryptonScrollBarRenderer
         GripColors[0] = _palette.ColorTable.GripLight;
         GripColors[1] = _palette.ColorTable.GripDark;
 
+        DropDownArrowGlyphCache.Clear();
     }
+
     #endregion
 
     #region Implementation
@@ -434,6 +441,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawBackgroundVertical(Graphics g, Rectangle rect)
     {
+        // Fill the full supplied bounds first. At high DPI the themed scrollbar is
+        // wider than the original 15px bitmap math, and fixed interior widths leave
+        // stale pixels along the inner edge while dragging.
+        using (var brush = new SolidBrush(_backgroundColors[4]))
+        {
+            g.FillRectangle(brush, rect);
+        }
+
         using (var p = new Pen(_backgroundColors[0]))
         {
             g.DrawLine(p, rect.Left + 1, rect.Top + 1, rect.Left + 1, rect.Bottom - 1);
@@ -445,20 +460,31 @@ internal static class KryptonScrollBarRenderer
             g.DrawLine(p, rect.Left + 2, rect.Top + 1, rect.Left + 2, rect.Bottom - 1);
         }
 
-        var firstRect = new Rectangle(rect.Left + 3, rect.Top, 8, rect.Height);
+        int gradientLeft = rect.Left + 3;
+        int gradientRight = rect.Right - 2;
 
-        var secondRect = new Rectangle(firstRect.Right - 1, firstRect.Top, 7, firstRect.Height);
-
-        using (var brush = new LinearGradientBrush(firstRect, _backgroundColors[2],
-                   _backgroundColors[3], LinearGradientMode.Horizontal))
+        if (gradientRight <= gradientLeft)
         {
-            g.FillRectangle(brush, firstRect);
+            return;
         }
 
-        using (var brush = new LinearGradientBrush(secondRect, _backgroundColors[3],
+        var gradientRect = Rectangle.FromLTRB(gradientLeft, rect.Top, gradientRight, rect.Bottom);
+
+        using (var brush = new LinearGradientBrush(gradientRect, _backgroundColors[2],
                    _backgroundColors[4], LinearGradientMode.Horizontal))
         {
-            g.FillRectangle(brush, secondRect);
+            brush.InterpolationColors = new ColorBlend(3)
+            {
+                Colors =
+                [
+                    _backgroundColors[2],
+                    _backgroundColors[3],
+                    _backgroundColors[4]
+                ],
+                Positions = [0f, .5f, 1f]
+            };
+
+            g.FillRectangle(brush, gradientRect);
         }
     }
 
@@ -469,6 +495,13 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawBackgroundHorizontal(Graphics g, Rectangle rect)
     {
+        // See DrawBackgroundVertical: this rect can be DPI-scaled, so the whole
+        // background must be repainted before drawing the themed interior.
+        using (var brush = new SolidBrush(_backgroundColors[4]))
+        {
+            g.FillRectangle(brush, rect);
+        }
+
         using (var p = new Pen(_backgroundColors[0]))
         {
             g.DrawLine(p, rect.Left + 1, rect.Top + 1, rect.Right - 1, rect.Top + 1);
@@ -480,20 +513,31 @@ internal static class KryptonScrollBarRenderer
             g.DrawLine(p, rect.Left + 1, rect.Top + 2, rect.Right - 1, rect.Top + 2);
         }
 
-        var firstRect = new Rectangle(rect.Left, rect.Top + 3, rect.Width, 8);
+        int gradientTop = rect.Top + 3;
+        int gradientBottom = rect.Bottom - 2;
 
-        var secondRect = new Rectangle(firstRect.Left, firstRect.Bottom - 1, firstRect.Width, 7);
-
-        using (var brush = new LinearGradientBrush(firstRect, _backgroundColors[2],
-                   _backgroundColors[3], LinearGradientMode.Vertical))
+        if (gradientBottom <= gradientTop)
         {
-            g.FillRectangle(brush, firstRect);
+            return;
         }
 
-        using (var brush = new LinearGradientBrush(secondRect, _backgroundColors[3],
+        var gradientRect = Rectangle.FromLTRB(rect.Left, gradientTop, rect.Right, gradientBottom);
+
+        using (var brush = new LinearGradientBrush(gradientRect, _backgroundColors[2],
                    _backgroundColors[4], LinearGradientMode.Vertical))
         {
-            g.FillRectangle(brush, secondRect);
+            brush.InterpolationColors = new ColorBlend(3)
+            {
+                Colors =
+                [
+                    _backgroundColors[2],
+                    _backgroundColors[3],
+                    _backgroundColors[4]
+                ],
+                Positions = [0f, .5f, 1f]
+            };
+
+            g.FillRectangle(brush, gradientRect);
         }
     }
 
@@ -504,7 +548,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawTrackVertical(Graphics g, Rectangle rect)
     {
-        var innerRect = new Rectangle(rect.Left + 1, rect.Top, 15, rect.Height);
+        // Keep this relative to rect.Width; hard-coded 15px track painting misses
+        // the right-side pixels when the scrollbar is scaled.
+        var innerRect = new Rectangle(rect.Left + 1, rect.Top, Math.Max(0, rect.Width - 2), rect.Height);
+
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
 
         using var brush = new LinearGradientBrush(innerRect, _trackColors[0], _trackColors[1],
             LinearGradientMode.Horizontal);
@@ -518,7 +569,14 @@ internal static class KryptonScrollBarRenderer
     /// <param name="rect">The rectangle in which to paint.</param>
     private static void DrawTrackHorizontal(Graphics g, Rectangle rect)
     {
-        var innerRect = new Rectangle(rect.Left, rect.Top + 1, rect.Width, 15);
+        // Keep this relative to rect.Height; hard-coded 15px track painting misses
+        // the lower pixels when the scrollbar is scaled.
+        var innerRect = new Rectangle(rect.Left, rect.Top + 1, rect.Width, Math.Max(0, rect.Height - 2));
+
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
 
         using var brush = new LinearGradientBrush(innerRect, _trackColors[0], _trackColors[1],
             LinearGradientMode.Vertical);
@@ -582,9 +640,22 @@ internal static class KryptonScrollBarRenderer
         Rectangle innerRect = rect;
         innerRect.Inflate(-1, -1);
 
-        Rectangle r = innerRect;
-        r.Width = 6;
-        r.Height++;
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
+
+        // Clear the full inner thumb before applying the split gradient. The old
+        // fixed 6px halves only covered a 12px interior and could leave stale
+        // vertical strips at high DPI.
+        using (var brush = new SolidBrush(_thumbColors[index, 5]))
+        {
+            g.FillRectangle(brush, innerRect);
+        }
+
+        int leftWidth = Math.Max(1, innerRect.Width / 2);
+
+        Rectangle r = new Rectangle(innerRect.Left, innerRect.Top, leftWidth, innerRect.Height + 1);
 
         // draw left gradient
         using (var brush = new LinearGradientBrush(r, _thumbColors[index, 1],
@@ -593,7 +664,7 @@ internal static class KryptonScrollBarRenderer
             g.FillRectangle(brush, r);
         }
 
-        r.X = r.Right;
+        r = new Rectangle(r.Right, innerRect.Top, Math.Max(1, innerRect.Right - r.Right), innerRect.Height + 1);
 
         // draw right gradient
         if (index == 0)
@@ -666,9 +737,22 @@ internal static class KryptonScrollBarRenderer
         Rectangle innerRect = rect;
         innerRect.Inflate(-1, -1);
 
-        Rectangle r = innerRect;
-        r.Height = 6;
-        r.Width++;
+        if (innerRect.Width <= 0 || innerRect.Height <= 0)
+        {
+            return;
+        }
+
+        // Clear the full inner thumb before applying the split gradient. The old
+        // fixed 6px halves only covered a 12px interior and could leave stale
+        // horizontal strips at high DPI.
+        using (var brush = new SolidBrush(_thumbColors[index, 5]))
+        {
+            g.FillRectangle(brush, innerRect);
+        }
+
+        int topHeight = Math.Max(1, innerRect.Height / 2);
+
+        Rectangle r = new Rectangle(innerRect.Left, innerRect.Top, innerRect.Width + 1, topHeight);
 
         // draw left gradient
         using (var brush = new LinearGradientBrush(r, _thumbColors[index, 1],
@@ -677,7 +761,7 @@ internal static class KryptonScrollBarRenderer
             g.FillRectangle(brush, r);
         }
 
-        r.Y = r.Bottom;
+        r = new Rectangle(innerRect.Left, r.Bottom, innerRect.Width + 1, Math.Max(1, innerRect.Bottom - r.Bottom));
 
         // draw right gradient
         if (index == 0)
@@ -742,13 +826,18 @@ internal static class KryptonScrollBarRenderer
         ScrollBarArrowButtonState state,
         bool arrowUp)
     {
-        using Image arrowImage = GetArrowDownButtonImage(state);
+        using Image chromeImage = GetArrowDownButtonChromeImage(state);
         if (arrowUp)
         {
-            arrowImage.RotateFlip(RotateFlipType.Rotate180FlipNone);
+            chromeImage.RotateFlip(RotateFlipType.Rotate180FlipNone);
         }
 
-        g.DrawImage(arrowImage, rect);
+        g.DrawImage(chromeImage, rect);
+
+        DropDownArrowGlyphDirection direction = arrowUp
+            ? DropDownArrowGlyphDirection.Up
+            : DropDownArrowGlyphDirection.Down;
+        DrawArrowGlyph(g, rect, state, direction);
     }
 
     /// <summary>
@@ -764,18 +853,60 @@ internal static class KryptonScrollBarRenderer
         ScrollBarArrowButtonState state,
         bool arrowUp)
     {
-        using Image arrowImage = GetArrowDownButtonImage(state);
-        arrowImage.RotateFlip(arrowUp ? RotateFlipType.Rotate90FlipNone : RotateFlipType.Rotate270FlipNone);
+        using Image chromeImage = GetArrowDownButtonChromeImage(state);
+        chromeImage.RotateFlip(arrowUp ? RotateFlipType.Rotate90FlipNone : RotateFlipType.Rotate270FlipNone);
 
-        g.DrawImage(arrowImage, rect);
+        g.DrawImage(chromeImage, rect);
+
+        DropDownArrowGlyphDirection direction = arrowUp
+            ? DropDownArrowGlyphDirection.Left
+            : DropDownArrowGlyphDirection.Right;
+        DrawArrowGlyph(g, rect, state, direction);
     }
 
+    private static void DrawArrowGlyph(
+        Graphics g,
+        Rectangle buttonRect,
+        ScrollBarArrowButtonState state,
+        DropDownArrowGlyphDirection direction)
+    {
+        Rectangle glyphRect = GetArrowGlyphCellRect(buttonRect);
+        if (glyphRect.Width <= 0 || glyphRect.Height <= 0)
+        {
+            return;
+        }
+
+        PaletteState paletteState = MapArrowStateToPaletteState(state);
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(_palette, paletteState);
+        DropDownArrowGlyphCache.Draw(g, glyphRect, outline, fill, direction);
+    }
+
+    private static Rectangle GetArrowGlyphCellRect(Rectangle buttonRect)
+    {
+        int size = Math.Min(buttonRect.Width, buttonRect.Height);
+        size = Math.Max(4, (size * 3) / 5);
+
+        return new Rectangle(
+            buttonRect.X + ((buttonRect.Width - size) / 2),
+            buttonRect.Y + ((buttonRect.Height - size) / 2),
+            size,
+            size);
+    }
+
+    private static PaletteState MapArrowStateToPaletteState(ScrollBarArrowButtonState state) => state switch
+    {
+        ScrollBarArrowButtonState.UpDisabled or ScrollBarArrowButtonState.DownDisabled => PaletteState.Disabled,
+        ScrollBarArrowButtonState.UpHot or ScrollBarArrowButtonState.DownHot => PaletteState.Tracking,
+        ScrollBarArrowButtonState.UpPressed or ScrollBarArrowButtonState.DownPressed => PaletteState.Pressed,
+        _ => PaletteState.Normal
+    };
+
     /// <summary>
-    /// Draws the arrow down button for the scrollbar.
+    /// Draws the arrow button chrome (without the chevron glyph) for the scrollbar.
     /// </summary>
     /// <param name="state">The button state.</param>
-    /// <returns>The arrow down button as <see cref="Image"/>.</returns>
-    private static Image GetArrowDownButtonImage(
+    /// <returns>The arrow button chrome as <see cref="Image"/>.</returns>
+    private static Image GetArrowDownButtonChromeImage(
         ScrollBarArrowButtonState state)
     {
         var rect = new Rectangle(0, 0, 15, 17);
@@ -786,25 +917,13 @@ internal static class KryptonScrollBarRenderer
         g.SmoothingMode = SmoothingMode.None;
         g.InterpolationMode = InterpolationMode.Low;
 
-        var index = -1;
-
-        switch (state)
+        var index = state switch
         {
-            case ScrollBarArrowButtonState.UpHot:
-            case ScrollBarArrowButtonState.DownHot:
-                index = 1;
-                break;
-
-            case ScrollBarArrowButtonState.UpActive:
-            case ScrollBarArrowButtonState.DownActive:
-                index = 0;
-                break;
-
-            case ScrollBarArrowButtonState.UpPressed:
-            case ScrollBarArrowButtonState.DownPressed:
-                index = 2;
-                break;
-        }
+            ScrollBarArrowButtonState.UpHot or ScrollBarArrowButtonState.DownHot => 1,
+            ScrollBarArrowButtonState.UpActive or ScrollBarArrowButtonState.DownActive => 0,
+            ScrollBarArrowButtonState.UpPressed or ScrollBarArrowButtonState.DownPressed => 2,
+            _ => -1
+        };
 
         if (index != -1)
         {
@@ -880,21 +999,6 @@ internal static class KryptonScrollBarRenderer
             {
                 g.FillRectangle(brush, lower);
             }
-        }
-
-        using var arrowIcon = (Image)GetScrollBarArrowDownBitmap().Clone();
-        if (state is ScrollBarArrowButtonState.DownDisabled or ScrollBarArrowButtonState.UpDisabled)
-        {
-            ControlPaint.DrawImageDisabled(
-                g,
-                arrowIcon,
-                3,
-                6,
-                Color.Transparent);
-        }
-        else
-        {
-            g.DrawImage(arrowIcon, 3, 6);
         }
 
         return bitmap;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -4343,6 +4343,61 @@ public enum PaletteDragFeedback
 }
 #endregion
 
+#region Enum DropDownArrowRenderMode
+/// <summary>
+/// Specifies how drop-down arrow glyphs are rendered across Krypton controls.
+/// </summary>
+public enum DropDownArrowRenderMode
+{
+    /// <summary>
+    /// Unicode triangle characters (e.g. ▼) drawn with a symbol font.
+    /// </summary>
+    Unicode,
+
+    /// <summary>
+    /// Pixel-aligned polygon glyphs using palette outline and fill colours.
+    /// </summary>
+    Polygon
+}
+#endregion
+
+#region Enum DropDownArrowGlyphStyle
+/// <summary>
+/// Specifies how two-tone drop-down arrow glyphs are composited from outline and fill layers.
+/// </summary>
+public enum DropDownArrowGlyphStyle
+{
+    /// <summary>
+    /// Fill and outline glyphs are drawn at the same position (outline on top).
+    /// </summary>
+    Flat,
+
+    /// <summary>
+    /// Raised bevel: outline at the origin, fill offset down-right.
+    /// </summary>
+    Bevel,
+
+    /// <summary>
+    /// Inset/embossed: fill at the origin, outline offset down-right.
+    /// </summary>
+    Emboss
+}
+#endregion
+
+#region DropDownArrowGlyphDefaults
+/// <summary>
+/// Default drop-down arrow glyph metrics shared by built-in palettes and renderers.
+/// </summary>
+public static class DropDownArrowGlyphDefaults
+{
+    /// <summary>
+    /// Base drop-down arrow size in logical pixels at 96 DPI.
+    /// </summary>
+    public const int DefaultBaseSizeAt96Dpi = 14;
+}
+#endregion
+
+
 #region Delegates
 /// <summary>
 /// Signature of methods that return an integer metric.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Material/Bases/PaletteMaterialBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Material/Bases/PaletteMaterialBase.cs
@@ -319,7 +319,7 @@ public abstract class PaletteMaterialBase : PaletteMicrosoft365Base
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 1;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -3095,7 +3095,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
@@ -3031,7 +3031,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
@@ -3103,7 +3103,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
@@ -2976,7 +2976,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
@@ -3009,7 +3009,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
@@ -2994,7 +2994,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
@@ -3010,7 +3010,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -3612,7 +3612,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -4118,7 +4118,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -3410,7 +3410,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -3895,7 +3895,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -3875,7 +3875,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -3918,7 +3918,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -3424,7 +3424,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
@@ -3109,7 +3109,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -3690,7 +3690,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -3312,7 +3312,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -3299,7 +3299,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -3341,7 +3341,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -3317,7 +3317,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -3017,7 +3017,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
@@ -2958,7 +2958,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
@@ -3010,7 +3010,7 @@ public class PaletteOffice2003Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -2718,7 +2718,7 @@ public class PaletteProfessionalSystem : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -3017,7 +3017,7 @@ public class PaletteSparkleBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
@@ -2864,7 +2864,7 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -2186,7 +2186,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -2977,7 +2977,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -2978,7 +2978,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -2976,7 +2976,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -2976,7 +2976,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteMetricInt.BarButtonEdgeInside:
                 return 3;
             case PaletteMetricInt.DropDownArrowBaseSize:
-                return 10;
+                return DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
             case PaletteMetricInt.None:
                 return 0;
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphCache.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphCache.cs
@@ -1,0 +1,115 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal static class DropDownArrowGlyphCache
+{
+    private static readonly Dictionary<(int Size, int Color, DropDownArrowGlyphDirection Direction, DropDownArrowRenderMode Mode, DropDownArrowGlyphLayer Layer), Image> _monochromeCache = new();
+
+    private static readonly Dictionary<(int Size, int Outline, int Fill, DropDownArrowGlyphDirection Direction, DropDownArrowRenderMode Mode, DropDownArrowGlyphStyle Style), Image> _compositeCache = new();
+
+    private static readonly object _lock = new();
+
+    static DropDownArrowGlyphCache()
+    {
+        KryptonManager.GlobalPaletteChanged += (_, _) => Clear();
+    }
+
+    internal static Image GetOrCreate(int size, Color outline, Color fill, DropDownArrowGlyphDirection direction)
+    {
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size));
+        }
+
+        var mode = KryptonManager.DropDownArrowRenderMode;
+
+        var style = KryptonManager.DropDownArrowGlyphStyle;
+
+        if (!DropDownArrowGlyphFactory.HasDistinctFill(outline, fill))
+        {
+            return GetMonochrome(size, outline, direction, mode, DropDownArrowGlyphLayer.Fill);
+        }
+
+        var key = (size, outline.ToArgb(), fill.ToArgb(), direction, mode, style);
+
+        lock (_lock)
+        {
+            if (_compositeCache.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            var image = DropDownArrowGlyphFactory.Create(size, outline, fill, direction, mode, style);
+
+            _compositeCache[key] = image;
+
+            return image;
+        }
+    }
+
+    private static Image GetMonochrome(int size, Color color, DropDownArrowGlyphDirection direction, DropDownArrowRenderMode mode, DropDownArrowGlyphLayer layer)
+    {
+        var key = (size, color.ToArgb(), direction, mode, layer);
+
+        lock (_lock)
+        {
+            if (_monochromeCache.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            var image = DropDownArrowGlyphFactory.CreateMonochrome(size, color, direction, mode, layer);
+
+            _monochromeCache[key] = image;
+
+            return image;
+        }
+    }
+
+    internal static void Draw(Graphics g, Rectangle cellRect, Color outline, Color fill, DropDownArrowGlyphDirection direction, Control? control = null)
+    {
+        int size = DropDownArrowGlyphMetrics.ResolvePixelSize(g, cellRect, control);
+
+        if (size <= 0)
+        {
+            return;
+        }
+
+        Image glyph = GetOrCreate(size, outline, fill, direction);
+
+        int x = cellRect.X + ((cellRect.Width - size) / 2);
+
+        int y = cellRect.Y + ((cellRect.Height - size) / 2);
+
+        g.DrawImage(glyph, x, y, size, size);
+
+    }
+
+    internal static void Clear()
+    {
+        lock (_lock)
+        {
+            foreach (Image image in _monochromeCache.Values)
+            {
+                image.Dispose();
+            }
+
+            foreach (Image image in _compositeCache.Values)
+            {
+                image.Dispose();
+            }
+
+            _monochromeCache.Clear();
+
+            _compositeCache.Clear();
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
@@ -1,0 +1,113 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal static class DropDownArrowGlyphColors
+{
+    internal static (Color Outline, Color Fill) Resolve(RenderContext? context, IPaletteContent paletteContent,  PaletteState state)
+    {
+        if (TryGetOverrideColor(context, out Color overrideColor))
+        {
+            return (overrideColor, NormalizeFill(overrideColor, Color.Empty));
+        }
+
+        if (TryResolvePalette(context, out PaletteBase? palette))
+        {
+            return FromPalette(palette, state);
+        }
+
+        return FromContent(paletteContent, state);
+    }
+
+    internal static (Color Outline, Color Fill) Resolve(PaletteBase palette, PaletteState state) => FromPalette(palette, state);
+
+    private static (Color Outline, Color Fill) FromPalette(PaletteBase palette, PaletteState state)
+    {
+
+        Color outline;
+        Color fill;
+        if (state == PaletteState.Disabled)
+        {
+            outline = palette.GetSchemeColor(SchemeBaseColors.InputDropDownDisabled1);
+            fill = palette.GetSchemeColor(SchemeBaseColors.InputDropDownDisabled2);
+            if (outline == Color.Empty || outline == Color.Empty)
+            {
+                outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Disabled);
+            }
+        }
+        else
+        {
+            outline = palette.GetSchemeColor(SchemeBaseColors.TextButtonNormal);
+            fill = palette.GetSchemeColor(SchemeBaseColors.InputDropDownNormal2);
+            if (outline == Color.Empty || outline == Color.Empty)
+            {
+                outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, state);
+            }
+        }
+
+        return (outline, NormalizeFill(outline, fill));
+    }
+
+
+
+    private static (Color Outline, Color Fill) FromContent(IPaletteContent paletteContent, PaletteState state)
+    {
+        Color outline = paletteContent.GetContentShortTextColor1(state);
+
+        Color fill = paletteContent.GetContentShortTextColor2(state);
+
+        return (outline, NormalizeFill(outline, fill));
+    }
+
+    private static Color NormalizeFill(Color outline, Color fill)
+    {
+        if (fill == Color.Empty || fill == Color.Transparent)
+        {
+            return Color.FromArgb(64, outline.R, outline.G, outline.B);
+        }
+
+        return fill;
+    }
+
+    private static bool TryResolvePalette(RenderContext? context, out PaletteBase palette)
+    {
+        if (context?.Control is VisualControlBase visualControl)
+        {
+            palette = visualControl.GetResolvedPalette();
+
+            return true;
+        }
+
+        palette = KryptonManager.CurrentGlobalPalette;
+
+        return true;
+    }
+
+    private static bool TryGetOverrideColor(RenderContext? context, out Color color)
+    {
+        color = Color.Empty;
+
+        if (context?.Control is KryptonDropButton dropButton)
+        {
+            Color? arrowColor = dropButton.Values.DropDownArrowColor;
+
+            if (arrowColor.HasValue && arrowColor.Value != Color.Empty)
+            {
+
+                color = arrowColor.Value;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
@@ -1,0 +1,276 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Specifies the direction of a drop-down arrow glyph.
+/// </summary>
+internal enum DropDownArrowGlyphDirection
+{
+
+    /// <summary>
+    /// Indicates the arrow points down.
+    /// </summary>
+    Down,
+    /// <summary>
+    /// Indicates the arrow points up.
+    /// </summary>
+    Up,
+    /// <summary>
+    /// Indicates the arrow points left.
+    /// </summary>
+    Left,
+    /// <summary>
+    /// Indicates the arrow points right.
+    /// </summary>
+    Right
+}
+
+/// <summary>
+/// Specifies the layer of a drop-down arrow glyph.
+/// </summary>
+internal enum DropDownArrowGlyphLayer
+{
+    /// <summary>
+    /// Indicates the fill layer of the glyph.
+    /// </summary>
+    Fill,
+    /// <summary>
+    /// Indicates the outline layer of the glyph.
+    /// </summary>
+    Outline
+}
+
+/// <summary>
+/// Provides factory methods for creating drop-down arrow glyphs.
+/// </summary>
+internal static class DropDownArrowGlyphFactory
+{
+    /// <summary>
+    /// Specifies the font families to use for the glyphs.
+    /// </summary>
+    private static readonly string[] SymbolFontFamilies = ["Segoe UI Symbol", "Segoe UI"];
+
+    /// <summary>
+    /// Creates a drop-down arrow glyph.
+    /// </summary>
+    /// <param name="size">The size of the glyph.</param>
+    /// <param name="outline">The outline color of the glyph.</param>
+    /// <param name="fill">The fill color of the glyph.</param>
+    /// <param name="direction">The direction of the glyph.</param>
+    /// <param name="renderMode">The render mode of the glyph.</param>
+    /// <param name="style">The glyph drawing style.</param>
+    internal static Image Create(int size, Color outline, Color fill, DropDownArrowGlyphDirection direction, DropDownArrowRenderMode renderMode, DropDownArrowGlyphStyle style)
+    {
+        if (!HasDistinctFill(outline, fill))
+        {
+            return CreateMonochrome(size, outline, direction, renderMode, DropDownArrowGlyphLayer.Fill);
+        }
+
+        DropDownArrowGlyphStyleLayout.GetLayerOffsets(style, size, out Point fillOffset, out Point outlineOffset);
+
+        var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.Clear(Color.Transparent);
+
+            using Image fillGlyph = CreateMonochrome(size, fill, direction, renderMode, DropDownArrowGlyphLayer.Fill);
+
+            using Image outlineGlyph = CreateMonochrome(size, outline, direction, renderMode, DropDownArrowGlyphLayer.Outline);
+
+            g.DrawImage(fillGlyph, fillOffset);
+
+            g.DrawImage(outlineGlyph, outlineOffset);
+
+        }
+
+        return bmp;
+    }
+
+    /// <summary>
+    /// Creates a monochrome drop-down arrow glyph.
+    /// </summary>
+    /// <param name="size">The size of the glyph.</param>
+    /// <param name="color">The color of the glyph.</param>
+    /// <param name="direction">The direction of the glyph.</param>
+    /// <param name="renderMode">The render mode of the glyph.</param>
+    /// <param name="layer">The layer of the glyph.</param>
+    internal static Image CreateMonochrome(int size, Color color, DropDownArrowGlyphDirection direction,  DropDownArrowRenderMode renderMode, DropDownArrowGlyphLayer layer)
+        => renderMode == DropDownArrowRenderMode.Unicode
+            ? CreateUnicodeMonochrome(size, color, direction)
+            : CreatePolygonMonochrome(size, color, direction, layer);
+
+    /// <summary>
+    /// Creates a Unicode monochrome drop-down arrow glyph.
+    /// </summary>
+    /// <param name="size">The size of the glyph.</param>
+    /// <param name="color">The color of the glyph.</param>
+    /// <param name="direction">The direction of the glyph.</param>
+    private static Image CreateUnicodeMonochrome(int size, Color color, DropDownArrowGlyphDirection direction)
+    {
+        var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+        using (var g = Graphics.FromImage(bmp))
+        {
+
+            g.Clear(Color.Transparent);
+
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit;
+
+
+            char glyph = GetUnicodeCharacter(direction, size);
+
+            using var format = new StringFormat(StringFormatFlags.NoWrap | StringFormatFlags.NoClip)
+            {
+
+                Alignment = StringAlignment.Center,
+
+                LineAlignment = StringAlignment.Center
+            };
+
+            using var font = CreateSymbolFont(g, size, glyph);
+
+            using var brush = new SolidBrush(color);
+
+            g.DrawString(glyph.ToString(), font, brush, new RectangleF(0, 0, size, size), format);
+
+        }
+
+        return bmp;
+    }
+
+    private static Image CreatePolygonMonochrome(int size, Color color, DropDownArrowGlyphDirection direction,  DropDownArrowGlyphLayer layer)
+    {
+        var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+        using (var g = Graphics.FromImage(bmp))
+        {
+
+            g.Clear(Color.Transparent);
+
+            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+
+            g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.None;
+
+            Point[] triangle = GetTrianglePoints(size, direction);
+
+            if (layer == DropDownArrowGlyphLayer.Fill)
+            {
+                using var brush = new SolidBrush(color);
+
+                g.FillPolygon(brush, triangle);
+            }
+            else
+            {
+                using var pen = new Pen(color, 1f);
+
+                g.DrawPolygon(pen, triangle);
+            }
+        }
+
+        return bmp;
+    }
+
+    internal static bool HasDistinctFill(Color outline, Color fill) =>
+        fill.A >= 16 && fill.ToArgb() != outline.ToArgb();
+
+    private static char GetUnicodeCharacter(DropDownArrowGlyphDirection direction, int size)
+    {
+        bool useSmall = size <= 12;
+
+        return direction switch
+        {
+            DropDownArrowGlyphDirection.Up => useSmall ? '\u25B4' : '\u25B2',
+            DropDownArrowGlyphDirection.Left => useSmall ? '\u25C2' : '\u25C0',
+            DropDownArrowGlyphDirection.Right => useSmall ? '\u25B8' : '\u25B6',
+            _ => useSmall ? '\u25BE' : '\u25BC'
+        };
+    }
+
+    private static Font CreateSymbolFont(Graphics g, int boxSize, char glyph)
+    {
+        string text = glyph.ToString();
+
+        for (float emSize = boxSize * 0.95f; emSize >= boxSize * 0.45f; emSize -= 0.5f)
+        {
+            foreach (string familyName in SymbolFontFamilies)
+            {
+                try
+                {
+                    using var probe = new Font(familyName, emSize, FontStyle.Regular, GraphicsUnit.Pixel);
+
+                    SizeF measured = g.MeasureString(text, probe);
+
+                    if (measured.Width <= boxSize && measured.Height <= boxSize)
+                    {
+                        return new Font(familyName, emSize, FontStyle.Regular, GraphicsUnit.Pixel);
+                    }
+                }
+                catch (ArgumentException)
+                {
+
+                }
+            }
+        }
+
+        FontFamily fontFamily = SystemFonts.MessageBoxFont?.FontFamily ?? FontFamily.GenericSansSerif;
+
+        return new Font(fontFamily, boxSize * 0.7f, FontStyle.Regular, GraphicsUnit.Pixel);
+    }
+
+    private static Point[] GetTrianglePoints(int size, DropDownArrowGlyphDirection direction)
+    {
+
+        int pad = Math.Max(1, size / 4);
+
+        int near = pad;
+
+        int far = size - pad - 1;
+
+        int mid = size / 2;
+
+        return direction switch
+        {
+            DropDownArrowGlyphDirection.Up => new[]
+            {
+                new Point(mid, near),
+
+                new Point(near, far),
+
+                new Point(far, far)
+            },
+            DropDownArrowGlyphDirection.Left => new[]
+            {
+                new Point(near, mid),
+
+                new Point(far, near),
+
+                new Point(far, far)
+            },
+            DropDownArrowGlyphDirection.Right => new[]
+            {
+                new Point(far, mid),
+
+                new Point(near, near),
+
+                new Point(near, far)
+            },
+            _ => new[]
+            {
+                new Point(near, near),
+
+                new Point(far, near),
+
+                new Point(mid, far)
+            }
+        };
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphMetrics.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphMetrics.cs
@@ -1,0 +1,57 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal static class DropDownArrowGlyphMetrics
+{
+    internal const int DefaultBaseSize = DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi;
+
+    /// <summary>
+    /// Resolves the square pixel size for a drop-down arrow glyph at the current DPI,
+    /// honouring <see cref="PaletteMetricInt.DropDownArrowBaseSize"/> and clamping to the available cell.
+    /// </summary>
+    internal static int ResolvePixelSize(float dpiY, Rectangle cellRect, Control? control, PaletteState state = PaletteState.Normal)
+    {
+        int baseSize = GetBaseSize(control, state);
+        int square = Math.Min(cellRect.Width, cellRect.Height);
+        square = Math.Min(square, baseSize);
+        square = (int)(square * dpiY / 96f);
+        return Math.Max(0, square);
+    }
+
+    internal static int ResolvePixelSize(Graphics g, Rectangle cellRect, Control? control, PaletteState state = PaletteState.Normal)
+        => ResolvePixelSize(g.DpiY, cellRect, control, state);
+
+    private static int GetBaseSize(Control? control, PaletteState state)
+    {
+        var paletteBase = KryptonManager.CurrentGlobalPalette;
+        if (paletteBase == null)
+        {
+            return DefaultBaseSize;
+        }
+
+        KryptonForm? owningForm = FindOwningKryptonForm(control);
+        int metric = paletteBase.GetMetricInt(owningForm, state, PaletteMetricInt.DropDownArrowBaseSize);
+        return metric > 0 ? metric : DefaultBaseSize;
+    }
+
+    private static KryptonForm? FindOwningKryptonForm(Control? control)
+    {
+        for (Control? current = control; current != null; current = current.Parent)
+        {
+            if (current is KryptonForm form)
+            {
+                return form;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
@@ -1,0 +1,47 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+internal static class DropDownArrowGlyphStyleLayout
+{
+    internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset)
+    {
+        if (size < 8 || style == DropDownArrowGlyphStyle.Flat)
+        {
+            fillOffset = Point.Empty;
+
+            outlineOffset = Point.Empty;
+
+            return;
+        }
+
+        switch (style)
+        {
+            case DropDownArrowGlyphStyle.Bevel:
+
+                fillOffset = new Point(1, 1);
+
+                outlineOffset = Point.Empty;
+                break;
+            case DropDownArrowGlyphStyle.Emboss:
+
+                fillOffset = Point.Empty;
+
+                outlineOffset = new Point(1, 1);
+                break;
+            default:
+                fillOffset = Point.Empty;
+
+                outlineOffset = Point.Empty;
+                break;
+        }
+    }
+}
+

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -4,7 +4,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  */
 #endregion
 
@@ -57,7 +57,6 @@ public class RenderStandard : RenderBase
 	private const int SPACING_TAB_SMOOTH_LRO = 9;
 	private const int SPACING_TAB_SMOOTH_TO = 7;
 	private const int GROUP_FRAME_TITLE_HEIGHT = 8;
-	private const int DROP_DOWN_ARROW_BASE_SIZE = 10;
 	private const float GROUP_GRADIENT_TWO = 0.16f;
 	private const float GROUP_GRADIENT_FRAME = 0.32f;
 
@@ -350,21 +349,21 @@ public class RenderStandard : RenderBase
 
 		_gridSortOrder = new ImageList
 		{
-			TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
+			TransparentColor = Color.Empty,
 			ImageSize = new Size(17, 11)
 		};
 		_gridSortOrder.Images.AddStrip(GridImageResources.GridSortOrder);
 
 		_gridRowIndicators = new ImageList
 		{
-			TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
+			TransparentColor = Color.Empty,
 			ImageSize = new Size(19, 13)
 		};
 		_gridRowIndicators.Images.AddStrip(GridImageResources.GridRowIndicators);
 
 		_gridErrorIcon = new ImageList
 		{
-			TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
+			TransparentColor = Color.Empty,
 			ImageSize = new Size(18, 17)
 		};
 		_gridErrorIcon.Images.AddStrip(GenericImageResources.GridErrorIcon);
@@ -501,7 +500,7 @@ public class RenderStandard : RenderBase
 			float paletteRounding = palette.GetBorderRounding(state);
 			float roundingForPadding = paletteRounding;
 
-			// Match CreateBorderBackPath: rounding must fit inside the outer rectangle (#3381)
+			// Match CreateBorderBackPath: rounding must fit inside the outer rectangle
 			if (borderOuterSize.Width > 0 && borderOuterSize.Height > 0)
 			{
 				float maxRounding = Math.Min(borderOuterSize.Width / 2f, borderOuterSize.Height / 2f) - borderWidth;
@@ -1374,6 +1373,22 @@ public class RenderStandard : RenderBase
 				palette.GetContentImageColorTo(state));
 		}
 
+		// Draw overlay image if present
+		if (standard.DrawOverlayImage && standard.OverlayImage != null &&
+			!standard.OverlayImageRect.IsEmpty &&
+			standard.OverlayImageRect.Width > 0 &&
+			standard.OverlayImageRect.Height > 0)
+		{
+			DrawImageHelper(context,
+				standard.OverlayImage,
+				standard.OverlayImageTransparentColor,
+				standard.OverlayImageRect,
+				orientation,
+				palette.GetContentImageEffect(state),
+				palette.GetContentImageColorMap(state),
+				palette.GetContentImageColorTo(state));
+		}
+
 		if (standard.DrawShortText)
 		{
 			using var hint = new GraphicsTextHint(context.Graphics, standard.ShortTextHint);
@@ -1775,62 +1790,48 @@ public class RenderStandard : RenderBase
 				// Calculate the extra needed for the outsize variant
 				var x = tabBorderStyle == TabBorderStyle.SlantOutsizeNear ? SPACING_TAB_OUTSIZE_PADDING : 0;
 
-				switch (orientation)
+				ret = orientation switch
 				{
-					case VisualOrientation.Top:
-						ret = rtl
-							? new Padding(borderWidth + x, borderWidth + x,
-								borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, 0)
-							: new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, borderWidth + x,
-								borderWidth + x, 0);
-
-						break;
-					case VisualOrientation.Left:
-						ret = new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, borderWidth + x, borderWidth + x, 0);
-						break;
-					case VisualOrientation.Right:
-						ret = new Padding(borderWidth + x, borderWidth + x, borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, 0);
-						break;
-					case VisualOrientation.Bottom:
-						ret = rtl
-							? new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, borderWidth + x,
-								borderWidth + x, 0)
-							: new Padding(borderWidth + x, borderWidth + x,
-								borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, 0);
-
-						break;
-				}
+					VisualOrientation.Top => rtl
+						? new Padding(borderWidth + x, borderWidth + x, borderWidth + x + SPACING_TAB_SLANT_PADDING - 1,
+							0)
+						: new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, borderWidth + x, borderWidth + x,
+							0),
+					VisualOrientation.Left => new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1,
+						borderWidth + x, borderWidth + x, 0),
+					VisualOrientation.Right => new Padding(borderWidth + x, borderWidth + x,
+						borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, 0),
+					VisualOrientation.Bottom => rtl
+						? new Padding(borderWidth + x + SPACING_TAB_SLANT_PADDING - 1, borderWidth + x, borderWidth + x,
+							0)
+						: new Padding(borderWidth + x, borderWidth + x, borderWidth + x + SPACING_TAB_SLANT_PADDING - 1,
+							0),
+					_ => ret
+				};
 				break;
 			case TabBorderStyle.SlantEqualFar:
 			case TabBorderStyle.SlantOutsizeFar:
 				// Calculate the extra needed for the outsize variant
 				var y = tabBorderStyle == TabBorderStyle.SlantOutsizeFar ? SPACING_TAB_OUTSIZE_PADDING : 0;
 
-				switch (orientation)
+				ret = orientation switch
 				{
-					case VisualOrientation.Top:
-						ret = rtl
-							? new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, borderWidth + y,
-								borderWidth + y, 0)
-							: new Padding(borderWidth + y, borderWidth + y,
-								borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, 0);
-
-						break;
-					case VisualOrientation.Left:
-						ret = new Padding(borderWidth + y, borderWidth + y, borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, 0);
-						break;
-					case VisualOrientation.Right:
-						ret = new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, borderWidth + y, borderWidth + y, 0);
-						break;
-					case VisualOrientation.Bottom:
-						ret = rtl
-							? new Padding(borderWidth + y, borderWidth + y,
-								borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, 0)
-							: new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, borderWidth + y,
-								borderWidth + y, 0);
-
-						break;
-				}
+					VisualOrientation.Top => rtl
+						? new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, borderWidth + y, borderWidth + y,
+							0)
+						: new Padding(borderWidth + y, borderWidth + y, borderWidth + y + SPACING_TAB_SLANT_PADDING - 1,
+							0),
+					VisualOrientation.Left => new Padding(borderWidth + y, borderWidth + y,
+						borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, 0),
+					VisualOrientation.Right => new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1,
+						borderWidth + y, borderWidth + y, 0),
+					VisualOrientation.Bottom => rtl
+						? new Padding(borderWidth + y, borderWidth + y, borderWidth + y + SPACING_TAB_SLANT_PADDING - 1,
+							0)
+						: new Padding(borderWidth + y + SPACING_TAB_SLANT_PADDING - 1, borderWidth + y, borderWidth + y,
+							0),
+					_ => ret
+				};
 				break;
 			case TabBorderStyle.SlantEqualBoth:
 			case TabBorderStyle.SlantOutsizeBoth:
@@ -1850,27 +1851,18 @@ public class RenderStandard : RenderBase
 				var bp = selected ? SPACING_TAB_ONE_NOTE_BPS : SPACING_TAB_ONE_NOTE_BPI;
 				var rp = selected ? SPACING_TAB_ONE_NOTE_RPS : SPACING_TAB_ONE_NOTE_RPI;
 
-				switch (orientation)
+				ret = orientation switch
 				{
-					case VisualOrientation.Top:
-						ret = rtl
-							? new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp)
-							: new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp);
-
-						break;
-					case VisualOrientation.Left:
-						ret = new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp);
-						break;
-					case VisualOrientation.Right:
-						ret = new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp);
-						break;
-					case VisualOrientation.Bottom:
-						ret = rtl
-							? new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp)
-							: new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp);
-
-						break;
-				}
+					VisualOrientation.Top => rtl
+						? new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp)
+						: new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp),
+					VisualOrientation.Left => new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp),
+					VisualOrientation.Right => new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp),
+					VisualOrientation.Bottom => rtl
+						? new Padding(borderWidth + lp, borderWidth + tp, borderWidth + rp, bp)
+						: new Padding(borderWidth + rp, borderWidth + tp, borderWidth + lp, bp),
+					_ => ret
+				};
 				break;
 			case TabBorderStyle.SmoothEqual:
 				ret = new Padding(borderWidth + SPACING_TAB_SMOOTH_LRE, borderWidth + SPACING_TAB_SMOOTH_TE, borderWidth + SPACING_TAB_SMOOTH_LRE, 0);
@@ -2566,16 +2558,11 @@ public class RenderStandard : RenderBase
 		PaletteState state,
 		VisualOrientation orientation)
 	{
-		var paletteBase = KryptonManager.CurrentGlobalPalette;
-		var baseSize = (paletteBase != null ? paletteBase.GetMetricInt(null, state, PaletteMetricInt.DropDownArrowBaseSize) : 0);
-		if (baseSize <= 0)
-		{
-			baseSize = DROP_DOWN_ARROW_BASE_SIZE;
-		}
-
-		var square = Math.Min(context.DisplayRectangle.Width, context.DisplayRectangle.Height);
-		square = Math.Min(square, baseSize);
-		square = (int)(square * context.Graphics.DpiY / 96f);
+		var square = DropDownArrowGlyphMetrics.ResolvePixelSize(
+			context.Graphics.DpiY,
+			context.DisplayRectangle,
+			context.Control,
+			state);
 
 		return new Size(square, square);
 	}
@@ -2609,72 +2596,15 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(palette));
 		}
 
-		var translateX = 0;
-		var translateY = 0;
-		var rotation = 0f;
-
-		// Perform any transformations needed for orientation
-		switch (orientation)
+		var direction = orientation switch
 		{
-			case VisualOrientation.Bottom:
-				// Translate to opposite side of origin, so the rotate can
-				// then bring it back to original position but mirror image
-				translateX = (displayRect.X * 2) + displayRect.Width;
-				translateY = (displayRect.Y * 2) + displayRect.Height;
-				rotation = 180f;
-				break;
+			VisualOrientation.Bottom => DropDownArrowGlyphDirection.Up,
+			VisualOrientation.Left => DropDownArrowGlyphDirection.Right,
+			VisualOrientation.Right => DropDownArrowGlyphDirection.Left,
+			_ => DropDownArrowGlyphDirection.Down
+		};
 
-			case VisualOrientation.Left:
-				// Invert the dimensions of the rectangle for drawing upwards
-				displayRect = displayRect with { Width = displayRect.Height, Height = displayRect.Width };
-				// Translate back from a quarter left turn to the original place
-				translateX = displayRect.X - displayRect.Y;
-				translateY = displayRect.X + displayRect.Y + displayRect.Width;
-				rotation = -90f;
-				break;
-
-			case VisualOrientation.Right:
-				// Invert the dimensions of the rectangle for drawing upwards
-				displayRect = displayRect with { Width = displayRect.Height, Height = displayRect.Width };
-				// Translate back from a quarter right turn to the original place
-				translateX = displayRect.X + displayRect.Y + displayRect.Height;
-				translateY = -(displayRect.X - displayRect.Y);
-				rotation = 90f;
-				break;
-		}
-
-		try
-		{
-			// Apply the transforms if we have any to apply
-			if ((translateX != 0) || (translateY != 0))
-			{
-				context.Graphics.TranslateTransform(translateX, translateY);
-			}
-
-			if (rotation != 0f)
-			{
-				context.Graphics.RotateTransform(rotation);
-			}
-
-			// Finally, just draw the image and let the transforms do the rest
-			DrawInputControlDropDownGlyph(context, displayRect, palette, state);
-		}
-		catch (ArgumentException)
-		{
-		}
-		finally
-		{
-			if (rotation != 0f)
-			{
-				context.Graphics.RotateTransform(-rotation);
-			}
-
-			// Remove the applied transforms
-			if ((translateX != 0) | (translateY != 0))
-			{
-				context.Graphics.TranslateTransform(-translateX, -translateY);
-			}
-		}
+		DrawInputControlDropDownGlyph(context, displayRect, palette, state, direction);
 	}
 
 	/// <summary>
@@ -2775,6 +2705,13 @@ public class RenderStandard : RenderBase
 		Rectangle cellRect,
 		[DisallowNull] IPaletteContent paletteContent,
 		PaletteState state)
+		=> DrawInputControlDropDownGlyph(context, cellRect, paletteContent, state, DropDownArrowGlyphDirection.Down);
+
+	private static void DrawInputControlDropDownGlyph(RenderContext context,
+		Rectangle cellRect,
+		IPaletteContent paletteContent,
+		PaletteState state,
+		DropDownArrowGlyphDirection direction)
 	{
 		Debug.Assert(context != null);
 		Debug.Assert(paletteContent != null);
@@ -2790,40 +2727,9 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(paletteContent));
 		}
 
-		Color c1 = paletteContent.GetContentShortTextColor1(state);
-		Color c2 = paletteContent.GetContentShortTextColor2(state);
-		if (c2 == Color.Empty
-			|| c2 == Color.Transparent)
-		{
-			c2 = Color.FromArgb(64, c1.R, c1.G, c1.B);
-		}
+		(Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(context, paletteContent, state);
 
-		// Find the top left starting position for drawing lines
-		float xOffset = cellRect.Width / 4f;
-		float yOffset = cellRect.Height / 4f;
-		float xStart = cellRect.Left + xOffset;
-		float yStart = cellRect.Top + yOffset;
-
-		//using Pen darkPen = new Pen(c1),
-		//    lightPen = new Pen(c2);
-
-		using var path = new GraphicsPath();
-		// Define path with the geometry information only
-		path.AddLines([
-			new PointF(xStart, yStart),
-			new PointF(xStart + 2 * xOffset, yStart),
-			new PointF(xStart + xOffset, yStart + 2 * yOffset)
-		]);
-		path.CloseFigure();
-
-		using var aa = new AntiAlias(context.Graphics);
-		// Fill Triangle
-		using var brush = new SolidBrush(c2);
-		context.Graphics.FillPath(brush, path);
-
-		// Draw Triangle
-		using Pen darkPen = new Pen(c1);
-		context.Graphics.DrawPath(darkPen, path);
+		DropDownArrowGlyphCache.Draw(context.Graphics, cellRect, outline, fill, direction, context.Control);
 	}
 
 	/// <summary>
@@ -3254,23 +3160,15 @@ public class RenderStandard : RenderBase
 		Debug.Assert(paletteContent is not null);
 
 		// Get the appropriate each to draw
-		Image? rowImage = null;
 
-		switch (rowGlyph)
+		Image? rowImage = rowGlyph switch
 		{
-			case GridRowGlyph.ArrowStar:
-				rowImage = _gridRowIndicators.Images[rtl ? 4 : 0];
-				break;
-			case GridRowGlyph.Star:
-				rowImage = _gridRowIndicators.Images[rtl ? 5 : 1];
-				break;
-			case GridRowGlyph.Pencil:
-				rowImage = _gridRowIndicators.Images[rtl ? 6 : 2];
-				break;
-			case GridRowGlyph.Arrow:
-				rowImage = _gridRowIndicators.Images[rtl ? 7 : 3];
-				break;
-		}
+			GridRowGlyph.ArrowStar => _gridRowIndicators.Images[rtl ? 4 : 0],
+			GridRowGlyph.Star => _gridRowIndicators.Images[rtl ? 5 : 1],
+			GridRowGlyph.Pencil => _gridRowIndicators.Images[rtl ? 6 : 2],
+			GridRowGlyph.Arrow => _gridRowIndicators.Images[rtl ? 7 : 3],
+			_ => null
+		};
 
 		// Is there enough room to draw the image?
 		if ((rowImage != null) &&
@@ -3340,7 +3238,7 @@ public class RenderStandard : RenderBase
 
 			if (state == PaletteState.Disabled)
 			{
-				ControlPaint.DrawImageDisabled(context!.Graphics, errorImage, x, y, GlobalStaticValues.EMPTY_COLOR);
+				ControlPaint.DrawImageDisabled(context!.Graphics, errorImage, x, y, Color.Empty);
 			}
 			else
 			{
@@ -5831,11 +5729,14 @@ public class RenderStandard : RenderBase
 					|| (displayRect.Height < memento.Image.Height)
 				   )
 				{
-					var ratio = 1.0f * Math.Min(memento.Image.Width, memento.Image.Height) / Math.Max(memento.Image.Width, memento.Image.Height);
+					float ratio = Math.Min(displayRect.Width / (float)memento.Image.Width,
+						displayRect.Height / (float)memento.Image.Height);
+
+					bool avoidPurple = memento.ImageTransparentColor != Color.Empty;
 
 					// Resize image to fit display area
-					memento.Image = CommonHelper.ScaleImageForSizedDisplay(memento.Image, displayRect.Width * ratio,
-						displayRect.Height * ratio, false);
+					memento.Image = CommonHelper.ScaleImageForSizedDisplay(memento.Image, memento.Image.Width * ratio,
+						memento.Image.Height * ratio, avoidPurple);
 				}
 
 				if (memento.Image != null)
@@ -6367,16 +6268,13 @@ public class RenderStandard : RenderBase
 		// If drawing from right to left...
 		if (rtl == RightToLeft.Yes)
 		{
-			switch (drawH)
+			drawH = drawH switch
 			{
 				// Then invert the near and far positioning
-				case PaletteRelativeAlign.Near:
-					drawH = PaletteRelativeAlign.Far;
-					break;
-				case PaletteRelativeAlign.Far:
-					drawH = PaletteRelativeAlign.Near;
-					break;
-			}
+				PaletteRelativeAlign.Near => PaletteRelativeAlign.Far,
+				PaletteRelativeAlign.Far => PaletteRelativeAlign.Near,
+				_ => drawH
+			};
 		}
 
 		switch (drawH)
@@ -8170,7 +8068,7 @@ public class RenderStandard : RenderBase
 				cache.Dispose();
 
 				// If c5 has a colour then use that to highlight the tab
-				if (c5 != GlobalStaticValues.EMPTY_COLOR)
+				if (c5 != Color.Empty)
 				{
 					if (!standard)
 					{
@@ -8447,7 +8345,7 @@ public class RenderStandard : RenderBase
 				cache.Dispose();
 
 				// If c5 has a colour then use that to highlight the tab
-				if (c5 != GlobalStaticValues.EMPTY_COLOR)
+				if (c5 != Color.Empty)
 				{
 					c1 = c5;
 					c2 = CommonHelper.MergeColors(c2, 0.8f, ControlPaint.Light(c5), 0.2f);
@@ -9374,7 +9272,7 @@ public class RenderStandard : RenderBase
 				cache.Dispose();
 
 				// If we have a context color to use then modify the drawing colors
-				if (c5 != GlobalStaticValues.EMPTY_COLOR)
+				if (c5 != Color.Empty)
 				{
 					if (!standard)
 					{
@@ -9406,7 +9304,7 @@ public class RenderStandard : RenderBase
 
 			context.Graphics.FillPath(cache.CenterBrush!, cache.OutsidePath!);
 
-			if (c5 != GlobalStaticValues.EMPTY_COLOR)
+			if (c5 != Color.Empty)
 			{
 				context.Graphics.FillPath(cache.InsideBrush!, cache.InsidePath!);
 			}
@@ -10427,7 +10325,7 @@ public class RenderStandard : RenderBase
 			Color topDark = palette.GetRibbonBackColor3(state);
 			Color bottomLight = palette.GetRibbonBackColor4(state);
 			Color bottomMedium = palette.GetRibbonBackColor5(state);
-			Color bottomDark = CommonHelper.MergeColors(topDark, 0.78f, GlobalStaticValues.EMPTY_COLOR, 0.22f);
+			Color bottomDark = CommonHelper.MergeColors(topDark, 0.78f, Color.Empty, 0.22f);
 
 			var generate = true;
 			MementoRibbonAppButton cache;
@@ -10924,7 +10822,7 @@ public class RenderStandard : RenderBase
 					90f);
 
 				cache.PressedFillBrush = new LinearGradientBrush(new RectangleF(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 2),
-					Color.FromArgb((dark ? GlobalStaticValues.EMPTY_COLOR : _whiten10).A, cache.C4),
+					Color.FromArgb((dark ? Color.Empty : _whiten10).A, cache.C4),
 					Color.FromArgb((dark ? _darken38 : _darken16).A, cache.C5),
 					90f);
 				cache.TrackFillBrush.Blend = _linear50Blend;
@@ -12182,6 +12080,7 @@ public class RenderStandard : RenderBase
 	#endregion
 
 	#region StandardContentMemento
+
 	/// <summary>
 	/// Internal help class used to store content rendering details.
 	/// </summary>
@@ -12194,6 +12093,12 @@ public class RenderStandard : RenderBase
 		public Image? Image;
 		public Color ImageTransparentColor;
 		public Rectangle ImageRect;
+		public bool DrawOverlayImage;
+		public Image? OverlayImage;
+		public Color OverlayImageTransparentColor;
+		public Rectangle OverlayImageRect;
+		public float OverlayImageScaleFactor;
+		public Size OverlayImageFixedSize;
 		public PaletteTextTrim ShortTextTrimming;
 		public AccurateTextMemento? ShortTextMemento;
 		public Rectangle ShortTextRect;
@@ -12212,6 +12117,8 @@ public class RenderStandard : RenderBase
 			LongTextTrimming = PaletteTextTrim.EllipsisCharacter;
 			ShortTextTrimming = PaletteTextTrim.EllipsisCharacter;
 			Orientation = VisualOrientation.Top;
+			OverlayImageScaleFactor = 0.5f;
+			OverlayImageFixedSize = new Size(16, 16);
 		}
 
 		/// <summary>
@@ -12258,8 +12165,10 @@ public class RenderStandard : RenderBase
 					// Reposition the short text relative the display rectangle
 					if (DrawShortText)
 					{
-						ShortTextRect.X = displayRect.Right - ShortTextRect.Width - (ShortTextRect.X - displayRect.Left);
-						ShortTextRect.Y = displayRect.Bottom - ShortTextRect.Height - (ShortTextRect.Y - displayRect.Top);
+						ShortTextRect.X = displayRect.Right - ShortTextRect.Width -
+										  (ShortTextRect.X - displayRect.Left);
+						ShortTextRect.Y = displayRect.Bottom - ShortTextRect.Height -
+										  (ShortTextRect.Y - displayRect.Top);
 					}
 
 					// Reposition the long text relative the display rectangle
@@ -12268,6 +12177,7 @@ public class RenderStandard : RenderBase
 						LongTextRect.X = displayRect.Right - LongTextRect.Width - (LongTextRect.X - displayRect.Left);
 						LongTextRect.Y = displayRect.Bottom - LongTextRect.Height - (LongTextRect.Y - displayRect.Top);
 					}
+
 					break;
 				case VisualOrientation.Left:
 					Orientation = VisualOrientation.Left;
@@ -12276,7 +12186,8 @@ public class RenderStandard : RenderBase
 					if (DrawImage)
 					{
 						var x = ImageRect.Y - displayRect.Top;
-						ImageRect.Y = displayRect.Top + displayRect.Width - ImageRect.Width - (ImageRect.X - displayRect.X);
+						ImageRect.Y = displayRect.Top + displayRect.Width - ImageRect.Width -
+									  (ImageRect.X - displayRect.X);
 						ImageRect.X = x + displayRect.Left;
 					}
 
@@ -12284,7 +12195,8 @@ public class RenderStandard : RenderBase
 					if (DrawShortText)
 					{
 						var x = ShortTextRect.Y - displayRect.Top;
-						ShortTextRect.Y = displayRect.Top + displayRect.Width - ShortTextRect.Width - (ShortTextRect.X - displayRect.X);
+						ShortTextRect.Y = displayRect.Top + displayRect.Width - ShortTextRect.Width -
+										  (ShortTextRect.X - displayRect.X);
 						ShortTextRect.X = x + displayRect.Left;
 						SwapRectangleSizes(ref ShortTextRect);
 					}
@@ -12293,10 +12205,12 @@ public class RenderStandard : RenderBase
 					if (DrawLongText)
 					{
 						var x = LongTextRect.Y - displayRect.Top;
-						LongTextRect.Y = displayRect.Top + displayRect.Width - LongTextRect.Width - (LongTextRect.X - displayRect.X);
+						LongTextRect.Y = displayRect.Top + displayRect.Width - LongTextRect.Width -
+										 (LongTextRect.X - displayRect.X);
 						LongTextRect.X = x + displayRect.Left;
 						SwapRectangleSizes(ref LongTextRect);
 					}
+
 					break;
 				case VisualOrientation.Right:
 					Orientation = VisualOrientation.Right;
@@ -12326,11 +12240,15 @@ public class RenderStandard : RenderBase
 						LongTextRect.Y = y + displayRect.Top;
 						SwapRectangleSizes(ref LongTextRect);
 					}
+
 					break;
 			}
 		}
 
-		private static void SwapRectangleSizes(ref Rectangle rect) => (rect.Width, rect.Height) = (rect.Height, rect.Width);
+		private static void SwapRectangleSizes(ref Rectangle rect) =>
+			(rect.Width, rect.Height) = (rect.Height, rect.Width);
+
 	}
+
 	#endregion
 }


### PR DESCRIPTION
# Use glyphs for drop-down arrows (#3663)

**Branch:** `V105-LTS-3663-feature-request-use-glyphs-for-dropdown-arrows` **Target:** `V105 LTS` (V105 LTS) **Closes:** [#3663](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3663) **Related:** [#2129](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2129) (DPI-aware arrow sizing)

## Summary

Replaces anti-aliased vector triangle paths with cached bitmap glyphs for drop-down and scroll arrows across Krypton controls. Glyphs are sharper at all DPI scales, follow the active theme, and can be switched between Unicode triangles and pixel-aligned polygons via `KryptonManager`.

This builds on the sizing work from #2129 (`PaletteMetricInt.DropDownArrowBaseSize`) and raises the default base size to **14 logical pixels at 96 DPI**.

## Motivation

Vector-drawn arrows used `GraphicsPath` with anti-aliasing, which looked soft or inconsistent at small sizes and high DPI. Bitmap glyphs (Unicode ▼ ▲ ◀ ▶ or polygon equivalents) render crisply, cache efficiently, and align with theme colours.

## What changed

### Rendering

- **`DropDownArrowGlyphFactory`** — creates direction glyphs (Down/Up/Left/Right) in Unicode or polygon mode.
- **`DropDownArrowGlyphCache`** — caches glyphs by size, colours, direction, and render mode; clears on global palette or render-mode change.
- **`DropDownArrowGlyphMetrics`** — resolves pixel size from `DropDownArrowBaseSize`, cell bounds, and DPI (same formula as #2129).
- **`DropDownArrowGlyphColors`** — resolves outline/fill from `SchemeBaseColors.TextButtonNormal` (disabled uses standard disabled button text); honours `ButtonValues.DropDownArrowColor` when set.
- **`RenderStandard`** — `DrawInputControlDropDownGlyph` and `DrawDropDownButton` use the glyph cache instead of vector paths; orientation maps to glyph direction without graphics rotation.

### Configuration

- **`DropDownArrowRenderMode`** enum (`Unicode` | `Polygon`) in `PaletteDefinitions.cs`.
- **`KryptonManager.DropDownArrowRenderMode`** (static) and **`GlobalDropDownArrowRenderMode`** (instance, designer category Visuals).
- **`DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi`** — shared constant (`14`); all built-in palettes reference it for `PaletteMetricInt.DropDownArrowBaseSize`.

### Controls

- **Combo boxes, date/time pickers, split/drop buttons** — arrows via `RenderStandard` (unchanged call sites).
- **`KryptonDataGridViewCellIndicatorImage`** — uses shared glyph cache instead of per-column bitmap scaling.
- **`KryptonScrollBar` / `KryptonHScrollBar` / `KryptonVScrollBar`** — chevrons drawn with the same glyph renderer; themed button chrome unchanged.
- **`VisualForm`** — repaints on `DpiChanged` so arrow sizes update with monitor DPI.

## API surface

| Member | Description |
|--------|-------------|
| `DropDownArrowRenderMode` | `Unicode` (default) or `Polygon` | | `KryptonManager.DropDownArrowRenderMode` | Application-wide render mode | | `KryptonManager.GlobalDropDownArrowRenderMode` | Designer-friendly instance property | | `DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi` | Default arrow size at 96 DPI (14) | | `PaletteMetricInt.DropDownArrowBaseSize` | Per-theme override (unchanged metric; default now 14) |

Existing **`ButtonValues.DropDownArrowColor`** continues to override glyph colour on `KryptonDropButton` when set.

## Behaviour notes

- **Unicode mode (default):** Segoe UI Symbol / Segoe UI triangles; two-tone fill/outline drawn under the glyph when the palette provides distinct colours.
- **Polygon mode:** Pixel-aligned filled triangles with outline + fill from palette (legacy-style appearance).
- **Colours:** `TextButtonNormal` from the active scheme; disabled state uses disabled button standalone text colour.
- **DPI:** Size scales with `dpiY / 96`, capped by the arrow cell; forms repaint on DPI change.

## Files (high level)

| Area | Files |
|------|--------|
| New | `DropDownArrowGlyphFactory.cs`, `DropDownArrowGlyphCache.cs`, `DropDownArrowGlyphColors.cs`, `DropDownArrowGlyphMetrics.cs` | | Core | `RenderStandard.cs`, `PaletteDefinitions.cs`, `KryptonManager.cs` | | Scrollbars | `KryptonScrollBarRenderer.cs` | | DGV | `KryptonDataGridViewCellIndicatorImage.cs` | | DPI | `VisualForm.cs` | | Palettes | Built-in palettes — `DropDownArrowBaseSize` → `DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi` | | Demo / docs | `DropDownArrowsDemo.*`, `Changelog.md` |

## Test plan

- [ ] Run **TestForm → DropDownArrowsDemo** at 100%, 125%, and 150% display scaling; confirm arrows stay sharp and scale correctly.
- [ ] Toggle **`KryptonManager.DropDownArrowRenderMode`** between `Unicode` and `Polygon`; confirm immediate repaint and cache refresh.
- [ ] Switch global palette (e.g. Office 2010 Blue, Microsoft 365, dark modes); confirm arrow colour matches **`TextButtonNormal`** and disabled controls look correct.
- [ ] **KryptonComboBox**, **KryptonDateTimePicker**, **KryptonDropButton** / split buttons — normal, tracking, pressed, and disabled states.
- [ ] **KryptonScrollBar**, **KryptonHScrollBar**, **KryptonVScrollBar** — all four directions; hot/pressed/disabled chrome + glyph.
- [ ] **KryptonDataGridView** columns with drop-down indicators — glyph size and colour with custom palette on the grid.
- [ ] Set **`ButtonValues.DropDownArrowColor`** on a drop button; confirm override wins over theme colour.
- [ ] Custom palette: adjust **`DropDownArrowBaseSize`** / navigator metric; confirm size override still works.
- [ ] Build **net472** (and CI targets if applicable).

## Breaking changes

None expected. Public API additions only; default arrow size increases from 10 to 14 logical pixels at 96 DPI (visual change only).

## Changelog

V105 LTS entry added under `Documents/Changelog/Changelog.md`.