### PR TITLE
* Message indicating that `KryptonCustomPaletteBase` has Not Implemented

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3741](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3741), Message indicating that `KryptonCustomPaletteBase` has Not Implemented. Fixed custom palette "Not Implemented" prompts when `GlobalCustomPalette` is set in designer mode (grid background/content `Tracking` and `ContextNormal` state fallbacks)
 * Resolved [#3736](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3736), Fixed high-dpi scaling causing magenta image borders
 * Implemented [#3718](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3718), Use 'switch' expression
 * Resolved [#3720](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3720), `KryptonTreeView` freezes blank after programmatic `SelectedNode = null` then re-select (drain leaked selection `BeginUpdate`/`EndUpdate` batches from #3282/#3498)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -5337,6 +5337,8 @@ public class KryptonCustomPaletteBase : PaletteBase
             case PaletteState.Disabled:
                 return grid.StateDisabled.Background;
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:    // Occurs from the TreeGrid
+            case PaletteState.Tracking:         // Grid background has no tracking state
                 return grid.StateNormal.Background;
             default:
                 // Should never happen!

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -889,6 +889,7 @@ public class PaletteRedirectGrids : PaletteRedirect
 
             case PaletteState.BoldedOverride:
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:    // From the TreeGrid
                 switch (style)
                 {
                     case PaletteBackStyle.GridBackgroundList:
@@ -939,6 +940,12 @@ public class PaletteRedirectGrids : PaletteRedirect
             case PaletteState.Tracking:
                 switch (style)
                 {
+                    case PaletteBackStyle.GridBackgroundList:
+                    case PaletteBackStyle.GridBackgroundSheet:
+                    case PaletteBackStyle.GridBackgroundCustom1:
+                    case PaletteBackStyle.GridBackgroundCustom2:
+                    case PaletteBackStyle.GridBackgroundCustom3:
+                        return _grid.StateNormal.Background;
                     case PaletteBackStyle.GridHeaderColumnList:
                     case PaletteBackStyle.GridHeaderColumnSheet:
                     case PaletteBackStyle.GridHeaderColumnCustom1:
@@ -1014,6 +1021,7 @@ public class PaletteRedirectGrids : PaletteRedirect
 
             case PaletteState.BoldedOverride:
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:    // From the TreeGrid
                 switch (style)
                 {
                     case PaletteBorderStyle.GridDataCellList:
@@ -1132,6 +1140,7 @@ public class PaletteRedirectGrids : PaletteRedirect
                 break;
 
             case PaletteState.Normal:
+            case PaletteState.ContextNormal:    // From the TreeGrid
                 switch (style)
                 {
                     case PaletteContentStyle.GridDataCellList:


### PR DESCRIPTION
# Fix custom palette "Not Implemented" prompts in designer (#3741)

## Summary

- Fixes [#3741](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3741): assigning `KryptonManager.GlobalCustomPalette` in the designer triggered `DebugTools.NotImplemented` dialogs for grid palette lookups using `PaletteState.Tracking` or `PaletteState.ContextNormal`.
- Maps grid background `Tracking` and `ContextNormal` to `StateNormal.Background` in `KryptonCustomPaletteBase.GetPaletteBackGridBackground` (grid background has no dedicated tracking/context entries, consistent with grid data cells and builtin palettes).
- Extends `PaletteRedirectGrids` inheritance routing so `ContextNormal` falls through with `Normal` for back, border, and content, and `Tracking` includes `GridBackground*` styles mapped to `StateNormal.Background`.

## Test plan

- [ ] Add a `KryptonCustomPaletteBase` and `KryptonManager` to a form; set `GlobalCustomPalette` — confirm no "Not Implemented" dialog appears in the designer.
- [ ] Open a form with `KryptonDataGridView` under a global custom palette; hover column/row headers and confirm no prompts or visual regressions.
- [ ] Open `TreeViewExample` (or another TreeGrid scenario) with a global custom palette and confirm grid/content rendering is unchanged.