### PR TITLE
* `Krypton.Standard.Toolkit.Nightly` NuGet package does not upload

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3751](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3751), `Krypton.Standard.Toolkit.Nightly` NuGet package does not upload
 * Implemented [#3657](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3657), OS X Aqua Themes
 * Resolved [#3741](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3741), Message indicating that `KryptonCustomPaletteBase` has Not Implemented. Fixed custom palette "Not Implemented" prompts when `GlobalCustomPalette` is set in designer mode (grid background/content `Tracking` and `ContextNormal` state fallbacks)
 * Resolved [#3736](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3736), Fixed high-dpi scaling causing magenta image borders

--- a/Scripts/Build/Krypton.Orchestration.targets
+++ b/Scripts/Build/Krypton.Orchestration.targets
@@ -12,6 +12,10 @@
 		<KryptonNavigatorProject>$(KryptonComponentsRoot)\Krypton.Navigator\Krypton.Navigator 2022.csproj</KryptonNavigatorProject>
 		<KryptonWorkspaceProject>$(KryptonComponentsRoot)\Krypton.Workspace\Krypton.Workspace 2022.csproj</KryptonWorkspaceProject>
 		<KryptonDockingProject>$(KryptonComponentsRoot)\Krypton.Docking\Krypton.Docking 2022.csproj</KryptonDockingProject>
+		<KryptonToolkitJumpListProject>$(KryptonComponentsRoot)\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj</KryptonToolkitJumpListProject>
+		<KryptonNavigatorUtilitiesProject>$(KryptonComponentsRoot)\Krypton.Navigator.Utilities\Krypton.Navigator.Utilities.csproj</KryptonNavigatorUtilitiesProject>
+		<KryptonToolkitUtilitiesProject>$(KryptonComponentsRoot)\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj</KryptonToolkitUtilitiesProject>
+		<KryptonStandardToolkitProject>$(KryptonComponentsRoot)\Krypton.Standard.Toolkit\Krypton.Standard.Toolkit.csproj</KryptonStandardToolkitProject>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' != ''">Configuration=$(Configuration);TFMs=$(TFMs);UseArtifactsOutput=$(UseArtifactsOutput)</KryptonComponentBuildProperties>
 		<KryptonComponentBuildProperties Condition="'$(TFMs)' == ''">Configuration=$(Configuration);TFMs=all;UseArtifactsOutput=$(UseArtifactsOutput)</KryptonComponentBuildProperties>
 		<KryptonComponentBuildProperties Condition="'$(ExcludeNet11)' != ''">$(KryptonComponentBuildProperties);ExcludeNet11=$(ExcludeNet11)</KryptonComponentBuildProperties>
@@ -49,6 +53,17 @@
 		<MSBuild Projects="$(KryptonDockingProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Build" />
+
+		<!-- Satellite assemblies for Krypton.Standard.Toolkit; sequential to avoid shared-output races. -->
+		<MSBuild Projects="$(KryptonToolkitJumpListProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+		<MSBuild Projects="$(KryptonNavigatorUtilitiesProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+		<MSBuild Projects="$(KryptonToolkitUtilitiesProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
 	</Target>
 
 	<Target Name="KryptonPack">
@@ -66,6 +81,15 @@
 		         Targets="Pack" />
 
 		<MSBuild Projects="$(KryptonDockingProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Pack" />
+
+		<!-- JumpList is bundled in the aggregate package but is not a Standard.Toolkit project reference. -->
+		<MSBuild Projects="$(KryptonToolkitJumpListProject)"
+		         Properties="$(KryptonComponentBuildProperties)"
+		         Targets="Build" />
+
+		<MSBuild Projects="$(KryptonStandardToolkitProject)"
 		         Properties="$(KryptonComponentBuildProperties)"
 		         Targets="Pack" />
 	</Target>


### PR DESCRIPTION
## Summary

Fixes [#3751](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3751) — the `Krypton.Standard.Toolkit.Nightly` NuGet package was never produced during nightly (or canary) CI runs, so the workflow had nothing to push to nuget.org.

`KryptonPack` in `Scripts/Build/Krypton.Orchestration.targets` only packed the five individual component packages. The aggregate `Krypton.Standard.Toolkit` project was removed from orchestration in [#3594](https://github.com/Krypton-Suite/Standard-Toolkit/pull/3594) to fix local build regressions; nightly and canary workflows never regained that step (unlike stable Release, which still packs the aggregate via `PackLite` in `build.proj`).

This change restores build and pack for the aggregate package and its satellite assemblies, keeping those steps **sequential** to avoid shared-output races on `Bin/` / `artifacts/bin/`.

## Changes

- **`Scripts/Build/Krypton.Orchestration.targets`**
  - **`KryptonBuild`**: after the five core libraries, sequentially build `Krypton.Toolkit.JumpList`, `Krypton.Navigator.Utilities`, and `Krypton.Toolkit.Utilities`.
  - **`KryptonPack`**: after the five core packages are packed, build `JumpList` (bundled in the aggregate package but not a project reference) and pack `Krypton.Standard.Toolkit` last.
- **`Documents/Changelog/Changelog.md`**: changelog entry for #3751.

## Packages affected

| Channel | Package ID |
|---------|------------|
| Nightly (alpha) | `Krypton.Standard.Toolkit.Nightly` | | Canary | `Krypton.Standard.Toolkit.Canary` |

Individual component packages (`Krypton.Toolkit.Nightly`, etc.) are unchanged.

## Test plan

- [ ] Merge to `alpha` (nightly workflow checks out `alpha`).
- [ ] Trigger **Nightly Release** via `workflow_dispatch` (or wait for the scheduled run after a commit in the last 24 hours).
- [ ] Confirm **Pack Nightly** produces `artifacts/packages/Nightly/Krypton.Standard.Toolkit.Nightly.*.nupkg` (or `Bin/Packages/Nightly/` without `UseArtifactsOutput`).
- [ ] Confirm package size is ≥ 10 MiB (passes `StandardToolkitNupkgGuard.ps1`).
- [ ] Confirm **Push NuGet Packages** logs a successful push for `Krypton.Standard.Toolkit.Nightly`.
- [ ] Optional: verify `Krypton.Standard.Toolkit.Canary` on the canary workflow after merge to `canary`.

### Local verification (optional)

```powershell
msbuild /m "Scripts/Build/nightly.proj" /t:Pack /p:Configuration=Nightly /p:UseArtifactsOutput=true
Get-ChildItem artifacts/packages/Nightly/Krypton.Standard.Toolkit.Nightly*.nupkg |
  Select-Object Name, @{N='MiB';E={[math]::Round($_.Length/1MB,2)}}
```