### PR TITLE
V105-Adjustment of the position and size of the buttons in `KryptonMessageBox`

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`
 * Implemented [#3663](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3663), Use glyphs for dropdown arrows. Drop-down arrows use cached bitmap glyphs instead of anti-aliased vector paths; Unicode triangles (e.g. ▼) are the default, with pixel-aligned polygon glyphs available via `KryptonManager.DropDownArrowRenderMode` / `GlobalDropDownArrowRenderMode`; two-tone arrows composite separate fill and outline glyph layers with configurable style via `DropDownArrowGlyphStyle` / `GlobalDropDownArrowGlyphStyle` (`Flat`, `Bevel`, `Emboss`); colours use `TextButtonNormal` + `InputDropDownNormal2` (disabled: `InputDropDownDisabled1` / `2`); `ButtonValues.DropDownArrowColor` overrides when set; default base size is 14 logical pixels at 96 DPI (`DropDownArrowGlyphDefaults.DefaultBaseSizeAt96Dpi`), with DPI scaling via `DropDownArrowBaseSize` on each paint and layout pass; `KryptonScrollBar`, `KryptonHScrollBar`, and `KryptonVScrollBar` arrow buttons use the same glyph renderer
 * Resolved [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), Fixed KContextMenu items overflow not visible
 * Resolved [#3682](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3682), Fixed KryptonDataGridView column resize flicker

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
@@ -103,7 +103,7 @@ namespace Krypton.Toolkit
             // _button4
             // 
             this._button4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._button4.AutoSize = true;
+            this._button4.AutoSize = false;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
             this._button4.Location = new System.Drawing.Point(203, 0);
@@ -119,7 +119,7 @@ namespace Krypton.Toolkit
             // _button3
             // 
             this._button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._button3.AutoSize = true;
+            this._button3.AutoSize = false;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
             this._button3.Location = new System.Drawing.Point(166, 0);
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit
             // _button1
             // 
             this._button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._button1.AutoSize = true;
+            this._button1.AutoSize = false;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
             this._button1.Location = new System.Drawing.Point(90, 0);
@@ -151,7 +151,7 @@ namespace Krypton.Toolkit
             // _button2
             // 
             this._button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._button2.AutoSize = true;
+            this._button2.AutoSize = false;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
             this._button2.Location = new System.Drawing.Point(128, 0);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -558,9 +558,12 @@ internal partial class VisualMessageBoxForm : KryptonForm
     {
         var numButtons = 1;
 
+        //Maximum width "Try Again" 62px
+        var minButtonWith = 62;
+
         // Button1 is always visible
         Size button1Size = _button1.GetPreferredSize(Size.Empty);
-        var maxButtonSize = button1Size with { Width = button1Size.Width + GlobalStaticValues.GLOBAL_BUTTON_PADDING };
+        var maxButtonSize = button1Size with { Width = Math.Max(minButtonWith, button1Size.Width) + GlobalStaticValues.GLOBAL_BUTTON_PADDING };
 
         // If Button2 is visible
         if (_button2.Enabled)


### PR DESCRIPTION
- Fix: #3767 

- Changed `autosize` to respect the size defined in `UpdateButtonsSizing`.

- Added the minimum width (the "Try again" button has 62px + 10 padding); All buttons are 72px, and can increase in size if translated in KryptonManager.

<img width="588" height="557" alt="image" src="https://github.com/user-attachments/assets/36bfacdd-0b84-4ea2-86db-60fdd138cadb" />