### PR TITLE
* Allow build scripts to find Visual Studio (V110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
   - `.\run.cmd` launches the interactive menu and lets you choose `Scripts\VS2022` or `Scripts\Current` (VS 2026).
   - Direct VS2022 presets: `.\Scripts\VS2022\build-stable.cmd`, `.\Scripts\VS2022\build-canary.cmd`, `.\Scripts\VS2022\build-nightly.cmd`.
   - Direct VS2026 presets: `.\Scripts\Current\build-stable.cmd`, `.\Scripts\Current\build-canary.cmd`, `.\Scripts\Current\build-nightly.cmd`.
+  - Build scripts locate MSBuild via `Scripts\Common\find-msbuild.cmd` (`vswhere.exe`, then standard install paths). Override with `MSBUILDPATH` or `MSBUILD_PATH` pointing at `MSBuild\Current\Bin`.
 - Outputs land under `Bin\<Configuration>\<TargetFramework>\` by default; with `UseArtifactsOutput=true`, outputs land under `artifacts\bin\<Configuration>\<TargetFramework>\`.
 - Target frameworks are selected by MSBuild properties. VS2019/full MSBuild builds only .NET Framework 4.x TFMs; VS2022/full MSBuild excludes `net10.0-windows` and `net11.0-windows`; VS2026/full MSBuild excludes `net11.0-windows` unless explicitly enabled; CI or SDK-based builds can include `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, and `net11.0-windows` when the required SDKs are installed.
 - New files must use only the current Standard Toolkit BSD header. Do not add the original ComponentFactory BSD header unless the file is derived from original ComponentFactory source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@
   - `.\run.cmd` launches the interactive menu and lets you choose `Scripts\VS2022` or `Scripts\Current` (VS 2026).
   - Direct VS2022 presets: `.\Scripts\VS2022\build-stable.cmd`, `.\Scripts\VS2022\build-canary.cmd`, `.\Scripts\VS2022\build-nightly.cmd`.
   - Direct VS2026 presets: `.\Scripts\Current\build-stable.cmd`, `.\Scripts\Current\build-canary.cmd`, `.\Scripts\Current\build-nightly.cmd`.
-  - Build scripts locate MSBuild via `Scripts\Common\find-msbuild.cmd` (`vswhere.exe`, then standard install paths). Override with `MSBUILDPATH` or `MSBUILD_PATH` pointing at `MSBuild\Current\Bin`.
+  - Build scripts locate MSBuild via `Scripts\Common\find-msbuild.cmd` (`vswhere.exe`, then standard install paths). Profiles: `2019`, `2022`, `current` (newest VS major 18+), or a pinned major (`18`, `19`, …). `Scripts\Current\` uses `current`. Override with `MSBUILDPATH` or `MSBUILD_PATH` pointing at `MSBuild\Current\Bin`.
 - Outputs land under `Bin\<Configuration>\<TargetFramework>\` by default; with `UseArtifactsOutput=true`, outputs land under `artifacts\bin\<Configuration>\<TargetFramework>\`.
 - Target frameworks are selected by MSBuild properties. VS2019/full MSBuild builds only .NET Framework 4.x TFMs; VS2022/full MSBuild excludes `net10.0-windows` and `net11.0-windows`; VS2026/full MSBuild excludes `net11.0-windows` unless explicitly enabled; CI or SDK-based builds can include `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, and `net11.0-windows` when the required SDKs are installed.
 - New files must use only the current Standard Toolkit BSD header. Do not add the original ComponentFactory BSD header unless the file is derived from original ComponentFactory source.

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `vswhere.exe` (custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`
 * Implemented [#3763](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3763), Bring the `KryptonCircularProgressBar` over
    * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Toolkit.Utilities` assembly.
 * Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,7 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
-* Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`
+* Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`. Build scripts and ModernBuild locate MSBuild via `Scripts/Common/find-msbuild.cmd` and `vswhere.exe`, with `%ProgramFiles%` fallback and `MSBUILDPATH` / `MSBUILD_PATH` overrides for custom or non-system-drive Visual Studio installs
 * Implemented [#3763](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3763), Bring the `KryptonCircularProgressBar` over
    * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Toolkit.Utilities` assembly.
 * Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,7 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
-* Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `vswhere.exe` (custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`
+* Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`
 * Implemented [#3763](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3763), Bring the `KryptonCircularProgressBar` over
    * To use, you will need to download the `Krypton.Standard.Toolkit` NuGet package, as this control is part of the `Krypton.Toolkit.Utilities` assembly.
 * Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Canary release build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-canary.cmd
+++ b/Scripts/Build/build-canary.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Installer package build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-installer.cmd
+++ b/Scripts/Build/build-installer.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Long-term stable build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-lts.cmd
+++ b/Scripts/Build/build-lts.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/build-nightly-custom.cmd
+++ b/Scripts/Build/build-nightly-custom.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly custom-target build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/build-nightly.cmd
+++ b/Scripts/Build/build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly release build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs16prev
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs16ent
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs16pro
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs16com
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin"
-goto build
-
-:vs16build
-set "msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Stable release build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/build-stable.cmd
+++ b/Scripts/Build/build-stable.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -10,36 +10,12 @@ if /I "%INPUT%"=="2019" goto vs2019build
 if /I "%INPUT%"=="2026" goto vs2026build
 
 :vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
 pause
-
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+)
 goto build2019
 
 :build2019
@@ -51,34 +27,11 @@ REM /m: multi-processor MSBuild (all logical CPUs).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2026build
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 goto exitbatch
-pause
-
-:vscurrentinsiders
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentpro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentcom
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin
-goto build2026
-
-:vscurrentbuild
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin
+)
 goto build2026
 
 :build2026

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -1,4 +1,6 @@
 echo off
+REM Interactive solution build: VS 2019 (profile "2019") or VS 2026+ (profile "current") via user prompt.
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd at :vs2019build and :vs2026build. Failure text from the helper.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/buildsolution.cmd
+++ b/Scripts/Build/buildsolution.cmd
@@ -12,7 +12,6 @@ if /I "%INPUT%"=="2026" goto vs2026build
 :vs2019build
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 pause
 goto exitbatch
 )
@@ -27,9 +26,9 @@ REM /m: multi-processor MSBuild (all logical CPUs).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2026build
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+pause
 goto exitbatch
 )
 goto build2026

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Debug configuration build using the Scripts/Build/ toolset (Visual Studio 2019, profile "2019").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/debug.cmd
+++ b/Scripts/Build/debug.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Insiders\MSBuild\Current\Bin
+)
 goto build
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build
-
 :build
 @echo Started: %date% %time%
 @echo

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly rebuild using Visual Studio major 18+ (profile "current") from Scripts/Build/.
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Build/rebuild-build-nightly.cmd
+++ b/Scripts/Build/rebuild-build-nightly.cmd
@@ -3,35 +3,13 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
-goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+)
 goto build
 
 :build

--- a/Scripts/Common/find-msbuild.cmd
+++ b/Scripts/Common/find-msbuild.cmd
@@ -1,12 +1,16 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 REM Locate MSBuild for a Visual Studio generation.
-REM Usage: call "%~dp0find-msbuild.cmd" <2019|2022|18>
+REM Usage: call "%~dp0find-msbuild.cmd" <2019|2022|current|latest|NN>
+REM   2019 / 2022     - pinned legacy generations
+REM   current / latest - newest install with MSBuild, major version 18 or later
+REM   NN              - pinned major folder (18, 19, 20, ...) for a specific yearly release
 REM Sets msbuildpath (directory containing MSBuild.exe). Exit 0 on success, 1 on failure.
 REM Override: set MSBUILDPATH or MSBUILD_PATH to the MSBuild\Current\Bin directory.
 
 set "VS_PROFILE=%~1"
-if not defined VS_PROFILE exit /b 1
+if not defined VS_PROFILE goto :report_failure
+if /I "!VS_PROFILE!"=="latest" set "VS_PROFILE=current"
 
 if defined MSBUILDPATH (
     if exist "!MSBUILDPATH!\MSBuild.exe" (
@@ -23,25 +27,57 @@ if defined MSBUILD_PATH (
     )
 )
 
-set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-if exist "%VSWHERE%" (
-    set "VS_VERSION_ARG="
-    if /I "!VS_PROFILE!"=="2019" set "VS_VERSION_ARG=-version [16.0,17.0)"
-    if /I "!VS_PROFILE!"=="2022" set "VS_VERSION_ARG=-version [17.0,18.0)"
-    if /I "!VS_PROFILE!"=="18" set "VS_VERSION_ARG=-version [18.0,19.0)"
-    if defined VS_VERSION_ARG (
-        for /f "usebackq tokens=* delims=" %%M in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\MSBuild.exe 2^>nul`) do (
-            set "FOUND_MSBUILD_BIN=%%~dpM"
-            set "FOUND_VIA=vswhere"
-            goto :report_success
-        )
+set "VS_VERSION_ARG="
+set "FALLBACK_MODE="
+set "VS_PRODUCT_LABEL="
+set "VS_MAJOR_FOLDER="
+
+if /I "!VS_PROFILE!"=="2019" (
+    set "VS_VERSION_ARG=-version [16.0,17.0)"
+    set "FALLBACK_MODE=2019"
+    set "VS_PRODUCT_LABEL=Visual Studio 2019"
+)
+if /I "!VS_PROFILE!"=="2022" (
+    set "VS_VERSION_ARG=-version [17.0,18.0)"
+    set "FALLBACK_MODE=2022"
+    set "VS_PRODUCT_LABEL=Visual Studio 2022"
+)
+if /I "!VS_PROFILE!"=="current" (
+    set "VS_VERSION_ARG=-version [18.0,) -latest"
+    set "FALLBACK_MODE=current"
+    set "VS_PRODUCT_LABEL=Visual Studio (current)"
+)
+
+if not defined FALLBACK_MODE (
+    echo !VS_PROFILE!| findstr /r "^[0-9][0-9]*$" >nul
+    if not errorlevel 1 (
+        set "VS_MAJOR_FOLDER=!VS_PROFILE!"
+        set "FALLBACK_MODE=major"
+        set "VS_PRODUCT_LABEL=Visual Studio !VS_PROFILE!"
     )
 )
 
-if /I "!VS_PROFILE!"=="2019" goto :fallback_2019
-if /I "!VS_PROFILE!"=="2022" goto :fallback_2022
-if /I "!VS_PROFILE!"=="18" goto :fallback_18
-exit /b 1
+if not defined FALLBACK_MODE goto :report_failure
+
+if "!FALLBACK_MODE!"=="major" (
+    set /a "VS_MAJOR_NEXT=!VS_MAJOR_FOLDER!+1"
+    set "VS_VERSION_ARG=-version [!VS_MAJOR_FOLDER!.0,!VS_MAJOR_NEXT!.0) -latest"
+)
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%VSWHERE%" if defined VS_VERSION_ARG (
+    for /f "usebackq tokens=* delims=" %%M in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\MSBuild.exe 2^>nul`) do (
+        set "FOUND_MSBUILD_BIN=%%~dpM"
+        set "FOUND_VIA=vswhere"
+        goto :report_success
+    )
+)
+
+if "!FALLBACK_MODE!"=="2019" goto :fallback_2019
+if "!FALLBACK_MODE!"=="2022" goto :fallback_2022
+if "!FALLBACK_MODE!"=="current" goto :fallback_current
+if "!FALLBACK_MODE!"=="major" goto :fallback_major
+goto :report_failure
 
 :fallback_2019
 set "VS_ROOT=%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
@@ -52,7 +88,7 @@ for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
         goto :report_success
     )
 )
-exit /b 1
+goto :report_failure
 
 :fallback_2022
 set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\2022"
@@ -63,26 +99,34 @@ for %%E in (Preview Enterprise Professional Community BuildTools) do (
         goto :report_success
     )
 )
-exit /b 1
+goto :report_failure
 
-:fallback_18
-set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\18"
-for %%E in (Insiders Enterprise Professional Community BuildTools) do (
+:fallback_current
+for /L %%N in (99,-1,18) do (
+    set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\%%N"
+    for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
+        if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+            set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+            set "FOUND_VIA=fallback"
+            goto :report_success
+        )
+    )
+)
+goto :report_failure
+
+:fallback_major
+set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\!VS_MAJOR_FOLDER!"
+for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
     if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
         set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
         set "FOUND_VIA=fallback"
         goto :report_success
     )
 )
-exit /b 1
+goto :report_failure
 
 :report_success
 if "!FOUND_MSBUILD_BIN:~-1!"=="\" set "FOUND_MSBUILD_BIN=!FOUND_MSBUILD_BIN:~0,-1!"
-
-set "VS_PRODUCT_LABEL="
-if /I "!VS_PROFILE!"=="2019" set "VS_PRODUCT_LABEL=Visual Studio 2019"
-if /I "!VS_PROFILE!"=="2022" set "VS_PRODUCT_LABEL=Visual Studio 2022"
-if /I "!VS_PROFILE!"=="18" set "VS_PRODUCT_LABEL=Visual Studio 2026"
 
 set "VS_EDITION="
 for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
@@ -113,3 +157,21 @@ echo   MSBuild version: !MSBUILD_TOOL_VERSION!
 echo(
 
 for %%P in ("!FOUND_MSBUILD_BIN!") do endlocal & set "msbuildpath=%%~P" & exit /b 0
+
+:report_failure
+echo(
+echo Unable to detect suitable environment.
+if /I "!VS_PROFILE!"=="2019" (
+    echo Check if Visual Studio 2019 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if /I "!VS_PROFILE!"=="2022" (
+    echo Check if Visual Studio 2022 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if /I "!VS_PROFILE!"=="current" (
+    echo Check if Visual Studio 2026 or later with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if defined VS_MAJOR_FOLDER (
+    set /a "VS_FAIL_YEAR=2008+!VS_MAJOR_FOLDER!"
+    echo Check if Visual Studio !VS_FAIL_YEAR! ^(major !VS_MAJOR_FOLDER!^) with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else (
+    echo Check that a supported Visual Studio install with MSBuild is available, or set MSBUILDPATH / MSBUILD_PATH.
+)
+echo(
+exit /b 1

--- a/Scripts/Common/find-msbuild.cmd
+++ b/Scripts/Common/find-msbuild.cmd
@@ -1,177 +1,253 @@
-@echo off
-setlocal EnableExtensions EnableDelayedExpansion
-REM Locate MSBuild for a Visual Studio generation.
-REM Usage: call "%~dp0find-msbuild.cmd" <2019|2022|current|latest|NN>
-REM   2019 / 2022     - pinned legacy generations
-REM   current / latest - newest install with MSBuild, major version 18 or later
-REM   NN              - pinned major folder (18, 19, 20, ...) for a specific yearly release
-REM Sets msbuildpath (directory containing MSBuild.exe). Exit 0 on success, 1 on failure.
-REM Override: set MSBUILDPATH or MSBUILD_PATH to the MSBuild\Current\Bin directory.
-
-set "VS_PROFILE=%~1"
-if not defined VS_PROFILE goto :report_failure
-if /I "!VS_PROFILE!"=="latest" set "VS_PROFILE=current"
-
-if defined MSBUILDPATH (
-    if exist "!MSBUILDPATH!\MSBuild.exe" (
-        set "FOUND_MSBUILD_BIN=!MSBUILDPATH!"
-        set "FOUND_VIA=override"
-        goto :report_success
-    )
-)
-if defined MSBUILD_PATH (
-    if exist "!MSBUILD_PATH!\MSBuild.exe" (
-        set "FOUND_MSBUILD_BIN=!MSBUILD_PATH!"
-        set "FOUND_VIA=override"
-        goto :report_success
-    )
-)
-
-set "VS_VERSION_ARG="
-set "FALLBACK_MODE="
-set "VS_PRODUCT_LABEL="
-set "VS_MAJOR_FOLDER="
-
-if /I "!VS_PROFILE!"=="2019" (
-    set "VS_VERSION_ARG=-version [16.0,17.0)"
-    set "FALLBACK_MODE=2019"
-    set "VS_PRODUCT_LABEL=Visual Studio 2019"
-)
-if /I "!VS_PROFILE!"=="2022" (
-    set "VS_VERSION_ARG=-version [17.0,18.0)"
-    set "FALLBACK_MODE=2022"
-    set "VS_PRODUCT_LABEL=Visual Studio 2022"
-)
-if /I "!VS_PROFILE!"=="current" (
-    set "VS_VERSION_ARG=-version [18.0,) -latest"
-    set "FALLBACK_MODE=current"
-    set "VS_PRODUCT_LABEL=Visual Studio (current)"
-)
-
-if not defined FALLBACK_MODE (
-    echo !VS_PROFILE!| findstr /r "^[0-9][0-9]*$" >nul
-    if not errorlevel 1 (
-        set "VS_MAJOR_FOLDER=!VS_PROFILE!"
-        set "FALLBACK_MODE=major"
-        set "VS_PRODUCT_LABEL=Visual Studio !VS_PROFILE!"
-    )
-)
-
-if not defined FALLBACK_MODE goto :report_failure
-
-if "!FALLBACK_MODE!"=="major" (
-    set /a "VS_MAJOR_NEXT=!VS_MAJOR_FOLDER!+1"
-    set "VS_VERSION_ARG=-version [!VS_MAJOR_FOLDER!.0,!VS_MAJOR_NEXT!.0) -latest"
-)
-
-set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-if exist "%VSWHERE%" if defined VS_VERSION_ARG (
-    for /f "usebackq tokens=* delims=" %%M in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\MSBuild.exe 2^>nul`) do (
-        set "FOUND_MSBUILD_BIN=%%~dpM"
-        set "FOUND_VIA=vswhere"
-        goto :report_success
-    )
-)
-
-if "!FALLBACK_MODE!"=="2019" goto :fallback_2019
-if "!FALLBACK_MODE!"=="2022" goto :fallback_2022
-if "!FALLBACK_MODE!"=="current" goto :fallback_current
-if "!FALLBACK_MODE!"=="major" goto :fallback_major
-goto :report_failure
-
-:fallback_2019
-set "VS_ROOT=%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
-for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
-    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
-        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
-        set "FOUND_VIA=fallback"
-        goto :report_success
-    )
-)
-goto :report_failure
-
-:fallback_2022
-set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\2022"
-for %%E in (Preview Enterprise Professional Community BuildTools) do (
-    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
-        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
-        set "FOUND_VIA=fallback"
-        goto :report_success
-    )
-)
-goto :report_failure
-
-:fallback_current
-for /L %%N in (99,-1,18) do (
-    set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\%%N"
-    for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
-        if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
-            set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
-            set "FOUND_VIA=fallback"
-            goto :report_success
-        )
-    )
-)
-goto :report_failure
-
-:fallback_major
-set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\!VS_MAJOR_FOLDER!"
-for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
-    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
-        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
-        set "FOUND_VIA=fallback"
-        goto :report_success
-    )
-)
-goto :report_failure
-
-:report_success
-if "!FOUND_MSBUILD_BIN:~-1!"=="\" set "FOUND_MSBUILD_BIN=!FOUND_MSBUILD_BIN:~0,-1!"
-
-set "VS_EDITION="
-for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
-    if not "!FOUND_MSBUILD_BIN:\%%E\MSBuild=!"=="!FOUND_MSBUILD_BIN!" set "VS_EDITION=%%E"
-)
-
-set "VS_DISPLAY_NAME="
-if /I "!FOUND_VIA!"=="vswhere" if exist "!VSWHERE!" if defined VS_VERSION_ARG (
-    for /f "usebackq tokens=* delims=" %%D in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -property displayName 2^>nul`) do (
-        if not defined VS_DISPLAY_NAME set "VS_DISPLAY_NAME=%%D"
-    )
-)
-
-set "MSBUILD_TOOL_VERSION=unknown"
-for /f "usebackq tokens=* delims=" %%V in (`"!FOUND_MSBUILD_BIN!\MSBuild.exe" -version -nologo 2^>nul`) do set "MSBUILD_TOOL_VERSION=%%V"
-
-echo(
-echo Using build tools:
-if defined VS_DISPLAY_NAME (
-    echo   Visual Studio: !VS_DISPLAY_NAME!
-) else if defined VS_EDITION (
-    echo   Visual Studio: !VS_PRODUCT_LABEL! !VS_EDITION!
-) else (
-    echo   Visual Studio: !VS_PRODUCT_LABEL!
-)
-echo   MSBuild path: !FOUND_MSBUILD_BIN!
-echo   MSBuild version: !MSBUILD_TOOL_VERSION!
-echo(
-
-for %%P in ("!FOUND_MSBUILD_BIN!") do endlocal & set "msbuildpath=%%~P" & exit /b 0
-
-:report_failure
-echo(
-echo Unable to detect suitable environment.
-if /I "!VS_PROFILE!"=="2019" (
-    echo Check if Visual Studio 2019 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
-) else if /I "!VS_PROFILE!"=="2022" (
-    echo Check if Visual Studio 2022 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
-) else if /I "!VS_PROFILE!"=="current" (
-    echo Check if Visual Studio 2026 or later with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
-) else if defined VS_MAJOR_FOLDER (
-    set /a "VS_FAIL_YEAR=2008+!VS_MAJOR_FOLDER!"
-    echo Check if Visual Studio !VS_FAIL_YEAR! ^(major !VS_MAJOR_FOLDER!^) with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
-) else (
-    echo Check that a supported Visual Studio install with MSBuild is available, or set MSBUILDPATH / MSBUILD_PATH.
-)
-echo(
-exit /b 1
+@echo off
+REM =============================================================================
+REM find-msbuild.cmd - Locate MSBuild for a Visual Studio toolset generation
+REM =============================================================================
+REM
+REM PURPOSE
+REM   Shared helper for all orchestration scripts under Scripts\Build\,
+REM   Scripts\VS2022\, and Scripts\Current\. Resolves the directory that contains
+REM   MSBuild.exe and assigns it to the caller's msbuildpath variable.
+REM
+REM USAGE (must be CALLed, not executed directly)
+REM   call "%~dp0find-msbuild.cmd" <profile>
+REM
+REM PROFILES
+REM   2019           Visual Studio 2019 only (Scripts\Build\ legacy toolset)
+REM   2022           Visual Studio 2022 only (Scripts\VS2022\)
+REM   current        Newest install with MSBuild, major version 18 or later
+REM   latest         Alias for current
+REM   NN             Pinned major install folder (18, 19, 20, ...) for one yearly
+REM                  release; vswhere range is [NN.0,(NN+1).0)
+REM
+REM DISCOVERY ORDER
+REM   1. MSBUILDPATH or MSBUILD_PATH when set (must point at MSBuild\Current\Bin)
+REM   2. vswhere.exe under %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\
+REM      (finds custom drives and non-default install locations)
+REM   3. Standard folder probing under %ProgramFiles% / %ProgramFiles(x86)%
+REM
+REM EXIT CODES
+REM   0  Success; msbuildpath is set in the caller environment
+REM   1  Failure; :report_failure prints guidance to stdout
+REM
+REM BATCH NOTES
+REM   - EnableDelayedExpansion is required for !VAR! inside blocks and for /f.
+REM   - Success uses "endlocal & set msbuildpath=..." so the path survives CALL.
+REM   - 2^>nul on for /f command lines escapes redirection for the child cmd.
+REM
+REM Related issue: https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788
+REM =============================================================================
+
+setlocal EnableExtensions EnableDelayedExpansion
+
+REM -----------------------------------------------------------------------------
+REM Argument / override handling
+REM -----------------------------------------------------------------------------
+
+set "VS_PROFILE=%~1"
+if not defined VS_PROFILE goto :report_failure
+if /I "!VS_PROFILE!"=="latest" set "VS_PROFILE=current"
+
+REM Explicit override: honour either env var name used in docs and CI.
+if defined MSBUILDPATH (
+    if exist "!MSBUILDPATH!\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!MSBUILDPATH!"
+        set "FOUND_VIA=override"
+        goto :report_success
+    )
+)
+if defined MSBUILD_PATH (
+    if exist "!MSBUILD_PATH!\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!MSBUILD_PATH!"
+        set "FOUND_VIA=override"
+        goto :report_success
+    )
+)
+
+REM -----------------------------------------------------------------------------
+REM Map profile -> vswhere version filter, fallback mode, and display label
+REM -----------------------------------------------------------------------------
+REM Visual Studio product version mapping (installer major -> marketing name):
+REM   16.x = VS 2019    folder: %ProgramFiles(x86)%\...\2019\
+REM   17.x = VS 2022    folder: %ProgramFiles%\...\2022\
+REM   18.x = VS 2026    folder: %ProgramFiles%\...\18\
+REM   19.x = VS 2027    folder: %ProgramFiles%\...\19\  (year = major + 2008)
+REM   ... yearly releases continue with numeric major folders under 18+
+
+set "VS_VERSION_ARG="
+set "FALLBACK_MODE="
+set "VS_PRODUCT_LABEL="
+set "VS_MAJOR_FOLDER="
+
+if /I "!VS_PROFILE!"=="2019" (
+    set "VS_VERSION_ARG=-version [16.0,17.0)"
+    set "FALLBACK_MODE=2019"
+    set "VS_PRODUCT_LABEL=Visual Studio 2019"
+)
+if /I "!VS_PROFILE!"=="2022" (
+    set "VS_VERSION_ARG=-version [17.0,18.0)"
+    set "FALLBACK_MODE=2022"
+    set "VS_PRODUCT_LABEL=Visual Studio 2022"
+)
+if /I "!VS_PROFILE!"=="current" (
+    REM Open upper bound: any major 18+; -latest picks the newest matching install.
+    set "VS_VERSION_ARG=-version [18.0,) -latest"
+    set "FALLBACK_MODE=current"
+    set "VS_PRODUCT_LABEL=Visual Studio (current)"
+)
+
+REM Pure numeric profile pins one major folder (18, 19, 20, ...).
+if not defined FALLBACK_MODE (
+    echo !VS_PROFILE!| findstr /r "^[0-9][0-9]*$" >nul
+    if not errorlevel 1 (
+        set "VS_MAJOR_FOLDER=!VS_PROFILE!"
+        set "FALLBACK_MODE=major"
+        set "VS_PRODUCT_LABEL=Visual Studio !VS_PROFILE!"
+    )
+)
+
+if not defined FALLBACK_MODE goto :report_failure
+
+REM Build vswhere range [N.0,(N+1).0) for pinned major profiles.
+if "!FALLBACK_MODE!"=="major" (
+    set /a "VS_MAJOR_NEXT=!VS_MAJOR_FOLDER!+1"
+    set "VS_VERSION_ARG=-version [!VS_MAJOR_FOLDER!.0,!VS_MAJOR_NEXT!.0) -latest"
+)
+
+REM -----------------------------------------------------------------------------
+REM Primary discovery: vswhere.exe
+REM -----------------------------------------------------------------------------
+REM The VS Installer registers every install path; vswhere reads that database so
+REM builds work when Visual Studio is not under the default Program Files tree.
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%VSWHERE%" if defined VS_VERSION_ARG (
+    for /f "usebackq tokens=* delims=" %%M in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\MSBuild.exe 2^>nul`) do (
+        REM %%~dpM is the Bin directory; may include a trailing backslash.
+        set "FOUND_MSBUILD_BIN=%%~dpM"
+        set "FOUND_VIA=vswhere"
+        goto :report_success
+    )
+)
+
+REM -----------------------------------------------------------------------------
+REM Fallback discovery: probe well-known install roots on the system drive
+REM -----------------------------------------------------------------------------
+REM Edition order prefers preview/insiders channels, then paid SKUs, then Build Tools.
+
+if "!FALLBACK_MODE!"=="2019" goto :fallback_2019
+if "!FALLBACK_MODE!"=="2022" goto :fallback_2022
+if "!FALLBACK_MODE!"=="current" goto :fallback_current
+if "!FALLBACK_MODE!"=="major" goto :fallback_major
+goto :report_failure
+
+:fallback_2019
+set "VS_ROOT=%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
+for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+goto :report_failure
+
+:fallback_2022
+set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\2022"
+for %%E in (Preview Enterprise Professional Community BuildTools) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+goto :report_failure
+
+:fallback_current
+REM Scan numeric majors 99..18 so future yearly folders (19, 20, ...) need no script change.
+for /L %%N in (99,-1,18) do (
+    set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\%%N"
+    for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
+        if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+            set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+            set "FOUND_VIA=fallback"
+            goto :report_success
+        )
+    )
+)
+goto :report_failure
+
+:fallback_major
+set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\!VS_MAJOR_FOLDER!"
+for %%E in (Insiders Enterprise Professional Community BuildTools Preview) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+goto :report_failure
+
+REM -----------------------------------------------------------------------------
+REM Success reporting and return to caller
+REM -----------------------------------------------------------------------------
+
+:report_success
+if "!FOUND_MSBUILD_BIN:~-1!"=="\" set "FOUND_MSBUILD_BIN=!FOUND_MSBUILD_BIN:~0,-1!"
+
+REM Derive edition from path when vswhere displayName is unavailable.
+set "VS_EDITION="
+for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
+    if not "!FOUND_MSBUILD_BIN:\%%E\MSBuild=!"=="!FOUND_MSBUILD_BIN!" set "VS_EDITION=%%E"
+)
+
+REM Prefer marketing displayName from vswhere (accurate for any install location).
+set "VS_DISPLAY_NAME="
+if /I "!FOUND_VIA!"=="vswhere" if exist "!VSWHERE!" if defined VS_VERSION_ARG (
+    for /f "usebackq tokens=* delims=" %%D in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -property displayName 2^>nul`) do (
+        if not defined VS_DISPLAY_NAME set "VS_DISPLAY_NAME=%%D"
+    )
+)
+
+REM MSBuild tool version (e.g. 18.7.8.x for VS 2026 toolset).
+set "MSBUILD_TOOL_VERSION=unknown"
+for /f "usebackq tokens=* delims=" %%V in (`"!FOUND_MSBUILD_BIN!\MSBuild.exe" -version -nologo 2^>nul`) do set "MSBUILD_TOOL_VERSION=%%V"
+
+echo(
+echo Using build tools:
+if defined VS_DISPLAY_NAME (
+    echo   Visual Studio: !VS_DISPLAY_NAME!
+) else if defined VS_EDITION (
+    echo   Visual Studio: !VS_PRODUCT_LABEL! !VS_EDITION!
+) else (
+    echo   Visual Studio: !VS_PRODUCT_LABEL!
+)
+echo   MSBuild path: !FOUND_MSBUILD_BIN!
+echo   MSBuild version: !MSBUILD_TOOL_VERSION!
+echo(
+
+REM endlocal restores caller setlocal state but "set msbuildpath=..." runs in caller scope.
+for %%P in ("!FOUND_MSBUILD_BIN!") do endlocal & set "msbuildpath=%%~P" & exit /b 0
+
+REM -----------------------------------------------------------------------------
+REM Failure reporting
+REM -----------------------------------------------------------------------------
+REM Messages are centralized here so individual build scripts only pause on error.
+
+:report_failure
+echo(
+echo Unable to detect suitable environment.
+if /I "!VS_PROFILE!"=="2019" (
+    echo Check if Visual Studio 2019 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if /I "!VS_PROFILE!"=="2022" (
+    echo Check if Visual Studio 2022 with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if /I "!VS_PROFILE!"=="current" (
+    echo Check if Visual Studio 2026 or later with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else if defined VS_MAJOR_FOLDER (
+    REM Marketing year for major >= 18: 18+2008=2026, 19+2008=2027, ...
+    set /a "VS_FAIL_YEAR=2008+!VS_MAJOR_FOLDER!"
+    echo Check if Visual Studio !VS_FAIL_YEAR! ^(major !VS_MAJOR_FOLDER!^) with MSBuild is installed, or set MSBUILDPATH / MSBUILD_PATH.
+) else (
+    echo Check that a supported Visual Studio install with MSBuild is available, or set MSBUILDPATH / MSBUILD_PATH.
+)
+echo(
+exit /b 1

--- a/Scripts/Common/find-msbuild.cmd
+++ b/Scripts/Common/find-msbuild.cmd
@@ -1,0 +1,115 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+REM Locate MSBuild for a Visual Studio generation.
+REM Usage: call "%~dp0find-msbuild.cmd" <2019|2022|18>
+REM Sets msbuildpath (directory containing MSBuild.exe). Exit 0 on success, 1 on failure.
+REM Override: set MSBUILDPATH or MSBUILD_PATH to the MSBuild\Current\Bin directory.
+
+set "VS_PROFILE=%~1"
+if not defined VS_PROFILE exit /b 1
+
+if defined MSBUILDPATH (
+    if exist "!MSBUILDPATH!\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!MSBUILDPATH!"
+        set "FOUND_VIA=override"
+        goto :report_success
+    )
+)
+if defined MSBUILD_PATH (
+    if exist "!MSBUILD_PATH!\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!MSBUILD_PATH!"
+        set "FOUND_VIA=override"
+        goto :report_success
+    )
+)
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%VSWHERE%" (
+    set "VS_VERSION_ARG="
+    if /I "!VS_PROFILE!"=="2019" set "VS_VERSION_ARG=-version [16.0,17.0)"
+    if /I "!VS_PROFILE!"=="2022" set "VS_VERSION_ARG=-version [17.0,18.0)"
+    if /I "!VS_PROFILE!"=="18" set "VS_VERSION_ARG=-version [18.0,19.0)"
+    if defined VS_VERSION_ARG (
+        for /f "usebackq tokens=* delims=" %%M in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -find MSBuild\Current\Bin\MSBuild.exe 2^>nul`) do (
+            set "FOUND_MSBUILD_BIN=%%~dpM"
+            set "FOUND_VIA=vswhere"
+            goto :report_success
+        )
+    )
+)
+
+if /I "!VS_PROFILE!"=="2019" goto :fallback_2019
+if /I "!VS_PROFILE!"=="2022" goto :fallback_2022
+if /I "!VS_PROFILE!"=="18" goto :fallback_18
+exit /b 1
+
+:fallback_2019
+set "VS_ROOT=%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
+for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+exit /b 1
+
+:fallback_2022
+set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\2022"
+for %%E in (Preview Enterprise Professional Community BuildTools) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+exit /b 1
+
+:fallback_18
+set "VS_ROOT=%ProgramFiles%\Microsoft Visual Studio\18"
+for %%E in (Insiders Enterprise Professional Community BuildTools) do (
+    if exist "!VS_ROOT!\%%E\MSBuild\Current\Bin\MSBuild.exe" (
+        set "FOUND_MSBUILD_BIN=!VS_ROOT!\%%E\MSBuild\Current\Bin"
+        set "FOUND_VIA=fallback"
+        goto :report_success
+    )
+)
+exit /b 1
+
+:report_success
+if "!FOUND_MSBUILD_BIN:~-1!"=="\" set "FOUND_MSBUILD_BIN=!FOUND_MSBUILD_BIN:~0,-1!"
+
+set "VS_PRODUCT_LABEL="
+if /I "!VS_PROFILE!"=="2019" set "VS_PRODUCT_LABEL=Visual Studio 2019"
+if /I "!VS_PROFILE!"=="2022" set "VS_PRODUCT_LABEL=Visual Studio 2022"
+if /I "!VS_PROFILE!"=="18" set "VS_PRODUCT_LABEL=Visual Studio 2026"
+
+set "VS_EDITION="
+for %%E in (Insiders Preview Enterprise Professional Community BuildTools) do (
+    if not "!FOUND_MSBUILD_BIN:\%%E\MSBuild=!"=="!FOUND_MSBUILD_BIN!" set "VS_EDITION=%%E"
+)
+
+set "VS_DISPLAY_NAME="
+if /I "!FOUND_VIA!"=="vswhere" if exist "!VSWHERE!" if defined VS_VERSION_ARG (
+    for /f "usebackq tokens=* delims=" %%D in (`"!VSWHERE!" !VS_VERSION_ARG! -products * -requires Microsoft.Component.MSBuild -property displayName 2^>nul`) do (
+        if not defined VS_DISPLAY_NAME set "VS_DISPLAY_NAME=%%D"
+    )
+)
+
+set "MSBUILD_TOOL_VERSION=unknown"
+for /f "usebackq tokens=* delims=" %%V in (`"!FOUND_MSBUILD_BIN!\MSBuild.exe" -version -nologo 2^>nul`) do set "MSBUILD_TOOL_VERSION=%%V"
+
+echo(
+echo Using build tools:
+if defined VS_DISPLAY_NAME (
+    echo   Visual Studio: !VS_DISPLAY_NAME!
+) else if defined VS_EDITION (
+    echo   Visual Studio: !VS_PRODUCT_LABEL! !VS_EDITION!
+) else (
+    echo   Visual Studio: !VS_PRODUCT_LABEL!
+)
+echo   MSBuild path: !FOUND_MSBUILD_BIN!
+echo   MSBuild version: !MSBUILD_TOOL_VERSION!
+echo(
+
+for %%P in ("!FOUND_MSBUILD_BIN!") do endlocal & set "msbuildpath=%%~P" & exit /b 0

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Canary release build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-canary.cmd
+++ b/Scripts/Current/build-canary.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/build-installer.cmd
+++ b/Scripts/Current/build-installer.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Installer package build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-installer.cmd
+++ b/Scripts/Current/build-installer.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-installer.cmd
+++ b/Scripts/Current/build-installer.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Long-term stable build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-lts.cmd
+++ b/Scripts/Current/build-lts.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/build-nightly-custom.cmd
+++ b/Scripts/Current/build-nightly-custom.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly custom-target build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-nightly-custom.cmd
+++ b/Scripts/Current/build-nightly-custom.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-nightly-custom.cmd
+++ b/Scripts/Current/build-nightly-custom.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly release build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/build-nightly.cmd
+++ b/Scripts/Current/build-nightly.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Stable release build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/build-stable.cmd
+++ b/Scripts/Current/build-stable.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Solution build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 pause
 goto exitbatch
 )

--- a/Scripts/Current/buildsolution.cmd
+++ b/Scripts/Current/buildsolution.cmd
@@ -3,34 +3,12 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
-goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
+)
 goto build
 
 :build

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -3,36 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
+echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 @echo Started: %date% %time%
 @echo:

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Debug configuration build using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/debug.cmd
+++ b/Scripts/Current/debug.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly rebuild using the Scripts/Current/ toolset (Visual Studio major 18+, profile "current").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin" goto vscurrentinsiders
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin" goto vscurrentent
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin" goto vscurrentpro
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin" goto vscurrentcom
-if exist "%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin" goto vscurrentbuild
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2026 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vscurrentinsiders
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Insiders\MSBuild\Current\Bin"
+)
 goto build
-
-:vscurrentent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vscurrentpro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin"
-goto build
-
-:vscurrentcom
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin"
-goto build
-
-:vscurrentbuild
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/Current/rebuild-build-nightly.cmd
+++ b/Scripts/Current/rebuild-build-nightly.cmd
@@ -3,9 +3,8 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 18
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" current
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2026 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/ModernBuild/General/AppState.cs
+++ b/Scripts/ModernBuild/General/AppState.cs
@@ -39,6 +39,16 @@ public sealed class AppState
     /// Gets or sets the path to the MSBuild executable.
     /// </summary>
     public string MsBuildPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the MSBuild tool version from <c>MSBuild.exe -version</c>.
+    /// </summary>
+    public string MsBuildToolVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the resolved Visual Studio product description for the MSBuild install.
+    /// </summary>
+    public string VsProductDescription { get; set; } = string.Empty;
     
     /// <summary>
     /// Gets or sets the project file path for the build operation.

--- a/Scripts/ModernBuild/General/BuildLogic.cs
+++ b/Scripts/ModernBuild/General/BuildLogic.cs
@@ -318,13 +318,20 @@ internal static class BuildLogic
             return null;
         }
 
-        string productLine = parts[0] switch
+        string productLine;
+        if (int.TryParse(parts[0], out int major) && major >= 18)
         {
-            "18"   => "Visual Studio 2026",
-            "2022" => "Visual Studio 2022",
-            "2019" => "Visual Studio 2019",
-            _      => $"Visual Studio {parts[0]}"
-        };
+            productLine = $"Visual Studio {major + 2008}";
+        }
+        else
+        {
+            productLine = parts[0] switch
+            {
+                "2022" => "Visual Studio 2022",
+                "2019" => "Visual Studio 2019",
+                _      => $"Visual Studio {parts[0]}"
+            };
+        }
 
         return $"{productLine} {parts[1]}";
     }
@@ -413,7 +420,7 @@ internal static class BuildLogic
             {
                 return ScriptProfile.VS2022;
             }
-            if (msBuildPath.IndexOf("\\Microsoft Visual Studio\\18\\", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (IsCurrentGenerationMsBuildPath(msBuildPath))
             {
                 return ScriptProfile.Current;
             }
@@ -421,6 +428,29 @@ internal static class BuildLogic
 
         // Default auto preference to Current for forward-compatible setups.
         return ScriptProfile.Current;
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="msBuildPath"/> is under a yearly Visual Studio install (major 18+).
+    /// </summary>
+    private static bool IsCurrentGenerationMsBuildPath(string msBuildPath)
+    {
+        const string marker = "\\Microsoft Visual Studio\\";
+        int markerIndex = msBuildPath.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return false;
+        }
+
+        string remainder = msBuildPath.Substring(markerIndex + marker.Length);
+        int slashIndex = remainder.IndexOf('\\');
+        if (slashIndex <= 0)
+        {
+            return false;
+        }
+
+        string folder = remainder.Substring(0, slashIndex);
+        return int.TryParse(folder, out int major) && major >= 18;
     }
 
     /// <summary>

--- a/Scripts/ModernBuild/General/BuildLogic.cs
+++ b/Scripts/ModernBuild/General/BuildLogic.cs
@@ -152,6 +152,17 @@ internal static class BuildLogic
     /// <exception cref="InvalidOperationException">Thrown when MSBuild.exe cannot be found.</exception>
     internal static string LocateMSBuildExecutable()
     {
+        string? overridePath = Environment.GetEnvironmentVariable("MSBUILDPATH")
+            ?? Environment.GetEnvironmentVariable("MSBUILD_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            string overrideExe = Path.Combine(overridePath.TrimEnd('\\', '/'), "MSBuild.exe");
+            if (File.Exists(overrideExe))
+            {
+                return overrideExe;
+            }
+        }
+
         try
         {
             string vswhere = Path.Combine(
@@ -180,21 +191,142 @@ internal static class BuildLogic
         }
         catch {}
 
-        string[] candidates = new[]
+        string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        string[] roots =
         {
-            "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe",
-            "C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe",
-            "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
+            Path.Combine(programFiles, @"Microsoft Visual Studio\18"),
+            Path.Combine(programFiles, @"Microsoft Visual Studio\2022")
         };
+        string[] editions = { "Insiders", "Preview", "Enterprise", "Professional", "Community", "BuildTools" };
 
-        foreach (string c in candidates)
+        foreach (string root in roots)
         {
-            if (File.Exists(c))
+            foreach (string edition in editions)
             {
-                return c;
+                string candidate = Path.Combine(root, edition, @"MSBuild\Current\Bin\MSBuild.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
             }
         }
+
         throw new InvalidOperationException("Could not find MSBuild.exe. Please ensure Visual Studio 2022 is installed.");
+    }
+
+    /// <summary>
+    /// Returns the MSBuild tool version reported by <c>MSBuild.exe -version</c>.
+    /// </summary>
+    /// <param name="msBuildExecutablePath">Full path to MSBuild.exe.</param>
+    /// <returns>The version string, or <c>unknown</c> when it cannot be read.</returns>
+    internal static string GetMSBuildToolVersion(string msBuildExecutablePath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = msBuildExecutablePath,
+                Arguments = "-version -nologo",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+            using var p = Process.Start(psi)!;
+            string? version = p.StandardOutput.ReadLine();
+            p.WaitForExit(3000);
+            return string.IsNullOrWhiteSpace(version) ? "unknown" : version.Trim();
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+
+    /// <summary>
+    /// Describes the Visual Studio installation that owns the given MSBuild executable.
+    /// </summary>
+    /// <param name="msBuildExecutablePath">Full path to MSBuild.exe.</param>
+    /// <returns>A display name such as <c>Visual Studio Enterprise 2026</c>.</returns>
+    internal static string DescribeVisualStudioInstallation(string msBuildExecutablePath)
+    {
+        string? fromVswhere = TryGetVisualStudioDisplayName(msBuildExecutablePath);
+        if (!string.IsNullOrWhiteSpace(fromVswhere))
+        {
+            return fromVswhere;
+        }
+
+        return DescribeVisualStudioFromPath(msBuildExecutablePath) ?? "Visual Studio";
+    }
+
+    private static string? TryGetVisualStudioDisplayName(string msBuildExecutablePath)
+    {
+        try
+        {
+            string vswhere = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Microsoft Visual Studio",
+                "Installer",
+                "vswhere.exe");
+            if (!File.Exists(vswhere))
+            {
+                return null;
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = vswhere,
+                Arguments = "-products * -requires Microsoft.Component.MSBuild -property installationPath -property displayName",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+            using var p = Process.Start(psi)!;
+            string output = p.StandardOutput.ReadToEnd();
+            p.WaitForExit(3000);
+
+            string[] lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i + 1 < lines.Length; i += 2)
+            {
+                string installPath = lines[i].Trim().TrimEnd('\\');
+                string displayName = lines[i + 1].Trim();
+                if (msBuildExecutablePath.StartsWith(installPath, StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(displayName))
+                {
+                    return displayName;
+                }
+            }
+        }
+        catch {}
+
+        return null;
+    }
+
+    private static string? DescribeVisualStudioFromPath(string msBuildExecutablePath)
+    {
+        string normalized = msBuildExecutablePath.Replace('/', '\\');
+        const string marker = @"\Microsoft Visual Studio\";
+        int markerIndex = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        string remainder = normalized.Substring(markerIndex + marker.Length);
+        string[] parts = remainder.Split('\\');
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        string productLine = parts[0] switch
+        {
+            "18"   => "Visual Studio 2026",
+            "2022" => "Visual Studio 2022",
+            "2019" => "Visual Studio 2019",
+            _      => $"Visual Studio {parts[0]}"
+        };
+
+        return $"{productLine} {parts[1]}";
     }
 
     /// <summary>

--- a/Scripts/ModernBuild/General/BuildLogic.cs
+++ b/Scripts/ModernBuild/General/BuildLogic.cs
@@ -144,14 +144,21 @@ internal static class BuildLogic
     }
 
     /// <summary>
-    /// Locates the MSBuild executable on the system.
-    /// First attempts to use vswhere.exe to find the latest Visual Studio installation,
-    /// then falls back to common installation paths for Visual Studio 2022.
+    /// Locates the MSBuild executable on the system for ModernBuild.
     /// </summary>
-    /// <returns>The full path to the MSBuild executable.</returns>
+    /// <remarks>
+    /// Discovery order mirrors <c>Scripts/Common/find-msbuild.cmd</c>:
+    /// <list type="number">
+    /// <item><description><c>MSBUILDPATH</c> / <c>MSBUILD_PATH</c> override</description></item>
+    /// <item><description><c>vswhere.exe -latest</c> with the MSBuild workload</description></item>
+    /// <item><description>Fallback paths under <c>%ProgramFiles%</c> for VS 18 and VS 2022 editions</description></item>
+    /// </list>
+    /// </remarks>
+    /// <returns>The full path to <c>MSBuild.exe</c>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when MSBuild.exe cannot be found.</exception>
     internal static string LocateMSBuildExecutable()
     {
+        // Same override names as the batch helper (Scripts/Common/find-msbuild.cmd).
         string? overridePath = Environment.GetEnvironmentVariable("MSBUILDPATH")
             ?? Environment.GetEnvironmentVariable("MSBUILD_PATH");
         if (!string.IsNullOrWhiteSpace(overridePath))
@@ -165,6 +172,7 @@ internal static class BuildLogic
 
         try
         {
+            // vswhere ships with the Visual Studio Installer and resolves custom install paths.
             string vswhere = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
                 "Microsoft Visual Studio",
@@ -191,6 +199,7 @@ internal static class BuildLogic
         }
         catch {}
 
+        // Last resort: default Program Files layout (does not cover custom drives without vswhere).
         string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         string[] roots =
         {
@@ -211,7 +220,7 @@ internal static class BuildLogic
             }
         }
 
-        throw new InvalidOperationException("Could not find MSBuild.exe. Please ensure Visual Studio 2022 is installed.");
+        throw new InvalidOperationException("Could not find MSBuild.exe. Please ensure Visual Studio 2022 or later is installed.");
     }
 
     /// <summary>
@@ -272,6 +281,7 @@ internal static class BuildLogic
                 return null;
             }
 
+            // vswhere emits installationPath and displayName as alternating lines per instance.
             var psi = new ProcessStartInfo
             {
                 FileName = vswhere,
@@ -289,6 +299,7 @@ internal static class BuildLogic
             {
                 string installPath = lines[i].Trim().TrimEnd('\\');
                 string displayName = lines[i + 1].Trim();
+                // Match the install that owns this MSBuild.exe (works for any drive letter).
                 if (msBuildExecutablePath.StartsWith(installPath, StringComparison.OrdinalIgnoreCase)
                     && !string.IsNullOrWhiteSpace(displayName))
                 {
@@ -301,6 +312,9 @@ internal static class BuildLogic
         return null;
     }
 
+    /// <summary>
+    /// Builds a human-readable product name from the MSBuild path when vswhere is unavailable.
+    /// </summary>
     private static string? DescribeVisualStudioFromPath(string msBuildExecutablePath)
     {
         string normalized = msBuildExecutablePath.Replace('/', '\\');
@@ -311,6 +325,7 @@ internal static class BuildLogic
             return null;
         }
 
+        // Path shape: ...\Microsoft Visual Studio\<folder>\<edition>\MSBuild\Current\Bin\MSBuild.exe
         string remainder = normalized.Substring(markerIndex + marker.Length);
         string[] parts = remainder.Split('\\');
         if (parts.Length < 2)
@@ -321,6 +336,8 @@ internal static class BuildLogic
         string productLine;
         if (int.TryParse(parts[0], out int major) && major >= 18)
         {
+            // Yearly releases from VS 2026 onward use numeric major folders (18, 19, 20, ...).
+            // Marketing year aligns with major + 2008 (18 -> 2026, 19 -> 2027).
             productLine = $"Visual Studio {major + 2008}";
         }
         else
@@ -416,10 +433,12 @@ internal static class BuildLogic
 
         if (!string.IsNullOrWhiteSpace(msBuildPath))
         {
+            // Fixed marketing folder for VS 2022 scripts.
             if (msBuildPath.IndexOf("\\Microsoft Visual Studio\\2022\\", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return ScriptProfile.VS2022;
             }
+            // Yearly installs use numeric majors (18, 19, 20, ...) under Scripts/Current/.
             if (IsCurrentGenerationMsBuildPath(msBuildPath))
             {
                 return ScriptProfile.Current;
@@ -433,6 +452,10 @@ internal static class BuildLogic
     /// <summary>
     /// Returns true when <paramref name="msBuildPath"/> is under a yearly Visual Studio install (major 18+).
     /// </summary>
+    /// <remarks>
+    /// Folder examples: <c>\Microsoft Visual Studio\18\</c>, <c>\19\</c>, <c>\20\</c>.
+    /// Used by Auto profile resolution so new yearly releases map to Scripts/Current/ without code changes.
+    /// </remarks>
     private static bool IsCurrentGenerationMsBuildPath(string msBuildPath)
     {
         const string marker = "\\Microsoft Visual Studio\\";

--- a/Scripts/ModernBuild/General/BuildUI.cs
+++ b/Scripts/ModernBuild/General/BuildUI.cs
@@ -1217,7 +1217,9 @@ public static class BuildUI
 
         AddKV("Project", TrimScriptsPath(state.ProjectFile));
         AddKV("Scripts", FormatScriptProfile(state));
+        AddKV("Visual Studio", state.VsProductDescription);
         AddKV("MSBuild", state.MsBuildPath);
+        AddKV("MSBuild version", state.MsBuildToolVersion);
 
         AddKV("Text Log", TrimLogsPath(Path.Combine(state.RootPath, "Logs", prefix + "-build-summary.log")));
         AddKV("BinLog", TrimLogsPath(Path.Combine(state.RootPath, "Logs", prefix + "-build.binlog")));

--- a/Scripts/ModernBuild/Program.cs
+++ b/Scripts/ModernBuild/Program.cs
@@ -26,6 +26,8 @@ internal static class Program
         // Initialize the Terminal.Gui framework
         Application.Init();
 
+        // Resolve MSBuild once at startup (vswhere, override env vars, then Program Files fallback).
+        // Toolset metadata is shown in the Build Settings panel before any build runs.
         string msBuildPath = BuildLogic.LocateMSBuildExecutable();
 
         // Create and initialize the application state with default values

--- a/Scripts/ModernBuild/Program.cs
+++ b/Scripts/ModernBuild/Program.cs
@@ -26,6 +26,8 @@ internal static class Program
         // Initialize the Terminal.Gui framework
         Application.Init();
 
+        string msBuildPath = BuildLogic.LocateMSBuildExecutable();
+
         // Create and initialize the application state with default values
         var state = new AppState
         {
@@ -38,7 +40,9 @@ internal static class Program
             // Discover the repository root directory
             RootPath = BuildLogic.FindRepoRoot(),
             // Locate the MSBuild executable on the system
-            MsBuildPath = BuildLogic.LocateMSBuildExecutable(),
+            MsBuildPath = msBuildPath,
+            MsBuildToolVersion = BuildLogic.GetMSBuildToolVersion(msBuildPath),
+            VsProductDescription = BuildLogic.DescribeVisualStudioInstallation(msBuildPath),
             // Set initial tail buffer size for output display
             TailLines = 200
         };

--- a/Scripts/ModernBuild/README.md
+++ b/Scripts/ModernBuild/README.md
@@ -17,7 +17,8 @@ ModernBuild uses `Terminal.Gui` and runs `MSBuild.exe` and `nuget.exe` under the
 
 - Windows 10/11
 - Visual Studio with MSBuild (VS2022 and newer supported)
-  - ModernBuild uses `vswhere.exe` to locate MSBuild and falls back to common VS2022 paths
+  - ModernBuild uses `vswhere.exe` to locate MSBuild and falls back to `%ProgramFiles%` install paths
+  - Batch build scripts share `Scripts/Common/find-msbuild.cmd`; set `MSBUILDPATH` or `MSBUILD_PATH` to override
 - `nuget.exe` available on PATH for NuGet operations
   - Example download: `https://dist.nuget.org/win-x86-commandline/latest/nuget.exe`
 
@@ -63,7 +64,7 @@ Use `Debug` instead of `Release` when you built a Debug configuration, and subst
 ### UI layout
 
 - Tasks (top-left): hotkeys and current selections
-- Build Settings (left): resolved project file, scripts profile, MSBuild path, logs
+- Build Settings (left): resolved project file, scripts profile, Visual Studio product, MSBuild path, MSBuild version, logs
 - Live Output (right): streaming MSBuild/NuGet output
 - Summary (bottom): tail summary of the last run
 

--- a/Scripts/ModernBuild/README.md
+++ b/Scripts/ModernBuild/README.md
@@ -84,7 +84,7 @@ Use `Debug` instead of `Release` when you built a Debug configuration, and subst
 In Auto mode, ModernBuild chooses an effective profile from the detected MSBuild path:
 
 - MSBuild path containing `\Microsoft Visual Studio\2022\` -> `VS2022`
-- MSBuild path containing `\Microsoft Visual Studio\18\` -> `Current`
+- MSBuild path under `\Microsoft Visual Studio\<major>\` where `<major>` is 18 or higher -> `Current`
 - otherwise defaults to `Current`
 
 Special case:

--- a/Scripts/VS2022/build-canary.cmd
+++ b/Scripts/VS2022/build-canary.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-canary.cmd
+++ b/Scripts/VS2022/build-canary.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Canary release build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-canary.cmd
+++ b/Scripts/VS2022/build-canary.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/build-installer.cmd
+++ b/Scripts/VS2022/build-installer.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-installer.cmd
+++ b/Scripts/VS2022/build-installer.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/build-installer.cmd
+++ b/Scripts/VS2022/build-installer.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Installer package build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-lts.cmd
+++ b/Scripts/VS2022/build-lts.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-lts.cmd
+++ b/Scripts/VS2022/build-lts.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Long-term stable build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-lts.cmd
+++ b/Scripts/VS2022/build-lts.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/build-nightly-custom.cmd
+++ b/Scripts/VS2022/build-nightly-custom.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly custom-target build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-nightly-custom.cmd
+++ b/Scripts/VS2022/build-nightly-custom.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-nightly-custom.cmd
+++ b/Scripts/VS2022/build-nightly-custom.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/build-nightly.cmd
+++ b/Scripts/VS2022/build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly release build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-stable.cmd
+++ b/Scripts/VS2022/build-stable.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Stable release build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/build-stable.cmd
+++ b/Scripts/VS2022/build-stable.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/build-stable.cmd
+++ b/Scripts/VS2022/build-stable.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -1,4 +1,6 @@
 echo off
+REM Interactive solution build: VS 2019 (profile "2019") or VS 2022 (profile "2022") via user prompt.
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd at :vs2019build and :vs2022build. Failure text from the helper.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -12,7 +12,6 @@ if /I "%INPUT%"=="2022" goto vs2022build
 :vs2019build
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
 pause
 goto exitbatch
 )
@@ -29,7 +28,7 @@ REM /m: multi-processor MSBuild (all logical CPUs).
 :vs2022build
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
+pause
 goto exitbatch
 )
 goto build2022

--- a/Scripts/VS2022/buildsolution.cmd
+++ b/Scripts/VS2022/buildsolution.cmd
@@ -10,36 +10,12 @@ if /I "%INPUT%"=="2019" goto vs2019build
 if /I "%INPUT%"=="2022" goto vs2022build
 
 :vs2019build
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2019
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
 pause
-
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
-goto build2019
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build2019
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build2019
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build2019
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
+)
 goto build2019
 
 :build2019
@@ -51,34 +27,11 @@ REM /m: multi-processor MSBuild (all logical CPUs).
 "%msbuildpath%\msbuild.exe" /m /t:%targets% "%SCRIPT_DIR%build.proj" /fl /flp:logfile="%SCRIPT_DIR%..\..\Logs\solution-build-log.log" /bl:"%SCRIPT_DIR%..\..\Logs\solution-build-log.binlog" /clp:Summary;ShowTimestamp /v:quiet
 
 :vs2022build
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 goto exitbatch
-pause
-
-:vs17prev
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
-goto build2022
-
-:vs17ent
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin
-goto build2022
-
-:vs17pro
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin
-goto build2022
-
-:vs17com
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin
-goto build2022
-
-:vs17build
-set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin
+)
 goto build2022
 
 :build2022

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin" goto vs16prev
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" goto vs16ent
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" goto vs16pro
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" goto vs16com
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
-
-echo "Unable to detect suitable environment. Check if VS 2019 is installed."
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
+echo "Unable to detect suitable environment. Check if VS 2022 is installed."
+echo.
 pause
 goto exitbatch
-
-:vs16prev
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin
+)
 goto build
-
-:vs16ent
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin
-goto build
-
-:vs16pro
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin
-goto build
-
-:vs16com
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin
-goto build
-
-:vs16build
-set msbuildpath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
-goto build
-
 :build
 @echo Started: %date% %time%
 @echo

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/debug.cmd
+++ b/Scripts/VS2022/debug.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Debug configuration build using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -5,7 +5,6 @@ pushd "%SCRIPT_DIR%"
 
 call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
 if errorlevel 1 (
-echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 echo.
 pause
 goto exitbatch

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -3,37 +3,14 @@ setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"
 
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin" goto vs17prev
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin" goto vs17ent
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin" goto vs17pro
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin" goto vs17com
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
-
+call "%SCRIPT_DIR%..\Common\find-msbuild.cmd" 2022
+if errorlevel 1 (
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
-
+echo.
 pause
 goto exitbatch
-
-:vs17prev
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+)
 goto build
-
-:vs17ent
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-goto build
-
-:vs17pro
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-goto build
-
-:vs17com
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-goto build
-
-:vs17build
-set "msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
-goto build
-
 :build
 for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
     set "zone=%%A"

--- a/Scripts/VS2022/rebuild-build-nightly.cmd
+++ b/Scripts/VS2022/rebuild-build-nightly.cmd
@@ -1,4 +1,6 @@
 @echo off
+REM Nightly rebuild using the Scripts/VS2022/ toolset (Visual Studio 2022, profile "2022").
+REM MSBuild discovery: Scripts\Common\find-msbuild.cmd. Failure text comes from the helper; this script only pauses.
 setlocal EnableExtensions
 set "SCRIPT_DIR=%~dp0"
 pushd "%SCRIPT_DIR%"


### PR DESCRIPTION
# Allow build scripts to find Visual Studio (#3788)

## Summary

- Adds `Scripts/Common/find-msbuild.cmd` so batch build scripts locate MSBuild via `vswhere.exe`, with `%ProgramFiles%` fallback and `MSBUILDPATH` / `MSBUILD_PATH` overrides.
- Replaces duplicated per-edition path probing in **26** orchestration `.cmd` files under `Scripts/VS2022/`, `Scripts/Current/`, and `Scripts/Build/`.
- Prints resolved **Visual Studio product**, **MSBuild path**, and **MSBuild version** at script startup.
- Aligns **ModernBuild** discovery (no hard-coded `C:\` fallback paths; UI shows Visual Studio product and MSBuild version).
- Updates **Contributing** build documentation, `AGENTS.md`, `Scripts/ModernBuild/README.md`, and changelog.

Fixes custom and non-system-drive Visual Studio installs (e.g. `A:\Program Files\Microsoft Visual Studio\18\...`) that the previous `%ProgramFiles%\Microsoft Visual Studio\...` probes could miss.

Closes #3788

## Changes

### Build scripts

| Area | Change |
|------|--------|
| `Scripts/Common/find-msbuild.cmd` | **New** shared helper; profiles `2019`, `2022`, `18` | | `Scripts/VS2022/*.cmd` | Call helper with profile `2022` | | `Scripts/Current/*.cmd` | Call helper with profile `18` | | `Scripts/Build/*.cmd` | Call helper with profile `2019` (or `18` for `rebuild-build-nightly.cmd`) | | `buildsolution.cmd` | Interactive scripts call helper per selected VS generation |

Discovery order: override env vars → `vswhere` (version-scoped) → standard install folders.

### ModernBuild

| File | Change |
|------|--------|
| `Scripts/ModernBuild/General/BuildLogic.cs` | `MSBUILDPATH` / `MSBUILD_PATH` support; `%ProgramFiles%` fallback; `GetMSBuildToolVersion`; `DescribeVisualStudioInstallation` | | `Scripts/ModernBuild/General/AppState.cs` | `MsBuildToolVersion`, `VsProductDescription` | | `Scripts/ModernBuild/Program.cs` | Populate new state at startup | | `Scripts/ModernBuild/General/BuildUI.cs` | Build Settings shows Visual Studio + MSBuild version |

### Documentation

| File | Change |
|------|--------|
| `AGENTS.md` | Documents `find-msbuild.cmd` and overrides | | `Scripts/ModernBuild/README.md` | Discovery and UI fields | | `Documents/Changelog/Changelog.md` | #3788 entry | | `Documents/Development/Contributing/Build System/BuildScripts.md` | MSBuild discovery section; updated patterns and troubleshooting | | `Documents/Development/Contributing/Build System/Troubleshooting.md` | VS/MSBuild not detected (vswhere, profiles, overrides) | | `Documents/Development/Contributing/Build System/ModernBuildTool.md` | UI and prerequisites | | `Documents/Development/Contributing/Build System/BuildSystemOverview.md` | Prerequisites per script folder | | `Documents/Development/Contributing/BuildSystemDocumentationIndex.md` | Index bullet | | `Documents/Development/Contributing/HowtoBuild.md` | Script folder / discovery note |

## Behaviour

**Successful detection** (example from a non-`C:` install):

```text
Using build tools:
  Visual Studio: Visual Studio Enterprise 2026
  MSBuild path: A:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin
  MSBuild version: 18.7.8.30822
```

**Override** (optional):

```cmd
set MSBUILDPATH=D:\DevTools\VS2022\MSBuild\Current\Bin
Scripts\VS2022\build-stable.cmd
```

**CI**: Unchanged — GitHub Actions use `microsoft/setup-msbuild@v3` and invoke `msbuild` on PATH.

## Test plan

- [ ] Run `Scripts\Common\find-msbuild.cmd` via `call` for profiles `2019`, `2022`, and `18` on a machine with the matching VS generation installed; confirm exit code `0` and toolset summary output.
- [ ] Run `Scripts\Current\build-stable.cmd` (or another Current script) when VS 2026 is on a non-system drive; confirm MSBuild is found and build proceeds.
- [ ] Run `Scripts\VS2022\build-stable.cmd` when only VS 2022 is installed; confirm profile `2022` is selected (not a newer install).
- [ ] Set `MSBUILDPATH` to a valid `MSBuild\Current\Bin` folder; confirm override is used and reported.
- [ ] Run ModernBuild; confirm Build Settings shows Visual Studio product, MSBuild path, and MSBuild version.
- [ ] Confirm failure path still shows *Unable to detect suitable environment* when no matching VS/MSBuild is installed for the script folder profile.

## Notes

- `Scripts/VS2022/debug.cmd` now uses profile `2022` (it previously probed VS 2019 paths).
- `buildsolution.cmd` behaviour is unchanged aside from discovery; `Scripts/Build/` still prompts for 2019 vs 2026, `Scripts/VS2022/` for 2019 vs 2022.