### PR TITLE
* Automatic update license years

### DIFF
--- a/.github/scripts/Update-LicenseYear.ps1
+++ b/.github/scripts/Update-LicenseYear.ps1
@@ -1,0 +1,108 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Updates the end year in Krypton "Modifications by Peter Wagner" license headers.
+
+.DESCRIPTION
+    Scans source and template files for license year ranges on lines containing
+    "Modifications by Peter Wagner" and sets the end year to the target year when
+    it is behind. Preserves UTF-8 BOM and existing line endings (CRLF/LF).
+
+.PARAMETER Year
+    The calendar year to use as the license end year. Defaults to the current year.
+
+.PARAMETER DryRun
+    Report files that would be updated without writing changes.
+#>
+param(
+    [int]$Year = (Get-Date).Year,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+$pattern = '(Modifications by Peter Wagner[^\r\n]*?)(\d{4})(\s*-\s*)(\d{4})'
+$extensions = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@('.cs', '.licenseheader', '.yml', '.yaml', '.md'),
+    [StringComparer]::OrdinalIgnoreCase
+)
+
+function Get-FileEncoding([byte[]]$Bytes) {
+    if ($Bytes.Length -ge 3 -and $Bytes[0] -eq 0xEF -and $Bytes[1] -eq 0xBB -and $Bytes[2] -eq 0xBF) {
+        return [System.Text.UTF8Encoding]::new($true), 3
+    }
+
+    return [System.Text.UTF8Encoding]::new($false), 0
+}
+
+function Test-ExcludedPath([string]$FullName) {
+    return $FullName -match '[\\/]bin[\\/]|[\\/]obj[\\/]|[\\/]Artefacts[\\/]|[\\/]\.git[\\/]'
+}
+
+$updatedFiles = 0
+
+Get-ChildItem -Path $repoRoot -Recurse -File | ForEach-Object {
+    $file = $_
+
+    if (Test-ExcludedPath $file.FullName) {
+        return
+    }
+
+    if (-not ($extensions.Contains($file.Extension) -or $file.Name -eq '.editorconfig')) {
+        return
+    }
+
+    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+    if ($bytes.Length -eq 0) {
+        return
+    }
+
+    $encoding, $bomSkip = Get-FileEncoding $bytes
+    $content = $encoding.GetString($bytes, $bomSkip, $bytes.Length - $bomSkip)
+
+    $newContent = [regex]::Replace($content, $pattern, {
+        param($Match)
+
+        $startYear = [int]$Match.Groups[2].Value
+        $separator = $Match.Groups[3].Value
+        $endYear = [int]$Match.Groups[4].Value
+
+        if ($endYear -ge $Year) {
+            return $Match.Value
+        }
+
+        return "$($Match.Groups[1].Value)$startYear$separator$Year"
+    })
+
+    if ($newContent -eq $content) {
+        return
+    }
+
+    $updatedFiles++
+    $relativePath = $file.FullName.Substring($repoRoot.Length).TrimStart('\', '/')
+
+    if ($DryRun) {
+        Write-Host "Would update: $relativePath"
+        return
+    }
+
+    $newBytes = $encoding.GetBytes($newContent)
+    if ($encoding.GetPreamble().Length -gt 0) {
+        [System.IO.File]::WriteAllBytes($file.FullName, $encoding.GetPreamble() + $newBytes)
+    }
+    else {
+        [System.IO.File]::WriteAllBytes($file.FullName, $newBytes)
+    }
+
+    Write-Host "Updated: $relativePath"
+}
+
+if ($DryRun) {
+    Write-Host "Dry run: $updatedFiles file(s) would be updated to end year $Year."
+}
+else {
+    Write-Host "Updated $updatedFiles file(s) to end year $Year."
+}
+
+Write-Output $updatedFiles

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -1,0 +1,85 @@
+# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+# Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, tobitege et al. 2026 - 2026. All rights reserved.
+#
+# Checks out alpha, bumps the end year in "Modifications by Peter Wagner" license headers,
+# and opens a pull request back into alpha.
+
+name: Update License Year
+
+on:
+  schedule:
+    # 06:00 UTC on 1 January each year
+    - cron: '0 6 1 1 *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview changes without modifying files or creating a PR'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-license-year:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout alpha
+        uses: actions/checkout@v6
+        with:
+          ref: alpha
+          fetch-depth: 0
+
+      - name: Update license header end year
+        id: update_year
+        shell: pwsh
+        run: |
+          $year = (Get-Date).Year
+          $dryRun = '${{ inputs.dry_run }}' -ieq 'true'
+          echo "year=$year" >> $env:GITHUB_OUTPUT
+          echo "dry_run=$($dryRun.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+
+          $scriptArgs = @{ Year = $year }
+          if ($dryRun) { $scriptArgs.DryRun = $true }
+
+          $updatedFiles = & "${{ github.workspace }}/.github/scripts/Update-LicenseYear.ps1" @scriptArgs
+          echo "updated_files=$updatedFiles" >> $env:GITHUB_OUTPUT
+
+          if ($dryRun) {
+            @"
+          ## License year dry run
+
+          - Target year: **$year**
+          - Files that would be updated: **$updatedFiles**
+          - No files were modified and no pull request was created.
+          "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+          }
+
+      - name: Create pull request into alpha
+        if: steps.update_year.outputs.dry_run != 'true' && steps.update_year.outputs.updated_files != '0'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: alpha
+          branch: automation/license-year-${{ steps.update_year.outputs.year }}
+          delete-branch: true
+          title: "chore: update license header end year to ${{ steps.update_year.outputs.year }}"
+          commit-message: "Update license header end year to ${{ steps.update_year.outputs.year }}"
+          body: |
+            Automated update of the end year in `Modifications by Peter Wagner` license headers.
+
+            - Target year: **${{ steps.update_year.outputs.year }}**
+            - Files updated: **${{ steps.update_year.outputs.updated_files }}**
+            - Base branch: **alpha**
+
+            *Triggered by the Update License Year workflow.*
+
+      - name: No changes required
+        if: steps.update_year.outputs.updated_files == '0'
+        run: |
+          if [ "${{ steps.update_year.outputs.dry_run }}" = "true" ]; then
+            echo "Dry run: all license headers already use end year ${{ steps.update_year.outputs.year }}."
+          else
+            echo "All license headers already use end year ${{ steps.update_year.outputs.year }}."
+          fi


### PR DESCRIPTION
## Summary

Adds an automated GitHub Actions workflow to keep Krypton license header end years current across the repository. The workflow checks out `alpha`, updates `Modifications by Peter Wagner` year ranges where the end year is behind the calendar year, and opens a pull request back into `alpha`.

## Changes

- **`.github/workflows/update-license-year.yml`** — new workflow
  - Scheduled: 1 January at 06:00 UTC
  - Manual: `workflow_dispatch` with optional **dry run** input
  - Creates PR on branch `automation/license-year-YYYY` targeting `alpha`
  - Skips PR creation when no files need updating
- **`.github/scripts/Update-LicenseYear.ps1`** — PowerShell script that:
  - Scans `*.cs`, `*.licenseheader`, `*.yml`, `*.yaml`, `*.md`, and `.editorconfig`
  - Matches lines containing `Modifications by Peter Wagner` with a `YYYY - YYYY` range
  - Bumps only the **end year** when it is less than the target year (e.g. `2025 - 2025` → `2025 - 2026`)
  - Leaves unrelated headers unchanged (e.g. Component Factory `2006 - 2016`, JDH `2013-2021`)
  - Preserves UTF-8 BOM and existing line endings (CRLF/LF)
  - Supports `-DryRun` to preview changes without writing files

## Example behaviour

| Current header | Target year | Result |
| --- | --- | --- |
| `2017 - 2025` | 2026 | `2017 - 2026` |
| `2025 - 2025` | 2026 | `2025 - 2026` |
| `2017 - 2026` | 2026 | unchanged |
| `2006 - 2016` (Component Factory) | 2026 | unchanged |

## Test plan

- [ ] Merge this PR into `alpha`
- [ ] Run **Actions → Update License Year → Run workflow** with **dry run** enabled
  - [ ] Confirm job summary reports the expected file count
  - [ ] Confirm log lines show `Would update: ...` and no files are committed
  - [ ] Confirm no PR is created
- [ ] Run the workflow again with **dry run** disabled
  - [ ] Confirm an `automation/license-year-YYYY` PR is opened against `alpha`
  - [ ] Spot-check updated `.licenseheader`, `.editorconfig`, and `.cs` files for correct year and preserved formatting
- [ ] Re-run the workflow (dry run or normal) when all headers are current
  - [ ] Confirm the job reports no changes and does not open a duplicate PR
- [ ] (Optional) Run locally: ```powershell pwsh -File .github/scripts/Update-LicenseYear.ps1 -Year 2026 -DryRun ```

## Notes

- The scheduled run on 1 January performs a real update and opens a PR; it does not use dry run.
- `GlobalStaticValues.cs` already uses `DateTime.Now.Year` for embedded license text and is unaffected by this workflow.
- First automated run after merge is expected to update remaining template files (e.g. `.licenseheader` files still on older end years).