### PR TITLE
3814-V85-DockingManagerStrings-has-a-few-flaws

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
+* Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Resolved [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), KContextMenu items overflow not visible
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages

--- a/Source/Krypton Components/Krypton.Docking/Palette/DockingManagerStrings.cs
+++ b/Source/Krypton Components/Krypton.Docking/Palette/DockingManagerStrings.cs
@@ -77,6 +77,7 @@ namespace Krypton.Docking
                                            _textDock.Equals(DEFAULT_TEXT_DOCK) &&
                                            _textFloat.Equals(DEFAULT_TEXT_FLOAT) &&
                                            _textHide.Equals(DEFAULT_TEXT_HIDE) &&
+                                           _textCloseAllButThis.Equals(DEFAULT_TEXT_CLOSE_ALL_BUT_THIS) &&
                                            _textTabbedDocument.Equals(DEFAULT_TEXT_TABBED_DOCUMENT) &&
                                            _textWindowLocation.Equals(DEFAULT_TEXT_WINDOW_LOCATION));
 
@@ -224,7 +225,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Resets the TextFloat property to its default value.
         /// </summary>
-        public void ResetTextFloat() => TextFloat = DEFAULT_TEXT_DOCK;
+        public void ResetTextFloat() => TextFloat = DEFAULT_TEXT_FLOAT;
         #endregion
 
         #region TextHide
@@ -253,7 +254,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Resets the TextHide property to its default value.
         /// </summary>
-        public void ResetTextHide() => TextHide = DEFAULT_TEXT_DOCK;
+        public void ResetTextHide() => TextHide = DEFAULT_TEXT_HIDE;
 
         #endregion
 


### PR DESCRIPTION
- Issue: #3814 
- Fixes three inconsistencies
- And the changelog

<img width="253" height="138" alt="image" src="https://github.com/user-attachments/assets/798106ba-e6c0-4f74-a476-90a2959e9781" />
