### PR TITLE
* Null reference in `KryptonToggleSwitch` (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3826](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3826), Null reference in `KryptonToggleSwitch` when the global palette changes
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Resolved [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`. Build scripts and ModernBuild locate MSBuild via `Scripts/Common/find-msbuild.cmd` and `vswhere.exe`, with `%ProgramFiles%` fallback and `MSBUILDPATH` / `MSBUILD_PATH` overrides for custom or non-system-drive Visual Studio installs
 * Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToggleSwitch.cs
@@ -191,13 +191,23 @@ public class KryptonToggleSwitch : Control, IContentValues
 
         ToggleSwitchValues = new ToggleSwitchValues { OffColor = Color.Red, OnColor = Color.Green };
 
+        // Cache the current global palette setting
+        _palette = KryptonManager.CurrentGlobalPalette;
+
+        // Hook into palette events
+        if (_palette != null)
+        {
+            _palette.PalettePaintInternal += OnPalettePaint;
+        }
+
+        // We want to be notified whenever the global palette changes
         KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
 
-        // Initialize PaletteRedirect with a default context
-        PaletteRedirect redirector = new PaletteRedirect(KryptonManager.CurrentGlobalPalette);
+        // Create a redirection to the base palette
+        _paletteRedirect = new PaletteRedirect(_palette);
 
         // Default state configuration
-        StateCommon = new PaletteTripleRedirect(redirector, PaletteBackStyle.ButtonStandalone, PaletteBorderStyle.ButtonStandalone, PaletteContentStyle.ButtonStandalone);
+        StateCommon = new PaletteTripleRedirect(_paletteRedirect, PaletteBackStyle.ButtonStandalone, PaletteBorderStyle.ButtonStandalone, PaletteContentStyle.ButtonStandalone);
         StateDisabled = new PaletteTriple(StateCommon, OnNeedPaintHandler);
         StateNormal = new PaletteTriple(StateCommon, OnNeedPaintHandler);
         StatePressed = new PaletteTriple(StateCommon, OnNeedPaintHandler);


### PR DESCRIPTION
Prevent NullReferenceException when the global palette changes by caching KryptonManager.CurrentGlobalPalette, creating a PaletteRedirect from the cached palette, and subscribing to its PalettePaintInternal event (with a null check). StateCommon now uses the new _paletteRedirect. Also added a changelog entry referencing #3826.