### PR TITLE
* Showing Tab ToolTips for Docking Pages (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829), Showing Tab ToolTips for Docking Pages
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Implemented [#880](https://github.com/Krypton-Suite/Standard-Toolkit/issues/880), Tree views, lists, button text colours _should_ not share the same values
 * Implemented [#3784](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3784), Optional pulsing border for `KryptonTextBox`, `KryptonMaskedTextBox`, `KryptonComboBox`, `KryptonRichTextBox`, `KryptonNumericUpDown`, `KryptonDomainUpDown`, `KryptonDateTimePicker`, `KryptonCalcInput`, `KryptonButton`, and `KryptonForm` via expandable `GlowingBorderValues` (Enable, Animate, `AnimationSpeed`, ShowWhen, `Style` as bottom-only or full border, and `Colors` with designer type converters); optional animated cue hint shimmer via `CueHint.Animate`, `CueHint.AnimationSpeed`, and `CueHint.HighlightColor`

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -478,7 +478,7 @@ public abstract class KryptonSpace : KryptonWorkspace
             cell.ToolTips.AllowButtonSpecToolTipPriority = false;
         }
 
-        cell.ToolTips.AllowPageToolTips = AllowPageToolTips;
+        cell.ToolTips.AllowPageToolTips = _allowPageToolTips;
 
         // Hook into cell specific events
         cell.ShowContextMenu += OnCellShowContextMenu;
@@ -1028,20 +1028,11 @@ public abstract class KryptonSpace : KryptonWorkspace
     {
         foreach (CachedCellState state in _lookupCellState.Values)
         {
-            if (state.DropDownButtonSpec != null)
-            {
-                state.DropDownButtonSpec.ToolTipTitle = DropDownTooltip;
-            }
+            state.DropDownButtonSpec?.ToolTipTitle = DropDownTooltip;
 
-            if (state.PinButtonSpec != null)
-            {
-                state.PinButtonSpec.ToolTipTitle = PinTooltip;
-            }
+            state.PinButtonSpec?.ToolTipTitle = PinTooltip;
 
-            if (state.CloseButtonSpec != null)
-            {
-                state.CloseButtonSpec.ToolTipTitle = CloseTooltip;
-            }
+            state.CloseButtonSpec?.ToolTipTitle = CloseTooltip;
         }
     }
 
@@ -1049,10 +1040,7 @@ public abstract class KryptonSpace : KryptonWorkspace
     {
         foreach (CachedCellState state in _lookupCellState.Values)
         {
-            if (state.Cell != null)
-            {
-                state.Cell.ToolTips.AllowPageToolTips = AllowPageToolTips;
-            }
+            state.Cell?.ToolTips.AllowPageToolTips = AllowPageToolTips;
         }
     }
     #endregion

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -71,6 +71,7 @@ public abstract class KryptonSpace : KryptonWorkspace
     private string _closeTooltip;
     private string _pinTooltip;
     private string _dropDownTooltip;
+    private bool _allowPageToolTips;
     private readonly string _storeName;
     #endregion
 
@@ -151,6 +152,7 @@ public abstract class KryptonSpace : KryptonWorkspace
         _closeTooltip = "Close";
         _pinTooltip = "Auto Hidden";
         _dropDownTooltip = "Window Position";
+        _allowPageToolTips = true;
         _storeName = storeName;
     }
 
@@ -227,7 +229,27 @@ public abstract class KryptonSpace : KryptonWorkspace
     }
 
     /// <summary>
-    /// Gets the button spec type for the pin button.
+    /// Gets and sets a value indicating if tooltips should be displayed for page tab headers.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should tooltips be displayed for page tab headers.")]
+    [DefaultValue(true)]
+    public bool AllowPageToolTips
+    {
+        get => _allowPageToolTips;
+
+        set
+        {
+            if (_allowPageToolTips != value)
+            {
+                _allowPageToolTips = value;
+                UpdatePageToolTips();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating if this space is hosting auto hidden content.
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -455,6 +477,8 @@ public abstract class KryptonSpace : KryptonWorkspace
             cell.ToolTips.AllowButtonSpecToolTips = true;
             cell.ToolTips.AllowButtonSpecToolTipPriority = false;
         }
+
+        cell.ToolTips.AllowPageToolTips = AllowPageToolTips;
 
         // Hook into cell specific events
         cell.ShowContextMenu += OnCellShowContextMenu;
@@ -1017,6 +1041,17 @@ public abstract class KryptonSpace : KryptonWorkspace
             if (state.CloseButtonSpec != null)
             {
                 state.CloseButtonSpec.ToolTipTitle = CloseTooltip;
+            }
+        }
+    }
+
+    private void UpdatePageToolTips()
+    {
+        foreach (CachedCellState state in _lookupCellState.Values)
+        {
+            if (state.Cell != null)
+            {
+                state.Cell.ToolTips.AllowPageToolTips = AllowPageToolTips;
             }
         }
     }

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
@@ -335,7 +335,11 @@ public class KryptonDockingManager : DockingElementOpenCollection
     {
         InitializeManager();
     }
-    #endregion    
+    #endregion
+
+    #region Instance Fields
+    private bool _allowPageToolTips = true;
+    #endregion
 
     #region Public
     /// <summary>
@@ -1392,6 +1396,26 @@ public class KryptonDockingManager : DockingElementOpenCollection
     /// </summary>
     [DefaultValue(typeof(DockingCloseRequest), "HidePage")]
     public DockingCloseRequest DefaultCloseRequest { get; set; }
+
+    /// <summary>
+    /// Gets and sets a value indicating if tooltips should be displayed for docking tab headers.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should tooltips be displayed for docking tab headers.")]
+    [DefaultValue(true)]
+    public bool AllowPageToolTips
+    {
+        get => _allowPageToolTips;
+
+        set
+        {
+            if (_allowPageToolTips != value)
+            {
+                _allowPageToolTips = value;
+                PropogateAction(DockingPropogateAction.StringChanged, null as string[]);
+            }
+        }
+    }
 
     /// <summary>
     /// Perform the close request for a set of named pages.

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
@@ -76,6 +76,8 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
             // Let base class perform standard processing
             base.Parent = value;
 
+            UpdatePageToolTips();
+
             // Generate event so that any dockable navigator customization can be performed.
             KryptonDockingManager? dockingManager = DockingManager;
             if (dockingManager != null)
@@ -526,6 +528,9 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
                 Console.WriteLine(GetType().ToString());
                 DockableNavigatorControl.DebugOutput();
                 break;
+            case DockingPropogateAction.StringChanged:
+                UpdatePageToolTips();
+                break;
         }
 
         // Let base class perform standard processing
@@ -920,6 +925,15 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
     #endregion
 
     #region Implementation
+    private void UpdatePageToolTips()
+    {
+        KryptonDockingManager? dockingManager = DockingManager;
+        if (dockingManager != null)
+        {
+            DockableNavigatorControl.ToolTips.AllowPageToolTips = dockingManager.AllowPageToolTips;
+        }
+    }
+
     private void OnDockableNavigatorDisposed(object? sender, EventArgs e)
     {
         // Unhook from events to prevent memory leaking

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -685,6 +685,7 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
                 SpaceControl.CloseTooltip = dockingManager.Strings.TextClose;
                 SpaceControl.PinTooltip = dockingManager.Strings.TextAutoHide;
                 SpaceControl.DropDownTooltip = dockingManager.Strings.TextWindowLocation;
+                SpaceControl.AllowPageToolTips = dockingManager.AllowPageToolTips;
             }
         }
     }

--- a/Source/Krypton Components/TestForm/DockingRedockDemo.cs
+++ b/Source/Krypton Components/TestForm/DockingRedockDemo.cs
@@ -26,7 +26,7 @@ public partial class DockingRedockDemo : KryptonForm
     {
         InitializeComponent();
         InitializeDocking();
-        UpdateStatus("Ready. Add a document, then undock (Float) and redock by dragging back.");
+        UpdateStatus("Ready. Add a document, hover tabs for tooltips, then undock (Float) and redock by dragging back.");
     }
 
     private void InitializeDocking()
@@ -44,6 +44,8 @@ public partial class DockingRedockDemo : KryptonForm
             Text = name,
             TextTitle = name,
             TextDescription = $"Document: {name}",
+            ToolTipTitle = name,
+            ToolTipBody = $"Document: {name} (hover the tab to verify docking page tooltips, Issue #3829)",
             UniqueName = $"Unique_{name}_{Guid.NewGuid():N}",
             MinimumSize = new Size(200, 200)
         };


### PR DESCRIPTION
# Show tab tooltips for docking pages (#3829)

## Summary

- Enable `KryptonPage` tab tooltips (`ToolTipTitle`, `ToolTipBody`, `ToolTipImage`) in Krypton Docking by default, without requiring apps to hook `KryptonWorkspaceCell` creation manually.
- Add `AllowPageToolTips` on `KryptonDockingManager` (default `true`) to opt out globally; changes propagate to all managed dockspaces, floatspaces, and dockable workspaces.
- Add matching `AllowPageToolTips` on `KryptonSpace` (default `true`) for per-space control in the designer; new and existing cells are updated when the value changes.

Closes [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829). Related discussion: [#3811](https://github.com/Krypton-Suite/Standard-Toolkit/discussions/3811).

## Problem

Setting `ToolTipBody` on a `KryptonPage` used in Krypton Docking did not show a tooltip when hovering a tab. Tab tooltips are controlled by `KryptonNavigator.ToolTips.AllowPageToolTips`, which defaults to `false`. Docking already enabled button-spec tooltips for docked panels but never enabled page tooltips.

The workaround from [#3811](https://github.com/Krypton-Suite/Standard-Toolkit/discussions/3811) required subscribing to workspace `Children.Inserted` and setting `cell.ToolTips.AllowPageToolTips = true` for each new `KryptonWorkspaceCell` — including for the managed dockable workspace, which does not apply docking tab appearance (`ApplyDockingAppearance => false`).

## Solution

1. **`KryptonSpace.NewCellInitialize`** — set `cell.ToolTips.AllowPageToolTips = AllowPageToolTips` for every docking cell (workspace, dockspace, floatspace, auto-hidden slide).
2. **`KryptonSpace.AllowPageToolTips`** — space-level property (default `true`); `UpdatePageToolTips()` refreshes all tracked cells when toggled.
3. **`KryptonDockingManager.AllowPageToolTips`** — manager-level property (default `true`); synced to spaces via existing `UpdateStrings()` when the docking hierarchy is attached or when the value changes (`StringChanged` propagation).
4. **`DockingRedockDemo`** — sample pages now set `ToolTipTitle` / `ToolTipBody` for manual verification.

Tooltips still only appear when the page has tooltip content (`PageToToolTipMapping.HasContent`). Pages without tooltip text are unchanged.

## API

```csharp
// Default — no code required; set page tooltip properties only
page.ToolTipTitle = "Editor";
page.ToolTipBody = "Main document editor";

// Opt out globally
kryptonDockingManager.AllowPageToolTips = false;

// Opt out per space (designer or code)
kryptonDockableWorkspace.AllowPageToolTips = false;
```

## Files changed

| File | Change |
|------|--------|
| `KryptonSpace.cs` | `AllowPageToolTips` property, cell init, live update of existing cells | | `KryptonDockingManager.cs` | `AllowPageToolTips` property with propagation | | `KryptonDockingSpace.cs` | Sync manager setting in `UpdateStrings()` | | `DockingRedockDemo.cs` | Tooltip repro on created pages | | `Documents/Changelog/Changelog.md` | V110 changelog entry |

## Test plan

- [ ] Run **TestForm** → open **Docking Redock Demo**
- [ ] Click **Add Document** (or **Add Multiple**)
- [ ] Hover workspace tabs — tooltip shows title/body from the page
- [ ] Right-click tab → **Float**; hover floating window tabs — tooltip still shows
- [ ] Redock by dragging back; confirm tooltips still work
- [ ] Set `kryptonDockingManager1.AllowPageToolTips = false` — tooltips no longer appear
- [ ] Set back to `true` — tooltips return on existing tabs without restarting
- [ ] Add a page with no `ToolTipBody` / `ToolTipTitle` — no tooltip on hover (no regression)

## Breaking changes

None. Behaviour is additive: docking tab tooltips are enabled by default where page tooltip content exists. Apps that relied on tooltips being absent can set `AllowPageToolTips = false` on the manager or individual space.

## TFM impact

`Krypton.Docking` only — all supported target frameworks (`net472` and later).