### PR TITLE
* Showing Tab ToolTips for Docking Pages (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829), Showing Tab ToolTips for Docking Pages
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Resolved [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`. Build scripts and ModernBuild locate MSBuild via `Scripts/Common/find-msbuild.cmd` and `vswhere.exe`, with `%ProgramFiles%` fallback and `MSBUILDPATH` / `MSBUILD_PATH` overrides for custom or non-system-drive Visual Studio installs
 * Resolved [#3767](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3767), Adjust the position and size of the buttons in the `KryptonMessageBox`

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -68,6 +68,7 @@ public abstract class KryptonSpace : KryptonWorkspace
     private bool _awaitingVisibleUpdate;
     private bool _pendingVisibleUpdateOnHandle;
     private bool _setFocus;
+    private bool _allowPageToolTips;
     private string _closeTooltip;
     private string _pinTooltip;
     private string _dropDownTooltip;
@@ -151,6 +152,7 @@ public abstract class KryptonSpace : KryptonWorkspace
         _closeTooltip = "Close";
         _pinTooltip = "Auto Hidden";
         _dropDownTooltip = "Window Position";
+        _allowPageToolTips = true;
         _storeName = storeName;
     }
 
@@ -175,6 +177,27 @@ public abstract class KryptonSpace : KryptonWorkspace
     #endregion
 
     #region Public
+
+    /// <summary>
+    /// Gets and sets a value indicating if tooltips should be displayed for page tab headers.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should tooltips be displayed for page tab headers.")]
+    [DefaultValue(true)]
+    public bool AllowPageToolTips
+    {
+        get => _allowPageToolTips;
+
+        set
+        {
+            if (_allowPageToolTips != value)
+            {
+                _allowPageToolTips = value;
+                UpdatePageToolTips();
+            }
+        }
+    }
+
     /// <summary>
     /// Gets and sets the tooltip used for the close button.
     /// </summary>
@@ -455,6 +478,8 @@ public abstract class KryptonSpace : KryptonWorkspace
             cell.ToolTips.AllowButtonSpecToolTips = true;
             cell.ToolTips.AllowButtonSpecToolTipPriority = false;
         }
+
+        cell.ToolTips.AllowPageToolTips = _allowPageToolTips;
 
         // Hook into cell specific events
         cell.ShowContextMenu += OnCellShowContextMenu;
@@ -1004,21 +1029,21 @@ public abstract class KryptonSpace : KryptonWorkspace
     {
         foreach (CachedCellState state in _lookupCellState.Values)
         {
-            if (state.DropDownButtonSpec != null)
-            {
-                state.DropDownButtonSpec.ToolTipTitle = DropDownTooltip;
-            }
+            state.DropDownButtonSpec?.ToolTipTitle = DropDownTooltip;
 
-            if (state.PinButtonSpec != null)
-            {
-                state.PinButtonSpec.ToolTipTitle = PinTooltip;
-            }
+            state.PinButtonSpec?.ToolTipTitle = PinTooltip;
 
-            if (state.CloseButtonSpec != null)
-            {
-                state.CloseButtonSpec.ToolTipTitle = CloseTooltip;
-            }
+            state.CloseButtonSpec?.ToolTipTitle = CloseTooltip;
         }
     }
+
+    private void UpdatePageToolTips()
+    {
+        foreach (CachedCellState state in _lookupCellState.Values)
+        {
+            state.Cell?.ToolTips.AllowPageToolTips = AllowPageToolTips;
+        }
+    }
+
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -28,6 +28,12 @@ namespace Krypton.Docking;
 [Description("Docking management component.")]
 public class KryptonDockingManager : DockingElementOpenCollection
 {
+    #region Instance Fields
+
+    private bool _allowPageToolTips = true;
+
+    #endregion
+
     #region Events
     /// <summary>
     /// Occurs when the user requests a page be closed.
@@ -1392,6 +1398,26 @@ public class KryptonDockingManager : DockingElementOpenCollection
     /// </summary>
     [DefaultValue(typeof(DockingCloseRequest), "HidePage")]
     public DockingCloseRequest DefaultCloseRequest { get; set; }
+
+    /// <summary>
+    /// Gets and sets a value indicating if tooltips should be displayed for docking tab headers.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Should tooltips be displayed for docking tab headers.")]
+    [DefaultValue(true)]
+    public bool AllowPageToolTips
+    {
+        get => _allowPageToolTips;
+
+        set
+        {
+            if (_allowPageToolTips != value)
+            {
+                _allowPageToolTips = value;
+                PropogateAction(DockingPropogateAction.StringChanged, null as string[]);
+            }
+        }
+    }
 
     /// <summary>
     /// Perform the close request for a set of named pages.

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
@@ -76,6 +76,8 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
             // Let base class perform standard processing
             base.Parent = value;
 
+            UpdatePageToolTips();
+
             // Generate event so that any dockable navigator customization can be performed.
             KryptonDockingManager? dockingManager = DockingManager;
             if (dockingManager != null)
@@ -526,6 +528,9 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
                 Console.WriteLine(GetType().ToString());
                 DockableNavigatorControl.DebugOutput();
                 break;
+            case DockingPropogateAction.StringChanged:
+                UpdatePageToolTips();
+                break;
         }
 
         // Let base class perform standard processing
@@ -920,6 +925,15 @@ public class KryptonDockingNavigator : DockingElementClosedCollection
     #endregion
 
     #region Implementation
+    private void UpdatePageToolTips()
+    {
+        KryptonDockingManager? dockingManager = DockingManager;
+        if (dockingManager != null)
+        {
+            DockableNavigatorControl.ToolTips.AllowPageToolTips = dockingManager.AllowPageToolTips;
+        }
+    }
+
     private void OnDockableNavigatorDisposed(object? sender, EventArgs e)
     {
         // Unhook from events to prevent memory leaking

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -685,6 +685,7 @@ public abstract class KryptonDockingSpace : DockingElementClosedCollection
                 SpaceControl.CloseTooltip = dockingManager.Strings.TextClose;
                 SpaceControl.PinTooltip = dockingManager.Strings.TextAutoHide;
                 SpaceControl.DropDownTooltip = dockingManager.Strings.TextWindowLocation;
+                SpaceControl.AllowPageToolTips = dockingManager.AllowPageToolTips;
             }
         }
     }


### PR DESCRIPTION
# Show tab tooltips for docking pages (#3829)

## Summary

- Enable `KryptonPage` tab tooltips (`ToolTipTitle`, `ToolTipBody`, `ToolTipImage`) in Krypton Docking by default, without requiring apps to hook `KryptonWorkspaceCell` creation manually.
- Add `AllowPageToolTips` on `KryptonDockingManager` (default `true`) to opt out globally; changes propagate to all managed dockspaces, floatspaces, and dockable workspaces.
- Add matching `AllowPageToolTips` on `KryptonSpace` (default `true`) for per-space control in the designer; new and existing cells are updated when the value changes.

Closes [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829). Related discussion: [#3811](https://github.com/Krypton-Suite/Standard-Toolkit/discussions/3811).

## Problem

Setting `ToolTipBody` on a `KryptonPage` used in Krypton Docking did not show a tooltip when hovering a tab. Tab tooltips are controlled by `KryptonNavigator.ToolTips.AllowPageToolTips`, which defaults to `false`. Docking already enabled button-spec tooltips for docked panels but never enabled page tooltips.

The workaround from [#3811](https://github.com/Krypton-Suite/Standard-Toolkit/discussions/3811) required subscribing to workspace `Children.Inserted` and setting `cell.ToolTips.AllowPageToolTips = true` for each new `KryptonWorkspaceCell` — including for the managed dockable workspace, which does not apply docking tab appearance (`ApplyDockingAppearance => false`).

## Solution

1. **`KryptonSpace.NewCellInitialize`** — set `cell.ToolTips.AllowPageToolTips = AllowPageToolTips` for every docking cell (workspace, dockspace, floatspace, auto-hidden slide).
2. **`KryptonSpace.AllowPageToolTips`** — space-level property (default `true`); `UpdatePageToolTips()` refreshes all tracked cells when toggled.
3. **`KryptonDockingManager.AllowPageToolTips`** — manager-level property (default `true`); synced to spaces via existing `UpdateStrings()` when the docking hierarchy is attached or when the value changes (`StringChanged` propagation).
4. **`DockingRedockDemo`** — sample pages now set `ToolTipTitle` / `ToolTipBody` for manual verification.

Tooltips still only appear when the page has tooltip content (`PageToToolTipMapping.HasContent`). Pages without tooltip text are unchanged.

## API

```csharp
// Default — no code required; set page tooltip properties only
page.ToolTipTitle = "Editor";
page.ToolTipBody = "Main document editor";

// Opt out globally
kryptonDockingManager.AllowPageToolTips = false;

// Opt out per space (designer or code)
kryptonDockableWorkspace.AllowPageToolTips = false;
```

## Files changed

| File | Change |
|------|--------|
| `KryptonSpace.cs` | `AllowPageToolTips` property, cell init, live update of existing cells | | `KryptonDockingManager.cs` | `AllowPageToolTips` property with propagation | | `KryptonDockingSpace.cs` | Sync manager setting in `UpdateStrings()` | | `Documents/Changelog/Changelog.md` | V105 LTS changelog entry |
## Breaking changes

None. Behaviour is additive: docking tab tooltips are enabled by default where page tooltip content exists. Apps that relied on tooltips being absent can set `AllowPageToolTips = false` on the manager or individual space.

## TFM impact

`Krypton.Docking` only — all supported target frameworks (`net472` and later).