### PR TITLE
* Tooltip hot-spot not respected (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,8 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850), Tooltip hot-spot not respected 
+   * Tooltip placement now respects cursor hotspot and full cursor bounds
 * Implemented [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829), Showing Tab ToolTips for Docking Pages
 * Resolved [#3826](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3826), Null reference in `KryptonToggleSwitch` when the global palette changes
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -62,7 +62,7 @@
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Fixed VisualForm resize flicker in .NET 10+
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Resolved [#3580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3580), Fix docked header autosizing
-* Resolved [#397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/397), normal context menus now use the same palette colours as `KryptonContextMenu`
+* Resolved [#397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/397), Normal context menus now use the same palette colours as `KryptonContextMenu`
 * Resolved [#1976](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1976), `MenuItem###` theme settings now apply to menu item selected, pressed, and border rendering.
 * Implemented [#3598](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3598), Fix KryptonContextMenu disposal leaks
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2026. All rights reserved.
  *  
  */
 #endregion
@@ -115,7 +115,10 @@ public class VisualPopupToolTip : VisualPopup
         {
             position = new PopupPositionValues();
         }
-        Point currentCursorHotSpot = CommonHelper.CaptureCursor();
+
+
+        Rectangle cursorBounds = CommonHelper.GetCursorScreenBounds(controlMousePosition);
+        const int cursorMargin = 2;
 
         Rectangle positionPlacementRectangle = position.PlacementRectangle;
         switch (position.PlacementMode)
@@ -128,7 +131,7 @@ public class VisualPopupToolTip : VisualPopup
             case PlacementMode.Mouse:
             case PlacementMode.MousePoint:
                 // The bounds of the mouse pointer. PlacementRectangle is ignored
-                positionPlacementRectangle = new Rectangle(controlMousePosition.X, controlMousePosition.Y, currentCursorHotSpot.X + 2, currentCursorHotSpot.Y + 2);
+                positionPlacementRectangle = cursorBounds;
                 break;
             default:
                 // The screen, or PlacementRectangle if it is set. The PlacementRectangle is relative to the screen.
@@ -143,7 +146,7 @@ public class VisualPopupToolTip : VisualPopup
                     }
                     else
                     {
-                        positionPlacementRectangle = new Rectangle(controlMousePosition.X, controlMousePosition.Y, currentCursorHotSpot.X + 2, currentCursorHotSpot.Y + 2);
+                        positionPlacementRectangle = cursorBounds;
                     }
                 }
                 else
@@ -166,10 +169,9 @@ public class VisualPopupToolTip : VisualPopup
             case PlacementMode.RelativePoint:
                 // The top-left corner of the target area.     The top-left corner of the Popup.
                 popupLocation = positionPlacementRectangle.Location;
-                if (positionPlacementRectangle.IntersectsWith(new Rectangle(controlMousePosition, (Size)currentCursorHotSpot)))
+                if (positionPlacementRectangle.IntersectsWith(cursorBounds))
                 {
-                    // TODO: SKC: Should really get the HotSpot from the Icon and use that !
-                    popupLocation.X = controlMousePosition.X + 4; // Still might "Bounce back" due to offscreen location
+                    popupLocation.X = cursorBounds.Right + cursorMargin;
                 }
                 break;
             case PlacementMode.Bottom:
@@ -181,10 +183,9 @@ public class VisualPopupToolTip : VisualPopup
                 // The center of the target area.     The center of the Popup.
                 popupLocation = positionPlacementRectangle.Location;
                 popupLocation.Offset(popupSize.Width / 2, -popupSize.Height / 2);
-                if (positionPlacementRectangle.IntersectsWith(new Rectangle(controlMousePosition, (Size)currentCursorHotSpot)))
+                if (positionPlacementRectangle.IntersectsWith(cursorBounds))
                 {
-                    // TODO: SKC: Should really get the HotSpot from the Icon and use that !
-                    popupLocation.X = controlMousePosition.X + 4; // Still might "Bounce back" due to offscreen location
+                    popupLocation.X = cursorBounds.Right + cursorMargin;
                 }
                 break;
             case PlacementMode.Left:
@@ -216,11 +217,13 @@ public class VisualPopupToolTip : VisualPopup
         // Get the size the popup would like to be
         Size popupSize = ViewManager!.GetPreferredSize(Renderer, Size.Empty);
 
-        // Find the screen position the popup will be relative to
-        Point currentCursorHotSpot = CommonHelper.CaptureCursor();
-        controlMousePosition.Offset(currentCursorHotSpot.X + 2, currentCursorHotSpot.Y + 2);
+        // Anchor below-right of the full cursor image so the hotspot is not covered
+        Rectangle cursorBounds = CommonHelper.GetCursorScreenBounds(controlMousePosition);
+        const int cursorMargin = 2;
+        var popupLocation = new Point(cursorBounds.Right + cursorMargin, cursorBounds.Bottom + cursorMargin);
+
         // Show it now!
-        Show(controlMousePosition, popupSize);
+        Show(popupLocation, popupSize);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2026. All rights reserved.
  *
  */
 #endregion
@@ -1665,6 +1665,50 @@ public static class CommonHelper
         Cursor cur = Cursor.Current ?? Cursors.Default;
 
         return cur.HotSpot;
+    }
+
+    /// <summary>
+    /// Gets the screen-space bounds of the active cursor image for a screen hotspot position.
+    /// </summary>
+    /// <param name="screenHotSpot">Screen coordinates of the cursor hotspot (for example from <c>GetCursorPos</c>).</param>
+    /// <returns>Rectangle covering the full cursor bitmap in screen coordinates.</returns>
+    public static Rectangle GetCursorScreenBounds(Point screenHotSpot)
+    {
+        Cursor cursor = Cursor.Current ?? Cursors.Default;
+        Point hotSpot = cursor.HotSpot;
+        Size size = cursor.Size;
+
+        if (PI.GetIconInfo(cursor.Handle, out PI.ICONINFO iconInfo))
+        {
+            hotSpot = new Point(iconInfo.xHotspot, iconInfo.yHotspot);
+
+            IntPtr hBitmap = iconInfo.hbmColor != IntPtr.Zero ? iconInfo.hbmColor : iconInfo.hbmMask;
+            if (hBitmap != IntPtr.Zero)
+            {
+                var bitmap = new PI.BITMAP();
+                if (PI.GetObject(hBitmap, Marshal.SizeOf<PI.BITMAP>(), ref bitmap) != 0)
+                {
+                    int height = iconInfo.hbmColor != IntPtr.Zero ? bitmap.bmHeight : bitmap.bmHeight / 2;
+                    size = new Size(bitmap.bmWidth, Math.Max(1, height));
+                }
+            }
+
+            if (iconInfo.hbmMask != IntPtr.Zero)
+            {
+                PI.DeleteObject(iconInfo.hbmMask);
+            }
+
+            if (iconInfo.hbmColor != IntPtr.Zero)
+            {
+                PI.DeleteObject(iconInfo.hbmColor);
+            }
+        }
+
+        return new Rectangle(
+            screenHotSpot.X - hotSpot.X,
+            screenHotSpot.Y - hotSpot.Y,
+            Math.Max(1, size.Width),
+            Math.Max(1, size.Height));
     }
 
     /// <summary>


### PR DESCRIPTION
# Fix tooltip placement to respect cursor hotspot (#3850)

Closes [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850)

## Summary

- Tooltip placement in `VisualPopupToolTip` now uses the full cursor image bounds in screen space instead of misusing hotspot coordinates as width/height.
- Adds `CommonHelper.GetCursorScreenBounds` to resolve hotspot and bitmap size via `GetIconInfo`, with fallback to `Cursor.HotSpot` and `Cursor.Size`.
- Adds a changelog entry.

## Problem

`VisualPopupToolTip` treated the cursor hotspot as a rectangle size when positioning tooltips:

- `PlacementMode.Mouse` built a tiny placement rectangle from hotspot X/Y as width/height.
- Overlap checks used `new Rectangle(screenHotSpot, (Size)hotSpot)`, which does not represent the cursor bitmap.
- When a tooltip would cover the cursor, placement nudged by a hard-coded `+ 4` pixels.
- `ShowCalculatingSize` offset from the hotspot by `(hotSpot.X + 2, hotSpot.Y + 2)` rather than anchoring past the full cursor image.

This caused tooltips to overlap the cursor hotspot, especially with non-default cursors (I-beam, wait, size-all).

## Solution

1. **`CommonHelper.GetCursorScreenBounds`**
   - Takes the screen hotspot position (from `GetCursorPos` / `ToolTipEventArgs.ControlMousePosition`).
   - Reads hotspot and bitmap dimensions from the active cursor handle via `GetIconInfo`.
   - Returns the cursor image rectangle in screen coordinates.

2. **`VisualPopupToolTip`**
   - `PlacementMode.Mouse` and fallback placement use `cursorBounds`.
   - `RelativePoint` / `Center` overlap detection uses `cursorBounds`.
   - Overlap nudge uses `cursorBounds.Right + 2`.
   - `ShowCalculatingSize` anchors below-right of the cursor image.

No public API changes. Binary-compatible bug fix.

## Files changed

| File | Change |
|------|--------|
| `Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs` | Add `GetCursorScreenBounds` | | `Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs` | Use cursor bounds for placement and overlap avoidance | | `Documents/Changelog/Changelog.md` | Changelog entry |