### PR TITLE
* Preserialized resources / `KryptonManager` startup failures

### DIFF
--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.BindingRedirects.props
@@ -23,15 +23,16 @@
 	        BeforeTargets="_GenerateSuggestedBindingRedirectsCache"
 	        Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(GenerateBindingRedirectsOutputType)' == 'true' And '$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true'">
 		<ItemGroup>
-			<_KryptonSreCopyLocalDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions'" />
+			<_KryptonSreCopyLocalDll Include="@(ReferenceCopyLocalPaths)"
+			                            Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
 		</ItemGroup>
 		<PropertyGroup>
-			<_KryptonSreDllPath Condition="'@(_KryptonSreCopyLocalDll)' != ''">@(_KryptonSreCopyLocalDll->'%(FullPath)')</_KryptonSreDllPath>
+			<_KryptonSreDllPath Condition="'@(_KryptonSreCopyLocalDll)' != ''">%(_KryptonSreCopyLocalDll.Identity)</_KryptonSreDllPath>
 			<_KryptonSreDllPath Condition="'$(_KryptonSreDllPath)' == '' And '$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net462\System.Resources.Extensions.dll</_KryptonSreDllPath>
 			<_KryptonSreDllPath Condition="'$(_KryptonSreDllPath)' == '' And '$(PkgSystem_Resources_Extensions)' != '' And Exists('$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll')">$(PkgSystem_Resources_Extensions)\lib\net461\System.Resources.Extensions.dll</_KryptonSreDllPath>
 		</PropertyGroup>
 		<GetAssemblyIdentity AssemblyFiles="$(_KryptonSreDllPath)"
-		                     Condition="'$(_KryptonSreDllPath)' != ''">
+		                     Condition="'$(_KryptonSreDllPath)' != '' And $([System.String]::Copy('$(_KryptonSreDllPath)').EndsWith('.dll'))">
 			<Output TaskParameter="Assemblies" ItemName="_KryptonSreAssemblyIdentity" />
 		</GetAssemblyIdentity>
 		<PropertyGroup Condition="'@(_KryptonSreAssemblyIdentity)' != ''">

--- a/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
+++ b/Source/Krypton Components/NetFramework.SystemResourcesExtensions.targets
@@ -37,15 +37,15 @@
 	        AfterTargets="Build"
 	        Condition="'$(GenerateResourceUsePreserializedResources)' == 'true' And '$(DesignTimeBuild)' != 'true'">
 		<ItemGroup>
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Formats.Nrbf'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Memory'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Buffers'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Runtime.CompilerServices.Unsafe'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Collections.Immutable'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Reflection.Metadata'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Numerics.Vectors'" />
-			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'Microsoft.Bcl.HashCode'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Resources.Extensions' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Formats.Nrbf' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Memory' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Buffers' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Runtime.CompilerServices.Unsafe' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Collections.Immutable' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Reflection.Metadata' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'System.Numerics.Vectors' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+			<_KryptonResourceRuntimeDll Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'Microsoft.Bcl.HashCode' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonSreDllPath)" Condition="'$(_KryptonSreDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonNrbfDllPath)" Condition="'$(_KryptonNrbfDllPath)' != ''" />
 			<_KryptonResourceRuntimeDll Include="$(_KryptonMemoryDllPath)" Condition="'$(_KryptonMemoryDllPath)' != ''" />


### PR DESCRIPTION
# Fix #3330: Preserialized resources / `KryptonManager` startup failures

## Summary

Fixes `System.TypeInitializationException` during `KryptonManager` static initialization on **.NET Framework 4.7.2–4.8.1** and **net8.0-windows** when preserialized `.resx` resources cannot load **`System.Resources.Extensions`** and its dependency closure.

**Related issue:** [#3330](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3330)

## Problem

Krypton uses **preserialized** embedded resources (`GenerateResourceUsePreserializedResources`). At runtime, static initialization of `KryptonManager` → `KryptonImageStorage` / `GlobalStaticVariables` loads toolbar images via `System.Resources.Extensions.DeserializingResourceReader`.

Failures observed:

| TFM | Typical inner exception |
|-----|-------------------------|
| **net472 / net48 / net481** | `FileLoadException` / `FileNotFoundException` for **System.Resources.Extensions** (version mismatch **9.0.0.0** vs deployed **9.0.0.10**) or **System.Memory 4.0.1.2** missing from output | | **net8.0-windows** | `FileNotFoundException` for **System.Resources.Extensions 4.0.0.0** (DLL not deployed beside `Krypton.Toolkit.dll`) | | **packages.config apps** | MSBuild error: `GetAssemblyIdentity` attempted to read **System.Resources.Extensions.xml** as an assembly |

**Root causes:**

1. **Wrong binding redirect** — `newVersion="9.0.0.0"` does not match package **9.0.10** (assembly **9.0.0.10**) → HRESULT `0x80131040`.
2. **Incomplete deployment** — Library projects + `UseCommonOutputDirectory` did not copy **SRE**, **Nrbf**, **System.Memory**, etc. to the shared output folder for every TFM.
3. **MSBuild props bug** — `ReferenceCopyLocalPaths` in non-SDK projects includes both `.dll` and `.xml` for the same filename; item transforms passed both paths to `GetAssemblyIdentity`.

## Solution (defense in depth)

| Layer | Purpose |
|-------|---------|
| **MSBuild copy targets** | Copy preserialized-resource runtime DLLs to `$(OutputPath)` for **all TFMs** (including net8.0-windows) | | **NuGet packaging** | Bundle SRE/Nrbf (and net4x deps) in `lib\$(TargetFramework)\`; ship `build` + `buildTransitive` **`.props` and `.targets`** | | **Binding redirects** | `GetAssemblyIdentity` on the **`.dll` only**; `MaxVersion` = actual assembly version (**9.0.0.10**) | | **`Krypton.Toolkit.dll.config`** | Redirects for **System.Resources.Extensions** and **System.Memory** (net4x) | | **Runtime** | `KryptonPreserializedResourceAssemblyResolve` — `AssemblyResolve` loads SRE and related assemblies from the app/toolkit directory on all TFMs |

## Changes

### Runtime (`Krypton.Toolkit`)

- **`General/KryptonPreserializedResourceAssemblyResolve.cs`** — `AssemblyResolve` for SRE, Nrbf, Memory, Buffers, Unsafe, Collections.Immutable, Reflection.Metadata, Numerics.Vectors.
- **`General/GlobalStaticVariables.cs`** — Register resolve hook before toolbar image static fields.
- **`Controls Toolkit/KryptonManager.cs`** — Register resolve hook at start of static field initialization.
- **`Krypton.Toolkit.dll.config`** — Binding redirects: SRE → **9.0.0.10**, System.Memory → **4.0.1.2**.

### MSBuild / NuGet

- **`NetFramework.SystemResourcesExtensions.BindingRedirects.props`**
  - `AutoGenerateBindingRedirects` for .NET Framework consumers.
  - `KryptonEnsureSystemResourcesExtensionsBindingRedirect` — resolve SRE path from **`ReferenceCopyLocalPaths` (`.dll` only)** or NuGet cache; inject correct `SuggestedBindingRedirects`.
  - **Fix:** filter `Extension == '.dll'`; use `%(_KryptonSreCopyLocalDll.Identity)` (avoids passing `.xml` to `GetAssemblyIdentity` on packages.config projects).
- **`NetFramework.SystemResourcesExtensions.targets`**
  - `KryptonCopyPreserializedResourceDependenciesToOutput` — copy full dependency closure after build (all TFMs).
  - `KryptonCopyBundledSystemResourcesExtensionsForConsumer` — copy bundled DLLs from package `lib\` for NuGet consumers.
  - **Fix:** all `ReferenceCopyLocalPaths` filters require **`.dll`** extension.
- **`Directory.Build.props`** — Package references for SRE, Nrbf, and net4x transitive deps with `GeneratePathProperty`.
- **`Directory.Build.targets`** — Import `.targets` (includes `.props`).
- **`Krypton.Toolkit 2022.csproj` / `Krypton.Standard.Toolkit.csproj`** — Pack props/targets; bundle runtime DLLs in nupkg.

## Consumer impact

- **No breaking API changes.**
- **SDK-style / PackageReference:** Rebuild; imported targets set redirects and deploy dependencies.
- **packages.config / non-SDK:** Ensure `build\*.targets` is imported; use **System.Resources.Extensions 9.0.10**; redirects must use **`newVersion="9.0.0.10"`** (not `9.0.0.0`).
- **Direct DLL reference:** Use build output that includes SRE, System.Memory (net4x), and `Krypton.Toolkit.dll.config`.

## Test plan

- [ ] `dotnet build` **Krypton.Toolkit** and **TestForm** for **net472**, **net48**, **net8.0-windows**.
- [ ] Confirm **`Bin/Debug/<tfm>/`** contains `System.Resources.Extensions.dll`; **net48** also has `System.Memory.dll`.
- [ ] Run **TestForm** — `StartScreen` / `KryptonForm` starts without `TypeInitializationException`.
- [ ] **packages.config** sample app (e.g. KryptonTest48) builds without `GetAssemblyIdentity` error on **System.Resources.Extensions.xml**.
- [ ] Verify generated **`exe.config`** uses `newVersion="9.0.0.10"` for System.Resources.Extensions.
- [ ] Pack **Krypton.Toolkit** nupkg; confirm `lib/net48/System.Resources.Extensions.dll` and `build/*.targets` present.

## Notes for reviewers

- Do **not** recommend `System.Resources.Extensions` **9.0.0** or binding redirect **`newVersion="9.0.0.0"`** — package **9.0.10** → assembly **9.0.0.10**.
- Preserialized resources cannot be disabled on current SDK (MSB3822/3823); deployment + correct redirects are required.
- `ReferenceCopyLocalPaths` filename filters must always include **`Extension == '.dll'`** for non-SDK Framework projects.