### PR TITLE
Customizing glyph colors (V105)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3861), Permits customizing glyph colors (#3663) using `KryptonCustomPalette`.
 * Implemented [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829), Showing Tab ToolTips for Docking Pages
 * Resolved [#3826](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3826), Null reference in `KryptonToggleSwitch` when the global palette changes
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
@@ -35,8 +35,8 @@ internal static class DropDownArrowGlyphColors
         Color fill;
         if (state == PaletteState.Disabled)
         {
-            outline = palette.GetSchemeColor(SchemeBaseColors.InputDropDownDisabled1);
-            fill = palette.GetSchemeColor(SchemeBaseColors.InputDropDownDisabled2);
+            outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonInputControl, PaletteState.Disabled);
+            fill = palette.GetContentShortTextColor2(PaletteContentStyle.ButtonInputControl, PaletteState.Disabled);
             if (outline == Color.Empty || outline == Color.Empty)
             {
                 outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Disabled);
@@ -44,8 +44,8 @@ internal static class DropDownArrowGlyphColors
         }
         else
         {
-            outline = palette.GetSchemeColor(SchemeBaseColors.TextButtonNormal);
-            fill = palette.GetSchemeColor(SchemeBaseColors.InputDropDownNormal2);
+            outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Normal);
+            fill = palette.GetContentShortTextColor2(PaletteContentStyle.ButtonInputControl, PaletteState.Normal);
             if (outline == Color.Empty || outline == Color.Empty)
             {
                 outline = palette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, state);


### PR DESCRIPTION
# Allows you to customize glyph colors (#3663) using KryptonCustomPalette. (#3861 )

Glyph colors are now retrieved from theme palettes, rather than directly from the color scheme.

The colors remain the same, but you can now customize them using KryptonCustomPalette.

### TestForm 
GlyphColor

### Test Plan
- [ ] Add a KryptonCustomPalette.
- [ ] Associate the KryptonCustomPalette with a KryptonManager or with the components.
- [ ] Customize the colors:
- Enabled      
Outline:
`ButtonStyles.ButtonStandalone.StateNormal.Content.ShortText.Color1 `
Fill:
`ButtonStyles.ButtonInputControl.StateNormal.Content.ShortText.Color2`
- Disabled      
Outline:
`ButtonStyles.ButtonInputControl.StateDisabled.Content.ShortText.Color1`
Fill:
`ButtonStyles.ButtonInputControl.StateDisabled.Content.ShortText.Color2`