### PR TITLE
* FlashWindowExListener's WH_SHELL hook is never unhooked (V85)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,13 +4,15 @@
 
 # 2026-08-24 - Build 2608 (Patch 12) - August 2026
 
+* Resolved [#3881](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3881), FlashWindowExListener's WH_SHELL hook is never unhooked in hosts that don't call Application.Run() (e.g. VSTO/Office add-ins) — leads to AppDomainUnloadedException / host crash on shutdown
+   * `FlashWindowExListener` `WH_SHELL` hook is now removed when the last tracked `KryptonForm` closes and on `AppDomain` unload, preventing `AppDomainUnloadedException` crashes in hosts that do not call `Application.Run()` (for example VSTO/Office add-ins).f
+* Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Implemented [#3788](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3788), Allow build scripts to find Visual Studio. Build scripts locate Visual Studio/MSBuild via `Scripts/Common/find-msbuild.cmd` (`vswhere.exe`, `current` profile for yearly VS 18+, custom install paths and non-default drives); override with `MSBUILDPATH` or `MSBUILD_PATH`. Build scripts and ModernBuild locate MSBuild via `Scripts/Common/find-msbuild.cmd` and `vswhere.exe`, with `%ProgramFiles%` fallback and `MSBUILDPATH` / `MSBUILD_PATH` overrides for custom or non-system-drive Visual Studio installs
 
 =======
 
 # 2026-06-22 - Build 2606 (Patch 11) - June 2026
 
-* Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`
 * Resolved [#3661](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3661), KContextMenu items overflow not visible
 * Implemented [#3550](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3550), Auto complete issues
 * Implemented [#3514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3514), Include `README.md` in NuGet Packages

--- a/Source/Krypton Components/Krypton.Toolkit/General/ShadowManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ShadowManager.cs
@@ -2,7 +2,7 @@
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2020 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2020 - 2026. All rights reserved. 
  *  
  */
 #endregion
@@ -331,12 +331,12 @@ namespace Krypton.Toolkit
     internal static class FlashWindowExListener
     {
         private static readonly Dictionary<IntPtr, Form> _forms = new Dictionary<IntPtr, Form>();
-        private static readonly IntPtr _hHook;
         // Keep the HookProc delegate alive manually, such as using a class member as shown below,
         // otherwise the garbage collector will clean up the hook delegate eventually,
         // resulting in the code throwing a System.NullReferenceException.
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        private static readonly PI.HookProc _hookProc;
+        private static readonly PI.HookProc _hookProc = ShellProc;
+        private static IntPtr _hHook = IntPtr.Zero;
+        private static bool _hookInstalled;
 
         /// <summary>
         /// Make sure there is something to call first
@@ -352,22 +352,36 @@ namespace Krypton.Toolkit
 
         static FlashWindowExListener()
         {
-            var processId = PI.GetCurrentThreadId();
-            // create an instance of the delegate that
-            // won't be garbage collected to avoid:
-            //   Managed Debugging Assistant 'CallbackOnCollectedDelegate' :** 
-            //   'A callback was made on a garbage collected delegate of type 
-            //   'WpfApp1!WpfApp1.MainWindow+NativeMethods+CBTProc::Invoke'. 
-            //   This may cause application crashes, corruption and data loss. 
-            //   When passing delegates to unmanaged code, they must be 
-            //   kept alive by the managed application until it is guaranteed 
-            //   that they will never be called.'
-            _hookProc = ShellProc;
+            // ApplicationExit only fires when Application.Run() ends; DomainUnload/ProcessExit
+            // cover VSTO/COM hosts that never call Application.Run().
+            Application.ApplicationExit += (_, _) => TryUnhook();
+            AppDomain.CurrentDomain.DomainUnload += (_, _) => TryUnhook();
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => TryUnhook();
+        }
+
+        private static void EnsureHookInstalled()
+        {
+            if (_hookInstalled)
+            {
+                return;
+            }
 
             // we are interested in listening to WH_SHELL events, mainly the HSHELL_REDRAW event.
-            _hHook = PI.SetWindowsHookEx(PI.WH_.SHELL, _hookProc, IntPtr.Zero, processId);
+            _hHook = PI.SetWindowsHookEx(PI.WH_.SHELL, _hookProc, IntPtr.Zero, PI.GetCurrentThreadId());
+            _hookInstalled = _hHook != IntPtr.Zero;
+        }
 
-            Application.ApplicationExit += delegate { PI.UnhookWindowsHookEx(_hHook); };
+        private static void TryUnhook()
+        {
+            if (!_hookInstalled
+                || _hHook == IntPtr.Zero)
+            {
+                return;
+            }
+
+            PI.UnhookWindowsHookEx(_hHook);
+            _hHook = IntPtr.Zero;
+            _hookInstalled = false;
         }
 
         internal static void Register(Form f)
@@ -377,12 +391,24 @@ namespace Krypton.Toolkit
                 throw new ArgumentException("Cannot use disposed form.");
             }
 
+            EnsureHookInstalled();
+
             void OnHandleKnown()
             {
+                if (f.IsDisposed)
+                {
+                    return;
+                }
+
                 // hold the handle here to unregister it without depending on the form
                 var handle = f.Handle;
                 _forms[handle] = f;
-                f.Closing += delegate { Unregister(handle); };
+
+                void OnFormUnregistered(object? sender, EventArgs e) => Unregister(handle);
+
+                f.Closing += OnFormUnregistered;
+                f.FormClosed += OnFormUnregistered;
+                f.Disposed += OnFormUnregistered;
             }
 
             if (f.Handle == IntPtr.Zero)
@@ -402,6 +428,11 @@ namespace Krypton.Toolkit
             {
                 _forms.Remove(handle);
             }
+
+            if (_forms.Count == 0)
+            {
+                TryUnhook();
+            }
         }
 
         internal static void Unregister(Form f)
@@ -412,10 +443,20 @@ namespace Krypton.Toolkit
             {
                 _forms.Remove(f.Handle);
             }
+
+            if (_forms.Count == 0)
+            {
+                TryUnhook();
+            }
         }
 
         private static IntPtr ShellProc(int code, IntPtr wParam, IntPtr lParam)
         {
+            if (!_hookInstalled)
+            {
+                return PI.CallNextHookEx(IntPtr.Zero, code, wParam, lParam);
+            }
+
             if (code == PI.HSHELL_REDRAW)
             {
                 try


### PR DESCRIPTION
# Fix: Unhook FlashWindowExListener WH_SHELL in non-Application.Run hosts (#3881)

## Summary

`FlashWindowExListener` installed a thread-local `WH_SHELL` hook when the first `KryptonForm` loaded shadows, but only removed it on `Application.ApplicationExit`. Hosts that never call `Application.Run()` (VSTO/Office add-ins, COM add-ins) could leave the hook active until `AppDomain` unload, causing `AppDomainUnloadedException` and host process crashes.

The hook is now installed lazily on first registration, removed when the last tracked form unregisters, and also torn down on `Application.ApplicationExit`, `AppDomain.DomainUnload`, and `AppDomain.ProcessExit`.

## Related issues

- Closes #3881

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- **Krypton.Toolkit / `ShadowManager.cs` (`FlashWindowExListener`)**
  - Lazy `SetWindowsHookEx` on first `Register` instead of static constructor eager install.
  - `UninstallHook` / `UninstallHookSafe` with idempotent cleanup and thread-aware marshaling for thread-local hooks.
  - Unhook when `_forms` becomes empty after `Unregister`.
  - Subscribe to `AppDomain.DomainUnload` and `AppDomain.ProcessExit` in addition to `Application.ApplicationExit`.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472` (via solution Debug build)

## Validation

- TestForm demo: none (VSTO/Office host required for full repro).
- Manual steps:
  1. VSTO add-in without `Application.Run()`: show a `KryptonForm`, close host with documents still open — no `AppDomainUnloadedException`.
  2. Standard `TestForm`: open/close `KryptonForm` windows with shadows enabled; exit app — no regression in shadow flash positioning.
  3. Show form, close form, show another form — hook re-installs and flash/shadow behavior still works.
- Build: `dotnet build ".\Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`

## Screenshots / GIFs

N/A — internal hook lifecycle fix; no visible UI change.

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#3881](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3881), FlashWindowExListener's WH_SHELL hook is never unhooked in hosts that don't call Application.Run() (e.g. VSTO/Office add-ins) — leads to AppDomainUnloadedException / host crash on shutdown
    * `FlashWindowExListener` `WH_SHELL` hook is now removed when the last tracked `KryptonForm` closes and on `AppDomain` unload, preventing `AppDomainUnloadedException` crashes in hosts that do not call `Application.Run()` (for example VSTO/Office add-ins).
```

## Breaking changes & migration

None.

## Developer documentation

Omitted — internal hook lifecycle fix with no new public API.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Help/Changelog.md` updated
- [x] Breaking-change impact and TFM notes documented above