### PR TITLE
* When the `KryptonComboBox` initializes in a disabled state, it disp…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -1,4 +1,4 @@
-# ![Krypton logo](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true) Standard Toolkit - ChangeLog
+﻿# ![Krypton logo](https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true) Standard Toolkit - ChangeLog
 
 =======
 

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3879](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3879), When the `KryptonComboBox` initializes in a disabled state, it displays using default system colors
+   * `KryptonComboBox` now displays theme disabled colors when initialized in a disabled state.
 * Implemented [#3807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3807), `KryptonKnob` control
 * Resolved [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850), Tooltip hot-spot not respected 
    * Tooltip placement now respects cursor hotspot and full cursor bounds

--- a/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
@@ -3159,6 +3159,10 @@ No 	                    No 	                    Show text only
 
     [DllImport(Libraries.User32, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern bool EnableWindow(IntPtr hWnd, bool bEnable);
+
+    [DllImport(Libraries.User32, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
 
     [DllImport(Libraries.User32, SetLastError = true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1409,6 +1409,9 @@ public class KryptonComboBox : VisualControlBase,
         // Force calculation of the drop-down items again so they are sized correctly
         _comboBox.DrawMode = DrawMode.OwnerDrawVariable;
 
+        // Designer may set Enabled=false before the handle exists; sync themed disabled colors now.
+        SyncComboBoxAppearance(_comboBox.IsHandleCreated);
+
         // Raise event to show control is now initialized
         OnInitialized(EventArgs.Empty);
     }
@@ -2609,6 +2612,10 @@ public class KryptonComboBox : VisualControlBase,
         // We need a layout to occur before any painting
         InvokeLayout();
 
+        // Layout can recreate the native edit child; hide it again before the first paint.
+        UpdateEditControl();
+        SyncComboBoxAppearance(true);
+
         // We need to recalculate the correct height
         Height = PreferredHeight;
     }
@@ -2619,6 +2626,9 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnEnabledChanged(EventArgs e)
     {
+        // Propagate to the internal ComboBox so InternalComboBox.OnEnabledChanged can suppress native disabled styling.
+        _comboBox.Enabled = Enabled;
+
         // Ensure we have subclassed the contained edit control
         UpdateEditControl();
 
@@ -2890,16 +2900,7 @@ public class KryptonComboBox : VisualControlBase,
             ForceControlLayout();
         }
 
-        if (!IsDisposed && !Disposing)
-        {
-            UpdateStateAndPalettes();
-            var triple = GetComboBoxTripleState();
-            PaletteState state = _drawDockerOuter.State;
-            _comboBox.BackColor = triple.PaletteBack.GetBackColor1(state);
-            _comboBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
-            _comboBox.Font = triple.PaletteContent.GetContentShortTextFont(state)!;
-            _comboHolder.BackColor = _comboBox.BackColor;
-        }
+        SyncComboBoxAppearance();
 
         base.OnNeedPaint(sender, e);
     }
@@ -3034,6 +3035,27 @@ public class KryptonComboBox : VisualControlBase,
 
     internal PaletteInputControlTripleStates GetComboBoxTripleState() => Enabled ? IsActive ? StateActive.ComboBox : StateNormal.ComboBox : StateDisabled.ComboBox;
 
+    private void SyncComboBoxAppearance(bool invalidateCombo = false)
+    {
+        if (IsDisposed || Disposing)
+        {
+            return;
+        }
+
+        UpdateStateAndPalettes();
+        var triple = GetComboBoxTripleState();
+        PaletteState state = _drawDockerOuter.State;
+        _comboBox.BackColor = triple.PaletteBack.GetBackColor1(state);
+        _comboBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+        _comboBox.Font = triple.PaletteContent.GetContentShortTextFont(state)!;
+        _comboHolder.BackColor = _comboBox.BackColor;
+
+        if (invalidateCombo && _comboBox.IsHandleCreated)
+        {
+            _comboBox.Invalidate(true);
+        }
+    }
+
     private int PreferredHeight
     {
         get
@@ -3053,32 +3075,33 @@ public class KryptonComboBox : VisualControlBase,
         // Do we need to draw the edit area
         if ((e.State & DrawItemState.ComboBoxEdit) == DrawItemState.ComboBoxEdit)
         {
-            // TODO: Check if this is covered by the WM_PAINT in the internal Combo
-            // Always get base implementation to draw the background
-            e.DrawBackground();
+            PaletteState state = Enabled
+                ? IsActive
+                    ? PaletteState.Tracking
+                    : PaletteState.Normal
+                : PaletteState.Disabled;
+            var triple = GetComboBoxTripleState();
+            Color backColor = triple.PaletteBack.GetBackColor1(state);
+            Color textColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+            Font? font = triple.PaletteContent.GetContentShortTextFont(state);
 
-            // Find correct text color
-            Color textColor = _comboBox.ForeColor;
             if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
             {
                 textColor = SystemColors.HighlightText;
+                backColor = SystemColors.Highlight;
             }
 
-            // Find correct background color
-            Color backColor = _comboBox.BackColor;
-            if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
+            using (var backBrush = new SolidBrush(backColor))
             {
-                backColor = SystemColors.Highlight;
+                e.Graphics.FillRectangle(backBrush, drawBounds);
             }
 
             // Is there an item to draw
             if (e.Index >= 0)
             {
-                // Set the correct text rendering hint for the text drawing. We only draw if the edit text is enabled so we
-                // just always grab the normal state value. Without this line the wrong hint can occur because it inherits
-                // it from the device context. Resulting in blurred text.
-                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
-                using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(StateNormal.Item.PaletteContent!.GetContentShortTextHint(PaletteState.Normal))))
+                // Without this line the wrong hint can occur because it inherits it from the device context.
+                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls.
+                using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(triple.Content.GetContentShortTextHint(state))))
                 {
                     TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding;
 
@@ -3093,7 +3116,7 @@ public class KryptonComboBox : VisualControlBase,
 
                     // Draw text using font defined by the control
                     TextRenderer.DrawText(e.Graphics,
-                        _comboBox.Text, _comboBox.Font,
+                        _comboBox.Text, font ?? _comboBox.Font,
                         drawBounds,
                         textColor, backColor,
                         flags);
@@ -3262,7 +3285,7 @@ public class KryptonComboBox : VisualControlBase,
     {
         UpdateStateAndPalettes();
 
-        if (DropDownStyle == ComboBoxStyle.DropDown)
+        if (DropDownStyle == ComboBoxStyle.DropDown && Enabled)
         {
             _subclassEdit!.Visible = true;
             PaletteState state = Enabled

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -307,6 +307,16 @@ public class KryptonComboBox : VisualControlBase,
         }
 
         /// <summary>
+        /// Raises the HandleCreated event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _kryptonComboBox.OnInternalComboBoxHandleCreatedSafe();
+        }
+
+        /// <summary>
         /// Raises the FontChanged event.
         /// </summary>
         /// <param name="e">Contains the event data.</param>
@@ -902,6 +912,20 @@ public class KryptonComboBox : VisualControlBase,
                     }
                     base.WndProc(ref m);
                     break;
+                case PI.WM_.ERASEBKGND:
+                case PI.WM_.PAINT:
+                    // Themed disabled content is painted by InternalComboBox.WM_PAINT; suppress native edit painting.
+                    if (!_kryptonComboBox.Enabled)
+                    {
+                        if (m.Msg == (int)PI.WM_.ERASEBKGND)
+                        {
+                            m.Result = (IntPtr)1;
+                        }
+
+                        return;
+                    }
+                    base.WndProc(ref m);
+                    break;
                 case PI.WM_.DESTROY:
                     // Remove this code as it prevents the auto suggest features from working
                     // _kryptonComboBox.DetachEditControl();
@@ -1410,7 +1434,14 @@ public class KryptonComboBox : VisualControlBase,
         _comboBox.DrawMode = DrawMode.OwnerDrawVariable;
 
         // Designer may set Enabled=false before the handle exists; sync themed disabled colors now.
-        SyncComboBoxAppearance(_comboBox.IsHandleCreated);
+        if (_comboBox.IsHandleCreated)
+        {
+            OnInternalComboBoxHandleCreatedSafe();
+        }
+        else
+        {
+            SyncComboBoxAppearance();
+        }
 
         // Raise event to show control is now initialized
         OnInitialized(EventArgs.Empty);
@@ -2603,18 +2634,14 @@ public class KryptonComboBox : VisualControlBase,
         // Let base class do standard stuff
         base.OnHandleCreated(e);
 
-        // Subclass the child edit control
-        UpdateEditControl();
-
         // Force the font to be set into the text box child control
         PerformNeedPaint(false);
 
         // We need a layout to occur before any painting
         InvokeLayout();
 
-        // Layout can recreate the native edit child; hide it again before the first paint.
-        UpdateEditControl();
-        SyncComboBoxAppearance(true);
+        // Layout can recreate the native edit child; ensure themed disabled paint is ready.
+        OnInternalComboBoxHandleCreatedSafe();
 
         // We need to recalculate the correct height
         Height = PreferredHeight;
@@ -2626,24 +2653,28 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnEnabledChanged(EventArgs e)
     {
-        // Propagate to the internal ComboBox so InternalComboBox.OnEnabledChanged can suppress native disabled styling.
-        _comboBox.Enabled = Enabled;
-
         // Ensure we have subclassed the contained edit control
         UpdateEditControl();
 
-        // Update view elements
-        _drawDockerInner.Enabled = Enabled;
-        _drawDockerOuter.Enabled = Enabled;
+        if (IsComboBoxAppearanceReady)
+        {
+            // Update view elements
+            _drawDockerInner.Enabled = Enabled;
+            _drawDockerOuter.Enabled = Enabled;
 
-        // Update state to reflect change in enabled state
-        _buttonManager?.RefreshButtons();
-        _buttonSpecAccessibilityProxyManager?.Sync();
+            // Update state to reflect change in enabled state
+            _buttonManager?.RefreshButtons();
+            _buttonSpecAccessibilityProxyManager?.Sync();
 
-        // Change in enabled state requires a layout and repaint
-        UpdateStateAndPalettes();
-        PerformNeedPaint(true);
-        CueHint.SyncAnimation();
+            // Change in enabled state requires a layout and repaint
+            UpdateStateAndPalettes();
+            PerformNeedPaint(true);
+            CueHint.SyncAnimation();
+        }
+        else
+        {
+            SyncComboBoxAppearance();
+        }
 
         // Let base class fire standard event
         base.OnEnabledChanged(e);
@@ -3017,8 +3048,50 @@ public class KryptonComboBox : VisualControlBase,
         }
     }
 
+    internal void OnInternalComboBoxHandleCreatedSafe()
+    {
+        UpdateEditControl();
+
+        if (!IsComboBoxAppearanceReady)
+        {
+            return;
+        }
+
+        SyncComboBoxAppearance(true);
+
+        if (!Enabled && _comboBox.IsHandleCreated)
+        {
+            _comboBox.Update();
+        }
+    }
+
+    private void RefreshDisabledDropDownAppearance()
+    {
+        if (!Enabled && DropDownStyle == ComboBoxStyle.DropDown)
+        {
+            UpdateEditControl();
+
+            if (IsComboBoxAppearanceReady)
+            {
+                SyncComboBoxAppearance(true);
+
+                if (_comboBox.IsHandleCreated)
+                {
+                    _comboBox.Update();
+                }
+            }
+        }
+    }
+
+    private bool IsComboBoxAppearanceReady => _drawDockerOuter is not null && _pulsingBorder is not null;
+
     private void UpdateStateAndPalettes()
     {
+        if (!IsComboBoxAppearanceReady)
+        {
+            return;
+        }
+
         // Get the correct palette settings to use
         var tripleState = GetComboBoxTripleState();
         _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
@@ -3042,9 +3115,17 @@ public class KryptonComboBox : VisualControlBase,
             return;
         }
 
-        UpdateStateAndPalettes();
+        PaletteState state = Enabled
+            ? IsActive ? PaletteState.Tracking : PaletteState.Normal
+            : PaletteState.Disabled;
+
+        if (IsComboBoxAppearanceReady)
+        {
+            UpdateStateAndPalettes();
+            state = _drawDockerOuter.State;
+        }
+
         var triple = GetComboBoxTripleState();
-        PaletteState state = _drawDockerOuter.State;
         _comboBox.BackColor = triple.PaletteBack.GetBackColor1(state);
         _comboBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
         _comboBox.Font = triple.PaletteContent.GetContentShortTextFont(state)!;
@@ -3320,6 +3401,7 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxTextChanged(object? sender, EventArgs e)
     {
+        RefreshDisabledDropDownAppearance();
         CueHint.SyncAnimation();
         OnTextChanged(e);
     }
@@ -3328,7 +3410,11 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxSelectionChangeCommitted(object? sender, EventArgs e) => OnSelectionChangeCommitted(e);
 
-    private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e) => OnSelectedIndexChanged(e);
+    private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        RefreshDisabledDropDownAppearance();
+        OnSelectedIndexChanged(e);
+    }
 
     private void OnComboBoxDropDownStyleChanged(object? sender, EventArgs e) => OnDropDownStyleChanged(e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -86,6 +86,28 @@ public class KryptonComboBox : VisualControlBase,
         #endregion
 
         #region Protected
+        protected override void OnEnabledChanged(EventArgs e)
+        {
+            if (!_kryptonComboBox.Enabled)
+            {
+                if (IsHandleCreated)
+                {
+                    PI.EnableWindow(Handle, true);
+                }
+
+                return;
+            }
+
+            base.OnEnabledChanged(e);
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            _kryptonComboBox.EnsureInternalComboBoxNativeEnabled();
+            base.OnHandleCreated(e);
+            _kryptonComboBox.OnInternalComboBoxHandleCreatedSafe();
+        }
+
         /// <summary>
         /// Process Windows-based messages.
         /// </summary>
@@ -110,6 +132,15 @@ public class KryptonComboBox : VisualControlBase,
 
             switch (m.Msg)
             {
+                case PI.WM_.ERASEBKGND:
+                    if (!_kryptonComboBox.Enabled)
+                    {
+                        m.Result = (IntPtr)1;
+                        return;
+                    }
+
+                    base.WndProc(ref m);
+                    break;
                 case PI.WM_.NCHITTEST:
                     if (_kryptonComboBox.InTransparentDesignMode)
                     {
@@ -300,6 +331,12 @@ public class KryptonComboBox : VisualControlBase,
         #region Protected
         protected override void OnEnabledChanged(EventArgs e)
         {
+            if (!_kryptonComboBox.Enabled)
+            {
+                _kryptonComboBox.EnsureInternalComboBoxNativeEnabled();
+                return;
+            }
+
             if (Enabled)
             {
                 base.OnEnabledChanged(e);
@@ -312,6 +349,7 @@ public class KryptonComboBox : VisualControlBase,
         /// <param name="e">An EventArgs containing the event data.</param>
         protected override void OnHandleCreated(EventArgs e)
         {
+            _kryptonComboBox.EnsureInternalComboBoxNativeEnabled();
             base.OnHandleCreated(e);
             _kryptonComboBox.OnInternalComboBoxHandleCreatedSafe();
         }
@@ -340,6 +378,12 @@ public class KryptonComboBox : VisualControlBase,
                 {
                     case PI.WM_.PAINT:
                     case PI.WM_.PRINTCLIENT:
+                        // Fall through to themed owner-draw when disabled; base paints system disabled colors.
+                        if (!_kryptonComboBox.Enabled)
+                        {
+                            break;
+                        }
+
                         base.WndProc(ref m);
                         return;
                     case PI.WM_.COMMAND:
@@ -351,6 +395,15 @@ public class KryptonComboBox : VisualControlBase,
 
             switch (m.Msg)
             {
+                case PI.WM_.ERASEBKGND:
+                    if (!_kryptonComboBox.Enabled)
+                    {
+                        m.Result = (IntPtr)1;
+                        return;
+                    }
+
+                    base.WndProc(ref m);
+                    break;
                 case PI.WM_.NCHITTEST:
                     if (_kryptonComboBox.InTransparentDesignMode)
                     {
@@ -686,7 +739,11 @@ public class KryptonComboBox : VisualControlBase,
             }
 
             // Fill background with the solid background color
-            using (var backBrush = new SolidBrush(BackColor))
+            PaletteInputControlTripleStates triple = _kryptonComboBox.GetComboBoxTripleState();
+            PaletteState backState = _kryptonComboBox.Enabled
+                ? _kryptonComboBox.IsActive ? PaletteState.Tracking : PaletteState.Normal
+                : PaletteState.Disabled;
+            using (var backBrush = new SolidBrush(triple.PaletteBack.GetBackColor1(backState)))
             {
                 g?.FillRectangle(backBrush, drawRect);
             }
@@ -913,22 +970,37 @@ public class KryptonComboBox : VisualControlBase,
                     base.WndProc(ref m);
                     break;
                 case PI.WM_.ERASEBKGND:
+                    if (!_kryptonComboBox.Enabled)
+                    {
+                        m.Result = (IntPtr)1;
+                        return;
+                    }
+
+                    base.WndProc(ref m);
+                    break;
                 case PI.WM_.PAINT:
+                case PI.WM_.PRINTCLIENT:
                     // Themed disabled content is painted by InternalComboBox.WM_PAINT; suppress native edit painting.
                     if (!_kryptonComboBox.Enabled)
                     {
-                        if (m.Msg == (int)PI.WM_.ERASEBKGND)
-                        {
-                            m.Result = (IntPtr)1;
-                        }
-
+                        ValidateSuppressedPaint(ref m);
                         return;
                     }
+
                     base.WndProc(ref m);
                     break;
                 case PI.WM_.DESTROY:
                     // Remove this code as it prevents the auto suggest features from working
                     // _kryptonComboBox.DetachEditControl();
+                    base.WndProc(ref m);
+                    break;
+                case PI.WM_.SHOWWINDOW:
+                    if (!_kryptonComboBox.Enabled && m.WParam != IntPtr.Zero)
+                    {
+                        Visible = false;
+                        return;
+                    }
+
                     base.WndProc(ref m);
                     break;
                 default:
@@ -949,6 +1021,20 @@ public class KryptonComboBox : VisualControlBase,
         /// <param name="e">An EventArgs containing the event data.</param>
         protected virtual void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
 
+        #endregion
+
+        #region Implementation
+        private void ValidateSuppressedPaint(ref Message m)
+        {
+            // WM_PAINT must pair BeginPaint/EndPaint or the update region stays invalid and
+            // the edit HWND keeps repainting an opaque system background over the themed combo.
+            if (m.Msg == (int)PI.WM_.PAINT && m.WParam == IntPtr.Zero)
+            {
+                var ps = new PI.PAINTSTRUCT();
+                PI.BeginPaint(Handle, ref ps);
+                PI.EndPaint(Handle, ref ps);
+            }
+        }
         #endregion
     }
     #endregion
@@ -1013,6 +1099,7 @@ public class KryptonComboBox : VisualControlBase,
     // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
     // _deferredComboBoxStyle caches the selected change which is applied when the control is enabled again.
     private ComboBoxStyle? _deferredComboBoxStyle;
+    private bool _ensuringNativeEnabled;
 
     #endregion
 
@@ -1434,7 +1521,11 @@ public class KryptonComboBox : VisualControlBase,
         _comboBox.DrawMode = DrawMode.OwnerDrawVariable;
 
         // Designer may set Enabled=false before the handle exists; sync themed disabled colors now.
-        if (_comboBox.IsHandleCreated)
+        if (!Enabled)
+        {
+            RefreshDisabledAppearance();
+        }
+        else if (_comboBox.IsHandleCreated)
         {
             OnInternalComboBoxHandleCreatedSafe();
         }
@@ -2645,6 +2736,37 @@ public class KryptonComboBox : VisualControlBase,
 
         // We need to recalculate the correct height
         Height = PreferredHeight;
+
+        if (!Enabled)
+        {
+            RefreshDisabledAppearance();
+        }
+    }
+
+    /// <summary>
+    /// Raises the ParentChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnParentChanged(EventArgs e)
+    {
+        base.OnParentChanged(e);
+        if (!Enabled)
+        {
+            RefreshDisabledAppearance();
+        }
+    }
+
+    /// <summary>
+    /// Raises the VisibleChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnVisibleChanged(EventArgs e)
+    {
+        base.OnVisibleChanged(e);
+        if (Visible && !Enabled)
+        {
+            RefreshDisabledAppearance();
+        }
     }
 
     /// <summary>
@@ -2653,7 +2775,13 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnEnabledChanged(EventArgs e)
     {
-        // Ensure we have subclassed the contained edit control
+        // Let base propagate enabled state first; it can show the native edit child with system colors.
+        base.OnEnabledChanged(e);
+
+        // Owner-draw paints disabled state; keep native HWNDs enabled so Windows disabled styling is not applied (#3879).
+        EnsureInternalComboBoxNativeEnabled();
+
+        // Re-hide the native edit HWND after base runs (#3879).
         UpdateEditControl();
 
         if (IsComboBoxAppearanceReady)
@@ -2676,8 +2804,11 @@ public class KryptonComboBox : VisualControlBase,
             SyncComboBoxAppearance();
         }
 
-        // Let base class fire standard event
-        base.OnEnabledChanged(e);
+        if (_comboBox.IsHandleCreated)
+        {
+            _comboBox.Invalidate(true);
+            _comboBox.Update();
+        }
 
         // #1697 Work-around
         // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
@@ -2954,7 +3085,14 @@ public class KryptonComboBox : VisualControlBase,
     protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
         base.OnPaletteNeedPaint(sender, e);
-        _comboBox.Invalidate();
+        if (!Enabled)
+        {
+            RefreshDisabledAppearance();
+        }
+        else
+        {
+            _comboBox.Invalidate();
+        }
     }
 
     /// <summary>
@@ -3050,6 +3188,7 @@ public class KryptonComboBox : VisualControlBase,
 
     internal void OnInternalComboBoxHandleCreatedSafe()
     {
+        EnsureInternalComboBoxNativeEnabled();
         UpdateEditControl();
 
         if (!IsComboBoxAppearanceReady)
@@ -3065,10 +3204,39 @@ public class KryptonComboBox : VisualControlBase,
         }
     }
 
-    private void RefreshDisabledDropDownAppearance()
+    private void EnsureInternalComboBoxNativeEnabled()
     {
-        if (!Enabled && DropDownStyle == ComboBoxStyle.DropDown)
+        if (IsDisposed || Disposing || Enabled || _ensuringNativeEnabled)
         {
+            return;
+        }
+
+        _ensuringNativeEnabled = true;
+        try
+        {
+            // WinForms cascades WS_DISABLED when the host is disabled; owner-draw supplies themed disabled chrome.
+            // Use EnableWindow only — setting Control.Enabled re-enters OnEnabledChanged and can stack-overflow.
+            if (_comboHolder.IsHandleCreated)
+            {
+                PI.EnableWindow(_comboHolder.Handle, true);
+            }
+
+            if (_comboBox.IsHandleCreated)
+            {
+                PI.EnableWindow(_comboBox.Handle, true);
+            }
+        }
+        finally
+        {
+            _ensuringNativeEnabled = false;
+        }
+    }
+
+    private void RefreshDisabledAppearance()
+    {
+        if (!Enabled)
+        {
+            EnsureInternalComboBoxNativeEnabled();
             UpdateEditControl();
 
             if (IsComboBoxAppearanceReady)
@@ -3079,6 +3247,10 @@ public class KryptonComboBox : VisualControlBase,
                 {
                     _comboBox.Update();
                 }
+            }
+            else
+            {
+                SyncComboBoxAppearance();
             }
         }
     }
@@ -3134,6 +3306,7 @@ public class KryptonComboBox : VisualControlBase,
         if (invalidateCombo && _comboBox.IsHandleCreated)
         {
             _comboBox.Invalidate(true);
+            _comboBox.Update();
         }
     }
 
@@ -3166,7 +3339,8 @@ public class KryptonComboBox : VisualControlBase,
             Color textColor = triple.PaletteContent!.GetContentShortTextColor1(state);
             Font? font = triple.PaletteContent.GetContentShortTextFont(state);
 
-            if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
+            if ((e.State & DrawItemState.Disabled) != DrawItemState.Disabled
+                && (e.State & DrawItemState.Selected) == DrawItemState.Selected)
             {
                 textColor = SystemColors.HighlightText;
                 backColor = SystemColors.Highlight;
@@ -3177,8 +3351,8 @@ public class KryptonComboBox : VisualControlBase,
                 e.Graphics.FillRectangle(backBrush, drawBounds);
             }
 
-            // Is there an item to draw
-            if (e.Index >= 0)
+            var displayText = e.Index >= 0 ? _comboBox.GetItemText(Items[e.Index]) : _comboBox.Text;
+            if (!string.IsNullOrEmpty(displayText))
             {
                 // Without this line the wrong hint can occur because it inherits it from the device context.
                 // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls.
@@ -3197,7 +3371,7 @@ public class KryptonComboBox : VisualControlBase,
 
                     // Draw text using font defined by the control
                     TextRenderer.DrawText(e.Graphics,
-                        _comboBox.Text, font ?? _comboBox.Font,
+                        displayText, font ?? _comboBox.Font,
                         drawBounds,
                         textColor, backColor,
                         flags);
@@ -3401,7 +3575,7 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxTextChanged(object? sender, EventArgs e)
     {
-        RefreshDisabledDropDownAppearance();
+        RefreshDisabledAppearance();
         CueHint.SyncAnimation();
         OnTextChanged(e);
     }
@@ -3412,7 +3586,7 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e)
     {
-        RefreshDisabledDropDownAppearance();
+        RefreshDisabledAppearance();
         OnSelectedIndexChanged(e);
     }
 

--- a/Source/Krypton Components/TestForm/Bug3879KryptonComboBoxDisabledDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3879KryptonComboBoxDisabledDemo.cs
@@ -119,7 +119,9 @@ public sealed class Bug3879KryptonComboBoxDisabledDemo : KryptonForm
 
         if (disabledInDesigner)
         {
+            comboBox.BeginInit();
             comboBox.Enabled = false;
+            comboBox.EndInit();
         }
 
         return comboBox;

--- a/Source/Krypton Components/TestForm/Bug3879KryptonComboBoxDisabledDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3879KryptonComboBoxDisabledDemo.cs
@@ -1,0 +1,157 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Reproduces issue #3879: KryptonComboBox disabled at design/startup should use theme colors.
+/// </summary>
+public sealed class Bug3879KryptonComboBoxDisabledDemo : KryptonForm
+{
+    private readonly KryptonWrapLabel _lblInfo;
+    private readonly KryptonThemeComboBox _themeComboBox;
+    private readonly KryptonButton _btnToggleEnabled;
+    private readonly KryptonComboBox _dropDownDesignDisabled;
+    private readonly KryptonComboBox _dropDownCtorDisabled;
+    private readonly KryptonComboBox _dropDownListDesignDisabled;
+
+    public Bug3879KryptonComboBoxDisabledDemo()
+    {
+        Text = @"Bug #3879 - KryptonComboBox Disabled Startup Colors";
+        StartPosition = FormStartPosition.CenterScreen;
+        Size = new Size(720, 420);
+        MinimumSize = new Size(640, 360);
+
+        _lblInfo = new KryptonWrapLabel
+        {
+            Dock = DockStyle.Top,
+            Height = 110,
+            Text =
+                @"How to test issue #3879:" + Environment.NewLine +
+                @"1) On load, all disabled combos below should use Krypton disabled palette colors (not system gray)." + Environment.NewLine +
+                @"2) Top row uses ComboBoxStyle.DropDown (the reported scenario); bottom row uses DropDownList for comparison." + Environment.NewLine +
+                @"3) Switch themes and use Toggle Enabled to confirm colors stay correct."
+        };
+
+        _themeComboBox = new KryptonThemeComboBox
+        {
+            Dock = DockStyle.Top,
+            DropDownWidth = 260,
+            IntegralHeight = false
+        };
+
+        _btnToggleEnabled = new KryptonButton
+        {
+            Dock = DockStyle.Top,
+            Height = 34,
+            Text = @"Toggle Enabled"
+        };
+        _btnToggleEnabled.Click += OnToggleEnabledClick;
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            RowCount = 4,
+            Padding = new Padding(12)
+        };
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+        layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+        var dropDownCaption = CreateCaption(@"DropDown — disabled in designer");
+        layout.Controls.Add(dropDownCaption, 0, 0);
+        layout.SetColumnSpan(dropDownCaption, 2);
+
+        _dropDownDesignDisabled = CreateComboBox(ComboBoxStyle.DropDown, disabledInDesigner: true);
+        _dropDownCtorDisabled = CreateComboBox(ComboBoxStyle.DropDown, disabledInDesigner: false);
+
+        layout.Controls.Add(CreateFieldPanel(@"Designer Enabled=false", _dropDownDesignDisabled), 0, 1);
+        layout.Controls.Add(CreateFieldPanel(@"Ctor sets Enabled=false", _dropDownCtorDisabled), 1, 1);
+
+        var dropDownListCaption = CreateCaption(@"DropDownList — disabled in designer");
+        layout.Controls.Add(dropDownListCaption, 0, 2);
+        layout.SetColumnSpan(dropDownListCaption, 2);
+
+        _dropDownListDesignDisabled = CreateComboBox(ComboBoxStyle.DropDownList, disabledInDesigner: true);
+        layout.Controls.Add(CreateFieldPanel(@"Designer Enabled=false", _dropDownListDesignDisabled), 0, 3);
+        layout.SetColumnSpan(layout.Controls[layout.Controls.Count - 1], 2);
+
+        Controls.Add(layout);
+        Controls.Add(_btnToggleEnabled);
+        Controls.Add(_themeComboBox);
+        Controls.Add(_lblInfo);
+
+        _dropDownCtorDisabled.Enabled = false;
+        _dropDownDesignDisabled.SelectedIndex = 0;
+        _dropDownCtorDisabled.SelectedIndex = 0;
+        _dropDownListDesignDisabled.SelectedIndex = 0;
+    }
+
+    private static KryptonWrapLabel CreateCaption(string text) =>
+        new()
+        {
+            AutoSize = true,
+            Margin = new Padding(0, 8, 0, 4),
+            Text = text
+        };
+
+    private static KryptonComboBox CreateComboBox(ComboBoxStyle style, bool disabledInDesigner)
+    {
+        var comboBox = new KryptonComboBox
+        {
+            DropDownStyle = style,
+            DropDownWidth = 240,
+            IntegralHeight = false,
+            Size = new Size(240, 22),
+            Text = style == ComboBoxStyle.DropDown ? @"Editable disabled text" : string.Empty
+        };
+        comboBox.Items.AddRange(["Item 1", "Item 2", "Item 3"]);
+
+        if (disabledInDesigner)
+        {
+            comboBox.Enabled = false;
+        }
+
+        return comboBox;
+    }
+
+    private static Control CreateFieldPanel(string caption, KryptonComboBox comboBox)
+    {
+        var panel = new KryptonPanel
+        {
+            Dock = DockStyle.Fill,
+            Margin = new Padding(0, 0, 8, 8)
+        };
+
+        var label = new KryptonWrapLabel
+        {
+            AutoSize = true,
+            Dock = DockStyle.Top,
+            Text = caption
+        };
+
+        comboBox.Dock = DockStyle.Top;
+        comboBox.Margin = new Padding(0, 4, 0, 0);
+
+        panel.Controls.Add(comboBox);
+        panel.Controls.Add(label);
+        return panel;
+    }
+
+    private void OnToggleEnabledClick(object? sender, EventArgs e)
+    {
+        _dropDownDesignDisabled.Enabled = !_dropDownDesignDisabled.Enabled;
+        _dropDownCtorDisabled.Enabled = !_dropDownCtorDisabled.Enabled;
+        _dropDownListDesignDisabled.Enabled = !_dropDownListDesignDisabled.Enabled;
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -152,6 +152,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<KryptonDialogExamples>("Krypton Dialog tests", "Tests the various types of dialogs.");
         CreateButton<FadeFormTest>("FadeForm", string.Empty);
         CreateButton<GroupBoxTest>("GroupBox", string.Empty);
+        CreateButton<Bug3879KryptonComboBoxDisabledDemo>("3879 ComboBox Disabled", "Issue #3879: KryptonComboBox disabled at startup (DropDown and DropDownList) should use theme disabled colors. Toggle Enabled and switch themes to verify.");
         CreateButton<InputBoxTest>("InputBox", string.Empty);
         CreateButton<JumpListTest>("Jump List Test", "Comprehensive demonstration of jump lists on KryptonForm with user tasks, custom categories, known categories, and interactive examples.");
         CreateButton<KryptonLoggerDemo>("Krypton Logger (#3856)", "Issue #3856: exercise KryptonLogger, CommonHelper.LogOutput, optional file logging (set KRYPTON_LOG or KRYPTON_LOG_PATH before launch), custom IKryptonLogger, parallel stress writes, and theme-swap WM tracing.");


### PR DESCRIPTION
…lays using default system colors (V110)

# Fix: KryptonComboBox disabled startup colors (#3879)

## Summary

`KryptonComboBox` now applies Krypton disabled palette colors when the control is created or initialized with `Enabled = false`, including `ComboBoxStyle.DropDown`. Previously the inner native combo could paint with system disabled colors until `Enabled` was toggled at runtime.

## Related issues

- Closes #3879

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- **Krypton.Toolkit / `KryptonComboBox`**
  - Added `SyncComboBoxAppearance()` to centralize palette-backed color/font sync for the internal combo and holder.
  - Call appearance sync from `EndInit()` and after layout in `OnHandleCreated()` so designer-disabled controls repaint with themed colors once handles exist.
  - Propagate `Enabled` to the internal `InternalComboBox` so its `OnEnabledChanged` guard suppresses native disabled styling.
  - `OnComboBoxDrawItem` (`ComboBoxEdit`) now fills with palette colors instead of `e.DrawBackground()` (system gray when disabled).
  - `OnComboBoxGotFocus` no longer shows the native edit child when the control is disabled.
- **TestForm**
  - Added `Bug3879KryptonComboBoxDisabledDemo` with `DropDown` and `DropDownList` disabled-at-startup scenarios, theme switching, and an enable toggle.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472`, `net8.0-windows` (via targeted `dotnet build`)

## Validation

- TestForm demo: `Bug3879KryptonComboBoxDisabledDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Run TestForm and open **3879 ComboBox Disabled**.
  2. Confirm all disabled combos use Krypton disabled palette colors on first paint (try a dark theme).
  3. Toggle **Toggle Enabled** and switch themes; colors should remain correct.
- Build: `dotnet build ".\Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#3879](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3879), When the `KryptonComboBox` initializes in a disabled state, it displays using default system colors
   * `KryptonComboBox` now displays theme disabled colors when initialized in a disabled state.
```

## Breaking changes & migration

None.

## Developer documentation

Omit for this bug fix.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Breaking-change impact and TFM notes documented above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native Win32 messaging, enabled-state propagation, and paint paths across multiple nested HWNDs in a widely used control; regression risk is moderate though scope is limited to disabled appearance.
> 
> **Overview**
> Fixes **#3879**: a `KryptonComboBox` with `Enabled = false` at design time or startup could show **system disabled gray** on the inner native combo/edit until enabled was toggled at runtime.
> 
> The control now keeps **owner-drawn Krypton disabled palette** colors on first paint by centralizing sync in `SyncComboBoxAppearance()` / `RefreshDisabledAppearance()`, calling them from `EndInit()`, handle creation, parent/visibility changes, and palette updates. While the host is disabled, inner HWNDs are re-enabled via **`PI.EnableWindow`** (new interop) so Windows does not apply native disabled chrome; `WndProc` suppresses native erase/paint on the edit child and pairs `BeginPaint`/`EndPaint` where needed. **ComboBoxEdit** drawing and the drop-down chrome background use palette triple state instead of `DrawBackground()` / `BackColor`. The native edit stays hidden when disabled (including on focus). **TestForm** adds `Bug3879KryptonComboBoxDisabledDemo` and a **Changelog** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c97d8063f257a20d01263d246353d846954f6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->