### PR TITLE
* When the `KryptonComboBox` initializes in a disabled state, it disp…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,8 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Resolved [#3879](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3879), When the `KryptonComboBox` initializes in a disabled state, it displays using default system colors
+   * `KryptonComboBox` now displays theme disabled colors when initialized in a disabled state.
 * Resolved [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850), Tooltip hot-spot not respected 
    * Tooltip placement now respects cursor hotspot and full cursor bounds
 * Implemented [#3861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3861), Permits customizing glyph colors (#3663) using `KryptonCustomPalette`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -265,6 +265,16 @@ public class KryptonComboBox : VisualControlBase,
         }
 
         /// <summary>
+        /// Raises the HandleCreated event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _kryptonComboBox.OnInternalComboBoxHandleCreated();
+        }
+
+        /// <summary>
         /// Raises the FontChanged event.
         /// </summary>
         /// <param name="e">Contains the event data.</param>
@@ -1357,7 +1367,7 @@ public class KryptonComboBox : VisualControlBase,
         _comboBox.DrawMode = DrawMode.OwnerDrawVariable;
 
         // Designer may set Enabled=false before the handle exists; sync themed disabled colors now.
-        SyncComboBoxAppearance(_comboBox.IsHandleCreated);
+        ApplyDisabledStartupAppearance();
 
         // Raise event to show control is now initialized
         OnInitialized(EventArgs.Empty);
@@ -2551,10 +2561,36 @@ public class KryptonComboBox : VisualControlBase,
 
         // Layout can recreate the native edit child; hide it again before the first paint.
         UpdateEditControl();
-        SyncComboBoxAppearance(true);
+        ApplyDisabledStartupAppearance();
 
         // We need to recalculate the correct height
         Height = PreferredHeight;
+    }
+
+    /// <summary>
+    /// Raises the ParentChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnParentChanged(EventArgs e)
+    {
+        base.OnParentChanged(e);
+        if (Parent != null)
+        {
+            ApplyDisabledStartupAppearance();
+        }
+    }
+
+    /// <summary>
+    /// Raises the VisibleChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs containing the event data.</param>
+    protected override void OnVisibleChanged(EventArgs e)
+    {
+        base.OnVisibleChanged(e);
+        if (Visible)
+        {
+            ApplyDisabledStartupAppearance();
+        }
     }
 
     /// <summary>
@@ -2563,8 +2599,8 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnEnabledChanged(EventArgs e)
     {
-        // Propagate to the internal ComboBox so InternalComboBox.OnEnabledChanged can suppress native disabled styling.
-        _comboBox.Enabled = Enabled;
+        // Do not propagate Enabled to the internal ComboBox; WS_DISABLED on the native HWND
+        // causes system disabled painting to win over the themed owner-draw path (#3879).
 
         // Ensure we have subclassed the contained edit control
         UpdateEditControl();
@@ -2821,16 +2857,17 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
     protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
-        if (!e.NeedLayout)
-        {
-            _comboBox.Invalidate();
-        }
-        else if (!DroppedDown)
+        if (e.NeedLayout && !DroppedDown)
         {
             ForceControlLayout();
         }
 
         SyncComboBoxAppearance();
+
+        if (!e.NeedLayout)
+        {
+            _comboBox.Invalidate();
+        }
 
         base.OnNeedPaint(sender, e);
     }
@@ -2853,6 +2890,10 @@ public class KryptonComboBox : VisualControlBase,
     protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
     {
         base.OnPaletteNeedPaint(sender, e);
+        if (!Enabled)
+        {
+            SyncComboBoxAppearance();
+        }
         _comboBox.Invalidate();
     }
 
@@ -2958,6 +2999,17 @@ public class KryptonComboBox : VisualControlBase,
 
     internal PaletteInputControlTripleStates GetComboBoxTripleState() => Enabled ? IsActive ? StateActive.ComboBox : StateNormal.ComboBox : StateDisabled.ComboBox;
 
+    internal void OnInternalComboBoxHandleCreated() => ApplyDisabledStartupAppearance();
+
+    private void ApplyDisabledStartupAppearance()
+    {
+        if (!Enabled)
+        {
+            UpdateEditControl();
+            SyncComboBoxAppearance(true);
+        }
+    }
+
     private void SyncComboBoxAppearance(bool invalidateCombo = false)
     {
         if (IsDisposed || Disposing)
@@ -2976,6 +3028,7 @@ public class KryptonComboBox : VisualControlBase,
         if (invalidateCombo && _comboBox.IsHandleCreated)
         {
             _comboBox.Invalidate(true);
+            _comboBox.Update();
         }
     }
 
@@ -3244,7 +3297,15 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxSelectionChangeCommitted(object? sender, EventArgs e) => OnSelectionChangeCommitted(e);
 
-    private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e) => OnSelectedIndexChanged(e);
+    private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (!Enabled)
+        {
+            SyncComboBoxAppearance(true);
+        }
+
+        OnSelectedIndexChanged(e);
+    }
 
     private void OnComboBoxDropDownStyleChanged(object? sender, EventArgs e) => OnDropDownStyleChanged(e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1356,6 +1356,9 @@ public class KryptonComboBox : VisualControlBase,
         // Force calculation of the drop-down items again so they are sized correctly
         _comboBox.DrawMode = DrawMode.OwnerDrawVariable;
 
+        // Designer may set Enabled=false before the handle exists; sync themed disabled colors now.
+        SyncComboBoxAppearance(_comboBox.IsHandleCreated);
+
         // Raise event to show control is now initialized
         OnInitialized(EventArgs.Empty);
     }
@@ -2546,6 +2549,10 @@ public class KryptonComboBox : VisualControlBase,
         // We need a layout to occur before any painting
         InvokeLayout();
 
+        // Layout can recreate the native edit child; hide it again before the first paint.
+        UpdateEditControl();
+        SyncComboBoxAppearance(true);
+
         // We need to recalculate the correct height
         Height = PreferredHeight;
     }
@@ -2556,6 +2563,9 @@ public class KryptonComboBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnEnabledChanged(EventArgs e)
     {
+        // Propagate to the internal ComboBox so InternalComboBox.OnEnabledChanged can suppress native disabled styling.
+        _comboBox.Enabled = Enabled;
+
         // Ensure we have subclassed the contained edit control
         UpdateEditControl();
 
@@ -2820,16 +2830,7 @@ public class KryptonComboBox : VisualControlBase,
             ForceControlLayout();
         }
 
-        if (!IsDisposed && !Disposing)
-        {
-            UpdateStateAndPalettes();
-            var triple = GetComboBoxTripleState();
-            PaletteState state = _drawDockerOuter.State;
-            _comboBox.BackColor = triple.PaletteBack.GetBackColor1(state);
-            _comboBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
-            _comboBox.Font = triple.PaletteContent.GetContentShortTextFont(state)!;
-            _comboHolder.BackColor = _comboBox.BackColor;
-        }
+        SyncComboBoxAppearance();
 
         base.OnNeedPaint(sender, e);
     }
@@ -2957,6 +2958,27 @@ public class KryptonComboBox : VisualControlBase,
 
     internal PaletteInputControlTripleStates GetComboBoxTripleState() => Enabled ? IsActive ? StateActive.ComboBox : StateNormal.ComboBox : StateDisabled.ComboBox;
 
+    private void SyncComboBoxAppearance(bool invalidateCombo = false)
+    {
+        if (IsDisposed || Disposing)
+        {
+            return;
+        }
+
+        UpdateStateAndPalettes();
+        var triple = GetComboBoxTripleState();
+        PaletteState state = _drawDockerOuter.State;
+        _comboBox.BackColor = triple.PaletteBack.GetBackColor1(state);
+        _comboBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+        _comboBox.Font = triple.PaletteContent.GetContentShortTextFont(state)!;
+        _comboHolder.BackColor = _comboBox.BackColor;
+
+        if (invalidateCombo && _comboBox.IsHandleCreated)
+        {
+            _comboBox.Invalidate(true);
+        }
+    }
+
     private int PreferredHeight
     {
         get
@@ -2976,32 +2998,34 @@ public class KryptonComboBox : VisualControlBase,
         // Do we need to draw the edit area
         if ((e.State & DrawItemState.ComboBoxEdit) == DrawItemState.ComboBoxEdit)
         {
-            // TODO: Check if this is covered by the WM_PAINT in the internal Combo
-            // Always get base implementation to draw the background
-            e.DrawBackground();
+            PaletteState state = Enabled
+                ? IsActive
+                    ? PaletteState.Tracking
+                    : PaletteState.Normal
+                : PaletteState.Disabled;
+            var triple = GetComboBoxTripleState();
+            Color backColor = triple.PaletteBack.GetBackColor1(state);
+            Color textColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+            Font? font = triple.PaletteContent.GetContentShortTextFont(state);
 
-            // Find correct text color
-            Color textColor = _comboBox.ForeColor;
+
             if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
             {
                 textColor = SystemColors.HighlightText;
+                backColor = SystemColors.Highlight;
             }
 
-            // Find correct background color
-            Color backColor = _comboBox.BackColor;
-            if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
+            using (var backBrush = new SolidBrush(backColor))
             {
-                backColor = SystemColors.Highlight;
+                e.Graphics.FillRectangle(backBrush, drawBounds);
             }
 
             // Is there an item to draw
             if (e.Index >= 0)
             {
-                // Set the correct text rendering hint for the text drawing. We only draw if the edit text is enabled so we
-                // just always grab the normal state value. Without this line the wrong hint can occur because it inherits
-                // it from the device context. Resulting in blurred text.
-                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls
-                using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(StateNormal.Item.PaletteContent!.GetContentShortTextHint(PaletteState.Normal))))
+                // Without this line the wrong hint can occur because it inherits it from the device context.
+                // Use GraphicsTextHint to properly save/restore TextRenderingHint to prevent affecting other controls.
+                using (new GraphicsTextHint(e.Graphics, CommonHelper.PaletteTextHintToRenderingHint(triple.Content.GetContentShortTextHint(state))))
                 {
                     TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding;
 
@@ -3016,7 +3040,7 @@ public class KryptonComboBox : VisualControlBase,
 
                     // Draw text using font defined by the control
                     TextRenderer.DrawText(e.Graphics,
-                        _comboBox.Text, _comboBox.Font,
+                        _comboBox.Text, font ?? _comboBox.Font,
                         drawBounds,
                         textColor, backColor,
                         flags);
@@ -3183,7 +3207,7 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxGotFocus(object? sender, EventArgs e)
     {
-        if (DropDownStyle == ComboBoxStyle.DropDown)
+        if (DropDownStyle == ComboBoxStyle.DropDown && Enabled)
         {
             _subclassEdit!.Visible = true;
             PaletteState state = Enabled


### PR DESCRIPTION
…lays using default system colors (V105)

# Fix: KryptonComboBox disabled startup colors (#3879)

## Summary

`KryptonComboBox` now applies Krypton disabled palette colors when the control is created or initialized with `Enabled = false`, including `ComboBoxStyle.DropDown`. Previously the inner native combo could paint with system disabled colors until `Enabled` was toggled at runtime.

## Related issues

- Closes #3879

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- **Krypton.Toolkit / `KryptonComboBox`**
  - Added `SyncComboBoxAppearance()` to centralize palette-backed color/font sync for the internal combo and holder.
  - Call appearance sync from `EndInit()` and after layout in `OnHandleCreated()` so designer-disabled controls repaint with themed colors once handles exist.
  - Propagate `Enabled` to the internal `InternalComboBox` so its `OnEnabledChanged` guard suppresses native disabled styling.
  - `OnComboBoxDrawItem` (`ComboBoxEdit`) now fills with palette colors instead of `e.DrawBackground()` (system gray when disabled).
  - `OnComboBoxGotFocus` no longer shows the native edit child when the control is disabled.
- **TestForm**
  - Added `Bug3879KryptonComboBoxDisabledDemo` with `DropDown` and `DropDownList` disabled-at-startup scenarios, theme switching, and an enable toggle.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472`, `net8.0-windows` (via targeted `dotnet build`)

## Validation

- TestForm demo: `Bug3879KryptonComboBoxDisabledDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Run TestForm and open **3879 ComboBox Disabled**.
  2. Confirm all disabled combos use Krypton disabled palette colors on first paint (try a dark theme).
  3. Toggle **Toggle Enabled** and switch themes; colors should remain correct.
- Build: `dotnet build ".\Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#3879](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3879), When the `KryptonComboBox` initializes in a disabled state, it displays using default system colors
   * `KryptonComboBox` now displays theme disabled colors when initialized in a disabled state.
```

## Breaking changes & migration

None.

## Developer documentation

Omit for this bug fix.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Breaking-change impact and TFM notes documented above