### PR TITLE
* Implement `IsDefault` on Values stubs (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3857](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3857), Implement `IsDefault` on `KryptonInputBoxValues` and `KryptonPalettePropertyGrid` so PropertyGrid display, designer reset, and `ToString()` no longer throw
 * Resolved [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850), Tooltip hot-spot not respected 
    * Tooltip placement now respects cursor hotspot and full cursor bounds
 * Implemented [#3861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3861), Permits customizing glyph colors (#3663) using `KryptonCustomPalette`.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPalettePropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPalettePropertyGrid.cs
@@ -22,5 +22,5 @@ public class KryptonPalettePropertyGrid : Storage
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => throw new NotImplementedException();
+    public override bool IsDefault => true;
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Values/KryptonInputBoxValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/KryptonInputBoxValues.cs
@@ -8,5 +8,5 @@ public class KryptonInputBoxValues : Storage
 {
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => throw new NotImplementedException();
+    public override bool IsDefault => true;
 }


### PR DESCRIPTION
## Summary

- Replace `NotImplementedException` with `IsDefault => true` on `KryptonInputBoxValues` and `KryptonPalettePropertyGrid` so PropertyGrid `ToString()`, designer reset, and serialization checks no longer throw.
- File-system Values types are V110-only; see PR #3888 for the full implementation.

## Related issues

- Closes #3857 (V105 scope: Storage stubs in `Krypton.Toolkit`)
