### PR TITLE
* `KryptonContextMenu` Improvements (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,8 @@
 
 ## 2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026
 
+* Implemented [#3891](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3891), `KryptonContextMenu` Improvements
+   * Shared `KryptonCommand` support for `KryptonContextMenu` items — multiple menu entries can reference one command and pass a `CommandParameter` so a single `Execute` handler can branch on the originating item; includes `IKryptonContextMenuCommandItem`, `KryptonCommandContext`, and `KryptonCommandExecuteEventArgs`.
 * Resolved [#3850](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3850), Tooltip hot-spot not respected 
    * Tooltip placement now respects cursor hotspot and full cursor bounds
 * Implemented [#3861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3861), Permits customizing glyph colors (#3663) using `KryptonCustomPalette`.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/IKryptonContextMenuCommandItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/IKryptonContextMenuCommandItem.cs
@@ -1,0 +1,26 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Identifies a context menu item that can share a <see cref="KryptonCommand"/> with other items.
+/// </summary>
+public interface IKryptonContextMenuCommandItem
+{
+    /// <summary>
+    /// Gets the command associated with the menu item.
+    /// </summary>
+    KryptonCommand? KryptonCommand { get; }
+
+    /// <summary>
+    /// Gets the optional parameter used to discriminate between items that share the same command.
+    /// </summary>
+    object? CommandParameter { get; }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit;
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Text))]
 [DefaultEvent(nameof(CheckedChanged))]
-public class KryptonContextMenuCheckBox : KryptonContextMenuItemBase
+public class KryptonContextMenuCheckBox : KryptonContextMenuItemBase, IKryptonContextMenuCommandItem
 {
     #region Instance Fields
     private bool _threeState;
@@ -35,6 +35,7 @@ public class KryptonContextMenuCheckBox : KryptonContextMenuItemBase
     private CheckState _checkState;
     private readonly PaletteContentInheritRedirect _stateCommonRedirect;
     private KryptonCommand? _command;
+    private object? _commandParameter;
     private LabelStyle _style;
     private string _text;
 
@@ -497,6 +498,32 @@ public class KryptonContextMenuCheckBox : KryptonContextMenuItemBase
     }
 
     /// <summary>
+    /// Gets and sets an optional parameter value that can be used inside a shared KryptonCommand Execute handler.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Value passed to the KryptonCommand Execute handler to discriminate between menu items.")]
+    [DefaultValue(null)]
+    [Browsable(true)]
+    [TypeConverter(typeof(StringConverter))]
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+
+        set
+        {
+            if (!Equals(_commandParameter, value))
+            {
+                _commandParameter = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CommandParameter)));
+            }
+        }
+    }
+
+    private bool ShouldSerializeCommandParameter() => CommandParameter != null;
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    /// <summary>
     /// Generates a Click event for the component.
     /// </summary>
     public void PerformClick() => OnClick(EventArgs.Empty);
@@ -512,8 +539,8 @@ public class KryptonContextMenuCheckBox : KryptonContextMenuItemBase
     {
         Click?.Invoke(this, e);
 
-        // If we have an attached command then execute it
-        KryptonCommand?.PerformExecute();
+        // If we have an attached command then execute it, indicating this item as the sender
+        KryptonCommand?.PerformExecute(this);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit;
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Text))]
 [DefaultEvent(nameof(CheckedChanged))]
-public class KryptonContextMenuCheckButton : KryptonContextMenuItemBase
+public class KryptonContextMenuCheckButton : KryptonContextMenuItemBase, IKryptonContextMenuCommandItem
 {
     #region Instance Fields
     private bool _autoCheck;
@@ -33,6 +33,7 @@ public class KryptonContextMenuCheckButton : KryptonContextMenuItemBase
     private Color _imageTransparentColor;
     private ButtonStyle _style;
     private KryptonCommand? _command;
+    private object? _commandParameter;
     private string _text;
 
     #endregion
@@ -471,6 +472,32 @@ public class KryptonContextMenuCheckButton : KryptonContextMenuItemBase
     }
 
     /// <summary>
+    /// Gets and sets an optional parameter value that can be used inside a shared KryptonCommand Execute handler.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Value passed to the KryptonCommand Execute handler to discriminate between menu items.")]
+    [DefaultValue(null)]
+    [Browsable(true)]
+    [TypeConverter(typeof(StringConverter))]
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+
+        set
+        {
+            if (!Equals(_commandParameter, value))
+            {
+                _commandParameter = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CommandParameter)));
+            }
+        }
+    }
+
+    private bool ShouldSerializeCommandParameter() => CommandParameter != null;
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    /// <summary>
     /// Generates a Click event for the component.
     /// </summary>
     public void PerformClick() => OnClick(EventArgs.Empty);
@@ -486,8 +513,8 @@ public class KryptonContextMenuCheckButton : KryptonContextMenuItemBase
     {
         Click?.Invoke(this, e);
 
-        // If we have an attached command then execute it
-        KryptonCommand?.PerformExecute();
+        // If we have an attached command then execute it, indicating this item as the sender
+        KryptonCommand?.PerformExecute(this);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit;
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Text))]
 [DefaultEvent(nameof(Click))]
-public class KryptonContextMenuItem : KryptonContextMenuItemBase
+public class KryptonContextMenuItem : KryptonContextMenuItemBase, IKryptonContextMenuCommandItem
 {
     #region Nested Classes
     // Provides proper design-time reference conversion for the KryptonCommand property even when the item is not sited.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit;
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Text))]
 [DefaultEvent(nameof(Click))]
-public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase
+public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase, IKryptonContextMenuCommandItem
 {
     #region Instance Fields
     private bool _autoClose;
@@ -37,6 +37,7 @@ public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase
     private readonly PaletteContentInheritOverride _overrideNotVisited;
     private readonly PaletteContentInheritOverride _overridePressed;
     private KryptonCommand? _command;
+    private object? _commandParameter;
     private LabelStyle _style;
     private string _text;
 
@@ -400,6 +401,32 @@ public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase
     }
 
     /// <summary>
+    /// Gets and sets an optional parameter value that can be used inside a shared KryptonCommand Execute handler.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Value passed to the KryptonCommand Execute handler to discriminate between menu items.")]
+    [DefaultValue(null)]
+    [Browsable(true)]
+    [TypeConverter(typeof(StringConverter))]
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+
+        set
+        {
+            if (!Equals(_commandParameter, value))
+            {
+                _commandParameter = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CommandParameter)));
+            }
+        }
+    }
+
+    private bool ShouldSerializeCommandParameter() => CommandParameter != null;
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    /// <summary>
     /// Generates a Click event for the component.
     /// </summary>
     public void PerformClick() => OnClick(EventArgs.Empty);
@@ -415,8 +442,8 @@ public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase
     {
         Click?.Invoke(this, e);
 
-        // If we have an attached command then execute it
-        KryptonCommand?.PerformExecute();
+        // If we have an attached command then execute it, indicating this item as the sender
+        KryptonCommand?.PerformExecute(this);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit;
 [DesignTimeVisible(false)]
 [DefaultProperty(nameof(Text))]
 [DefaultEvent(nameof(CheckedChanged))]
-public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase
+public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase, IKryptonContextMenuCommandItem
 {
     #region Instance Fields
     private bool _autoCheck;
@@ -33,6 +33,7 @@ public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase
     private Color _imageTransparentColor;
     private readonly PaletteContentInheritRedirect _stateCommonRedirect;
     private KryptonCommand? _command;
+    private object? _commandParameter;
     private LabelStyle _style;
     private string _text;
 
@@ -421,6 +422,32 @@ public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase
     }
 
     /// <summary>
+    /// Gets and sets an optional parameter value that can be used inside a shared KryptonCommand Execute handler.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Value passed to the KryptonCommand Execute handler to discriminate between menu items.")]
+    [DefaultValue(null)]
+    [Browsable(true)]
+    [TypeConverter(typeof(StringConverter))]
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+
+        set
+        {
+            if (!Equals(_commandParameter, value))
+            {
+                _commandParameter = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CommandParameter)));
+            }
+        }
+    }
+
+    private bool ShouldSerializeCommandParameter() => CommandParameter != null;
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    /// <summary>
     /// Generates a Click event for the component.
     /// </summary>
     public void PerformClick() => OnClick(EventArgs.Empty);
@@ -437,8 +464,8 @@ public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase
     {
         Click?.Invoke(this, e);
 
-        // If we have an attached command then execute it
-        KryptonCommand?.PerformExecute();
+        // If we have an attached command then execute it, indicating this item as the sender
+        KryptonCommand?.PerformExecute(this);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -382,9 +382,18 @@ public class KryptonCommand : Component, IKryptonCommand, INotifyPropertyChanged
     /// </summary>
     public void PerformExecute() => OnExecute(EventArgs.Empty);
 
-    // Allow specifying the originating sender so shared commands can identify the source control
+    /// <summary>
+    /// Generates an Execute event for a command, passing the originating source as the event sender.
+    /// </summary>
+    /// <param name="sender">The object that initiated command execution.</param>
     public void PerformExecute(object? sender)
-        => Execute?.Invoke(sender ?? this, EventArgs.Empty);
+    {
+        var source = sender ?? this;
+
+        KryptonCommandContext.TryGetCommandParameter(source, out var parameter);
+
+        Execute?.Invoke(source, new KryptonCommandExecuteEventArgs(source, parameter));
+    }
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/EventArgs/KryptonCommandExecuteEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/EventArgs/KryptonCommandExecuteEventArgs.cs
@@ -1,0 +1,41 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Event data for a <see cref="KryptonCommand"/> Execute event raised with an originating source.
+/// </summary>
+public class KryptonCommandExecuteEventArgs : EventArgs
+{
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the <see cref="KryptonCommandExecuteEventArgs"/> class.
+    /// </summary>
+    /// <param name="source">The object that initiated command execution.</param>
+    /// <param name="parameter">Optional parameter from a shared command context menu item.</param>
+    public KryptonCommandExecuteEventArgs(object source, object? parameter)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        Parameter = parameter;
+    }
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// Gets the object that initiated command execution.
+    /// </summary>
+    public object Source { get; }
+
+    /// <summary>
+    /// Gets the optional parameter from a shared command context menu item.
+    /// </summary>
+    public object? Parameter { get; }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -503,6 +503,12 @@ public interface IKryptonCommand
     /// Generates an Execute event for a command.
     /// </summary>
     void PerformExecute();
+
+    /// <summary>
+    /// Generates an Execute event for a command, passing the originating source as the event sender.
+    /// </summary>
+    /// <param name="sender">The object that initiated command execution.</param>
+    void PerformExecute(object? sender);
 }
 #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonCommandContext.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonCommandContext.cs
@@ -1,0 +1,44 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Helper methods for shared <see cref="KryptonCommand"/> execution from context menu items.
+/// </summary>
+public static class KryptonCommandContext
+{
+    /// <summary>
+    /// Attempts to read a <see cref="IKryptonContextMenuCommandItem.CommandParameter"/> from the execute sender.
+    /// </summary>
+    /// <param name="sender">The sender passed to a <see cref="KryptonCommand"/> Execute handler.</param>
+    /// <param name="parameter">The command parameter when the sender implements <see cref="IKryptonContextMenuCommandItem"/>.</param>
+    /// <returns><c>true</c> when the sender is a command-backed context menu item.</returns>
+    public static bool TryGetCommandParameter(object? sender, out object? parameter)
+    {
+        if (sender is IKryptonContextMenuCommandItem item)
+        {
+            parameter = item.CommandParameter;
+            return true;
+        }
+
+        parameter = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="IKryptonContextMenuCommandItem.CommandParameter"/> from the execute sender, or <c>null</c>.
+    /// </summary>
+    /// <param name="sender">The sender passed to a <see cref="KryptonCommand"/> Execute handler.</param>
+    public static object? GetCommandParameter(object? sender)
+    {
+        TryGetCommandParameter(sender, out var parameter);
+        return parameter;
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
@@ -198,7 +198,10 @@ internal class ViewDrawMenuCheckBox : ViewComposite
     /// <summary>
     /// Resolves the correct text string to use from the menu item.
     /// </summary>
-    public string ResolveText => _cachedCommand != null ? _cachedCommand.Text : KryptonContextMenuCheckBox.Text;
+    public string ResolveText => _cachedCommand != null
+    && !string.IsNullOrEmpty(_cachedCommand.Text)
+        ? _cachedCommand.Text
+    : KryptonContextMenuCheckBox.Text;
 
     #endregion
 
@@ -206,7 +209,10 @@ internal class ViewDrawMenuCheckBox : ViewComposite
     /// <summary>
     /// Resolves the correct extra text string to use from the menu item.
     /// </summary>
-    public string ResolveExtraText => _cachedCommand != null ? _cachedCommand.ExtraText : KryptonContextMenuCheckBox.ExtraText;
+    public string ResolveExtraText => _cachedCommand != null
+                                      && !string.IsNullOrEmpty(_cachedCommand.ExtraText)
+        ? _cachedCommand.ExtraText
+        : KryptonContextMenuCheckBox.ExtraText;
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
@@ -179,7 +179,8 @@ internal class ViewDrawMenuCheckButton : ViewComposite
     /// <summary>
     /// Resolves the correct text string to use from the menu item.
     /// </summary>
-    public string ResolveText => _cachedCommand != null ? _cachedCommand.Text : KryptonContextMenuCheckButton.Text;
+    public string ResolveText => _cachedCommand != null 
+                                 && !string.IsNullOrEmpty(_cachedCommand.Text) ? _cachedCommand.Text : KryptonContextMenuCheckButton.Text;
 
     #endregion
 
@@ -187,7 +188,7 @@ internal class ViewDrawMenuCheckButton : ViewComposite
     /// <summary>
     /// Resolves the correct extra text string to use from the menu item.
     /// </summary>
-    public string ResolveExtraText => _cachedCommand != null ? _cachedCommand.ExtraText : KryptonContextMenuCheckButton.ExtraText;
+    public string ResolveExtraText => _cachedCommand != null && !string.IsNullOrEmpty(_cachedCommand.ExtraText) ? _cachedCommand.ExtraText : KryptonContextMenuCheckButton.ExtraText;
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
@@ -141,7 +141,8 @@ internal class ViewDrawMenuLinkLabel : ViewComposite
     /// <summary>
     /// Resolves the correct text string to use from the menu item.
     /// </summary>
-    public string ResolveText => _cachedCommand != null ? _cachedCommand.Text : KryptonContextMenuLinkLabel.Text;
+    public string ResolveText => _cachedCommand != null
+                                 && !string.IsNullOrEmpty(_cachedCommand.Text) ? _cachedCommand.Text : KryptonContextMenuLinkLabel.Text;
 
     #endregion
 
@@ -150,7 +151,10 @@ internal class ViewDrawMenuLinkLabel : ViewComposite
     /// Resolves the correct extra text string to use from the menu item.
     /// </summary>
     public string ResolveExtraText =>
-        (_cachedCommand != null ? _cachedCommand.ExtraText : KryptonContextMenuLinkLabel.ExtraText)!;
+        (_cachedCommand != null
+         && !string.IsNullOrEmpty(_cachedCommand.ExtraText)
+            ? _cachedCommand.ExtraText
+            : KryptonContextMenuLinkLabel.ExtraText)!;
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
@@ -161,6 +161,27 @@ internal class ViewDrawMenuRadioButton: ViewComposite
 
     #endregion
 
+    #region ResolveText
+
+    /// <summary>
+    /// Gets the resolved text value of the radio button item.
+    /// </summary>
+    private string ResolveText => _cachedCommand != null
+                                  && !string.IsNullOrEmpty(_cachedCommand.Text) ? _cachedCommand.Text : KryptonContextMenuRadioButton.Text;
+
+    #endregion
+
+    #region ResolveExtraText
+
+    /// <summary>
+    /// Gets the resolved extra text value of the radio button item.
+    /// </summary>
+    private string ResolveExtraText => _cachedCommand != null
+                                       && !string.IsNullOrEmpty(_cachedCommand.ExtraText) ? _cachedCommand.ExtraText : KryptonContextMenuRadioButton.ExtraText ?? string.Empty;
+
+    
+    #endregion
+
     #region KryptonContextMenuRadioButton
     /// <summary>
     /// Gets access to the actual radio button definiton.


### PR DESCRIPTION
# Feature: Shared KryptonContextMenu command (#3891)

## Summary

Multiple `KryptonContextMenu` items can now share a single `KryptonCommand`. Each item exposes `CommandParameter` so one `Execute` handler can branch on the originating entry instead of creating a separate command per menu item. Command-backed item types pass themselves as the execute sender and raise `KryptonCommandExecuteEventArgs` with the resolved parameter.

## Related issues

- Closes #3891

## Type of change

- [ ] Bug fix (`Resolved`)
- [x] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `KryptonContextMenuItem`: implements `IKryptonContextMenuCommandItem`; `CommandParameter` and `PerformExecute(this)` (existing behaviour formalised).
- `KryptonContextMenuCheckButton`, `KryptonContextMenuCheckBox`, `KryptonContextMenuRadioButton`, `KryptonContextMenuLinkLabel`: added `CommandParameter`; execute shared commands via `PerformExecute(this)`.
- `KryptonCommand`: `PerformExecute(object? sender)` raises `KryptonCommandExecuteEventArgs` with `Source` and `Parameter`.
- `IKryptonCommand`: added `PerformExecute(object? sender)`.
- New API: `IKryptonContextMenuCommandItem`, `KryptonCommandContext`, `KryptonCommandExecuteEventArgs`.
- View draw types: when a shared command has empty `Text`/`ExtraText`, item-level captions are shown.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472`, `net8.0-windows` (via solution Debug build)

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#3891](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3891), `KryptonContextMenu` Improvements
   * Shared `KryptonCommand` support for `KryptonContextMenu` items — multiple menu entries can reference one command and pass a `CommandParameter` so a single `Execute` handler can branch on the originating item; includes `IKryptonContextMenuCommandItem`, `KryptonCommandContext`, and `KryptonCommandExecuteEventArgs`.
```

## Breaking changes & migration

None. Existing `Execute` handlers that inspect `sender` continue to work. Handlers may optionally read `e as KryptonCommandExecuteEventArgs` for the resolved `Parameter`.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated)
- [x] Breaking-change impact and TFM notes documented above