### PR TITLE
* Individual rounded corners (bugfix)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -73,7 +73,9 @@
 * Resolved `KryptonMessageBoxExtended` appending a spurious `[60]` countdown to the caption when the timeout facility was not being used
 * Resolved `KryptonMessageBoxExtended` collapsing line breaks in the Normal (text) container by normalising line endings so a lone `\n` renders correctly (previously only `\r\n` produced a line break)
 * Resolved `KryptonMessageBoxExtended` sizing issues where the action buttons overlapped and overflowed the right edge and the message text was clipped (the buttons are now fixed-width like the standard `KryptonMessageBox` and the content area is given the full measured width and height)
-* Implemented [#797](https://github.com/Krypton-Suite/Standard-Toolkit/issues/797), Individual border corner rounding via `PaletteBorder.CornerRounding` and per-corner `RoundingTopLeft`, `RoundingTopRight`, `RoundingBottomRight`, and `RoundingBottomLeft` properties (`-1` inherits from `Rounding`). Rendering, layout padding, and orientation handling honor mixed corner radii.
+* Implemented [#797](https://github.com/Krypton-Suite/Standard-Toolkit/issues/797), Individual rounded corners
+   * Individual border corner rounding via `PaletteBorder.CornerRounding` and per-corner `RoundingTopLeft`, `RoundingTopRight`, `RoundingBottomRight`, and `RoundingBottomLeft` properties (`-1` inherits from `Rounding`). Rendering, layout padding, and orientation handling honor mixed corner radii.
+   * Per-corner border rounding no longer leaves gaps or clipped segments on the bottom and left edges when corners use mixed radii.
 * Implemented [#3861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3861), Permits customizing glyph colors (#3663) using `KryptonCustomPalette`.
 * Implemented [#3829](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3829), Showing Tab ToolTips for Docking Pages
 * Resolved [#3826](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3826), Null reference in `KryptonToggleSwitch` when the global palette changes

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/RoundedPathHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/RoundedPathHelper.cs
@@ -82,52 +82,106 @@ internal static class RoundedPathHelper
         float tr = arcs.TopRight;
         float br = arcs.BottomRight;
         float bl = arcs.BottomLeft;
+        float tlR = tl * 0.5f;
+        float trR = tr * 0.5f;
+        float brR = br * 0.5f;
+        float blR = bl * 0.5f;
         float trX = tr > 0f ? tr + 1f : 0f;
         float brX = br > 0f ? br + 1f : 0f;
         float blY = bl > 0f ? bl + 1f : 0f;
         float brY = br > 0f ? br + 1f : 0f;
 
+        // Top-left corner
         if (tl > 0f)
         {
-            path.AddLine(left, top + tl, left, top + tl);
             path.AddArc(left, top, tl, tl, 180f, 90f);
         }
-        else
+        else if (tr > 0f || br > 0f || bl > 0f)
         {
             path.AddLine(left, top, left, top);
         }
 
+        // Top edge when the adjacent corner is square
+        if (tl > 0f && tr == 0f)
+        {
+            path.AddLine(left + tlR, top, right, top);
+        }
+        else if (tl == 0f && tr > 0f)
+        {
+            path.AddLine(left, top, right - trX + trR, top);
+        }
+        else if (tl == 0f && tr == 0f && (br > 0f || bl > 0f))
+        {
+            path.AddLine(left, top, right, top);
+        }
+
+        // Top-right corner
         if (tr > 0f)
         {
-            path.AddLine(left + (tl > 0f ? tl : 0f), top, right - trX, top);
             path.AddArc(right - trX, top, tr, tr, 270f, 90f);
         }
-        else
+        else if (br > 0f || bl > 0f)
         {
-            path.AddLine(left + (tl > 0f ? tl : 0f), top, right, top);
+            path.AddLine(right, top, right, top);
         }
 
+        // Right edge when the adjacent corner is square
+        if (tr > 0f && br == 0f)
+        {
+            path.AddLine(right, top + trR, right, bottom);
+        }
+        else if (tr == 0f && br > 0f)
+        {
+            path.AddLine(right, top, right, bottom - brY + brR);
+        }
+        else if (tr == 0f && br == 0f && bl > 0f)
+        {
+            path.AddLine(right, top, right, bottom);
+        }
+
+        // Bottom-right corner
         if (br > 0f)
         {
-            path.AddLine(right, top + (tr > 0f ? tr : 0f), right, bottom - brY);
             path.AddArc(right - brX, bottom - brY, br, br, 0f, 90f);
         }
-        else
+        else if (bl > 0f)
         {
-            path.AddLine(right, top + (tr > 0f ? tr : 0f), right, bottom);
+            path.AddLine(right, bottom, right, bottom);
         }
 
+        // Bottom edge when the adjacent corner is square
+        if (br > 0f && bl == 0f)
+        {
+            path.AddLine(right - brX + brR, bottom, left, bottom);
+        }
+        else if (br == 0f && bl > 0f)
+        {
+            path.AddLine(right, bottom, left + blR, bottom);
+        }
+        else if (br == 0f && bl == 0f && tl > 0f)
+        {
+            path.AddLine(right, bottom, left, bottom);
+        }
+
+        // Bottom-left corner
         if (bl > 0f)
         {
-            path.AddLine(right - (br > 0f ? brX : 0f), bottom, left + bl, bottom);
             path.AddArc(left, bottom - blY, bl, bl, 90f, 90f);
         }
-        else
+        else if (tl > 0f)
         {
-            path.AddLine(right - (br > 0f ? brX : 0f), bottom, left, bottom);
+            path.AddLine(left, bottom, left, bottom);
         }
 
-        path.AddLine(left, bottom - (bl > 0f ? blY : 0f), left, top + (tl > 0f ? tl : 0f));
+        // Left edge when the adjacent corner is square
+        if (bl > 0f && tl == 0f)
+        {
+            path.AddLine(left, bottom - blY + blR, left, top);
+        }
+        else if (bl == 0f && tl > 0f)
+        {
+            path.AddLine(left, bottom, left, top + tlR);
+        }
 
         if (closeFigure)
         {

--- a/Source/Krypton Components/TestForm/Issue797IndividualCornerRoundingDemo.cs
+++ b/Source/Krypton Components/TestForm/Issue797IndividualCornerRoundingDemo.cs
@@ -17,5 +17,14 @@ public partial class Issue797IndividualCornerRoundingDemo : KryptonForm
     public Issue797IndividualCornerRoundingDemo()
     {
         InitializeComponent();
+        ConfigureCornerRounding();
+    }
+
+    private void ConfigureCornerRounding()
+    {
+        kbIndividualCorners.StateCommon.Border.RoundingTopLeft = 5F;
+        kbIndividualCorners.StateCommon.Border.RoundingTopRight = 5F;
+        kbIndividualCorners.StateCommon.Border.RoundingBottomLeft = 5F;
+        kbIndividualCorners.StateCommon.Border.RoundingBottomRight = 0F;
     }
 }


### PR DESCRIPTION
# Fix: Individual corner rounding bottom/left edge gaps (#797)

## Summary

Fixes a regression from per-corner border rounding (#3803) where mixed corner radii produced broken bottom and left border segments on controls that draw all four edges. Path construction now matches the prior chained-arc geometry and only inserts straight edge segments when an adjacent corner is square.

## Related issues

- Closes #797

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `Krypton.Toolkit`: Rewrote `RoundedPathHelper.AppendRoundedRectangle` to use correct tangent points (half arc diameter) and arc chaining for mixed radii.
- `TestForm`: `Issue797IndividualCornerRoundingDemo` now applies TL/TR/BL = 5 and BR = 0 on the mixed-corners sample button.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net8.0-windows`

## Validation

- TestForm demo: `Issue797IndividualCornerRoundingDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Run TestForm and open **Issue 797 Individual corner rounding**.
  2. Compare the left button (mixed corners) with the right button (uniform rounding).
  3. Confirm the mixed-corners button has a sharp bottom-right corner and continuous bottom/left borders with no clipped or doubled segments.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug -f net8.0-windows`

## Screenshots / GIFs

See [issue comment](https://github.com/Krypton-Suite/Standard-Toolkit/issues/797#issuecomment-4950159705) for the before screenshot.

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#797](https://github.com/Krypton-Suite/Standard-Toolkit/issues/797), Individual rounded corners
   * Individual border corner rounding via `PaletteBorder.CornerRounding` and per-corner `RoundingTopLeft`, `RoundingTopRight`, `RoundingBottomRight`, and `RoundingBottomLeft` properties (`-1` inherits from `Rounding`). Rendering, layout padding, and orientation handling honor mixed corner radii.
   * Per-corner border rounding no longer leaves gaps or clipped segments on the bottom and left edges when corners use mixed radii.
```

## Breaking changes & migration

None.

## Developer documentation

None (bug fix only).