### PR TITLE
* Add Krypton.Interop verification in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,6 +276,26 @@ jobs:
       - name: Pack Release
         run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all
 
+      # Verify Krypton.Interop in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Release
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
+
       - name: Get Version
         id: get_version
         shell: pwsh

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -245,6 +245,27 @@ jobs:
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/canarylongtermstable.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
+      # Verify Krypton.Interop is present in the generated NuGet packages (V110+ only).
+      - name: Resolve Krypton toolkit major version
+        if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Canary
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.canary_lts_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Canary -PackageSearchPaths 'Artefacts/Packages/Canary/*.nupkg' -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
+
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
         id: push_nuget

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -49,10 +49,16 @@ jobs:
       - name: Security - Verify Repository
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         shell: pwsh
+        env:
+          EXPECTED_REPOSITORY: ${{ vars.EXPECTED_REPOSITORY }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:GITHUB_REPOSITORY -ne 'Krypton-Suite/Standard-Toolkit') {
-            Write-Error "Security: Invalid repository '$env:GITHUB_REPOSITORY'. This workflow should only run on Krypton-Suite/Standard-Toolkit"
+          $expectedRepository = $env:EXPECTED_REPOSITORY
+          if ([string]::IsNullOrWhiteSpace($expectedRepository)) {
+            $expectedRepository = 'Krypton-Suite/Standard-Toolkit'
+          }
+          if ($env:GITHUB_REPOSITORY -ne $expectedRepository) {
+            Write-Error "Security: Invalid repository '$env:GITHUB_REPOSITORY'. This workflow should only run on $expectedRepository"
             exit 1
           }
           Write-Host "✓ Repository verified: $env:GITHUB_REPOSITORY"
@@ -260,6 +266,27 @@ jobs:
       - name: Pack Canary
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      # Verify Krypton.Interop is present in the NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Canary
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Canary -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
       - name: Save NuGet cache
         if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,10 +47,16 @@ jobs:
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         shell: pwsh
+        env:
+          EXPECTED_REPOSITORY: ${{ vars.EXPECTED_REPOSITORY }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:GITHUB_REPOSITORY -ne 'Krypton-Suite/Standard-Toolkit') {
-            Write-Error "Security: Invalid repository '$env:GITHUB_REPOSITORY'. This workflow should only run on Krypton-Suite/Standard-Toolkit"
+          $expectedRepository = $env:EXPECTED_REPOSITORY
+          if ([string]::IsNullOrWhiteSpace($expectedRepository)) {
+            $expectedRepository = 'Krypton-Suite/Standard-Toolkit'
+          }
+          if ($env:GITHUB_REPOSITORY -ne $expectedRepository) {
+            Write-Error "Security: Invalid repository '$env:GITHUB_REPOSITORY'. This workflow should only run on $expectedRepository"
             exit 1
           }
           Write-Host "✓ Repository verified: $env:GITHUB_REPOSITORY"
@@ -286,6 +292,27 @@ jobs:
       - name: Pack Nightly
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      # Verify Krypton.Interop is present in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Nightly
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Nightly -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
       - name: Push NuGet Packages to nuget.org
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,27 @@ jobs:
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
+      # Verify Krypton.Interop is present in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.release_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Release
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
+
       - name: Save NuGet cache
         # Kill switch check
         if: success() && steps.release_kill_switch.outputs.enabled == 'true'
@@ -548,6 +569,27 @@ jobs:
         # Kill switch check
         if: steps.release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      # Verify Krypton.Interop is present in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.release_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Release
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
       - name: Save NuGet cache
         # Kill switch check
@@ -912,6 +954,27 @@ jobs:
         if: steps.canary_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/canary.proj" /t:Pack /restore /p:Configuration=Canary /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
+      # Verify Krypton.Interop is present in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Canary
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Canary -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
+
       - name: Save NuGet cache
         # Kill switch check
         if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'
@@ -1265,6 +1328,27 @@ jobs:
         # Kill switch check
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
         run: msbuild /m "Scripts/Build/nightly.proj" /t:Pack /restore /p:Configuration=Nightly /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+
+      # Verify Krypton.Interop is present in NuGet packages (V110+ only)
+      - name: Resolve Krypton toolkit major version
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true'
+        id: krypton_major_version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          $major = Get-KryptonToolkitMajorVersion -Configuration Nightly
+          echo "major=$major" >> $env:GITHUB_OUTPUT
+
+      - name: Verify Krypton.Interop in NuGet packages
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
+          Test-KryptonInteropInPackages -Configuration Nightly -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
       - name: Save NuGet cache
         # Kill switch check

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -85,9 +85,12 @@ jobs:
 
       - name: Security - Verify Repository
         if: steps.kill_switch.outputs.enabled == 'true'
+        env:
+          EXPECTED_REPOSITORY: ${{ vars.EXPECTED_REPOSITORY }}
         run: |
-          if [ "$GITHUB_REPOSITORY" != "Krypton-Suite/Standard-Toolkit" ]; then
-            echo "::error::Security: Invalid repository '$GITHUB_REPOSITORY'. This workflow should only run on Krypton-Suite/Standard-Toolkit"
+          expected_repository="${EXPECTED_REPOSITORY:-Krypton-Suite/Standard-Toolkit}"
+          if [ "$GITHUB_REPOSITORY" != "$expected_repository" ]; then
+            echo "::error::Security: Invalid repository '$GITHUB_REPOSITORY'. This workflow should only run on $expected_repository"
             exit 1
           fi
           echo "Repository verified: $GITHUB_REPOSITORY"

--- a/.github/workflows/sync-github-from-master.yml
+++ b/.github/workflows/sync-github-from-master.yml
@@ -46,9 +46,12 @@ jobs:
       - name: Security - Verify Repository
         if: steps.kill_switch.outputs.enabled == 'true'
         shell: bash
+        env:
+          EXPECTED_REPOSITORY: ${{ vars.EXPECTED_REPOSITORY }}
         run: |
-          if [ "$GITHUB_REPOSITORY" != "Krypton-Suite/Standard-Toolkit" ]; then
-            echo "::error::Invalid repository: $GITHUB_REPOSITORY"
+          expected_repository="${EXPECTED_REPOSITORY:-Krypton-Suite/Standard-Toolkit}"
+          if [ "$GITHUB_REPOSITORY" != "$expected_repository" ]; then
+            echo "::error::Invalid repository '$GITHUB_REPOSITORY'. This workflow should only run on $expected_repository"
             exit 1
           fi
 

--- a/Scripts/CI/Test-KryptonInteropInPackages.ps1
+++ b/Scripts/CI/Test-KryptonInteropInPackages.ps1
@@ -1,0 +1,188 @@
+# Verifies packable Krypton module .nupkg files include Krypton.Interop.dll under lib/<tfm>/.
+# Dot-source this script, then call Test-KryptonInteropInPackages after msbuild Pack.
+#
+# Parameters:
+#   -Configuration          Release, Canary, Nightly, etc. (searches artifacts/packages and Bin/Packages)
+#   -PackageSearchPaths     Additional glob paths for .nupkg files
+#   -SkipIfInteropProjectMissing  Exit 0 when Krypton.Interop.csproj is absent (LTS branches without Interop)
+#   -MinimumMajorVersion    Exit 0 when the evaluated toolkit major version is below this value (V110+ Interop)
+
+function Get-KryptonToolkitMajorVersion {
+    param(
+        [string]$Configuration = 'Release',
+        [string]$RepoRoot = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        $RepoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') {
+            $env:GITHUB_WORKSPACE
+        }
+        else {
+            (Get-Location).Path
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Configuration)) {
+        $Configuration = 'Release'
+    }
+
+    $proj = Join-Path $RepoRoot 'Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj'
+    if (-not (Test-Path -LiteralPath $proj)) {
+        Write-Error "Krypton.Toolkit project not found at '$proj'."
+    }
+
+    $versionProperties = @('LibraryVersion', 'AssemblyVersion', 'Version')
+    foreach ($property in $versionProperties) {
+        $evaluated = (& dotnet msbuild $proj -getProperty:$property -p:Configuration=$Configuration -nologo -v:q).Trim()
+        if ($evaluated -match '^(\d+)\.') {
+            return [int]$Matches[1]
+        }
+    }
+
+    Write-Error "Could not resolve Krypton toolkit major version from MSBuild (tried: $($versionProperties -join ', '))."
+}
+
+function Test-PackageRequiresKryptonInterop {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageFileName
+    )
+
+    if ($PackageFileName -match '\.snupkg$') {
+        return $false
+    }
+
+    $packageId = [System.IO.Path]::GetFileNameWithoutExtension($PackageFileName)
+    $roots = @(
+        'Krypton.Toolkit',
+        'Krypton.Ribbon',
+        'Krypton.Navigator',
+        'Krypton.Docking',
+        'Krypton.Workspace',
+        'Krypton.Standard.Toolkit'
+    )
+
+    foreach ($root in $roots) {
+        if ($packageId.Equals($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+
+        if ($packageId.StartsWith("$root.", [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-NupkgContainsKryptonInterop {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$Package
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Package.FullName)
+    try {
+        $interopEntries = @(
+            $zip.Entries |
+                Where-Object { $_.FullName -match '(?i)^lib/[^/]+/Krypton\.Interop\.dll$' }
+        )
+
+        return $interopEntries.Count -gt 0
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
+
+function Test-KryptonInteropInPackages {
+    param(
+        [string]$Configuration = '',
+        [string[]]$PackageSearchPaths = @(),
+        [switch]$SkipIfInteropProjectMissing,
+        [int]$MinimumMajorVersion = 0
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') {
+        $env:GITHUB_WORKSPACE
+    }
+    else {
+        (Get-Location).Path
+    }
+
+    $msbuildConfiguration = if ([string]::IsNullOrWhiteSpace($Configuration)) { 'Release' } else { $Configuration }
+
+    if ($MinimumMajorVersion -gt 0) {
+        $major = Get-KryptonToolkitMajorVersion -Configuration $msbuildConfiguration -RepoRoot $repoRoot
+        if ($major -lt $MinimumMajorVersion) {
+            Write-Host "::notice:: Major version $major is below $MinimumMajorVersion; skipping Krypton.Interop NuGet package verification."
+            return
+        }
+    }
+
+    $interopProject = Join-Path $repoRoot 'Source/Krypton Components/Krypton.Interop/Krypton.Interop.csproj'
+    if ($SkipIfInteropProjectMissing -and -not (Test-Path -LiteralPath $interopProject)) {
+        Write-Host '::notice:: Krypton.Interop project not present; skipping NuGet package verification.'
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $interopProject)) {
+        Write-Error "Krypton.Interop project not found at '$interopProject'."
+    }
+
+    $searchPaths = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrWhiteSpace($Configuration)) {
+        $searchPaths.Add("artifacts/packages/$Configuration/*.nupkg")
+        $searchPaths.Add("Bin/Packages/$Configuration/*.nupkg")
+        $searchPaths.Add("Artefacts/Packages/$Configuration/*.nupkg")
+    }
+
+    foreach ($path in $PackageSearchPaths) {
+        if (-not [string]::IsNullOrWhiteSpace($path)) {
+            $searchPaths.Add($path)
+        }
+    }
+
+    if ($searchPaths.Count -eq 0) {
+        $searchPaths.Add('artifacts/packages/*/*.nupkg')
+        $searchPaths.Add('Bin/Packages/*/*.nupkg')
+        $searchPaths.Add('Artefacts/Packages/*/*.nupkg')
+    }
+
+    $packages = @()
+    foreach ($pattern in $searchPaths) {
+        $packages += Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue
+    }
+
+    $packages = @($packages | Where-Object { $_ -ne $null } | Sort-Object FullName -Unique)
+
+    if ($packages.Count -eq 0) {
+        Write-Error "No .nupkg files found. Searched: $($searchPaths -join '; ')"
+    }
+
+    $requiredPackages = @($packages | Where-Object { Test-PackageRequiresKryptonInterop -PackageFileName $_.Name })
+    if ($requiredPackages.Count -eq 0) {
+        Write-Error "Found $($packages.Count) .nupkg file(s), but none match packable Krypton module package IDs."
+    }
+
+    $failures = [System.Collections.Generic.List[string]]::new()
+    foreach ($package in $requiredPackages) {
+        if (Test-NupkgContainsKryptonInterop -Package $package) {
+            Write-Host "OK: $($package.Name) contains lib/*/Krypton.Interop.dll"
+            continue
+        }
+
+        $failures.Add($package.Name)
+        Write-Host "::error file=$($package.FullName)::Missing lib/*/Krypton.Interop.dll in $($package.Name)"
+    }
+
+    if ($failures.Count -gt 0) {
+        throw "Krypton.Interop.dll verification failed for $($failures.Count) package(s): $($failures -join ', ')"
+    }
+
+    Write-Host "Verified Krypton.Interop.dll in $($requiredPackages.Count) Krypton module package(s)."
+}


### PR DESCRIPTION
Introduces a new PowerShell script (Test-KryptonInteropInPackages.ps1) to verify that Krypton.Interop.dll is present in NuGet packages for V110+ releases. This verification is integrated into all packaging CI workflows (build, release, canary, nightly). Also enhances repository security checks to use configurable EXPECTED_REPOSITORY environment variables instead of hardcoded repository names, improving workflow flexibility across forks and mirrors.