### PR TITLE
* `Krypton.Interop` is not bundled with each NuGet packages

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#3908](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3908), `Krypton.Interop` is not bundled with each NuGet packages
 * Resolved [#3879](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3879), When the `KryptonComboBox` initializes in a disabled state, it displays using default system colors
    * `KryptonComboBox` now displays theme disabled colors when initialized in a disabled state.
 * Implemented [#3807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3807), `KryptonKnob` control


### PR DESCRIPTION
Appends a 'Resolved [#3908]' entry to Documents/Changelog/Changelog.md documenting the fix for Krypton.Interop not being bundled with NuGet packages.