### PR TITLE
* Refactor PR body in scan-license-headers workflow

### DIFF
--- a/.github/scripts/Update-LicenseHeaders.ps1
+++ b/.github/scripts/Update-LicenseHeaders.ps1
@@ -16,7 +16,7 @@ $ErrorActionPreference = 'Stop'
 
 $ModificationsMarker = 'Modifications by Peter Wagner (aka '
 $CanonicalPrefix = 'Modifications by Peter Wagner (aka PWagner1), Simon Coghlan (aka Smurf-IV)'
-$CanonicalContributors = ', Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs)'
+$CanonicalContributors = ', Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs)'
 
 $linePattern = [regex]::new(
     '^(?<leading>.*?)(?<prefix>Modifications by Peter Wagner \(aka (?:Wagnerp|PWagner1)\), Simon Coghlan \(aka Smurf-IV\))(?<old>,.*?)(?<suffix> et al\.\s+\d{4}\s*-\s*\d{4}\.\s*All rights reserved\.\s*)$',

--- a/.github/workflows/scan-license-headers.yml
+++ b/.github/workflows/scan-license-headers.yml
@@ -116,7 +116,7 @@ jobs:
             Automated partial replacement of BSD license header contributor lines.
 
             - Fixed prefix: `Modifications by Peter Wagner (aka PWagner1), Simon Coghlan (aka Smurf-IV)`
-            - Canonical contributors: Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al.
+            - Canonical contributors: Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al.
             - Each file keeps its existing year range and rights suffix.
 
             **Files updated:** ${{ steps.update.outputs.files_changed }}

--- a/.github/workflows/scan-license-headers.yml
+++ b/.github/workflows/scan-license-headers.yml
@@ -111,6 +111,17 @@ jobs:
           BRANCH: ${{ inputs.branch }}
           CREATE_PR: ${{ inputs.create_pr }}
           FILES_CHANGED: ${{ steps.update.outputs.files_changed }}
+          PR_BODY: |
+            ## Summary
+            Automated partial replacement of BSD license header contributor lines.
+
+            - Fixed prefix: `Modifications by Peter Wagner (aka PWagner1), Simon Coghlan (aka Smurf-IV)`
+            - Canonical contributors: Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al.
+            - Each file keeps its existing year range and rights suffix.
+
+            **Files updated:** ${{ steps.update.outputs.files_changed }}
+
+            *Triggered by Scan license headers workflow.*
         run: |
           set -euo pipefail
 
@@ -131,19 +142,7 @@ jobs:
               --base "$BRANCH" \
               --head "$work_branch" \
               --title "chore: normalize license header contributor lines" \
-              --body "$(cat <<EOF
-## Summary
-Automated partial replacement of BSD license header contributor lines.
-
-- Fixed prefix: \`Modifications by Peter Wagner (aka PWagner1), Simon Coghlan (aka Smurf-IV)\`
-- Canonical contributors: Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al.
-- Each file keeps its existing year range and rights suffix.
-
-**Files updated:** $FILES_CHANGED
-
-*Triggered by Scan license headers workflow.*
-EOF
-)"
+              --body "$PR_BODY"
           else
             git push origin "HEAD:$BRANCH"
           fi


### PR DESCRIPTION
Move the PR body template to an environment variable for improved readability and maintainability. This avoids embedding a complex here-document inside the `gh pr create` command while preserving the exact same PR body content.