### PR TITLE
* CI: verify artifacts and avoid Pack restore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,12 +269,29 @@ jobs:
       - name: Restore
         run: msbuild /m "Scripts/Build/build.proj" /t:Restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all
 
+      # Fail early if Restore did not write assets under artifacts/obj (would surface later as NETSDK1005 in Pack).
+      - name: Verify artifacts/obj exists
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $objRoot = "Source/Krypton Components/artifacts/obj"
+          if (-not (Test-Path -LiteralPath $objRoot)) {
+            Write-Error "Artifacts obj folder missing: $objRoot"
+          }
+          $assets = @(Get-ChildItem -Path $objRoot -Recurse -Filter "project.assets.json")
+          if ($assets.Count -eq 0) {
+            Write-Error "No project.assets.json found under $objRoot"
+          }
+          $assets | ForEach-Object { Write-Host "Found: $($_.FullName)" }
+
       # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
       - name: Build Release
         run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
 
+      # No /restore here: the explicit Restore step already produced artifacts/obj; a second implicit restore
+      # can write project.assets.json elsewhere / with different properties and trigger NETSDK1005.
       - name: Pack Release
-        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all
+        run: msbuild /m "Scripts/Build/build.proj" /t:Pack /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all /p:Restore=false
 
       # Verify Krypton.Interop in NuGet packages (V110+ only)
       - name: Resolve Krypton toolkit major version

--- a/.github/workflows/scan-code-todos.yml
+++ b/.github/workflows/scan-code-todos.yml
@@ -62,8 +62,14 @@ on:
       max_issues:
         description: Maximum new issues to create per run
         required: true
-        default: 25
-        type: number
+        default: '25'
+        type: choice
+        options:
+          - '5'
+          - '10'
+          - '25'
+          - '50'
+          - '100'
       group_duplicates:
         description: Group identical comment text into one issue
         required: true
@@ -365,10 +371,15 @@ jobs:
             const lineNumber = event.data.line_number;
             const lineText = event.data.lines?.text || '';
             const captures = event.data.submatches || [];
-            const markerRaw = (captures[0]?.match?.text || '').trim();
-            let commentText = (captures[1]?.match?.text || '').trim();
+            // ripgrep --json submatches carry the whole match (no capture groups),
+            // so the marker word and comment text are re-parsed from the match text.
+            const matchText = (captures[0]?.match?.text || '').trim();
+            const parsed = matchText.match(/^(TODO|ToDo|FIXME|HACK)\b(?:\s*\(\s*issue\s*\))?\s*[:\s]*(.*)$/i);
+            const markerRaw = (parsed?.[1] || '').trim();
+            let commentText = (parsed?.[2] || '').trim();
             if (!commentText) {
-              const fallback = lineText.match(/(?:TODO|ToDo|FIXME|HACK)(?:\s*\(\s*issue\s*\))?\s*[:\s]+(.+)$/i);
+              // lines.text keeps its trailing newline; trim it or (.+)$ can never match.
+              const fallback = lineText.trimEnd().match(/(?:TODO|ToDo|FIXME|HACK)(?:\s*\(\s*issue\s*\))?\s*[:\s]+(.+)$/i);
               commentText = (fallback?.[1] || '').trim();
             }
 


### PR DESCRIPTION
Add an early verification step in .github/workflows/build.yml to ensure Restore produced project.assets.json under Source/Krypton Components/artifacts/obj and fail the job early if missing. Stop Pack from doing an implicit restore (/p:Restore=false) to avoid NETSDK1005 from mismatched assets. In .github/workflows/scan-code-todos.yml change max_issues input to a string choice with preset options and improve ripgrep submatch parsing: re-parse the whole match to extract marker and comment text and trim trailing newlines when falling back to line text.