### PR TITLE
* Fix nightly build change detection and validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,16 +141,28 @@ jobs:
             exit 0
           }
 
-          # Get commits from last 24 hours on alpha branch, ignoring commits that only touch .github
+          # Get commits from last 24 hours on alpha branch, but skip when they only touch .github
           # (e.g. the automated .github sync from master) so CI-only changes do not trigger a release
           $yesterday = (Get-Date).AddDays(-1).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")
-          $commitCount = git rev-list --count --since="$yesterday" alpha -- . ':(exclude).github'
+          $recentCommits = @(git rev-list --since="$yesterday" alpha)
+          $commitCount = $recentCommits.Count
 
-          Write-Host "Commits in last 24 hours (excluding .github-only changes): $commitCount"
+          Write-Host "Commits in last 24 hours: $commitCount"
 
-          if ([int]$commitCount -gt 0) {
+          if ($commitCount -gt 0) {
+            $changedFiles = @($recentCommits | ForEach-Object { git diff-tree --no-commit-id --name-only -r $_ } | Sort-Object -Unique)
+            $nonGitHubFiles = @($changedFiles | Where-Object { $_ -and -not ($_.Replace('\', '/') -like '.github/*') })
+
+            Write-Host "Changed files in last 24 hours: $($changedFiles.Count)"
+            Write-Host "Changed files outside .github: $($nonGitHubFiles.Count)"
+          }
+
+          if ($commitCount -gt 0 -and $nonGitHubFiles.Count -gt 0) {
             Write-Host "Changes detected - proceeding with nightly build"
             echo "has_changes=true" >> $env:GITHUB_OUTPUT
+          } elseif ($commitCount -gt 0) {
+            Write-Host "Only .github changes detected - skipping nightly build"
+            echo "has_changes=false" >> $env:GITHUB_OUTPUT
           } else {
             Write-Host "No changes detected - skipping nightly build"
             echo "has_changes=false" >> $env:GITHUB_OUTPUT

--- a/Scripts/CI/Test-KryptonInteropInPackages.ps1
+++ b/Scripts/CI/Test-KryptonInteropInPackages.ps1
@@ -97,6 +97,39 @@ function Test-NupkgContainsKryptonInterop {
     }
 }
 
+function Test-NupkgDeclaresKryptonInteropDependency {
+    # Krypton.Interop is never published to nuget.org; a nuspec <dependency id="Krypton.Interop"> makes
+    # consumer restore fail with NU1101 (#3908), so packages must bundle the DLL instead of depending on it.
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$Package
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Package.FullName)
+    try {
+        $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -match '(?i)^[^/]+\.nuspec$' } | Select-Object -First 1
+        if ($null -eq $nuspecEntry) {
+            return $false
+        }
+
+        $reader = New-Object System.IO.StreamReader($nuspecEntry.Open())
+        try {
+            [xml]$nuspec = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        $dependencies = @($nuspec.GetElementsByTagName('dependency') | Where-Object { $_.id -eq 'Krypton.Interop' })
+        return $dependencies.Count -gt 0
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
+
 function Test-KryptonInteropInPackages {
     param(
         [string]$Configuration = '',
@@ -171,8 +204,14 @@ function Test-KryptonInteropInPackages {
 
     $failures = [System.Collections.Generic.List[string]]::new()
     foreach ($package in $requiredPackages) {
+        if (Test-NupkgDeclaresKryptonInteropDependency -Package $package) {
+            $failures.Add($package.Name)
+            Write-Host "::error file=$($package.FullName)::$($package.Name) declares a nuspec dependency on Krypton.Interop, which is not published to nuget.org (NU1101, #3908)"
+            continue
+        }
+
         if (Test-NupkgContainsKryptonInterop -Package $package) {
-            Write-Host "OK: $($package.Name) contains lib/*/Krypton.Interop.dll"
+            Write-Host "OK: $($package.Name) contains lib/*/Krypton.Interop.dll and no Krypton.Interop dependency"
             continue
         }
 


### PR DESCRIPTION
Improve the nightly build trigger to properly skip when only .github files are modified, preventing unnecessary builds from CI automation sync.

Add Test-NupkgDeclaresKryptonInteropDependency function to validate that NuGet packages do not declare dependencies on Krypton.Interop, which is not published to nuget.org. This prevents NU1101 restore errors for package consumers (issue #3908).