### PR TITLE
* `KryptonRichTextBox` Support for justify  (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
+   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
 * Implemented [#3849](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3849), Krypton-themed designer property and collection editors replace native WinForms dialogs
    * Designer collection and property editors now use Krypton controls and `KryptonForm` chrome — workspace sequence, context menu items, breadcrumb items, check-button collections, tree nodes, string/`Items` collections, multiline text/`Lines`, format string, and related binding/image/index editors inherit the owning component palette at design time
    * Migrated editor dialogs use `KryptonDesignerEditorDpi` for consistent scaling on high-DPI displays

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -47,6 +47,7 @@
 
 * Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
    * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
+   * Resolved themed scrollbar overlay covering native-wrapper content (RichTextBox, TextBox, ListBox, ListView, TreeView, PropertyGrid) after flush-to-border scrollbars; content is inset when the bar is visible so text is not clipped
 * Implemented [#3849](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3849), Krypton-themed designer property and collection editors replace native WinForms dialogs
    * Designer collection and property editors now use Krypton controls and `KryptonForm` chrome — workspace sequence, context menu items, breadcrumb items, check-button collections, tree nodes, string/`Items` collections, multiline text/`Lines`, format string, and related binding/image/index editors inherit the owning component palette at design time
    * Migrated editor dialogs use `KryptonDesignerEditorDpi` for consistent scaling on high-DPI displays

--- a/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
@@ -3029,6 +3029,24 @@ No 	                    No 	                    Show text only
     internal const int PRF_CLIENT = 0x00000004;
     internal const int MA_NOACTIVATE = 0x03;
     internal const int EM_FORMATRANGE = 0x0439;
+    /// <summary>Gets the paragraph formatting of the current selection (RichEdit).</summary>
+    internal const int EM_GETPARAFORMAT = 0x043D; // WM_USER + 61
+    /// <summary>Sets the paragraph formatting of the current selection (RichEdit).</summary>
+    internal const int EM_SETPARAFORMAT = 0x0447; // WM_USER + 71
+    /// <summary>Sets RichEdit typography options (advanced line breaking / justification).</summary>
+    internal const int EM_SETTYPOGRAPHYOPTIONS = 0x04CA; // WM_USER + 202
+    /// <summary>Enables advanced typography (required for paragraph justify).</summary>
+    internal const int TO_ADVANCEDTYPOGRAPHY = 0x0001;
+    /// <summary>PARAFORMAT.dwMask: wAlignment is valid.</summary>
+    internal const uint PFM_ALIGNMENT = 0x00000008;
+    /// <summary>PARAFORMAT.wAlignment: left.</summary>
+    internal const ushort PFA_LEFT = 1;
+    /// <summary>PARAFORMAT.wAlignment: right.</summary>
+    internal const ushort PFA_RIGHT = 2;
+    /// <summary>PARAFORMAT.wAlignment: center.</summary>
+    internal const ushort PFA_CENTER = 3;
+    /// <summary>PARAFORMAT.wAlignment: justify (RichEdit 3+).</summary>
+    internal const ushort PFA_JUSTIFY = 4;
     internal const int RDW_INVALIDATE = 0x0001;
     internal const int RDW_UPDATENOW = 0x0100;
     internal const int RDW_FRAME = 0x0400;
@@ -3484,6 +3502,10 @@ No 	                    No 	                    Show text only
     [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref TV_ITEM lParam);
+
+    [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref PARAFORMAT lParam);
 
     [DllImport(Libraries.User32, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -4893,6 +4915,26 @@ No 	                    No 	                    Show text only
         public RECT rc;
         public RECT rcPage;
         public CHARRANGE chrg;
+    }
+
+    /// <summary>
+    /// RichEdit paragraph format (alignment and related paragraph properties).
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PARAFORMAT
+    {
+        public uint cbSize;
+        public uint dwMask;
+        public ushort wNumbering;
+        public ushort wEffects;
+        public int dxStartIndent;
+        public int dxRightIndent;
+        public int dxOffset;
+        public ushort wAlignment;
+        public short cTabCount;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public int[] rgxTabs;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
@@ -746,6 +746,18 @@ public class KryptonRibbonGroupRichTextBox : KryptonRibbonGroupItem
     }
 
     /// <summary>
+    /// Gets and sets paragraph alignment for the current selection, including full justify.
+    /// </summary>
+    [Browsable(false)]
+    [DefaultValue(typeof(RichTextParagraphAlignment), "Left")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextParagraphAlignment SelectionParagraphAlignment
+    {
+        get => RichTextBox!.SelectionParagraphAlignment;
+        set => RichTextBox!.SelectionParagraphAlignment = value;
+    }
+
+    /// <summary>
     /// Gets and sets the background color of the selected area.
     /// </summary>
     [Browsable(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1640,7 +1640,7 @@ public class KryptonListBox : VisualControlBase,
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
             Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                _layoutFill, _scrollbarManager, UseKryptonScrollbars);
             _listBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -698,8 +698,12 @@ public class KryptonListBox : VisualControlBase,
     {
         if (disposing)
         {
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
         }
 
         base.Dispose(disposing);
@@ -1635,7 +1639,8 @@ public class KryptonListBox : VisualControlBase,
         // to allow a relayout or if in design mode.
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
-            Rectangle fillRect = _layoutFill.FillRect;
+            Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
             _listBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }
@@ -1969,14 +1974,18 @@ public class KryptonListBox : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_listBox, ScrollbarManagerMode.NativeWrapper);
             }
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     private void RefreshScrollbarManager()
     {
@@ -1997,7 +2006,11 @@ public class KryptonListBox : VisualControlBase,
         }
 
         // Re-attach (rather than dispose/recreate) so user settings on the manager persist.
-        _scrollbarManager?.Detach();
+        if (_scrollbarManager != null)
+        {
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
+        }
 
         UpdateScrollbarManager();
         _scrollbarManager?.UpdateScrollbars();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -517,8 +517,12 @@ public class KryptonListView : VisualControlBase,
     {
         if (disposing)
         {
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
         }
 
         base.Dispose(disposing);
@@ -1673,7 +1677,8 @@ public class KryptonListView : VisualControlBase,
         // to allow a relayout or if in design mode.
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
-            Rectangle fillRect = _layoutFill.FillRect;
+            Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
             _listView.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }
@@ -1777,14 +1782,18 @@ public class KryptonListView : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_listView, ScrollbarManagerMode.NativeWrapper);
             }
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     NativeWrapperScrollbarLayout IKryptonNativeWrapperScrollbarBounds.GetNativeWrapperScrollbarLayout() =>
         KryptonNativeWrapperScrollbarBoundsHelper.GetLayout(this, _layoutFill);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -1678,7 +1678,7 @@ public class KryptonListView : VisualControlBase,
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
             Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                _layoutFill, _scrollbarManager, UseKryptonScrollbars);
             _listView.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -919,7 +919,7 @@ public class KryptonPropertyGrid : VisualControlBase,
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
             Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                _layoutFill, _scrollbarManager, UseKryptonScrollbars);
             _propertyGrid.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -338,8 +338,12 @@ public class KryptonPropertyGrid : VisualControlBase,
         {
             _resetContextMenu.Close();
             _resetContextMenu.Dispose();
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
         }
 
         base.Dispose(disposing);
@@ -914,7 +918,8 @@ public class KryptonPropertyGrid : VisualControlBase,
         // to allow a relayout or if in design mode.
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
-            Rectangle fillRect = _layoutFill.FillRect;
+            Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
             _propertyGrid.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }
@@ -1048,16 +1053,20 @@ public class KryptonPropertyGrid : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_propertyGrid, ScrollbarManagerMode.NativeWrapper);
             }
 
             ScrollbarManager.Enabled = Enabled;
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     NativeWrapperScrollbarLayout IKryptonNativeWrapperScrollbarBounds.GetNativeWrapperScrollbarLayout() =>
         KryptonNativeWrapperScrollbarBoundsHelper.GetLayout(this, _layoutFill);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2083,7 +2083,7 @@ public class KryptonRichTextBox : VisualControlBase,
             if (_forcedLayout || DesignMode)
             {
                 Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                    _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                    _layoutFill, _scrollbarManager, UseKryptonScrollbars);
                 _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -151,9 +151,85 @@ public class KryptonRichTextBox : VisualControlBase,
             //Return last + 1 character printer
             return (int)res.ToInt64();
         }
+
+        /// <summary>
+        /// Gets and sets paragraph alignment for the current selection, including justify.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextParagraphAlignment SelectionParagraphAlignment
+        {
+            get
+            {
+                if (!IsHandleCreated)
+                {
+                    return RichTextParagraphAlignment.Left;
+                }
+
+                var format = new PI.PARAFORMAT
+                {
+                    cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                    rgxTabs = new int[32]
+                };
+
+                PI.SendMessage(new HandleRef(this, Handle), PI.EM_GETPARAFORMAT, 0, ref format);
+
+                if ((format.dwMask & PI.PFM_ALIGNMENT) == 0)
+                {
+                    return RichTextParagraphAlignment.Left;
+                }
+
+                switch (format.wAlignment)
+                {
+                    case PI.PFA_RIGHT:
+                        return RichTextParagraphAlignment.Right;
+                    case PI.PFA_CENTER:
+                        return RichTextParagraphAlignment.Center;
+                    case PI.PFA_JUSTIFY:
+                        return RichTextParagraphAlignment.Justify;
+                    default:
+                        return RichTextParagraphAlignment.Left;
+                }
+            }
+            set
+            {
+                // Force handle creation so RichEdit can apply paragraph format.
+                if (!IsHandleCreated)
+                {
+                    _ = Handle;
+                }
+
+                if (value == RichTextParagraphAlignment.Justify)
+                {
+                    EnableAdvancedTypography();
+                }
+
+                var format = new PI.PARAFORMAT
+                {
+                    cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                    dwMask = PI.PFM_ALIGNMENT,
+                    wAlignment = (ushort)value,
+                    rgxTabs = new int[32]
+                };
+
+                PI.SendMessage(new HandleRef(this, Handle), PI.EM_SETPARAFORMAT, 0, ref format);
+            }
+        }
         #endregion
 
         #region Protected
+        /// <summary>
+        /// Raises the HandleCreated event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            // Justify requires advanced typography; enable once the RichEdit HWND exists.
+            EnableAdvancedTypography();
+        }
+
         protected override void OnEnabledChanged(EventArgs e)
         {
             // Do not forward, to allow the correct Background for disabled state
@@ -279,6 +355,20 @@ public class KryptonRichTextBox : VisualControlBase,
             base.OnMouseMove(e);
 
             _kryptonRichTextBox.OnMouseMove(e);
+        }
+        #endregion
+
+        #region Implementation
+        private void EnableAdvancedTypography()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            PI.SendMessage(Handle, PI.EM_SETTYPOGRAPHYOPTIONS,
+                (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY,
+                (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY);
         }
         #endregion
     }
@@ -854,6 +944,28 @@ public class KryptonRichTextBox : VisualControlBase,
         {
             PerformNeedPaint(true);
             _richTextBox.SelectionAlignment = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets paragraph alignment for the current selection, including full justify.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this property over <see cref="SelectionAlignment"/> when justify is required.
+    /// WinForms <see cref="HorizontalAlignment"/> does not expose a justify value; justified
+    /// paragraphs report as <see cref="HorizontalAlignment.Left"/> via <see cref="SelectionAlignment"/>.
+    /// </remarks>
+    [Browsable(false)]
+    [DefaultValue(RichTextParagraphAlignment.Left)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextParagraphAlignment SelectionParagraphAlignment
+    {
+        get => _richTextBox.SelectionParagraphAlignment;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionParagraphAlignment = value;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -611,8 +611,12 @@ public class KryptonRichTextBox : VisualControlBase,
             // Remove any showing tooltip
             OnCancelToolTip(this, EventArgs.Empty);
 
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
 
             _pulsingBorder.Dispose();
 
@@ -2078,7 +2082,8 @@ public class KryptonRichTextBox : VisualControlBase,
             // to allow a relayout or if in design mode.
             if (_forcedLayout || DesignMode)
             {
-                Rectangle fillRect = _layoutFill.FillRect;
+                Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                    _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
                 _richTextBox.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
             }
         }
@@ -2413,14 +2418,18 @@ public class KryptonRichTextBox : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_richTextBox, ScrollbarManagerMode.NativeWrapper);
             }
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     private void UpdateStateAndPalettes()
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1744,7 +1744,7 @@ public class KryptonTextBox : VisualControlBase,
         if (IsHandleCreated || _forcedLayout || (DesignMode && (_textBox != null)))
         {
             Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                _layoutFill, _scrollbarManager, UseKryptonScrollbars);
             //  for centering the inner text field vertically
             var y = Height / 2 - _textBox.Height / 2;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -583,8 +583,12 @@ public class KryptonTextBox : VisualControlBase,
             _buttonSpecAccessibilityProxyManagerFixed?.Dispose();
             _buttonSpecAccessibilityProxyManagerFixed = null;
 
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
 
             _pulsingBorder.Dispose();
 
@@ -1739,7 +1743,8 @@ public class KryptonTextBox : VisualControlBase,
         // to allow a relayout or if in design mode.
         if (IsHandleCreated || _forcedLayout || (DesignMode && (_textBox != null)))
         {
-            Rectangle fillRect = _layoutFill.FillRect;
+            Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
             //  for centering the inner text field vertically
             var y = Height / 2 - _textBox.Height / 2;
 
@@ -2186,14 +2191,18 @@ public class KryptonTextBox : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_textBox, ScrollbarManagerMode.NativeWrapper);
             }
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     NativeWrapperScrollbarLayout IKryptonNativeWrapperScrollbarBounds.GetNativeWrapperScrollbarLayout() =>
         KryptonNativeWrapperScrollbarBoundsHelper.GetLayout(this, _layoutFill);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -684,8 +684,12 @@ public class KryptonTreeView : VisualControlBase,
     {
         if (disposing)
         {
-            _scrollbarManager?.Dispose();
-            _scrollbarManager = null;
+            if (_scrollbarManager != null)
+            {
+                _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+                _scrollbarManager.Dispose();
+                _scrollbarManager = null;
+            }
         }
         base.Dispose(disposing);
     }
@@ -1918,7 +1922,8 @@ public class KryptonTreeView : VisualControlBase,
         // to allow a relayout or if in design mode.
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
-            Rectangle fillRect = _layoutFill.FillRect;
+            Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
+                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
             _treeView.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }
@@ -1987,14 +1992,18 @@ public class KryptonTreeView : VisualControlBase,
             // attachment to the inner control follows the enabled state.
             if (ScrollbarManager.TargetControl == null)
             {
+                ScrollbarManager.ScrollbarsChanged += OnManagedScrollbarsChanged;
                 ScrollbarManager.Attach(_treeView, ScrollbarManagerMode.NativeWrapper);
             }
         }
-        else
+        else if (_scrollbarManager != null)
         {
-            _scrollbarManager?.Detach();
+            _scrollbarManager.ScrollbarsChanged -= OnManagedScrollbarsChanged;
+            _scrollbarManager.Detach();
         }
     }
+
+    private void OnManagedScrollbarsChanged(object? sender, EventArgs e) => ForceControlLayout();
 
     private void UpdateItemHeight()
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -1923,7 +1923,7 @@ public class KryptonTreeView : VisualControlBase,
         if (IsHandleCreated || _forcedLayout || (DesignMode))
         {
             Rectangle fillRect = KryptonNativeWrapperScrollbarBoundsHelper.GetNativeChildBounds(
-                _layoutFill.FillRect, _scrollbarManager, UseKryptonScrollbars);
+                _layoutFill, _scrollbarManager, UseKryptonScrollbars);
             _treeView.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -4597,3 +4597,39 @@ public enum KryptonTaskbarProgressState
 }
 
 #endregion
+
+#region Enum RichTextParagraphAlignment
+
+/// <summary>
+/// Specifies paragraph alignment for a rich text selection, including full justify.
+/// </summary>
+/// <remarks>
+/// Values match RichEdit <c>PFA_*</c> constants used by <c>EM_SETPARAFORMAT</c>.
+/// Use <see cref="KryptonRichTextBox.SelectionParagraphAlignment"/> instead of
+/// <see cref="KryptonRichTextBox.SelectionAlignment"/> when justify is required;
+/// WinForms <see cref="HorizontalAlignment"/> does not include a justify value.
+/// </remarks>
+public enum RichTextParagraphAlignment
+{
+    /// <summary>
+    /// Align text to the left margin.
+    /// </summary>
+    Left = 1,
+
+    /// <summary>
+    /// Align text to the right margin.
+    /// </summary>
+    Right = 2,
+
+    /// <summary>
+    /// Center text between the margins.
+    /// </summary>
+    Center = 3,
+
+    /// <summary>
+    /// Fully justify text between the margins (RichEdit advanced typography).
+    /// </summary>
+    Justify = 4
+}
+
+#endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonNativeWrapperScrollbarBoundsHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonNativeWrapperScrollbarBoundsHelper.cs
@@ -79,4 +79,19 @@ internal static class KryptonNativeWrapperScrollbarBoundsHelper
 
         return new NativeWrapperScrollbarLayout(laneRect, contentRect);
     }
+
+    /// <summary>
+    /// Shrinks the native child fill rectangle when themed overlay scrollbars are visible.
+    /// </summary>
+    internal static Rectangle GetNativeChildBounds(Rectangle fillRect,
+        KryptonScrollbarManager? scrollbarManager,
+        bool useKryptonScrollbars)
+    {
+        if (!useKryptonScrollbars || scrollbarManager == null)
+        {
+            return fillRect;
+        }
+
+        return scrollbarManager.GetInsetContentBounds(fillRect);
+    }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonNativeWrapperScrollbarBoundsHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonNativeWrapperScrollbarBoundsHelper.cs
@@ -83,15 +83,26 @@ internal static class KryptonNativeWrapperScrollbarBoundsHelper
     /// <summary>
     /// Shrinks the native child fill rectangle when themed overlay scrollbars are visible.
     /// </summary>
-    internal static Rectangle GetNativeChildBounds(Rectangle fillRect,
+    /// <remarks>
+    /// Clips to the scrollbar edge in lane coordinates so existing
+    /// <see cref="ViewLayoutFill.DisplayPadding"/> is not subtracted twice.
+    /// </remarks>
+    internal static Rectangle GetNativeChildBounds(ViewLayoutFill layoutFill,
         KryptonScrollbarManager? scrollbarManager,
         bool useKryptonScrollbars)
     {
+        Rectangle fillRect = layoutFill.FillRect;
         if (!useKryptonScrollbars || scrollbarManager == null)
         {
             return fillRect;
         }
 
-        return scrollbarManager.GetInsetContentBounds(fillRect);
+        Rectangle laneRect = layoutFill.ClientRectangle;
+        if (laneRect.IsEmpty)
+        {
+            laneRect = fillRect;
+        }
+
+        return scrollbarManager.GetInsetContentBounds(fillRect, laneRect);
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
@@ -1673,33 +1673,48 @@ public class KryptonScrollbarManager : IDisposable
     private static int ManagedScrollBarHeight => SystemInformation.HorizontalScrollBarHeight + ScrollBarLanePadding;
 
     /// <summary>
-    /// Returns native-child bounds inset so overlay themed scrollbars do not cover content.
+    /// Returns native-child bounds clipped so overlay themed scrollbars do not cover content.
     /// </summary>
     /// <param name="fillRect">The full fill rectangle for the native child.</param>
+    /// <param name="laneRect">
+    /// Outer lane inside the themed border (where overlay scrollbars are positioned).
+    /// </param>
     /// <returns>
-    /// <paramref name="fillRect"/> reduced on the right and/or bottom when the matching
-    /// themed scrollbar is visible. Bars stay flush to the themed border; content shrinks instead.
+    /// <paramref name="fillRect"/> with its right/bottom edges clipped to the scrollbar
+    /// edges when visible. Bars stay flush to the themed border; content ends where the bar starts.
     /// </returns>
-    public Rectangle GetInsetContentBounds(Rectangle fillRect)
+    public Rectangle GetInsetContentBounds(Rectangle fillRect, Rectangle laneRect)
     {
         if (_mode != ScrollbarManagerMode.NativeWrapper || !_enabled)
         {
             return fillRect;
         }
 
-        int width = fillRect.Width;
-        int height = fillRect.Height;
+        if (laneRect.IsEmpty)
+        {
+            laneRect = fillRect;
+        }
 
+        int right = fillRect.Right;
+        int bottom = fillRect.Bottom;
+
+        // Clip to the overlay bar edge rather than subtracting bar width from FillRect.
+        // FillRect is already inset by DisplayPadding from the lane; subtracting again
+        // left a visible gutter between wrapped text and the scrollbar.
         if (_verticalScrollBar?.Visible == true)
         {
-            width = Math.Max(0, width - ManagedScrollBarWidth);
+            int scrollbarLeft = laneRect.Right - ManagedScrollBarWidth;
+            right = Math.Min(right, scrollbarLeft);
         }
 
         if (_horizontalScrollBar?.Visible == true)
         {
-            height = Math.Max(0, height - ManagedScrollBarHeight);
+            int scrollbarTop = laneRect.Bottom - ManagedScrollBarHeight;
+            bottom = Math.Min(bottom, scrollbarTop);
         }
 
+        int width = Math.Max(0, right - fillRect.Left);
+        int height = Math.Max(0, bottom - fillRect.Top);
         return new Rectangle(fillRect.X, fillRect.Y, width, height);
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonScrollbarManager.cs
@@ -1672,6 +1672,37 @@ public class KryptonScrollbarManager : IDisposable
 
     private static int ManagedScrollBarHeight => SystemInformation.HorizontalScrollBarHeight + ScrollBarLanePadding;
 
+    /// <summary>
+    /// Returns native-child bounds inset so overlay themed scrollbars do not cover content.
+    /// </summary>
+    /// <param name="fillRect">The full fill rectangle for the native child.</param>
+    /// <returns>
+    /// <paramref name="fillRect"/> reduced on the right and/or bottom when the matching
+    /// themed scrollbar is visible. Bars stay flush to the themed border; content shrinks instead.
+    /// </returns>
+    public Rectangle GetInsetContentBounds(Rectangle fillRect)
+    {
+        if (_mode != ScrollbarManagerMode.NativeWrapper || !_enabled)
+        {
+            return fillRect;
+        }
+
+        int width = fillRect.Width;
+        int height = fillRect.Height;
+
+        if (_verticalScrollBar?.Visible == true)
+        {
+            width = Math.Max(0, width - ManagedScrollBarWidth);
+        }
+
+        if (_horizontalScrollBar?.Visible == true)
+        {
+            height = Math.Max(0, height - ManagedScrollBarHeight);
+        }
+
+        return new Rectangle(fillRect.X, fillRect.Y, width, height);
+    }
+
     private void OnCornerNeedPaint(object? sender, NeedLayoutEventArgs e) => _scrollBarCorner?.Invalidate();
 
     private void BringScrollbarsToFront()

--- a/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.Designer.cs
@@ -1,0 +1,293 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class Feature4008RichTextBoxJustifyDemo
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.kwlblInstructions = new Krypton.Toolkit.KryptonWrapLabel();
+            this.klblKryptonCaption = new Krypton.Toolkit.KryptonLabel();
+            this.flowKryptonAlign = new System.Windows.Forms.FlowLayoutPanel();
+            this.kbtnLeft = new Krypton.Toolkit.KryptonButton();
+            this.kbtnCenter = new Krypton.Toolkit.KryptonButton();
+            this.kbtnRight = new Krypton.Toolkit.KryptonButton();
+            this.kbtnJustify = new Krypton.Toolkit.KryptonButton();
+            this.kbtnSelectAll = new Krypton.Toolkit.KryptonButton();
+            this.krtbDemo = new Krypton.Toolkit.KryptonRichTextBox();
+            this.klblNativeCaption = new Krypton.Toolkit.KryptonLabel();
+            this.flowNativeAlign = new System.Windows.Forms.FlowLayoutPanel();
+            this.kbtnNativeLeft = new Krypton.Toolkit.KryptonButton();
+            this.kbtnNativeCenter = new Krypton.Toolkit.KryptonButton();
+            this.kbtnNativeRight = new Krypton.Toolkit.KryptonButton();
+            this.rtbNative = new System.Windows.Forms.RichTextBox();
+            this.klblStatus = new Krypton.Toolkit.KryptonLabel();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
+            this.kryptonPanelMain.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.flowKryptonAlign.SuspendLayout();
+            this.flowNativeAlign.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // kryptonPanelMain
+            //
+            this.kryptonPanelMain.Controls.Add(this.tableLayoutPanel1);
+            this.kryptonPanelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanelMain.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanelMain.Name = "kryptonPanelMain";
+            this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
+            this.kryptonPanelMain.Size = new System.Drawing.Size(900, 620);
+            this.kryptonPanelMain.TabIndex = 0;
+            //
+            // tableLayoutPanel1
+            //
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.kwlblInstructions, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.klblKryptonCaption, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.flowKryptonAlign, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.krtbDemo, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.klblNativeCaption, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.flowNativeAlign, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.rtbNative, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.klblStatus, 0, 7);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 8;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(876, 596);
+            this.tableLayoutPanel1.TabIndex = 0;
+            //
+            // kwlblInstructions
+            //
+            this.kwlblInstructions.AutoSize = false;
+            this.kwlblInstructions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kwlblInstructions.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.kwlblInstructions.LabelStyle = Krypton.Toolkit.LabelStyle.NormalPanel;
+            this.kwlblInstructions.Location = new System.Drawing.Point(3, 0);
+            this.kwlblInstructions.Name = "kwlblInstructions";
+            this.kwlblInstructions.Size = new System.Drawing.Size(870, 72);
+            this.kwlblInstructions.Text = "Issue #4008 — KryptonRichTextBox.SelectionParagraphAlignment (Left / Center / Right / Justify).\r\n\r\nUse the Krypton buttons to apply paragraph alignment. Justify should fill soft spaces to both margins on full lines. The native RichTextBox below only has SelectionAlignment (no Justify). Narrow the window to see wrapping differences more clearly.";
+            //
+            // klblKryptonCaption
+            //
+            this.klblKryptonCaption.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.klblKryptonCaption.Location = new System.Drawing.Point(3, 72);
+            this.klblKryptonCaption.Name = "klblKryptonCaption";
+            this.klblKryptonCaption.Size = new System.Drawing.Size(870, 24);
+            this.klblKryptonCaption.TabIndex = 0;
+            this.klblKryptonCaption.Values.Text = "KryptonRichTextBox — SelectionParagraphAlignment";
+            //
+            // flowKryptonAlign
+            //
+            this.flowKryptonAlign.Controls.Add(this.kbtnLeft);
+            this.flowKryptonAlign.Controls.Add(this.kbtnCenter);
+            this.flowKryptonAlign.Controls.Add(this.kbtnRight);
+            this.flowKryptonAlign.Controls.Add(this.kbtnJustify);
+            this.flowKryptonAlign.Controls.Add(this.kbtnSelectAll);
+            this.flowKryptonAlign.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowKryptonAlign.Location = new System.Drawing.Point(3, 99);
+            this.flowKryptonAlign.Name = "flowKryptonAlign";
+            this.flowKryptonAlign.Size = new System.Drawing.Size(870, 34);
+            this.flowKryptonAlign.TabIndex = 1;
+            //
+            // kbtnLeft
+            //
+            this.kbtnLeft.Location = new System.Drawing.Point(3, 3);
+            this.kbtnLeft.Name = "kbtnLeft";
+            this.kbtnLeft.Size = new System.Drawing.Size(90, 28);
+            this.kbtnLeft.TabIndex = 0;
+            this.kbtnLeft.Values.Text = "Left";
+            this.kbtnLeft.Click += new System.EventHandler(this.kbtnLeft_Click);
+            //
+            // kbtnCenter
+            //
+            this.kbtnCenter.Location = new System.Drawing.Point(99, 3);
+            this.kbtnCenter.Name = "kbtnCenter";
+            this.kbtnCenter.Size = new System.Drawing.Size(90, 28);
+            this.kbtnCenter.TabIndex = 1;
+            this.kbtnCenter.Values.Text = "Center";
+            this.kbtnCenter.Click += new System.EventHandler(this.kbtnCenter_Click);
+            //
+            // kbtnRight
+            //
+            this.kbtnRight.Location = new System.Drawing.Point(195, 3);
+            this.kbtnRight.Name = "kbtnRight";
+            this.kbtnRight.Size = new System.Drawing.Size(90, 28);
+            this.kbtnRight.TabIndex = 2;
+            this.kbtnRight.Values.Text = "Right";
+            this.kbtnRight.Click += new System.EventHandler(this.kbtnRight_Click);
+            //
+            // kbtnJustify
+            //
+            this.kbtnJustify.Location = new System.Drawing.Point(291, 3);
+            this.kbtnJustify.Name = "kbtnJustify";
+            this.kbtnJustify.Size = new System.Drawing.Size(90, 28);
+            this.kbtnJustify.TabIndex = 3;
+            this.kbtnJustify.Values.Text = "Justify";
+            this.kbtnJustify.Click += new System.EventHandler(this.kbtnJustify_Click);
+            //
+            // kbtnSelectAll
+            //
+            this.kbtnSelectAll.Location = new System.Drawing.Point(387, 3);
+            this.kbtnSelectAll.Name = "kbtnSelectAll";
+            this.kbtnSelectAll.Size = new System.Drawing.Size(100, 28);
+            this.kbtnSelectAll.TabIndex = 4;
+            this.kbtnSelectAll.Values.Text = "Select All";
+            this.kbtnSelectAll.Click += new System.EventHandler(this.kbtnSelectAll_Click);
+            //
+            // krtbDemo
+            //
+            this.krtbDemo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.krtbDemo.Location = new System.Drawing.Point(3, 139);
+            this.krtbDemo.Multiline = true;
+            this.krtbDemo.Name = "krtbDemo";
+            this.krtbDemo.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            this.krtbDemo.Size = new System.Drawing.Size(870, 160);
+            this.krtbDemo.TabIndex = 2;
+            this.krtbDemo.Text = "";
+            this.krtbDemo.SelectionChanged += new System.EventHandler(this.krtbDemo_SelectionChanged);
+            //
+            // klblNativeCaption
+            //
+            this.klblNativeCaption.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.klblNativeCaption.Location = new System.Drawing.Point(3, 302);
+            this.klblNativeCaption.Name = "klblNativeCaption";
+            this.klblNativeCaption.Size = new System.Drawing.Size(870, 24);
+            this.klblNativeCaption.TabIndex = 3;
+            this.klblNativeCaption.Values.Text = "Native WinForms RichTextBox — SelectionAlignment only (no Justify)";
+            //
+            // flowNativeAlign
+            //
+            this.flowNativeAlign.Controls.Add(this.kbtnNativeLeft);
+            this.flowNativeAlign.Controls.Add(this.kbtnNativeCenter);
+            this.flowNativeAlign.Controls.Add(this.kbtnNativeRight);
+            this.flowNativeAlign.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowNativeAlign.Location = new System.Drawing.Point(3, 329);
+            this.flowNativeAlign.Name = "flowNativeAlign";
+            this.flowNativeAlign.Size = new System.Drawing.Size(870, 34);
+            this.flowNativeAlign.TabIndex = 4;
+            //
+            // kbtnNativeLeft
+            //
+            this.kbtnNativeLeft.Location = new System.Drawing.Point(3, 3);
+            this.kbtnNativeLeft.Name = "kbtnNativeLeft";
+            this.kbtnNativeLeft.Size = new System.Drawing.Size(90, 28);
+            this.kbtnNativeLeft.TabIndex = 0;
+            this.kbtnNativeLeft.Values.Text = "Left";
+            this.kbtnNativeLeft.Click += new System.EventHandler(this.kbtnNativeLeft_Click);
+            //
+            // kbtnNativeCenter
+            //
+            this.kbtnNativeCenter.Location = new System.Drawing.Point(99, 3);
+            this.kbtnNativeCenter.Name = "kbtnNativeCenter";
+            this.kbtnNativeCenter.Size = new System.Drawing.Size(90, 28);
+            this.kbtnNativeCenter.TabIndex = 1;
+            this.kbtnNativeCenter.Values.Text = "Center";
+            this.kbtnNativeCenter.Click += new System.EventHandler(this.kbtnNativeCenter_Click);
+            //
+            // kbtnNativeRight
+            //
+            this.kbtnNativeRight.Location = new System.Drawing.Point(195, 3);
+            this.kbtnNativeRight.Name = "kbtnNativeRight";
+            this.kbtnNativeRight.Size = new System.Drawing.Size(90, 28);
+            this.kbtnNativeRight.TabIndex = 2;
+            this.kbtnNativeRight.Values.Text = "Right";
+            this.kbtnNativeRight.Click += new System.EventHandler(this.kbtnNativeRight_Click);
+            //
+            // rtbNative
+            //
+            this.rtbNative.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.rtbNative.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rtbNative.Location = new System.Drawing.Point(3, 369);
+            this.rtbNative.Multiline = true;
+            this.rtbNative.Name = "rtbNative";
+            this.rtbNative.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            this.rtbNative.Size = new System.Drawing.Size(870, 160);
+            this.rtbNative.TabIndex = 5;
+            this.rtbNative.Text = "";
+            this.rtbNative.SelectionChanged += new System.EventHandler(this.rtbNative_SelectionChanged);
+            //
+            // klblStatus
+            //
+            this.klblStatus.AutoSize = false;
+            this.klblStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.klblStatus.Location = new System.Drawing.Point(3, 535);
+            this.klblStatus.Name = "klblStatus";
+            this.klblStatus.Size = new System.Drawing.Size(870, 40);
+            this.klblStatus.StateCommon.ShortText.Color1 = System.Drawing.Color.DimGray;
+            this.klblStatus.TabIndex = 6;
+            this.klblStatus.Values.Text = "Status";
+            //
+            // Feature4008RichTextBoxJustifyDemo
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(900, 620);
+            this.Controls.Add(this.kryptonPanelMain);
+            this.MinimumSize = new System.Drawing.Size(640, 480);
+            this.Name = "Feature4008RichTextBoxJustifyDemo";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Issue #4008 — RichTextBox paragraph justify";
+            this.Load += new System.EventHandler(this.Feature4008RichTextBoxJustifyDemo_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).EndInit();
+            this.kryptonPanelMain.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.flowKryptonAlign.ResumeLayout(false);
+            this.flowNativeAlign.ResumeLayout(false);
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanelMain;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private Krypton.Toolkit.KryptonWrapLabel kwlblInstructions;
+        private Krypton.Toolkit.KryptonLabel klblKryptonCaption;
+        private System.Windows.Forms.FlowLayoutPanel flowKryptonAlign;
+        private Krypton.Toolkit.KryptonButton kbtnLeft;
+        private Krypton.Toolkit.KryptonButton kbtnCenter;
+        private Krypton.Toolkit.KryptonButton kbtnRight;
+        private Krypton.Toolkit.KryptonButton kbtnJustify;
+        private Krypton.Toolkit.KryptonButton kbtnSelectAll;
+        private Krypton.Toolkit.KryptonRichTextBox krtbDemo;
+        private Krypton.Toolkit.KryptonLabel klblNativeCaption;
+        private System.Windows.Forms.FlowLayoutPanel flowNativeAlign;
+        private Krypton.Toolkit.KryptonButton kbtnNativeLeft;
+        private Krypton.Toolkit.KryptonButton kbtnNativeCenter;
+        private Krypton.Toolkit.KryptonButton kbtnNativeRight;
+        private System.Windows.Forms.RichTextBox rtbNative;
+        private Krypton.Toolkit.KryptonLabel klblStatus;
+    }
+}

--- a/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.cs
+++ b/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.cs
@@ -29,6 +29,11 @@ public partial class Feature4008RichTextBoxJustifyDemo : KryptonForm
 
     private void Feature4008RichTextBoxJustifyDemo_Load(object? sender, EventArgs e)
     {
+        // Match fonts and force a vertical scrollbar on the native control so wrap width
+        // is comparable to Krypton (themed scrollbars reserve the same lane).
+        rtbNative.Font = krtbDemo.Font;
+        rtbNative.ScrollBars = RichTextBoxScrollBars.Vertical;
+
         krtbDemo.Text = SampleParagraph;
         rtbNative.Text = SampleParagraph;
         UpdateStatus();

--- a/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.cs
+++ b/Source/Krypton Components/TestForm/Feature4008RichTextBoxJustifyDemo.cs
@@ -1,0 +1,102 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Demo for Issue #4008: KryptonRichTextBox.SelectionParagraphAlignment including full justify.
+/// Native WinForms RichTextBox.SelectionAlignment has no Justify value; Krypton exposes it via RichEdit.
+/// </summary>
+public partial class Feature4008RichTextBoxJustifyDemo : KryptonForm
+{
+    private const string SampleParagraph =
+        "The quick brown fox jumps over the lazy dog. Justified text stretches soft spaces so each " +
+        "full line meets both margins, similar to a word processor. Short final lines stay left-aligned.\r\n\r\n" +
+        "Select a paragraph or the whole document, then use the alignment buttons. With Justify, word " +
+        "spacing should redistribute so lines fill the control width. Left, Center, and Right should match " +
+        "the usual RichTextBox behaviour.";
+
+    public Feature4008RichTextBoxJustifyDemo()
+    {
+        InitializeComponent();
+    }
+
+    private void Feature4008RichTextBoxJustifyDemo_Load(object? sender, EventArgs e)
+    {
+        krtbDemo.Text = SampleParagraph;
+        rtbNative.Text = SampleParagraph;
+        UpdateStatus();
+    }
+
+    private void kbtnLeft_Click(object? sender, EventArgs e) =>
+        ApplyKryptonAlignment(RichTextParagraphAlignment.Left);
+
+    private void kbtnCenter_Click(object? sender, EventArgs e) =>
+        ApplyKryptonAlignment(RichTextParagraphAlignment.Center);
+
+    private void kbtnRight_Click(object? sender, EventArgs e) =>
+        ApplyKryptonAlignment(RichTextParagraphAlignment.Right);
+
+    private void kbtnJustify_Click(object? sender, EventArgs e) =>
+        ApplyKryptonAlignment(RichTextParagraphAlignment.Justify);
+
+    private void kbtnSelectAll_Click(object? sender, EventArgs e)
+    {
+        krtbDemo.SelectAll();
+        krtbDemo.Focus();
+        UpdateStatus();
+    }
+
+    private void kbtnNativeLeft_Click(object? sender, EventArgs e) =>
+        ApplyNativeAlignment(HorizontalAlignment.Left);
+
+    private void kbtnNativeCenter_Click(object? sender, EventArgs e) =>
+        ApplyNativeAlignment(HorizontalAlignment.Center);
+
+    private void kbtnNativeRight_Click(object? sender, EventArgs e) =>
+        ApplyNativeAlignment(HorizontalAlignment.Right);
+
+    private void krtbDemo_SelectionChanged(object? sender, EventArgs e) => UpdateStatus();
+
+    private void rtbNative_SelectionChanged(object? sender, EventArgs e) => UpdateStatus();
+
+    private void ApplyKryptonAlignment(RichTextParagraphAlignment alignment)
+    {
+        if (krtbDemo.SelectionLength == 0)
+        {
+            krtbDemo.SelectAll();
+        }
+
+        krtbDemo.SelectionParagraphAlignment = alignment;
+        krtbDemo.Focus();
+        UpdateStatus();
+    }
+
+    private void ApplyNativeAlignment(HorizontalAlignment alignment)
+    {
+        if (rtbNative.SelectionLength == 0)
+        {
+            rtbNative.SelectAll();
+        }
+
+        rtbNative.SelectionAlignment = alignment;
+        rtbNative.Focus();
+        UpdateStatus();
+    }
+
+    private void UpdateStatus()
+    {
+        klblStatus.Values.Text =
+            $"Krypton SelectionParagraphAlignment={krtbDemo.SelectionParagraphAlignment}; " +
+            $"SelectionAlignment={krtbDemo.SelectionAlignment} " +
+            $"(Justify reads as Left via SelectionAlignment).  |  " +
+            $"Native SelectionAlignment={rtbNative.SelectionAlignment} " +
+            "(no Justify API on HorizontalAlignment).";
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -137,6 +137,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<TouchscreenHighDpiDemo>("Touchscreen + High DPI Demo", "Comprehensive demonstration of touchscreen support with per-monitor high DPI scaling (Issue #2844).");
         CreateButton<KryptonFormTitleBarDemo>("Title Bar Menu", "Demonstrates titlebar menu.");
         CreateButton<RichTextBoxFormattingTest>("RichTextBox Formatting Test", "Tests fix for RichTextBox formatting preservation when palette changes (Issue #2832)");
+        CreateButton<Feature4008RichTextBoxJustifyDemo>("Feature 4008 RichTextBox Justify", "Issue #4008: KryptonRichTextBox.SelectionParagraphAlignment with Left/Center/Right/Justify. Compare with native RichTextBox SelectionAlignment (no Justify). Resize the form to see justified word spacing.");
         CreateButton<Bug3343RichTextBoxEditLossDemo>("Bug 3343 RichTextBox mouse leave", "Issue #3343: type in KryptonRichTextBox, move the mouse out without changing focus; text and TextLength must not reset. Includes KryptonTextBox for comparison.");
         CreateButton<RTLFormBorderTest>("RTL Layout Test", "Test for RTL compliance");
         CreateButton<ToastNotificationTestChoice>("Toast", "For breakfast....?");


### PR DESCRIPTION
# Feature: KryptonRichTextBox paragraph justify (#4008)

## Summary

Adds `KryptonRichTextBox.SelectionParagraphAlignment` (and the matching ribbon group forwarder) so consumers can apply full paragraph justification. WinForms `SelectionAlignment` / `HorizontalAlignment` cannot express justify; this API uses RichEdit `EM_SETPARAFORMAT` with `PFA_JUSTIFY` after enabling advanced typography.

## Related issues

- Closes #4008

## Type of change

- [x] Feature / enhancement (`Implemented`)

## Changes

- `Krypton.Interop`: RichEdit `PARAFORMAT`, `EM_GET/SETPARAFORMAT`, `EM_SETTYPOGRAPHYOPTIONS`, and `PFA_*` / `PFM_ALIGNMENT` constants.
- `Krypton.Toolkit`: public `RichTextParagraphAlignment` enum; `SelectionParagraphAlignment` on `KryptonRichTextBox` (implemented on the inner RichEdit control).
- `Krypton.Ribbon`: `SelectionParagraphAlignment` forwarded from `KryptonRibbonGroupRichTextBox`.
- `TestForm`: `Feature4008RichTextBoxJustifyDemo` side-by-side with native `RichTextBox`.

## Affected packages & target frameworks

- Packages: `Krypton.Interop`, `Krypton.Toolkit`, `Krypton.Ribbon`, `TestForm`
- TFMs verified: project default Debug build for `Krypton.Toolkit` / `Krypton.Ribbon` / `TestForm`

## Validation

- TestForm demo: `Feature4008RichTextBoxJustifyDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Open the demo; sample text loads in Krypton and native rich text boxes.
  2. Click **Justify** on the Krypton side — full lines should stretch to both margins.
  3. Click Left / Center / Right and confirm expected alignment; status shows `SelectionParagraphAlignment` and that `SelectionAlignment` still reports Left when justified.
  4. Confirm native control has no Justify button and only Left/Center/Right via `SelectionAlignment`.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug` (and Ribbon / TestForm as needed)

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify
   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
```

## GIF

<img width="918" height="661" alt="4008" src="https://github.com/user-attachments/assets/cfeacf95-2291-4679-bf0a-f8698a699c3f" />


## Breaking changes & migration

None. Existing `SelectionAlignment` is unchanged. Prefer `SelectionParagraphAlignment` when justify is required; a justified paragraph still reports as `HorizontalAlignment.Left` through `SelectionAlignment`.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above