### PR TITLE
* `KryptonRichTextBox` Support for justify  (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 ## Table of Contents
 
+* [2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026](#2026-10-26---build-2610-version-105-lts---patch-4---october-2026)
 * [2026-07-20 - Build 2607 (Version 105-LTS - Patch 3) - July 2026](#2026-07-20---build-2607-version-105-lts---patch-3---july-2026)
 * [2026-04-20 - Build 2604 (Version 105-LTS - Patch 2) - April 2026](#2026-04-20---build-2604-version-105-lts---patch-2---april-2026)
 * [2026-01-19 - Build 2501 (Version 100-LTS - Patch 1) - January 2026](#2026-01-19---build-2501-version-100-lts---patch-1---january-2026)
@@ -42,6 +43,13 @@
 * [2020-03-01 - Build 2003 - March 2020](#2020-03-01---build-2003---march-2020)
 * [2020-02-07 - Build 2002.1 - February 2020 (Update 1)](#2020-02-07---build-20021---february-2020-update-1)
 * [2020-02-01 - Build 2002 - February 2020](#2020-02-01---build-2002---february-2020)
+
+====
+
+## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
+
+* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
+   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
 
 ====
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
@@ -746,6 +746,18 @@ public class KryptonRibbonGroupRichTextBox : KryptonRibbonGroupItem
     }
 
     /// <summary>
+    /// Gets and sets paragraph alignment for the current selection, including full justify.
+    /// </summary>
+    [Browsable(false)]
+    [DefaultValue(typeof(RichTextParagraphAlignment), "Left")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextParagraphAlignment SelectionParagraphAlignment
+    {
+        get => RichTextBox!.SelectionParagraphAlignment;
+        set => RichTextBox!.SelectionParagraphAlignment = value;
+    }
+
+    /// <summary>
     /// Gets and sets the background color of the selected area.
     /// </summary>
     [Browsable(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -150,9 +150,87 @@ public class KryptonRichTextBox : VisualControlBase,
             //Return last + 1 character printer
             return (int)res.ToInt64();
         }
+
+        /// <summary>
+        /// Gets and sets paragraph alignment for the current selection, including justify.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextParagraphAlignment SelectionParagraphAlignment
+        {
+            get
+            {
+                if (!IsHandleCreated)
+                {
+                    return RichTextParagraphAlignment.Left;
+                }
+
+                var format = new PI.PARAFORMAT
+                {
+                    cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                    rgxTabs = new int[32]
+                };
+
+                PI.SendMessage(new HandleRef(this, Handle), PI.EM_GETPARAFORMAT, 0, ref format);
+
+                if ((format.dwMask & PI.PFM_ALIGNMENT) == 0)
+                {
+                    return RichTextParagraphAlignment.Left;
+                }
+
+                switch (format.wAlignment)
+                {
+                    case PI.PFA_RIGHT:
+                        return RichTextParagraphAlignment.Right;
+                    case PI.PFA_CENTER:
+                        return RichTextParagraphAlignment.Center;
+                    case PI.PFA_JUSTIFY:
+                        return RichTextParagraphAlignment.Justify;
+                    default:
+                        return RichTextParagraphAlignment.Left;
+                }
+            }
+            set
+            {
+                // Force handle creation so RichEdit can apply paragraph format.
+                if (!IsHandleCreated)
+                {
+                    _ = Handle;
+                }
+
+                if (value == RichTextParagraphAlignment.Justify)
+                {
+                    EnableAdvancedTypography();
+                }
+
+                var format = new PI.PARAFORMAT
+                {
+                    cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                    dwMask = PI.PFM_ALIGNMENT,
+                    wAlignment = (ushort)value,
+                    rgxTabs = new int[32]
+                };
+
+                PI.SendMessage(new HandleRef(this, Handle), PI.EM_SETPARAFORMAT, 0, ref format);
+            }
+        }
+
         #endregion
 
         #region Protected
+
+        /// <summary>
+        /// Raises the HandleCreated event.
+        /// </summary>
+        /// <param name="e">An EventArgs instance containing the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            // Justify requires advanced typography; enable once the RichEdit HWND exists.
+            EnableAdvancedTypography();
+        }
+
         protected override void OnEnabledChanged(EventArgs e)
         {
             // Do not forward, to allow the correct Background for disabled state
@@ -279,6 +357,20 @@ public class KryptonRichTextBox : VisualControlBase,
             base.OnMouseMove(e);
 
             _kryptonRichTextBox.OnMouseMove(e);
+        }
+        #endregion
+
+        #region Implementation
+        private void EnableAdvancedTypography()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            PI.SendMessage(Handle, PI.EM_SETTYPOGRAPHYOPTIONS,
+                (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY,
+                (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY);
         }
         #endregion
     }
@@ -843,6 +935,28 @@ public class KryptonRichTextBox : VisualControlBase,
         {
             PerformNeedPaint(true);
             _richTextBox.SelectionAlignment = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets and sets paragraph alignment for the current selection, including full justify.
+    /// </summary>
+    /// <remarks>
+    /// Prefer this property over <see cref="SelectionAlignment"/> when justify is required.
+    /// WinForms <see cref="HorizontalAlignment"/> does not expose a justify value; justified
+    /// paragraphs report as <see cref="HorizontalAlignment.Left"/> via <see cref="SelectionAlignment"/>.
+    /// </remarks>
+    [Browsable(false)]
+    [DefaultValue(RichTextParagraphAlignment.Left)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public RichTextParagraphAlignment SelectionParagraphAlignment
+    {
+        get => _richTextBox.SelectionParagraphAlignment;
+
+        set
+        {
+            PerformNeedPaint(true);
+            _richTextBox.SelectionParagraphAlignment = value;
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -4449,6 +4449,42 @@ public enum IconSelectionStrategy
 
 #endregion
 
+#region Enum RichTextParagraphAlignment
+
+/// <summary>
+/// Specifies paragraph alignment for a rich text selection, including full justify.
+/// </summary>
+/// <remarks>
+/// Values match RichEdit <c>PFA_*</c> constants used by <c>EM_SETPARAFORMAT</c>.
+/// Use <see cref="KryptonRichTextBox.SelectionParagraphAlignment"/> instead of
+/// <see cref="KryptonRichTextBox.SelectionAlignment"/> when justify is required;
+/// WinForms <see cref="HorizontalAlignment"/> does not include a justify value.
+/// </remarks>
+public enum RichTextParagraphAlignment
+{
+    /// <summary>
+    /// Align text to the left margin.
+    /// </summary>
+    Left = 1,
+
+    /// <summary>
+    /// Align text to the right margin.
+    /// </summary>
+    Right = 2,
+
+    /// <summary>
+    /// Center text between the margins.
+    /// </summary>
+    Center = 3,
+
+    /// <summary>
+    /// Fully justify text between the margins (RichEdit advanced typography).
+    /// </summary>
+    Justify = 4
+}
+
+#endregion
+
 #region IFocusLostMenuItem
 /// <summary>
 /// This interface can be implemented by any (derived) control or component that needs focus handling via the FocusLostMenuHelper.

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3028,6 +3028,26 @@ No 	                    No 	                    Show text only
     internal const int PRF_CLIENT = 0x00000004;
     internal const int MA_NOACTIVATE = 0x03;
     internal const int EM_FORMATRANGE = 0x0439;
+
+    /// <summary>Gets the paragraph formatting of the current selection (RichEdit).</summary>
+    internal const int EM_GETPARAFORMAT = 0x043D; // WM_USER + 61
+    /// <summary>Sets the paragraph formatting of the current selection (RichEdit).</summary>
+    internal const int EM_SETPARAFORMAT = 0x0447; // WM_USER + 71
+    /// <summary>Sets RichEdit typography options (advanced line breaking / justification).</summary>
+    internal const int EM_SETTYPOGRAPHYOPTIONS = 0x04CA; // WM_USER + 202
+    /// <summary>Enables advanced typography (required for paragraph justify).</summary>
+    internal const int TO_ADVANCEDTYPOGRAPHY = 0x0001;
+    /// <summary>PARAFORMAT.dwMask: wAlignment is valid.</summary>
+    internal const uint PFM_ALIGNMENT = 0x00000008;
+    /// <summary>PARAFORMAT.wAlignment: left.</summary>
+    internal const ushort PFA_LEFT = 1;
+    /// <summary>PARAFORMAT.wAlignment: right.</summary>
+    internal const ushort PFA_RIGHT = 2;
+    /// <summary>PARAFORMAT.wAlignment: center.</summary>
+    internal const ushort PFA_CENTER = 3;
+    /// <summary>PARAFORMAT.wAlignment: justify (RichEdit 3+).</summary>
+    internal const ushort PFA_JUSTIFY = 4;
+
     internal const int RDW_INVALIDATE = 0x0001;
     internal const int RDW_UPDATENOW = 0x0100;
     internal const int RDW_FRAME = 0x0400;
@@ -3469,6 +3489,10 @@ No 	                    No 	                    Show text only
     [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref TV_ITEM lParam);
+
+    [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref PARAFORMAT lParam);
 
     [DllImport(Libraries.User32, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -4932,6 +4956,26 @@ No 	                    No 	                    Show text only
         ALERT_HIGH = 0x10000000, // This information is of high priority
         PROTECTED = 0x20000000, // access to this is restricted
         VALID = 0x3FFFFFFF
+    }
+
+    /// <summary>
+    /// RichEdit paragraph format (alignment and related paragraph properties).
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PARAFORMAT
+    {
+        public uint cbSize;
+        public uint dwMask;
+        public ushort wNumbering;
+        public ushort wEffects;
+        public int dxStartIndent;
+        public int dxRightIndent;
+        public int dxOffset;
+        public ushort wAlignment;
+        public short cTabCount;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public int[] rgxTabs;
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
# Feature: KryptonRichTextBox paragraph justify (#4008)

## Summary

Adds `KryptonRichTextBox.SelectionParagraphAlignment` (and the matching ribbon group forwarder) so consumers can apply full paragraph justification. WinForms `SelectionAlignment` / `HorizontalAlignment` cannot express justify; this API uses RichEdit `EM_SETPARAFORMAT` with `PFA_JUSTIFY` after enabling advanced typography.

## Related issues

- Closes #4008

## Type of change

- [x] Feature / enhancement (`Implemented`)

## Changes

- `Krypton.Interop`: RichEdit `PARAFORMAT`, `EM_GET/SETPARAFORMAT`, `EM_SETTYPOGRAPHYOPTIONS`, and `PFA_*` / `PFM_ALIGNMENT` constants.
- `Krypton.Toolkit`: public `RichTextParagraphAlignment` enum; `SelectionParagraphAlignment` on `KryptonRichTextBox` (implemented on the inner RichEdit control).
- `Krypton.Ribbon`: `SelectionParagraphAlignment` forwarded from `KryptonRibbonGroupRichTextBox`.
- `TestForm`: `Feature4008RichTextBoxJustifyDemo` side-by-side with native `RichTextBox`.

## Affected packages & target frameworks

- Packages: `Krypton.Interop`, `Krypton.Toolkit`, `Krypton.Ribbon`, `TestForm`
- TFMs verified: project default Debug build for `Krypton.Toolkit` / `Krypton.Ribbon` / `TestForm`

## Validation

- TestForm demo: `Feature4008RichTextBoxJustifyDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Open the demo; sample text loads in Krypton and native rich text boxes.
  2. Click **Justify** on the Krypton side — full lines should stretch to both margins.
  3. Click Left / Center / Right and confirm expected alignment; status shows `SelectionParagraphAlignment` and that `SelectionAlignment` still reports Left when justified.
  4. Confirm native control has no Justify button and only Left/Center/Right via `SelectionAlignment`.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug` (and Ribbon / TestForm as needed)

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify
   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
```

## GIF

<img width="918" height="661" alt="4008" src="https://github.com/user-attachments/assets/cfeacf95-2291-4679-bf0a-f8698a699c3f" />

## Breaking changes & migration

None. Existing `SelectionAlignment` is unchanged. Prefer `SelectionParagraphAlignment` when justify is required; a justified paragraph still reports as `HorizontalAlignment.Left` through `SelectionAlignment`.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above