### PR TITLE
* `KryptonRichTextBox` Support for justify  (V85 LTS)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -4,6 +4,8 @@
 
 # 2026-08-24 - Build 2608 (Patch 12) - August 2026
 
+* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
+   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
 * Resolved [#3881](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3881), FlashWindowExListener's WH_SHELL hook is never unhooked in hosts that don't call Application.Run() (e.g. VSTO/Office add-ins) — leads to AppDomainUnloadedException / host crash on shutdown
    * `FlashWindowExListener` `WH_SHELL` hook is now removed when the last tracked `KryptonForm` closes and on `AppDomain` unload, preventing `AppDomainUnloadedException` crashes in hosts that do not call `Application.Run()` (for example VSTO/Office add-ins).f
 * Resolved [#3814](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3814), Fixes three inconsistencies in `DockingManagerStrings`

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
@@ -775,6 +775,18 @@ namespace Krypton.Ribbon
         }
 
         /// <summary>
+        /// Gets and sets paragraph alignment for the current selection, including full justify.
+        /// </summary>
+        [Browsable(false)]
+        [DefaultValue(typeof(RichTextParagraphAlignment), "Left")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextParagraphAlignment SelectionParagraphAlignment
+        {
+            get => RichTextBox!.SelectionParagraphAlignment;
+            set => RichTextBox!.SelectionParagraphAlignment = value;
+        }
+
+        /// <summary>
         /// Gets and sets the background color of the selected area.
         /// </summary>
         [Browsable(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -149,9 +149,87 @@ namespace Krypton.Toolkit
                 //Return last + 1 character printer
                 return (int)res.ToInt64();
             }
+
+            /// <summary>
+            /// Gets and sets paragraph alignment for the current selection, including justify.
+            /// </summary>
+            [Browsable(false)]
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+            public RichTextParagraphAlignment SelectionParagraphAlignment
+            {
+                get
+                {
+                    if (!IsHandleCreated)
+                    {
+                        return RichTextParagraphAlignment.Left;
+                    }
+
+                    var format = new PI.PARAFORMAT
+                    {
+                        cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                        rgxTabs = new int[32]
+                    };
+
+                    PI.SendMessage(new HandleRef(this, Handle), PI.EM_GETPARAFORMAT, 0, ref format);
+
+                    if ((format.dwMask & PI.PFM_ALIGNMENT) == 0)
+                    {
+                        return RichTextParagraphAlignment.Left;
+                    }
+
+                    switch (format.wAlignment)
+                    {
+                        case PI.PFA_RIGHT:
+                            return RichTextParagraphAlignment.Right;
+                        case PI.PFA_CENTER:
+                            return RichTextParagraphAlignment.Center;
+                        case PI.PFA_JUSTIFY:
+                            return RichTextParagraphAlignment.Justify;
+                        default:
+                            return RichTextParagraphAlignment.Left;
+                    }
+                }
+                set
+                {
+                    // Force handle creation so RichEdit can apply paragraph format.
+                    if (!IsHandleCreated)
+                    {
+                        _ = Handle;
+                    }
+
+                    if (value == RichTextParagraphAlignment.Justify)
+                    {
+                        EnableAdvancedTypography();
+                    }
+
+                    var format = new PI.PARAFORMAT
+                    {
+                        cbSize = (uint)Marshal.SizeOf(typeof(PI.PARAFORMAT)),
+                        dwMask = PI.PFM_ALIGNMENT,
+                        wAlignment = (ushort)value,
+                        rgxTabs = new int[32]
+                    };
+
+                    PI.SendMessage(new HandleRef(this, Handle), PI.EM_SETPARAFORMAT, 0, ref format);
+                }
+            }
+
             #endregion
 
             #region Protected
+
+            /// <summary>
+            /// Raises the HandleCreated event.
+            /// </summary>
+            /// <param name="e">An EventArgs instance containing the event data.</param>
+            protected override void OnHandleCreated(EventArgs e)
+            {
+                base.OnHandleCreated(e);
+
+                // Justify requires advanced typography; enable once the RichEdit HWND exists.
+                EnableAdvancedTypography();
+            }
+
             protected override void OnEnabledChanged(EventArgs e)
             {
                 // Do not forward, to allow the correct Background for disabled state
@@ -281,6 +359,22 @@ namespace Krypton.Toolkit
 
                 _kryptonRichTextBox.OnMouseMove(e);
             }
+            #endregion
+
+            #region Implementation
+
+            private void EnableAdvancedTypography()
+            {
+                if (!IsHandleCreated)
+                {
+                    return;
+                }
+
+                PI.SendMessage(Handle, PI.EM_SETTYPOGRAPHYOPTIONS,
+                    (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY,
+                    (IntPtr)PI.TO_ADVANCEDTYPOGRAPHY);
+            }
+            
             #endregion
         }
         #endregion
@@ -851,6 +945,28 @@ namespace Krypton.Toolkit
             {
                 PerformNeedPaint(true);
                 _richTextBox.SelectionAlignment = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets paragraph alignment for the current selection, including full justify.
+        /// </summary>
+        /// <remarks>
+        /// Prefer this property over <see cref="SelectionAlignment"/> when justify is required.
+        /// WinForms <see cref="HorizontalAlignment"/> does not expose a justify value; justified
+        /// paragraphs report as <see cref="HorizontalAlignment.Left"/> via <see cref="SelectionAlignment"/>.
+        /// </remarks>
+        [Browsable(false)]
+        [DefaultValue(RichTextParagraphAlignment.Left)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public RichTextParagraphAlignment SelectionParagraphAlignment
+        {
+            get => _richTextBox.SelectionParagraphAlignment;
+
+            set
+            {
+                PerformNeedPaint(true);
+                _richTextBox.SelectionParagraphAlignment = value;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -4405,3 +4405,39 @@ public enum KryptonTaskbarProgressState
 }
 
 #endregion
+
+#region Enum RichTextParagraphAlignment
+
+/// <summary>
+/// Specifies paragraph alignment for a rich text selection, including full justify.
+/// </summary>
+/// <remarks>
+/// Values match RichEdit <c>PFA_*</c> constants used by <c>EM_SETPARAFORMAT</c>.
+/// Use <see cref="KryptonRichTextBox.SelectionParagraphAlignment"/> instead of
+/// <see cref="KryptonRichTextBox.SelectionAlignment"/> when justify is required;
+/// WinForms <see cref="HorizontalAlignment"/> does not include a justify value.
+/// </remarks>
+public enum RichTextParagraphAlignment
+{
+    /// <summary>
+    /// Align text to the left margin.
+    /// </summary>
+    Left = 1,
+
+    /// <summary>
+    /// Align text to the right margin.
+    /// </summary>
+    Right = 2,
+
+    /// <summary>
+    /// Center text between the margins.
+    /// </summary>
+    Center = 3,
+
+    /// <summary>
+    /// Fully justify text between the margins (RichEdit advanced typography).
+    /// </summary>
+    Justify = 4
+}
+
+#endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -2796,6 +2796,26 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         internal const int PRF_CLIENT = 0x00000004;
         internal const int MA_NOACTIVATE = 0x03;
         internal const int EM_FORMATRANGE = 0x0439;
+
+        /// <summary>Gets the paragraph formatting of the current selection (RichEdit).</summary>
+        internal const int EM_GETPARAFORMAT = 0x043D; // WM_USER + 61
+        /// <summary>Sets the paragraph formatting of the current selection (RichEdit).</summary>
+        internal const int EM_SETPARAFORMAT = 0x0447; // WM_USER + 71
+        /// <summary>Sets RichEdit typography options (advanced line breaking / justification).</summary>
+        internal const int EM_SETTYPOGRAPHYOPTIONS = 0x04CA; // WM_USER + 202
+        /// <summary>Enables advanced typography (required for paragraph justify).</summary>
+        internal const int TO_ADVANCEDTYPOGRAPHY = 0x0001;
+        /// <summary>PARAFORMAT.dwMask: wAlignment is valid.</summary>
+        internal const uint PFM_ALIGNMENT = 0x00000008;
+        /// <summary>PARAFORMAT.wAlignment: left.</summary>
+        internal const ushort PFA_LEFT = 1;
+        /// <summary>PARAFORMAT.wAlignment: right.</summary>
+        internal const ushort PFA_RIGHT = 2;
+        /// <summary>PARAFORMAT.wAlignment: center.</summary>
+        internal const ushort PFA_CENTER = 3;
+        /// <summary>PARAFORMAT.wAlignment: justify (RichEdit 3+).</summary>
+        internal const ushort PFA_JUSTIFY = 4;
+
         internal const int RDW_INVALIDATE = 0x0001;
         internal const int RDW_UPDATENOW = 0x0100;
         internal const int RDW_FRAME = 0x0400;
@@ -3223,6 +3243,10 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref TV_ITEM lParam);
+
+        [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern IntPtr SendMessage(HandleRef hWnd, int msg, int wParam, ref PARAFORMAT lParam);
 
         [DllImport(Libraries.User32, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -4596,6 +4620,26 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             ALERT_HIGH = 0x10000000,  // This information is of high priority
             PROTECTED = 0x20000000,  // access to this is restricted
             VALID = 0x3FFFFFFF
+        }
+
+        /// <summary>
+        /// RichEdit paragraph format (alignment and related paragraph properties).
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct PARAFORMAT
+        {
+            public uint cbSize;
+            public uint dwMask;
+            public ushort wNumbering;
+            public ushort wEffects;
+            public int dxStartIndent;
+            public int dxRightIndent;
+            public int dxOffset;
+            public ushort wAlignment;
+            public short cTabCount;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            public int[] rgxTabs;
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
# Feature: KryptonRichTextBox paragraph justify (#4008)

## Summary

Adds `KryptonRichTextBox.SelectionParagraphAlignment` (and the matching ribbon group forwarder) so consumers can apply full paragraph justification. WinForms `SelectionAlignment` / `HorizontalAlignment` cannot express justify; this API uses RichEdit `EM_SETPARAFORMAT` with `PFA_JUSTIFY` after enabling advanced typography.

## Related issues

- Closes #4008

## Type of change

- [x] Feature / enhancement (`Implemented`)

## Changes

- `Krypton.Interop`: RichEdit `PARAFORMAT`, `EM_GET/SETPARAFORMAT`, `EM_SETTYPOGRAPHYOPTIONS`, and `PFA_*` / `PFM_ALIGNMENT` constants.
- `Krypton.Toolkit`: public `RichTextParagraphAlignment` enum; `SelectionParagraphAlignment` on `KryptonRichTextBox` (implemented on the inner RichEdit control).
- `Krypton.Ribbon`: `SelectionParagraphAlignment` forwarded from `KryptonRibbonGroupRichTextBox`.
- `TestForm`: `Feature4008RichTextBoxJustifyDemo` side-by-side with native `RichTextBox`.

## Affected packages & target frameworks

- Packages: `Krypton.Interop`, `Krypton.Toolkit`, `Krypton.Ribbon`, `TestForm`
- TFMs verified: project default Debug build for `Krypton.Toolkit` / `Krypton.Ribbon` / `TestForm`

## Validation

- TestForm demo: `Feature4008RichTextBoxJustifyDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Open the demo; sample text loads in Krypton and native rich text boxes.
  2. Click **Justify** on the Krypton side — full lines should stretch to both margins.
  3. Click Left / Center / Right and confirm expected alignment; status shows `SelectionParagraphAlignment` and that `SelectionAlignment` still reports Left when justified.
  4. Confirm native control has no Justify button and only Left/Center/Right via `SelectionAlignment`.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug` (and Ribbon / TestForm as needed)

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify
   * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
```

## GIF

<img width="918" height="661" alt="4008" src="https://github.com/user-attachments/assets/cfeacf95-2291-4679-bf0a-f8698a699c3f" />

## Breaking changes & migration

None. Existing `SelectionAlignment` is unchanged. Prefer `SelectionParagraphAlignment` when justify is required; a justified paragraph still reports as `HorizontalAlignment.Left` through `SelectionAlignment`.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above