### PR TITLE
* Extract shared Pack targets and force restore (V105 LTS)

### DIFF
--- a/Scripts/Build/Krypton.Pack.targets
+++ b/Scripts/Build/Krypton.Pack.targets
@@ -1,0 +1,48 @@
+<Project>
+
+	<!--
+	  Shared PackLite / PackAll orchestration for stable, LTS, canary, nightly, and installer builds.
+	  Set KryptonPackProjectProperties before importing (e.g. ExcludeVs2022UnsupportedTargetFrameworks=true).
+	  Post-delete restore must force regeneration of project.assets.json; incremental restore skips it when TFMs are unchanged.
+	-->
+	<PropertyGroup>
+		<KryptonPackProjectProperties Condition="'$(KryptonPackProjectProperties)' == ''"></KryptonPackProjectProperties>
+		<KryptonPackRestoreSuffix Condition="'$(KryptonPackProjectProperties)' != ''">;$(KryptonPackProjectProperties)</KryptonPackRestoreSuffix>
+		<KryptonPackRestoreSuffix Condition="'$(KryptonPackProjectProperties)' == ''"></KryptonPackRestoreSuffix>
+	</PropertyGroup>
+
+	<Target Name="PackLite">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;Restore=true;RestoreForce=true$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite$(KryptonPackRestoreSuffix)" Targets="Pack" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="PackAll">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
+	</Target>
+
+</Project>

--- a/Scripts/Build/build.proj
+++ b/Scripts/Build/build.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -31,40 +32,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Build/canary.proj
+++ b/Scripts/Build/canary.proj
@@ -46,7 +46,7 @@
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Build/canarylongtermstable.proj
+++ b/Scripts/Build/canarylongtermstable.proj
@@ -46,7 +46,7 @@
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Build/installer.proj
+++ b/Scripts/Build/installer.proj
@@ -48,7 +48,7 @@
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
 	</Target>
 	

--- a/Scripts/Build/longtermstable.proj
+++ b/Scripts/Build/longtermstable.proj
@@ -3,6 +3,7 @@
 	<Import Project="..\..\Directory.Build.props" />
 
 	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="Krypton.Pack.targets" />
 
 
 
@@ -58,72 +59,6 @@
 		</ItemGroup>
 
 		<Delete Files="@(NugetPkgs)" />
-
-	</Target>
-
-
-
-	<Target Name="PackLite">
-
-		<ItemGroup>
-
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-
-		</ItemGroup>
-
-		<ItemGroup>
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-
-		</ItemGroup>
-
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-
-		<Delete Files="@(NugetAssets)" />
-
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-
-	</Target>
-
-
-
-	<Target Name="PackAll">
-
-		<ItemGroup>
-
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-
-		</ItemGroup>
-
-		<ItemGroup>
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-
-		</ItemGroup>
-
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-
-		<Delete Files="@(NugetAssets)" />
-
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-
-		<CallTarget Targets="KryptonPack" />
 
 	</Target>
 

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -48,7 +48,7 @@
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -31,40 +32,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -31,23 +32,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Current/canarylongtermstable.proj
+++ b/Scripts/Current/canarylongtermstable.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -31,23 +32,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/Current/installer.proj
+++ b/Scripts/Current/installer.proj
@@ -10,7 +10,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 	</Target>	
 
@@ -18,7 +18,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 	</Target>
 	
 	<Target Name="Build" DependsOnTargets="Restore">
@@ -45,10 +45,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
 	</Target>
 	

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -29,40 +30,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -33,23 +34,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/build.proj
+++ b/Scripts/VS2022/build.proj
@@ -1,11 +1,13 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
 		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
@@ -32,40 +34,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/VS2022/canary.proj
+++ b/Scripts/VS2022/canary.proj
@@ -1,11 +1,13 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
 		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
@@ -32,23 +34,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/canarylongtermstable.proj
+++ b/Scripts/VS2022/canarylongtermstable.proj
@@ -1,11 +1,13 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
 		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
@@ -32,23 +34,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Canary\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/installer.proj
+++ b/Scripts/VS2022/installer.proj
@@ -49,7 +49,7 @@
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" />
 	</Target>
 	

--- a/Scripts/VS2022/longtermstable.proj
+++ b/Scripts/VS2022/longtermstable.proj
@@ -1,11 +1,13 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
 		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -30,40 +32,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -1,11 +1,13 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
 		<ExcludeVs2022UnsupportedTargetFrameworks>true</ExcludeVs2022UnsupportedTargetFrameworks>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
@@ -34,23 +36,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />


### PR DESCRIPTION
Extract duplicate PackLite and PackAll targets into a shared Krypton.Pack.targets file to reduce duplication across build configurations. Add Restore=true;RestoreForce=true to force regeneration of project.assets.json after cleanup, ensuring incremental restore doesn't skip TFM changes. Support build property injection via KryptonPackProjectProperties for flexible configuration.