### PR TITLE
* Extract Pack targets to shared Krypton.Pack.targets (V110)

### DIFF
--- a/Scripts/Build/Krypton.Pack.targets‎
+++ b/Scripts/Build/Krypton.Pack.targets‎
@@ -1,0 +1,48 @@
+<Project>
+
+	<!--
+	  Shared PackLite / PackAll orchestration for stable, LTS, canary, nightly, and installer builds.
+	  Set KryptonPackProjectProperties before importing (e.g. ExcludeVs2022UnsupportedTargetFrameworks=true).
+	  Post-delete restore must force regeneration of project.assets.json; incremental restore skips it when TFMs are unchanged.
+	-->
+	<PropertyGroup>
+		<KryptonPackProjectProperties Condition="'$(KryptonPackProjectProperties)' == ''"></KryptonPackProjectProperties>
+		<KryptonPackRestoreSuffix Condition="'$(KryptonPackProjectProperties)' != ''">;$(KryptonPackProjectProperties)</KryptonPackRestoreSuffix>
+		<KryptonPackRestoreSuffix Condition="'$(KryptonPackProjectProperties)' == ''"></KryptonPackRestoreSuffix>
+	</PropertyGroup>
+
+	<Target Name="PackLite">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite;Restore=true;RestoreForce=true$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite$(KryptonPackRestoreSuffix)" Targets="Pack" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="PackAll">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<ItemGroup>
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
+			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all$(KryptonPackRestoreSuffix)" Targets="Clean" BuildInParallel="false" />
+		<Delete Files="@(NugetAssets)" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true$(KryptonPackRestoreSuffix)" Targets="Restore" BuildInParallel="false" />
+		<CallTarget Targets="KryptonPack" />
+	</Target>
+
+</Project>

--- a/Scripts/Build/build.proj
+++ b/Scripts/Build/build.proj
@@ -1,6 +1,7 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -32,39 +33,7 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
+		<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
 
 	<Target Name="Push">
 		<ItemGroup>

--- a/Scripts/Build/canary.proj
+++ b/Scripts/Build/canary.proj
@@ -44,7 +44,7 @@
 		</ItemGroup>
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Build/canarylongtermstable.proj
+++ b/Scripts/Build/canarylongtermstable.proj
@@ -44,7 +44,7 @@
 		</ItemGroup>
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Build/installer.proj
+++ b/Scripts/Build/installer.proj
@@ -48,7 +48,7 @@
 		</ItemGroup>
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Pack" />
 	</Target>
 	

--- a/Scripts/Build/longtermstable.proj
+++ b/Scripts/Build/longtermstable.proj
@@ -1,73 +1,42 @@
-<Project>
-	<Import Project="..\..\Directory.Build.props" />
-	<Import Project="Krypton.Orchestration.targets" />
-
-	<PropertyGroup>
-		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
-		<Configuration>Release</Configuration>
-	</PropertyGroup>
-
-	<Target Name="Clean">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="Restore">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
-
-	<Target Name="CleanPackages">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
-		</ItemGroup>
-		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
-
-	<Target Name="Push">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
-		</ItemGroup>
-		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
-	</Target>
-</Project>
+<Project>
+	<Import Project="..\..\Directory.Build.props" />
+	<Import Project="Krypton.Orchestration.targets" />
+	<Import Project="Krypton.Pack.targets" />
+
+	<PropertyGroup>
+		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
+		<Configuration>Release</Configuration>
+	</PropertyGroup>
+
+	<Target Name="Clean">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="Restore">
+		<ItemGroup>
+			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
+		</ItemGroup>
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+	</Target>
+
+	<Target Name="Build" DependsOnTargets="Restore;KryptonBuild" />
+
+	<Target Name="CleanPackages">
+		<ItemGroup>
+			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
+		</ItemGroup>
+		<Delete Files="@(NugetPkgs)" />
+	</Target>
+
+	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
+
+	<Target Name="Push">
+		<ItemGroup>
+			<NugetPkgs Include="..\Bin\Packages\Release\*.$(LibraryVersion).nupkg" />
+		</ItemGroup>
+		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
+	</Target>
+</Project>

--- a/Scripts/Build/nightly.proj
+++ b/Scripts/Build/nightly.proj
@@ -46,7 +46,7 @@
 		</ItemGroup>
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;Restore=true;RestoreForce=true" Targets="Restore" BuildInParallel="false" />
 		<CallTarget Targets="KryptonPack" />
 	</Target>
 

--- a/Scripts/Current/build.proj
+++ b/Scripts/Current/build.proj
@@ -4,6 +4,7 @@
 		<ExcludeNet11>true</ExcludeNet11>
 	</PropertyGroup>
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -34,40 +35,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Current/canary.proj
+++ b/Scripts/Current/canary.proj
@@ -4,6 +4,7 @@
 		<ExcludeNet11>true</ExcludeNet11>
 	</PropertyGroup>
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -36,25 +37,7 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
-	<!--PackLite;-->
 
 	<Target Name="Push">
 		<ItemGroup>

--- a/Scripts/Current/canarylongtermstable.proj
+++ b/Scripts/Current/canarylongtermstable.proj
@@ -4,6 +4,7 @@
 		<ExcludeNet11>true</ExcludeNet11>
 	</PropertyGroup>
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -36,25 +37,7 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
-	<!--PackLite;-->
 
 	<Target Name="Push">
 		<ItemGroup>

--- a/Scripts/Current/installer.proj
+++ b/Scripts/Current/installer.proj
@@ -11,7 +11,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" />
 	</Target>	
 
@@ -19,7 +19,7 @@
 		<ItemGroup>
 			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true;Restore=true;RestoreForce=true" Targets="Restore" />
 	</Target>
 	
 	<Target Name="Build" DependsOnTargets="Restore">
@@ -46,10 +46,10 @@
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
 			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
 		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Pack" />
 	</Target>
 	

--- a/Scripts/Current/longtermstable.proj
+++ b/Scripts/Current/longtermstable.proj
@@ -4,6 +4,7 @@
 		<ExcludeNet11>true</ExcludeNet11>
 	</PropertyGroup>
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -32,40 +33,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/Current/nightly.proj
+++ b/Scripts/Current/nightly.proj
@@ -4,6 +4,7 @@
 		<ExcludeNet11>true</ExcludeNet11>
 	</PropertyGroup>
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
@@ -36,23 +37,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Nightly\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeNet11=true" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />

--- a/Scripts/VS2022/build.proj
+++ b/Scripts/VS2022/build.proj
@@ -1,10 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<ReleaseBuildPath>..\Bin\Release\Zips</ReleaseBuildPath>
 		<ReleaseZipName>Krypton-Release</ReleaseZipName>
 	</PropertyGroup>
@@ -32,39 +34,7 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
+		<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />
 
 	<Target Name="Push">
 		<ItemGroup>

--- a/Scripts/VS2022/canary.proj
+++ b/Scripts/VS2022/canary.proj
@@ -1,10 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary</CanaryZipName>
 	</PropertyGroup>
@@ -32,35 +34,7 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
-	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
-	<!--PackLite;-->
-
-	<Target Name="Push">
-		<ItemGroup>
-			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
-		</ItemGroup>
-		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
-	</Target>
-
-
-
-	<Target Name="CreateCanaryZip">
+		<Target Name="CreateCanaryZip">
 		<PropertyGroup>
 			<StringDate>$([System.DateTime]::Now.ToString('yyyyMMdd'))</StringDate>
 		</PropertyGroup>

--- a/Scripts/VS2022/canarylongtermstable.proj
+++ b/Scripts/VS2022/canarylongtermstable.proj
@@ -1,10 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Canary</Configuration>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<CanaryBuildPath>..\Bin\Canary\Zips</CanaryBuildPath>
 		<CanaryZipName>Krypton-Canary-LTS</CanaryZipName>
 	</PropertyGroup>
@@ -32,33 +34,14 @@
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
 
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
-	<!--PackLite;-->
-
+	
 	<Target Name="Push">
 		<ItemGroup>
 			<NugetPkgs Include="..\Bin\Packages\Canary\*.$(LibraryVersion).nupkg" />
 		</ItemGroup>
 		<Exec Command="nuget.exe push %(NugetPkgs.Identity)" />
 	</Target>
-
-
 
 	<Target Name="CreateCanaryZip">
 		<PropertyGroup>

--- a/Scripts/VS2022/installer.proj
+++ b/Scripts/VS2022/installer.proj
@@ -48,7 +48,7 @@
 		</ItemGroup>
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Clean" />
 		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Restore" />
+		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true;Restore=true;RestoreForce=true" Targets="Restore" />
 		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all;ExcludeVs2022UnsupportedTargetFrameworks=true" Targets="Pack" />
 	</Target>
 

--- a/Scripts/VS2022/longtermstable.proj
+++ b/Scripts/VS2022/longtermstable.proj
@@ -1,10 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Release</Configuration>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 	</PropertyGroup>
 
 	<Target Name="Clean">
@@ -28,38 +30,6 @@
 			<NugetPkgs Include="..\Bin\Packages\Release\*.nupkg" />
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
-	</Target>
-
-	<Target Name="PackLite">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Restore" BuildInParallel="false" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=lite" Targets="Pack" BuildInParallel="false" />
-	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
 	</Target>
 
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackLite;PackAll" />

--- a/Scripts/VS2022/nightly.proj
+++ b/Scripts/VS2022/nightly.proj
@@ -1,10 +1,12 @@
 <Project>
 	<Import Project="..\..\Directory.Build.props" />
 	<Import Project="..\Build\Krypton.Orchestration.targets" />
+	<Import Project="..\Build\Krypton.Pack.targets" />
 
 	<PropertyGroup>
 		<RootFolder>$(MSBuildProjectDirectory)</RootFolder>
 		<Configuration>Nightly</Configuration>
+		<KryptonPackProjectProperties>ExcludeVs2022UnsupportedTargetFrameworks=true</KryptonPackProjectProperties>
 		<NightlyBuildPath>..\Bin\Nightly\Zips</NightlyBuildPath>
 		<NightlyZipName>Krypton-Nightly</NightlyZipName>
 	</PropertyGroup>
@@ -33,23 +35,7 @@
 		</ItemGroup>
 		<Delete Files="@(NugetPkgs)" />
 	</Target>
-
-	<Target Name="PackAll">
-		<ItemGroup>
-			<Projects Include="..\..\Source\Krypton Components\Krypton.*\*.csproj" />
-		</ItemGroup>
-		<ItemGroup>
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.json" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.cache" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.targets" />
-			<NugetAssets Include="..\..\Source\Krypton Components\Krypton.*\obj\*.g.props" />
-		</ItemGroup>
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Clean" BuildInParallel="false" />
-		<Delete Files="@(NugetAssets)" />
-		<MSBuild Projects="@(Projects)" Properties="Configuration=$(Configuration);TFMs=all" Targets="Restore" BuildInParallel="false" />
-		<CallTarget Targets="KryptonPack" />
-	</Target>
-
+	
 	<Target Name="Pack" DependsOnTargets="CleanPackages;PackAll" />
 
 	<Target Name="Push">


### PR DESCRIPTION
Add a new shared MSBuild file Scripts/Build/Krypton.Pack.targets that centralizes PackLite/PackAll orchestration for packaging. Update build scripts (Scripts/Build/*, Scripts/Current/*, Scripts/VS2022/*) to import the new targets and remove duplicated Pack target blocks. Also add explicit Restore=true;RestoreForce=true to several MSBuild Restore calls to force regeneration of project.assets.json and avoid incremental-restore issues. Provide a KryptonPackProjectProperties hook (used in VS2022 scripts) to allow per-invocation TFMs exclusions (e.g. ExcludeVs2022UnsupportedTargetFrameworks=true).