### PR TITLE
* Refresh toolbar images when theme changes (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,7 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Resolved [#4000](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4000), `KryptonManager.Images.ToolbarImages` now updates to the active theme pack when the global palette changes
 * Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
    * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -173,6 +173,9 @@ public sealed class KryptonManager : Component
         // We need to notice when system color settings change
         SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
 
+        // Align toolbar image storage with the startup theme before any change event
+        UpdatePaletteImages(CurrentGlobalPaletteMode);
+
         // Update the tool strip global renderer with the default setting
         UpdateToolStripManager();
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Storage/Images/KryptonImageStorage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Storage/Images/KryptonImageStorage.cs
@@ -61,8 +61,8 @@ public class KryptonImageStorage : Storage
     /// <value><c>true</c> if this instance is default; otherwise, <c>false</c>.</value>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => !(ShouldSerializeGenericToolkitImages() ||
-                                        ShouldSerializeGenericToolkitImages());
+    public override bool IsDefault => !ShouldSerializeGenericToolkitImages() &&
+                                      !ShouldSerializeToolbarImages();
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Storage/Images/Toolbar/ToolBarImageStorage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Storage/Images/Toolbar/ToolBarImageStorage.cs
@@ -11,32 +11,34 @@
 namespace Krypton.Toolkit;
 
 /// <summary>Access to the integrated and quick access toolbar images.</summary>
-/// ToDo: Get images from theme, when changed
 [TypeConverter(typeof(ExpandableObjectConverter))]
 public class ToolBarImageStorage : Storage
 {
     #region Static Fields
 
-    private readonly Image _new = GenericToolbarImageResources.GenericNewDocument;
-    private readonly Image _open = GenericToolbarImageResources.GenericOpenFolder;
-    private readonly Image _save = GenericToolbarImageResources.GenericSave;
-    private readonly Image _saveAs = GenericToolbarImageResources.GenericSaveAs;
-    private readonly Image _saveAll = GenericToolbarImageResources.GenericSaveAll;
-    private readonly Image _cut = GenericToolbarImageResources.GenericCut;
-    private readonly Image _copy = GenericToolbarImageResources.GenericCopy;
-    private readonly Image _paste = GenericToolbarImageResources.GenericPaste;
-    private readonly Image _undo = GenericToolbarImageResources.GenericUndo;
-    private readonly Image _redo = GenericToolbarImageResources.GenericRedo;
-    private readonly Image _pageSetup = GenericToolbarImageResources.GenericPrintSetup;
-    private readonly Image _printPreview = GenericToolbarImageResources.GenericPrintPreview;
-    private readonly Image _print = GenericToolbarImageResources.GenericPrint;
-    private readonly Image _quickPrint = GenericToolbarImageResources.GenericQuickPrint;
+    private const int REQUIRED_TOOLBAR_IMAGE_COUNT = 14;
 
     #endregion
 
     #region Instance Fields
 
-    private List<Image> _toolBarImages;
+    // Theme baselines; updated when KryptonManager pushes a new toolbar image pack.
+    private Image _new = GenericToolbarImageResources.GenericNewDocument;
+    private Image _open = GenericToolbarImageResources.GenericOpenFolder;
+    private Image _save = GenericToolbarImageResources.GenericSave;
+    private Image _saveAs = GenericToolbarImageResources.GenericSaveAs;
+    private Image _saveAll = GenericToolbarImageResources.GenericSaveAll;
+    private Image _cut = GenericToolbarImageResources.GenericCut;
+    private Image _copy = GenericToolbarImageResources.GenericCopy;
+    private Image _paste = GenericToolbarImageResources.GenericPaste;
+    private Image _undo = GenericToolbarImageResources.GenericUndo;
+    private Image _redo = GenericToolbarImageResources.GenericRedo;
+    private Image _pageSetup = GenericToolbarImageResources.GenericPrintSetup;
+    private Image _printPreview = GenericToolbarImageResources.GenericPrintPreview;
+    private Image _print = GenericToolbarImageResources.GenericPrint;
+    private Image _quickPrint = GenericToolbarImageResources.GenericQuickPrint;
+
+    private readonly List<Image> _toolBarImages;
 
     #endregion
 
@@ -45,7 +47,7 @@ public class ToolBarImageStorage : Storage
     /// <summary>Initializes a new instance of the <see cref="ToolBarImageStorage" /> class.</summary>
     public ToolBarImageStorage()
     {
-        _toolBarImages = new List<Image>();
+        _toolBarImages = new List<Image>(REQUIRED_TOOLBAR_IMAGE_COUNT);
 
         Reset();
     }
@@ -86,9 +88,7 @@ public class ToolBarImageStorage : Storage
 
     #region IsDefault
 
-    /// <summary>
-    /// Gets a value indicating if all the strings are default values.
-    /// </summary>
+    /// <summary>Gets a value indicating if all the images are default values for the current theme pack.</summary>
     /// <returns>True if all values are defaulted; otherwise false.</returns>
     [Browsable(false)]
     public override bool IsDefault => New.Equals(_new) &&
@@ -96,6 +96,9 @@ public class ToolBarImageStorage : Storage
                                       Save.Equals(_save) &&
                                       SaveAs.Equals(_saveAs) &&
                                       SaveAll.Equals(_saveAll) &&
+                                      Cut.Equals(_cut) &&
+                                      Copy.Equals(_copy) &&
+                                      Paste.Equals(_paste) &&
                                       Undo.Equals(_undo) &&
                                       Redo.Equals(_redo) &&
                                       PageSetup.Equals(_pageSetup) &&
@@ -127,7 +130,7 @@ public class ToolBarImageStorage : Storage
 
     /// <summary>Adds the palette toolbar images to an array.</summary>
     /// <param name="paletteToolBarImages">The palette toolbar images.</param>
-    public /*static*/ void AddImagesToArray(Image[] paletteToolBarImages)
+    public void AddImagesToArray(Image[] paletteToolBarImages)
     {
         foreach (var image in paletteToolBarImages)
         {
@@ -139,34 +142,67 @@ public class ToolBarImageStorage : Storage
     /// <returns>A collection of toolbar images.</returns>
     public List<Image> ReturnToolBarImages() => _toolBarImages;
 
-    internal void SetToolBarImages(Image[] images)
+    /// <summary>
+    /// Replaces the stored toolbar images with a theme pack and updates public properties.
+    /// </summary>
+    /// <param name="images">Theme toolbar images in fixed slot order (14 images).</param>
+    internal void SetToolBarImages(Image[]? images)
     {
-        AddImagesToArray(images);
+        if (images == null || images.Length < REQUIRED_TOOLBAR_IMAGE_COUNT)
+        {
+            return;
+        }
 
-        AssignImageValues(ReturnToolBarImages());
+        // Replace, do not append — previous theme packs must not remain at indices 0..13.
+        _toolBarImages.Clear();
+        for (int i = 0; i < REQUIRED_TOOLBAR_IMAGE_COUNT; i++)
+        {
+            _toolBarImages.Add(images[i]);
+        }
+
+        UpdateThemeBaselines(images);
+        AssignImageValues(_toolBarImages);
+    }
+
+    private void UpdateThemeBaselines(Image[] images)
+    {
+        _new = images[0];
+        _open = images[1];
+        _save = images[2];
+        _saveAs = images[3];
+        _saveAll = images[4];
+        _cut = images[5];
+        _copy = images[6];
+        _paste = images[7];
+        _undo = images[8];
+        _redo = images[9];
+        _pageSetup = images[10];
+        _printPreview = images[11];
+        _print = images[12];
+        _quickPrint = images[13];
     }
 
     private void AssignImageValues(List<Image> imageCollection)
     {
-        if (imageCollection.Count > 0)
+        if (imageCollection.Count < REQUIRED_TOOLBAR_IMAGE_COUNT)
         {
-            Image[] toolBarImages = imageCollection.ToArray();
-
-            New = toolBarImages[0];
-            Open = toolBarImages[1];
-            Save = toolBarImages[2];
-            SaveAs = toolBarImages[3];
-            SaveAll = toolBarImages[4];
-            Cut = toolBarImages[5];
-            Copy = toolBarImages[6];
-            Paste = toolBarImages[7];
-            Undo = toolBarImages[8];
-            Redo = toolBarImages[9];
-            PageSetup = toolBarImages[10];
-            PrintPreview = toolBarImages[11];
-            Print = toolBarImages[12];
-            QuickPrint = toolBarImages[13];
+            return;
         }
+
+        New = imageCollection[0];
+        Open = imageCollection[1];
+        Save = imageCollection[2];
+        SaveAs = imageCollection[3];
+        SaveAll = imageCollection[4];
+        Cut = imageCollection[5];
+        Copy = imageCollection[6];
+        Paste = imageCollection[7];
+        Undo = imageCollection[8];
+        Redo = imageCollection[9];
+        PageSetup = imageCollection[10];
+        PrintPreview = imageCollection[11];
+        Print = imageCollection[12];
+        QuickPrint = imageCollection[13];
     }
 
     #endregion


### PR DESCRIPTION
# Fix: Refresh toolbar images when theme changes (#4000)

## Summary

`KryptonManager.Images.ToolbarImages` now replaces its image pack when the global palette changes, instead of appending packs and leaving properties stuck on the first theme.

## Related issues

- Closes #4000

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `ToolBarImageStorage.SetToolBarImages` clears and replaces the stored pack, updates theme baselines used by `IsDefault`/`Reset`, and includes Cut/Copy/Paste in `IsDefault`.
- `KryptonManager` static constructor calls `UpdatePaletteImages` so storage matches the startup theme.
- `KryptonImageStorage.IsDefault` now considers both generic and toolbar image storage.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#4000](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4000), `KryptonManager.Images.ToolbarImages` now updates to the active theme pack when the global palette changes
```

## Breaking changes & migration

None.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [ ] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above