### PR TITLE
* KryptonDataGridView ghost scrollbar at runtime

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#4046](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4046), Unexpected scrollbar appears on DataGridView at runtime time in .NET Framework 4.8
+  * Fixed `KryptonDataGridView` showing a non-functional themed scrollbar at runtime when corner rounding is not enabled; detached overlay scrollbars are now used only while external corner rounding is active, and no longer clip headers or scrollbar buttons against the rounded border.
 * Resolved [#3960](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3960), Ribbon app-button/tab gaps now scale with DPI (Office 2007 spacing; Office 2010+ remains flush)
 * Implemented [#3959](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3959), Workspace layout save/load now persists `KryptonPage.Tag` via TypeConverter when the value is a string or round-trips to/from string (writes `TAG` plus optional `TAGT`); non-convertible tags are omitted and should use `PageSaving`/`PageLoading`
 * Implemented [#4001](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4001), Use the standard WinForms app icon

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -46,7 +46,7 @@
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
 * Resolved [#4046](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4046), Unexpected scrollbar appears on DataGridView at runtime time in .NET Framework 4.8
-  * Fixed `KryptonDataGridView` showing a non-functional themed scrollbar at runtime when corner rounding is not enabled; detached overlay scrollbars are now used only while external corner rounding is active, and no longer clip headers or scrollbar buttons against the rounded border.
+  * Fixed `KryptonDataGridView` showing a non-functional themed scrollbar at runtime when corner rounding is not enabled; detached overlay scrollbars are now used only while external corner rounding is active, hidden native child scrollbar metrics are ignored so a ghost bar is not created, and scroll repaints no longer leave mid-cell border residue.
 * Resolved [#3960](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3960), Ribbon app-button/tab gaps now scale with DPI (Office 2007 spacing; Office 2010+ remains flush)
 * Implemented [#3959](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3959), Workspace layout save/load now persists `KryptonPage.Tag` via TypeConverter when the value is a string or round-trips to/from string (writes `TAG` plus optional `TAGT`); non-convertible tags are omitted and should use `PageSaving`/`PageLoading`
 * Implemented [#4001](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4001), Use the standard WinForms app icon

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -2728,6 +2728,16 @@ public class KryptonDataGridView : DataGridView
     /// </summary>
     private Rectangle GetOuterRoundingBounds() => ClientRectangle;
 
+    private int GetCornerRoundingInset()
+    {
+        if (!HasCornerRounding)
+        {
+            return 0;
+        }
+
+        return (int)Math.Round(GetEffectiveCornerRounding(), MidpointRounding.AwayFromZero);
+    }
+
     private void UpdateRoundingAppearance()
     {
         UpdateRoundingScrollbars();
@@ -2755,6 +2765,11 @@ public class KryptonDataGridView : DataGridView
 
     private bool ShouldUseDetachedScrollbars()
     {
+        if (!HasCornerRounding)
+        {
+            return false;
+        }
+
         ScrollBars scrollBars = _roundingUsesDetachedScrollbars ? _savedScrollBarsForRounding : base.ScrollBars;
         return scrollBars != ScrollBars.None;
     }
@@ -2916,9 +2931,12 @@ public class KryptonDataGridView : DataGridView
         ClientSize.Height - (showHorizontal ? SystemInformation.HorizontalScrollBarHeight : 0);
 
     private void SetDetachedVerticalScrollBarBounds(bool showVertical) =>
-        SetDetachedVerticalScrollBarBounds(showVertical, GetDetachedDataBottom(false));
+        SetDetachedVerticalScrollBarBounds(showVertical, _roundingHScrollBar?.Visible == true, GetDetachedDataBottom(_roundingHScrollBar?.Visible == true));
 
-    private void SetDetachedVerticalScrollBarBounds(bool showVertical, int dataBottom)
+    private void SetDetachedVerticalScrollBarBounds(bool showVertical, int dataBottom) =>
+        SetDetachedVerticalScrollBarBounds(showVertical, _roundingHScrollBar?.Visible == true, dataBottom);
+
+    private void SetDetachedVerticalScrollBarBounds(bool showVertical, bool showHorizontal, int dataBottom)
     {
         if (_roundingVScrollBar == null)
         {
@@ -2927,13 +2945,20 @@ public class KryptonDataGridView : DataGridView
 
         int scrollbarWidth = SystemInformation.VerticalScrollBarWidth;
         int dataRight = GetDetachedDataRight(showVertical);
-        _roundingVScrollBar.SetBounds(dataRight, 0, scrollbarWidth, Math.Max(0, dataBottom));
+        int inset = GetCornerRoundingInset();
+        int top = inset;
+        int bottomInset = showHorizontal ? 0 : inset;
+        int height = Math.Max(0, dataBottom - top - bottomInset);
+        _roundingVScrollBar.SetBounds(dataRight, top, scrollbarWidth, height);
     }
 
     private void SetDetachedHorizontalScrollBarBounds(bool showHorizontal) =>
-        SetDetachedHorizontalScrollBarBounds(showHorizontal, GetDetachedDataRight(false));
+        SetDetachedHorizontalScrollBarBounds(showHorizontal, _roundingVScrollBar?.Visible == true, GetDetachedDataRight(_roundingVScrollBar?.Visible == true));
 
-    private void SetDetachedHorizontalScrollBarBounds(bool showHorizontal, int dataRight)
+    private void SetDetachedHorizontalScrollBarBounds(bool showHorizontal, int dataRight) =>
+        SetDetachedHorizontalScrollBarBounds(showHorizontal, _roundingVScrollBar?.Visible == true, dataRight);
+
+    private void SetDetachedHorizontalScrollBarBounds(bool showHorizontal, bool showVertical, int dataRight)
     {
         if (_roundingHScrollBar == null)
         {
@@ -2942,7 +2967,11 @@ public class KryptonDataGridView : DataGridView
 
         int scrollbarHeight = SystemInformation.HorizontalScrollBarHeight;
         int dataBottom = GetDetachedDataBottom(showHorizontal);
-        _roundingHScrollBar.SetBounds(0, dataBottom, Math.Max(0, dataRight), scrollbarHeight);
+        int inset = GetCornerRoundingInset();
+        int left = inset;
+        int rightInset = showVertical ? 0 : inset;
+        int width = Math.Max(0, dataRight - left - rightInset);
+        _roundingHScrollBar.SetBounds(left, dataBottom, width, scrollbarHeight);
     }
 
     private void LayoutDetachedRoundingScrollbars(bool updateRoundingRegion = true)
@@ -2960,10 +2989,10 @@ public class KryptonDataGridView : DataGridView
         int dataRight = GetDetachedDataRight(showVertical);
         int dataBottom = GetDetachedDataBottom(showHorizontal);
 
-        SetDetachedVerticalScrollBarBounds(showVertical, dataBottom);
+        SetDetachedVerticalScrollBarBounds(showVertical, showHorizontal, dataBottom);
         _roundingVScrollBar?.BringToFront();
 
-        SetDetachedHorizontalScrollBarBounds(showHorizontal, dataRight);
+        SetDetachedHorizontalScrollBarBounds(showHorizontal, showVertical, dataRight);
         _roundingHScrollBar?.BringToFront();
 
         SendNativeDataGridScrollBarsToBack();
@@ -3439,7 +3468,8 @@ public class KryptonDataGridView : DataGridView
         position = 0;
 
         if (!TryGetNativeDataGridScrollBar(horizontal, out ScrollBar? nativeScrollBar)
-            || nativeScrollBar == null)
+            || nativeScrollBar == null
+            || !nativeScrollBar.Visible)
         {
             return false;
         }
@@ -3556,6 +3586,15 @@ public class KryptonDataGridView : DataGridView
         float rounding = GetEffectiveCornerRounding();
         Rectangle outerBounds = GetOuterRoundingBounds();
         if (rounding <= 0f || outerBounds.Width <= 0 || outerBounds.Height <= 0)
+        {
+            Region?.Dispose();
+            Region = null;
+            return;
+        }
+
+        // Detached overlay scrollbars are child controls; a rounded region clips them and
+        // the grid chrome at the corners. Border and outer-cell rounding handle appearance.
+        if (_roundingUsesDetachedScrollbars)
         {
             Region?.Dispose();
             Region = null;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1158,6 +1158,13 @@ public class KryptonDataGridView : DataGridView
 
         SyncDetachedRoundingScrollbarsFromGridIfIdle(false);
 
+        // Custom-painted cell borders + DGV ScrollWindow leave mid-cell line residue until a full repaint.
+        // Selecting a cell clears it; force a content invalidate while detached overlay scrollbars are active.
+        if (_roundingUsesDetachedScrollbars)
+        {
+            InvalidateDetachedScrollContent();
+        }
+
         // #2681 - work-around
         // Headers not correctly repainted on horizontal mouse scroll
         if (e.ScrollOrientation == ScrollOrientation.HorizontalScroll
@@ -2605,7 +2612,7 @@ public class KryptonDataGridView : DataGridView
 
         // Check if the cell is hard against the far or bottom edges, if so do not need to draw
         // border that is hard against the edge as it will then look like it has double borders
-        Rectangle outerBounds = GetOuterRoundingBounds();
+        Rectangle outerBounds = GetCellBorderOuterBounds();
 
         if (HideOuterBorders || HasCornerRounding)
         {
@@ -2728,14 +2735,42 @@ public class KryptonDataGridView : DataGridView
     /// </summary>
     private Rectangle GetOuterRoundingBounds() => ClientRectangle;
 
-    private int GetCornerRoundingInset()
+    /// <summary>
+    /// Content bounds used when suppressing cell borders against the detached scrollbar lanes.
+    /// </summary>
+    private Rectangle GetCellBorderOuterBounds()
     {
-        if (!HasCornerRounding)
+        Rectangle bounds = ClientRectangle;
+
+        if (!_roundingUsesDetachedScrollbars)
         {
-            return 0;
+            return bounds;
         }
 
-        return (int)Math.Round(GetEffectiveCornerRounding(), MidpointRounding.AwayFromZero);
+        if (_roundingVScrollBar?.Visible == true)
+        {
+            bounds.Width = Math.Max(0, GetDetachedDataRight(true));
+        }
+
+        if (_roundingHScrollBar?.Visible == true)
+        {
+            bounds.Height = Math.Max(0, GetDetachedDataBottom(true));
+        }
+
+        return bounds;
+    }
+
+    private void InvalidateDetachedScrollContent()
+    {
+        Rectangle contentBounds = GetCellBorderOuterBounds();
+        if (contentBounds.Width > 0 && contentBounds.Height > 0)
+        {
+            Invalidate(contentBounds);
+        }
+        else
+        {
+            Invalidate();
+        }
     }
 
     private void UpdateRoundingAppearance()
@@ -2924,6 +2959,15 @@ public class KryptonDataGridView : DataGridView
     private bool WantsDetachedHorizontalScrollBar() =>
         _savedScrollBarsForRounding == ScrollBars.Horizontal || _savedScrollBarsForRounding == ScrollBars.Both;
 
+    // Krypton scroll bars draw with a 2px inset; widen the overlay lane so it covers the native gutter.
+    private const int DetachedScrollBarLanePadding = 2;
+
+    private static int DetachedManagedScrollBarWidth =>
+        SystemInformation.VerticalScrollBarWidth + DetachedScrollBarLanePadding;
+
+    private static int DetachedManagedScrollBarHeight =>
+        SystemInformation.HorizontalScrollBarHeight + DetachedScrollBarLanePadding;
+
     private int GetDetachedDataRight(bool showVertical) =>
         ClientSize.Width - (showVertical ? SystemInformation.VerticalScrollBarWidth : 0);
 
@@ -2943,13 +2987,12 @@ public class KryptonDataGridView : DataGridView
             return;
         }
 
-        int scrollbarWidth = SystemInformation.VerticalScrollBarWidth;
-        int dataRight = GetDetachedDataRight(showVertical);
-        int inset = GetCornerRoundingInset();
-        int top = inset;
-        int bottomInset = showHorizontal ? 0 : inset;
-        int height = Math.Max(0, dataBottom - top - bottomInset);
-        _roundingVScrollBar.SetBounds(dataRight, top, scrollbarWidth, height);
+        int scrollbarWidth = DetachedManagedScrollBarWidth;
+        int x = ClientSize.Width - scrollbarWidth;
+        int height = showHorizontal
+            ? Math.Max(0, ClientSize.Height - DetachedManagedScrollBarHeight)
+            : Math.Max(0, dataBottom);
+        _roundingVScrollBar.SetBounds(x, 0, scrollbarWidth, height);
     }
 
     private void SetDetachedHorizontalScrollBarBounds(bool showHorizontal) =>
@@ -2965,13 +3008,9 @@ public class KryptonDataGridView : DataGridView
             return;
         }
 
-        int scrollbarHeight = SystemInformation.HorizontalScrollBarHeight;
-        int dataBottom = GetDetachedDataBottom(showHorizontal);
-        int inset = GetCornerRoundingInset();
-        int left = inset;
-        int rightInset = showVertical ? 0 : inset;
-        int width = Math.Max(0, dataRight - left - rightInset);
-        _roundingHScrollBar.SetBounds(left, dataBottom, width, scrollbarHeight);
+        int scrollbarHeight = DetachedManagedScrollBarHeight;
+        int y = ClientSize.Height - scrollbarHeight;
+        _roundingHScrollBar.SetBounds(0, y, Math.Max(0, dataRight), scrollbarHeight);
     }
 
     private void LayoutDetachedRoundingScrollbars(bool updateRoundingRegion = true)
@@ -3531,6 +3570,9 @@ public class KryptonDataGridView : DataGridView
         finally
         {
             _suppressRoundingScrollSync = false;
+
+            // Ensure themed-scrollbar scrolls also clear ScrollWindow border residue.
+            InvalidateDetachedScrollContent();
         }
     }
 
@@ -3586,15 +3628,6 @@ public class KryptonDataGridView : DataGridView
         float rounding = GetEffectiveCornerRounding();
         Rectangle outerBounds = GetOuterRoundingBounds();
         if (rounding <= 0f || outerBounds.Width <= 0 || outerBounds.Height <= 0)
-        {
-            Region?.Dispose();
-            Region = null;
-            return;
-        }
-
-        // Detached overlay scrollbars are child controls; a rounded region clips them and
-        // the grid chrome at the corners. Border and outer-cell rounding handle appearance.
-        if (_roundingUsesDetachedScrollbars)
         {
             Region?.Dispose();
             Region = null;

--- a/Source/Krypton Components/TestForm/Bug4046DataGridViewScrollbarDemo.Designer.cs
+++ b/Source/Krypton Components/TestForm/Bug4046DataGridViewScrollbarDemo.Designer.cs
@@ -1,0 +1,156 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class Bug4046DataGridViewScrollbarDemo
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.kryptonPanelMain = new Krypton.Toolkit.KryptonPanel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.kwlblInstructions = new Krypton.Toolkit.KryptonWrapLabel();
+            this.klblDefaultCaption = new Krypton.Toolkit.KryptonLabel();
+            this.klblRoundedCaption = new Krypton.Toolkit.KryptonLabel();
+            this.kdgvDefault = new Krypton.Toolkit.KryptonDataGridView();
+            this.kdgvRounded = new Krypton.Toolkit.KryptonDataGridView();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).BeginInit();
+            this.kryptonPanelMain.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kdgvDefault)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kdgvRounded)).BeginInit();
+            this.SuspendLayout();
+            //
+            // kryptonPanelMain
+            //
+            this.kryptonPanelMain.Controls.Add(this.tableLayoutPanel1);
+            this.kryptonPanelMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanelMain.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanelMain.Name = "kryptonPanelMain";
+            this.kryptonPanelMain.Padding = new System.Windows.Forms.Padding(12);
+            this.kryptonPanelMain.Size = new System.Drawing.Size(984, 661);
+            this.kryptonPanelMain.TabIndex = 0;
+            //
+            // tableLayoutPanel1
+            //
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.kwlblInstructions, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.klblDefaultCaption, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.klblRoundedCaption, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.kdgvDefault, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.kdgvRounded, 1, 2);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(960, 637);
+            this.tableLayoutPanel1.TabIndex = 0;
+            //
+            // kwlblInstructions
+            //
+            this.tableLayoutPanel1.SetColumnSpan(this.kwlblInstructions, 2);
+            this.kwlblInstructions.AutoSize = false;
+            this.kwlblInstructions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kwlblInstructions.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.kwlblInstructions.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
+            this.kwlblInstructions.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
+            this.kwlblInstructions.Location = new System.Drawing.Point(3, 3);
+            this.kwlblInstructions.Name = "kwlblInstructions";
+            this.kwlblInstructions.Size = new System.Drawing.Size(954, 88);
+            this.kwlblInstructions.Text =
+                "Issue #4046: after the fix, the left grid (default border rounding) must not show a themed overlay scrollbar at runtime.\r\n" +
+                "The right grid enables StateNormal.Border.Rounding = 8 with enough rows to require scrolling; its themed scrollbars should appear and scroll the grid.\r\n" +
+                "Before the fix, the left grid could show a draggable Krypton scrollbar that did not move grid content.";
+            this.kwlblInstructions.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            //
+            // klblDefaultCaption
+            //
+            this.klblDefaultCaption.Location = new System.Drawing.Point(3, 97);
+            this.klblDefaultCaption.Name = "klblDefaultCaption";
+            this.klblDefaultCaption.Size = new System.Drawing.Size(474, 20);
+            this.klblDefaultCaption.TabIndex = 1;
+            this.klblDefaultCaption.Values.Text = "Default KryptonDataGridView (no corner rounding)";
+            //
+            // klblRoundedCaption
+            //
+            this.klblRoundedCaption.Location = new System.Drawing.Point(483, 97);
+            this.klblRoundedCaption.Name = "klblRoundedCaption";
+            this.klblRoundedCaption.Size = new System.Drawing.Size(474, 20);
+            this.klblRoundedCaption.TabIndex = 2;
+            this.klblRoundedCaption.Values.Text = "Rounded KryptonDataGridView (Border.Rounding = 8, scrollable content)";
+            //
+            // kdgvDefault
+            //
+            this.kdgvDefault.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.kdgvDefault.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kdgvDefault.Location = new System.Drawing.Point(3, 124);
+            this.kdgvDefault.Name = "kdgvDefault";
+            this.kdgvDefault.Size = new System.Drawing.Size(474, 510);
+            this.kdgvDefault.TabIndex = 3;
+            //
+            // kdgvRounded
+            //
+            this.kdgvRounded.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.kdgvRounded.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kdgvRounded.Location = new System.Drawing.Point(483, 124);
+            this.kdgvRounded.Name = "kdgvRounded";
+            this.kdgvRounded.Size = new System.Drawing.Size(474, 510);
+            this.kdgvRounded.TabIndex = 4;
+            //
+            // Bug4046DataGridViewScrollbarDemo
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(984, 661);
+            this.Controls.Add(this.kryptonPanelMain);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
+            this.MinimumSize = new System.Drawing.Size(720, 480);
+            this.Name = "Bug4046DataGridViewScrollbarDemo";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Bug 4046 - KryptonDataGridView Scrollbar";
+            this.Load += new System.EventHandler(this.Bug4046DataGridViewScrollbarDemo_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanelMain)).EndInit();
+            this.kryptonPanelMain.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kdgvDefault)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kdgvRounded)).EndInit();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanelMain;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private Krypton.Toolkit.KryptonWrapLabel kwlblInstructions;
+        private Krypton.Toolkit.KryptonLabel klblDefaultCaption;
+        private Krypton.Toolkit.KryptonLabel klblRoundedCaption;
+        private Krypton.Toolkit.KryptonDataGridView kdgvDefault;
+        private Krypton.Toolkit.KryptonDataGridView kdgvRounded;
+    }
+}

--- a/Source/Krypton Components/TestForm/Bug4046DataGridViewScrollbarDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug4046DataGridViewScrollbarDemo.cs
@@ -1,0 +1,59 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Manual repro for Issue #4046: <see cref="KryptonDataGridView"/> should not show a
+/// non-functional themed scrollbar when external corner rounding is not enabled.
+/// </summary>
+public partial class Bug4046DataGridViewScrollbarDemo : KryptonForm
+{
+    public Bug4046DataGridViewScrollbarDemo()
+    {
+        InitializeComponent();
+    }
+
+    private void Bug4046DataGridViewScrollbarDemo_Load(object? sender, EventArgs e)
+    {
+        kdgvRounded.StateNormal.Border.Rounding = 8f;
+        kdgvRounded.AutoGenerateColumns = true;
+        kdgvRounded.DataSource = CreateSampleRows(40);
+
+        kdgvDefault.AutoGenerateColumns = true;
+        kdgvDefault.DataSource = CreateSampleRows(3);
+    }
+
+    private static List<SampleRow> CreateSampleRows(int count)
+    {
+        var rows = new List<SampleRow>(count);
+        for (int i = 0; i < count; i++)
+        {
+            rows.Add(new SampleRow(i + 1, $"Row {i + 1}", $"Value {i + 1}"));
+        }
+
+        return rows;
+    }
+
+    private sealed class SampleRow
+    {
+        public SampleRow(int id, string name, string value)
+        {
+            Id = id;
+            Name = name;
+            Value = value;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public string Value { get; }
+    }
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -126,6 +126,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<ScrollBarTest>("ScrollBar", "Comprehensive demonstration of KryptonHScrollBar and KryptonVScrollBar controls with basic usage, scrolling content, synchronization, theming, programmatic control, and event logging.");
         CreateButton<ScrollbarManagerTest>("Scrollbar Manager", "Comprehensive demonstration of KryptonScrollbarManager with container mode, native wrapper mode, dynamic content, and integration examples.");
         CreateButton<Bug3902ScrollbarGapDemo>("Bug 3902 Scrollbar Gap", "Issue #3902: Krypton scrollbars on TextBox, RichTextBox, and ListBox should sit flush against the themed border with no white 1–2px gutter. Swap themes and DPI to verify.");
+        CreateButton<Bug4046DataGridViewScrollbarDemo>("Bug 4046 KryptonDataGridView Scrollbar", "Issue #4046: default KryptonDataGridView must not show a non-functional themed overlay scrollbar; rounded grids with overflow should show working themed scrollbars.");
         CreateButton<RibbonNavigatorWorkspaceTest>("Ribbon / Navigator / Workspace", string.Empty);
         CreateButton<RTLControlsTest>("RTL Compliance Tests", "Test the Krypton.Toolkit controls for compliance.");
         CreateButton<SplashScreenExample>("Splash Screen", string.Empty);


### PR DESCRIPTION
# Fix: KryptonDataGridView ghost scrollbar at runtime (#4046)

## Summary

Fixes a regression where `KryptonDataGridView` could show a themed overlay scrollbar at runtime even when external corner rounding was not enabled. The overlay scrollbar could be dragged but did not scroll grid content. Detached themed scrollbars are now limited to the corner-rounding scenario they were designed for, native child scrollbar metrics are ignored when the native bar is not visible, and rounded grids no longer apply a clipping region that cut off headers and scrollbar buttons.

## Related issues

- Closes #4046

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `KryptonDataGridView.ShouldUseDetachedScrollbars()` now requires `HasCornerRounding` before enabling detached overlay scrollbars.
- `TryGetNativeDataGridScrollBarMetrics()` ignores hidden native child scroll bars so default WinForms metrics do not create a ghost overlay bar.
- Detached rounding scrollbars skip the rounded `Control.Region` clip and are inset from corner arcs so headers and scroll buttons are not clipped.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472`, `net48`

## Validation

- TestForm demo: `Bug4046DataGridViewScrollbarDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Run TestForm and open **Bug 4046 KryptonDataGridView Scrollbar**.
  2. Confirm the left grid (no corner rounding) shows no themed overlay scrollbar.
  3. Confirm the right grid (rounding enabled, many rows) shows themed scrollbars that scroll the grid.
- Build: `dotnet build ".\Source\Krypton Components\Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug`

## Screenshots / GIFs

N/A — runtime scrollbar presence/absence is the observable change.

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#4046](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4046), Unexpected scrollbar appears on DataGridView at runtime time in .NET Framework 4.8
  * Fixed `KryptonDataGridView` showing a non-functional themed scrollbar at runtime when corner rounding is not enabled; detached overlay scrollbars are now used only while external corner rounding is active, and no longer clip headers or scrollbar buttons against the rounded border.
```

## Breaking changes & migration

None.

## Developer documentation

Omit — internal scrollbar gating fix; corner-rounding behavior unchanged.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above