### PR TITLE
Using glyphs in KryptonDomainUpDown and KryptonNumericUpDown (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -44,6 +44,7 @@
 =======
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
+
 * Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -44,7 +44,10 @@
 =======
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
-
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+   * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
+   * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
+   * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types
 * Implemented [#3874](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3874), Use the more optimised `LibraryImport`
    * Use source-generated `LibraryImport` for eligible Win32 P/Invokes on modern TFMs (Framework TFMs keep `DllImport`)
    * `GetClassName`, `GetMenuString`, and `LoadString` now use `[Out] char[]` on modern TFMs with `GetClassNameString` / `GetMenuStringString` / string-returning `LoadString` helpers

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
@@ -168,8 +168,9 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
     /// For use by non-selected, non-highlighted, non-editing cells.
     /// </summary>
     /// <param name="size">Desired square size in pixels.</param>
+    /// <param name="cellType">Desired cell type.</param>
     /// <returns>Bitmap image; null if renderer/palette not available.</returns>
-    internal Image? GetOrCreate(int size)
+    internal Image? GetOrCreate(int size, DataGridViewCell? cellType = null)
     {
         if (size <= 0)
         {
@@ -182,6 +183,7 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
         }
 
         PaletteBase palette = _dataGridView.GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        _paletteState = _dataGridView.Enabled ? PaletteState.Normal : PaletteState.Disabled;
         (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(palette, _paletteState);
 
         int maxSize = Math.Max(size, 1);
@@ -203,7 +205,29 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
             return _image;
         }
 
-        return DropDownArrowGlyphCache.GetOrCreate(glyphSize, outline, fill, DropDownArrowGlyphDirection.Down);
+        switch (cellType)
+        {
+            case KryptonDataGridViewDomainUpDownCell:
+            case KryptonDataGridViewNumericUpDownCell:
+                glyphSize = Math.Max(glyphSize, size);
+                int half = glyphSize / 2;
+                int offsetX = ((glyphSize - half) / 2 ) + 2;
+
+                var imageUpDown = new Bitmap(glyphSize, glyphSize, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                Image up = DropDownArrowGlyphCache.GetOrCreate(half, outline, fill, DropDownArrowGlyphDirection.Up);
+                Image down = DropDownArrowGlyphCache.GetOrCreate(half, outline, fill, DropDownArrowGlyphDirection.Down);
+
+                using (var g = Graphics.FromImage(imageUpDown))
+                {
+                    g.Clear(Color.Transparent);
+                    g.DrawImage(up, offsetX, 0, half, half);
+                    g.DrawImage(down, offsetX, half, half, half);
+                }
+                return imageUpDown;
+
+            default:
+                return DropDownArrowGlyphCache.GetOrCreate(glyphSize, outline, fill, DropDownArrowGlyphDirection.Down);
+        }
     }
     #endregion Private
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -147,7 +147,7 @@ public class KryptonDataGridViewDomainUpDownCell : KryptonDataGridViewTextBoxCel
             var righToLeft = DataGridView.RightToLeft == RightToLeft.Yes;
 
             // Use the same button width as the editor so renderer output matches
-            int buttonWidth = SystemInformation.VerticalScrollBarWidth - 2;
+            int buttonWidth = SystemInformation.VerticalScrollBarWidth + 1;
             int reservedStrip = buttonWidth + IndicatorGap;
 
             if (righToLeft)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -102,7 +102,7 @@ public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColu
     [Category(@"Data")]
     [Description(@"The allowable items of the domain up down.")]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    [Editor(@"System.Windows.Forms.Design.StringCollectionEditor", typeof(UITypeEditor))]
+    [Editor(typeof(KryptonDesignerStringCollectionEditor), typeof(UITypeEditor))]
     public StringCollection Items { get; }
 
     [Category(@"Behavior")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -102,7 +102,7 @@ public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColu
     [Category(@"Data")]
     [Description(@"The allowable items of the domain up down.")]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    [Editor(typeof(KryptonDesignerStringCollectionEditor), typeof(UITypeEditor))]
+    [Editor(@"System.Windows.Forms.Design.StringCollectionEditor", typeof(UITypeEditor))]
     public StringCollection Items { get; }
 
     [Category(@"Behavior")]
@@ -160,7 +160,7 @@ public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColu
     /// For internal use only.
     /// </summary>
     internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
-    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size);
+    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size, CellTemplate);
     #endregion Internal
 
     #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
@@ -352,7 +352,7 @@ public class KryptonDataGridViewNumericUpDownCell : KryptonDataGridViewTextBoxCe
             var righToLeft = DataGridView.RightToLeft == RightToLeft.Yes;
 
             // Use the same button width as the editor so renderer output matches
-            int buttonWidth = SystemInformation.VerticalScrollBarWidth - 2;
+            int buttonWidth = SystemInformation.VerticalScrollBarWidth + 1;
             int reservedStrip = buttonWidth + IndicatorGap;
 
             if (righToLeft)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
@@ -452,7 +452,7 @@ public class KryptonDataGridViewNumericUpDownColumn : KryptonDataGridViewIconCol
     /// For internal use only.
     /// </summary>
     internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
-    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size);
+    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size, CellTemplate);
     #endregion Internal
 
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -75,7 +75,7 @@ internal static class DropDownArrowGlyphFactory
             return CreateMonochrome(size, outline, direction, renderMode, DropDownArrowGlyphLayer.Fill, fitToCell);
         }
 
-        DropDownArrowGlyphStyleLayout.GetLayerOffsets(style, size, out Point fillOffset, out Point outlineOffset, direction);
+        DropDownArrowGlyphStyleLayout.GetLayerOffsets(style, size, out Point fillOffset, out Point outlineOffset);
 
         var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
@@ -284,7 +284,7 @@ internal static class DropDownArrowGlyphFactory
         switch (direction)
         {
             case DropDownArrowGlyphDirection.Up:
-                bmp.RotateFlip(RotateFlipType.RotateNoneFlipY);
+                bmp.RotateFlip(RotateFlipType.Rotate180FlipNone);
                 break;
 
             case DropDownArrowGlyphDirection.Left:
@@ -292,7 +292,7 @@ internal static class DropDownArrowGlyphFactory
                 break;
 
             case DropDownArrowGlyphDirection.Right:
-                bmp.RotateFlip(RotateFlipType.Rotate270FlipY);
+                bmp.RotateFlip(RotateFlipType.Rotate270FlipNone);
                 break;
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
@@ -75,7 +75,7 @@ internal static class DropDownArrowGlyphFactory
             return CreateMonochrome(size, outline, direction, renderMode, DropDownArrowGlyphLayer.Fill, fitToCell);
         }
 
-        DropDownArrowGlyphStyleLayout.GetLayerOffsets(style, size, out Point fillOffset, out Point outlineOffset);
+        DropDownArrowGlyphStyleLayout.GetLayerOffsets(style, size, out Point fillOffset, out Point outlineOffset, direction);
 
         var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
@@ -248,7 +248,24 @@ internal static class DropDownArrowGlyphFactory
 
             g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.None;
 
-            Point[] triangle = GetTrianglePoints(size, direction);
+            //Point[] triangle = GetTrianglePoints(size, direction);
+            //Always draw the polygon pointing downward, and then rotate and/or flip the image to the correct orientation
+            //The result is uniform polygons in all directions.
+
+            int near = Math.Max(1, size / 4);
+
+            int far = size - near - 1;
+
+            int mid = size / 2;
+
+            Point[] triangle = new[]
+            {
+                new Point(near, near),
+
+                new Point(far, near),
+
+                new Point(mid, far)
+            };
 
             if (layer == DropDownArrowGlyphLayer.Fill)
             {
@@ -264,6 +281,21 @@ internal static class DropDownArrowGlyphFactory
             }
         }
 
+        switch (direction)
+        {
+            case DropDownArrowGlyphDirection.Up:
+                bmp.RotateFlip(RotateFlipType.RotateNoneFlipY);
+                break;
+
+            case DropDownArrowGlyphDirection.Left:
+                bmp.RotateFlip(RotateFlipType.Rotate90FlipNone);
+                break;
+
+            case DropDownArrowGlyphDirection.Right:
+                bmp.RotateFlip(RotateFlipType.Rotate270FlipY);
+                break;
+        }
+
         return bmp;
     }
 
@@ -272,7 +304,7 @@ internal static class DropDownArrowGlyphFactory
 
     private static char GetUnicodeCharacter(DropDownArrowGlyphDirection direction, int size)
     {
-        bool useSmall = size <= 12;
+        bool useSmall = size <= 4;
 
         return direction switch
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -11,9 +11,9 @@ namespace Krypton.Toolkit;
 
 internal static class DropDownArrowGlyphStyleLayout
 {
-    internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset, DropDownArrowGlyphDirection direction)
+    internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset)
     {
-        if (size < 5 || style == DropDownArrowGlyphStyle.Flat)
+        if (size <= 9 || style == DropDownArrowGlyphStyle.Flat)
         {
             fillOffset = Point.Empty;
 
@@ -22,25 +22,11 @@ internal static class DropDownArrowGlyphStyleLayout
             return;
         }
 
-        int pointX = 1;
-        int pointY = 1;
-
-        switch (direction)
-        {
-            case DropDownArrowGlyphDirection.Up:
-                pointY = -1;
-                break;
-
-            case DropDownArrowGlyphDirection.Left:
-                pointX = -1;
-                break;
-        }
-
         switch (style)
         {
             case DropDownArrowGlyphStyle.Bevel:
 
-                fillOffset = new Point(pointX, pointY);
+                fillOffset = new Point(1, 1);
 
                 outlineOffset = Point.Empty;
                 break;
@@ -48,7 +34,7 @@ internal static class DropDownArrowGlyphStyleLayout
 
                 fillOffset = Point.Empty;
 
-                outlineOffset = new Point(pointX, pointY);
+                outlineOffset = new Point(1, 1);
                 break;
             default:
                 fillOffset = Point.Empty;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
@@ -11,9 +11,9 @@ namespace Krypton.Toolkit;
 
 internal static class DropDownArrowGlyphStyleLayout
 {
-    internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset)
+    internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset, DropDownArrowGlyphDirection direction)
     {
-        if (size < 8 || style == DropDownArrowGlyphStyle.Flat)
+        if (size < 5 || style == DropDownArrowGlyphStyle.Flat)
         {
             fillOffset = Point.Empty;
 
@@ -22,11 +22,25 @@ internal static class DropDownArrowGlyphStyleLayout
             return;
         }
 
+        int pointX = 1;
+        int pointY = 1;
+
+        switch (direction)
+        {
+            case DropDownArrowGlyphDirection.Up:
+                pointY = -1;
+                break;
+
+            case DropDownArrowGlyphDirection.Left:
+                pointX = -1;
+                break;
+        }
+
         switch (style)
         {
             case DropDownArrowGlyphStyle.Bevel:
 
-                fillOffset = new Point(1, 1);
+                fillOffset = new Point(pointX, pointY);
 
                 outlineOffset = Point.Empty;
                 break;
@@ -34,7 +48,7 @@ internal static class DropDownArrowGlyphStyleLayout
 
                 fillOffset = Point.Empty;
 
-                outlineOffset = new Point(1, 1);
+                outlineOffset = new Point(pointX, pointY);
                 break;
             default:
                 fillOffset = Point.Empty;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2645,21 +2645,10 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(paletteContent));
 		}
 
-		Color c1 = paletteContent.GetContentShortTextColor1(state);
-		Color c2 = paletteContent.GetContentShortTextColor2(state);
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(context, paletteContent, state);
 
-		// Find the top left starting position for drawing lines
-		var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
-		var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
-
-		using var darkPen = new Pen(c1);
-		context.Graphics.DrawLine(darkPen, xStart, yStart + 3, xStart + 4, yStart + 3);
-		context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 2, xStart + 3, yStart + 2);
-		context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
-		using var lightPen = new Pen(c2);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart + 4, yStart + 2);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart, yStart + 2);
-	}
+        DropDownArrowGlyphCache.Draw(context.Graphics, cellRect, outline, fill, DropDownArrowGlyphDirection.Up, context.Control);
+    }
 
 	/// <summary>
 	/// Draw a numeric down button image appropriate for an input control.
@@ -2688,21 +2677,10 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(paletteContent));
 		}
 
-		Color c1 = paletteContent.GetContentShortTextColor1(state);
-		Color c2 = paletteContent.GetContentShortTextColor2(state);
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(context, paletteContent, state);
 
-		// Find the top left starting position for drawing lines
-		var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
-		var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
-
-		using var darkPen = new Pen(c1);
-		context.Graphics.DrawLine(darkPen, xStart, yStart, xStart + 4, yStart);
-		context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 1, xStart + 3, yStart + 1);
-		context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
-		using var lightPen = new Pen(c2);
-		context.Graphics.DrawLine(lightPen, xStart, yStart + 1, xStart + 2, yStart + 3);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart + 3, xStart + 4, yStart + 1);
-	}
+        DropDownArrowGlyphCache.Draw(context.Graphics, cellRect, outline, fill, DropDownArrowGlyphDirection.Down, context.Control);
+    }
 
 	/// <summary>
 	/// Draw a drop-down grid appropriate for an input control.

--- a/Source/Krypton Components/TestForm/GlyphColors.Designer.cs
+++ b/Source/Krypton Components/TestForm/GlyphColors.Designer.cs
@@ -47,26 +47,56 @@
             this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
             this.kryptonPropertyGrid1 = new Krypton.Toolkit.KryptonPropertyGrid();
             this.kryptonPropertyGrid2 = new Krypton.Toolkit.KryptonPropertyGrid();
+            this.kryptonNumericUpDown1 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonNumericUpDown2 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonDomainUpDown1 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonDomainUpDown2 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonNumericUpDown3 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonNumericUpDown4 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonDomainUpDown3 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonDomainUpDown4 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonDataGridView1 = new Krypton.Toolkit.KryptonDataGridView();
+            this.Column3 = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
+            this.Column1 = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
+            this.Column2 = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
+            this.kryptonDataGridView2 = new Krypton.Toolkit.KryptonDataGridView();
+            this.kryptonDataGridViewComboBoxColumn1 = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
+            this.kryptonDataGridViewDomainUpDownColumn1 = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
+            this.kryptonDataGridViewNumericUpDownColumn1 = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
+            this.kryptonDataGridView3 = new Krypton.Toolkit.KryptonDataGridView();
+            this.kryptonDataGridViewComboBoxColumn2 = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
+            this.kryptonDataGridViewDomainUpDownColumn2 = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
+            this.kryptonDataGridViewNumericUpDownColumn2 = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
+            this.kryptonDataGridView4 = new Krypton.Toolkit.KryptonDataGridView();
+            this.kryptonDataGridViewComboBoxColumn3 = new Krypton.Toolkit.KryptonDataGridViewComboBoxColumn();
+            this.kryptonDataGridViewDomainUpDownColumn3 = new Krypton.Toolkit.KryptonDataGridViewDomainUpDownColumn();
+            this.kryptonDataGridViewNumericUpDownColumn3 = new Krypton.Toolkit.KryptonDataGridViewNumericUpDownColumn();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox3)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView3)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView4)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonDropButton1
             // 
-            this.kryptonDropButton1.Location = new System.Drawing.Point(38, 84);
+            this.kryptonDropButton1.Location = new System.Drawing.Point(28, 68);
+            this.kryptonDropButton1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDropButton1.Name = "kryptonDropButton1";
-            this.kryptonDropButton1.Size = new System.Drawing.Size(197, 30);
+            this.kryptonDropButton1.Size = new System.Drawing.Size(148, 24);
             this.kryptonDropButton1.TabIndex = 2;
             this.kryptonDropButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonDropButton1.Values.Text = "kryptonDropButton1";
             // 
             // kryptonComboBox1
             // 
-            this.kryptonComboBox1.Location = new System.Drawing.Point(38, 120);
+            this.kryptonComboBox1.Location = new System.Drawing.Point(28, 98);
+            this.kryptonComboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonComboBox1.Name = "kryptonComboBox1";
-            this.kryptonComboBox1.Size = new System.Drawing.Size(197, 26);
+            this.kryptonComboBox1.Size = new System.Drawing.Size(148, 22);
             this.kryptonComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonComboBox1.TabIndex = 3;
             this.kryptonComboBox1.Text = "kryptonComboBox1";
@@ -74,17 +104,19 @@
             // kryptonDateTimePicker1
             // 
             this.kryptonDateTimePicker1.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.kryptonDateTimePicker1.Location = new System.Drawing.Point(38, 152);
+            this.kryptonDateTimePicker1.Location = new System.Drawing.Point(28, 124);
+            this.kryptonDateTimePicker1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDateTimePicker1.Name = "kryptonDateTimePicker1";
-            this.kryptonDateTimePicker1.Size = new System.Drawing.Size(197, 25);
+            this.kryptonDateTimePicker1.Size = new System.Drawing.Size(148, 21);
             this.kryptonDateTimePicker1.TabIndex = 4;
             // 
             // kryptonDropButton2
             // 
             this.kryptonDropButton2.Enabled = false;
-            this.kryptonDropButton2.Location = new System.Drawing.Point(38, 196);
+            this.kryptonDropButton2.Location = new System.Drawing.Point(28, 159);
+            this.kryptonDropButton2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDropButton2.Name = "kryptonDropButton2";
-            this.kryptonDropButton2.Size = new System.Drawing.Size(197, 30);
+            this.kryptonDropButton2.Size = new System.Drawing.Size(148, 24);
             this.kryptonDropButton2.TabIndex = 2;
             this.kryptonDropButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonDropButton2.Values.Text = "kryptonDropButton1";
@@ -92,9 +124,10 @@
             // kryptonComboBox2
             // 
             this.kryptonComboBox2.Enabled = false;
-            this.kryptonComboBox2.Location = new System.Drawing.Point(38, 232);
+            this.kryptonComboBox2.Location = new System.Drawing.Point(28, 188);
+            this.kryptonComboBox2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonComboBox2.Name = "kryptonComboBox2";
-            this.kryptonComboBox2.Size = new System.Drawing.Size(197, 26);
+            this.kryptonComboBox2.Size = new System.Drawing.Size(148, 22);
             this.kryptonComboBox2.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonComboBox2.TabIndex = 3;
             this.kryptonComboBox2.Text = "kryptonComboBox1";
@@ -103,18 +136,20 @@
             // 
             this.kryptonDateTimePicker2.Enabled = false;
             this.kryptonDateTimePicker2.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.kryptonDateTimePicker2.Location = new System.Drawing.Point(38, 264);
+            this.kryptonDateTimePicker2.Location = new System.Drawing.Point(28, 214);
+            this.kryptonDateTimePicker2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDateTimePicker2.Name = "kryptonDateTimePicker2";
-            this.kryptonDateTimePicker2.Size = new System.Drawing.Size(197, 25);
+            this.kryptonDateTimePicker2.Size = new System.Drawing.Size(148, 21);
             this.kryptonDateTimePicker2.TabIndex = 4;
             // 
             // kryptonDropButton3
             // 
             this.kryptonDropButton3.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonDropButton3.Location = new System.Drawing.Point(38, 413);
+            this.kryptonDropButton3.Location = new System.Drawing.Point(28, 336);
+            this.kryptonDropButton3.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDropButton3.Name = "kryptonDropButton3";
             this.kryptonDropButton3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonDropButton3.Size = new System.Drawing.Size(197, 30);
+            this.kryptonDropButton3.Size = new System.Drawing.Size(148, 24);
             this.kryptonDropButton3.TabIndex = 2;
             this.kryptonDropButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonDropButton3.Values.Text = "kryptonDropButton1";
@@ -130,10 +165,11 @@
             // kryptonComboBox3
             // 
             this.kryptonComboBox3.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonComboBox3.Location = new System.Drawing.Point(38, 449);
+            this.kryptonComboBox3.Location = new System.Drawing.Point(28, 365);
+            this.kryptonComboBox3.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonComboBox3.Name = "kryptonComboBox3";
             this.kryptonComboBox3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonComboBox3.Size = new System.Drawing.Size(197, 26);
+            this.kryptonComboBox3.Size = new System.Drawing.Size(148, 22);
             this.kryptonComboBox3.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonComboBox3.TabIndex = 3;
             this.kryptonComboBox3.Text = "kryptonComboBox1";
@@ -142,10 +178,11 @@
             // 
             this.kryptonDropButton4.Enabled = false;
             this.kryptonDropButton4.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonDropButton4.Location = new System.Drawing.Point(38, 526);
+            this.kryptonDropButton4.Location = new System.Drawing.Point(28, 427);
+            this.kryptonDropButton4.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDropButton4.Name = "kryptonDropButton4";
             this.kryptonDropButton4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonDropButton4.Size = new System.Drawing.Size(197, 30);
+            this.kryptonDropButton4.Size = new System.Drawing.Size(148, 24);
             this.kryptonDropButton4.TabIndex = 2;
             this.kryptonDropButton4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonDropButton4.Values.Text = "kryptonDropButton1";
@@ -154,20 +191,22 @@
             // 
             this.kryptonDateTimePicker3.Format = System.Windows.Forms.DateTimePickerFormat.Short;
             this.kryptonDateTimePicker3.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonDateTimePicker3.Location = new System.Drawing.Point(38, 481);
+            this.kryptonDateTimePicker3.Location = new System.Drawing.Point(28, 391);
+            this.kryptonDateTimePicker3.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDateTimePicker3.Name = "kryptonDateTimePicker3";
             this.kryptonDateTimePicker3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonDateTimePicker3.Size = new System.Drawing.Size(197, 25);
+            this.kryptonDateTimePicker3.Size = new System.Drawing.Size(148, 21);
             this.kryptonDateTimePicker3.TabIndex = 4;
             // 
             // kryptonComboBox4
             // 
             this.kryptonComboBox4.Enabled = false;
             this.kryptonComboBox4.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonComboBox4.Location = new System.Drawing.Point(38, 562);
+            this.kryptonComboBox4.Location = new System.Drawing.Point(28, 457);
+            this.kryptonComboBox4.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonComboBox4.Name = "kryptonComboBox4";
             this.kryptonComboBox4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonComboBox4.Size = new System.Drawing.Size(197, 26);
+            this.kryptonComboBox4.Size = new System.Drawing.Size(148, 22);
             this.kryptonComboBox4.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonComboBox4.TabIndex = 3;
             this.kryptonComboBox4.Text = "kryptonComboBox1";
@@ -177,27 +216,30 @@
             this.kryptonDateTimePicker4.Enabled = false;
             this.kryptonDateTimePicker4.Format = System.Windows.Forms.DateTimePickerFormat.Short;
             this.kryptonDateTimePicker4.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonDateTimePicker4.Location = new System.Drawing.Point(38, 594);
+            this.kryptonDateTimePicker4.Location = new System.Drawing.Point(28, 483);
+            this.kryptonDateTimePicker4.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonDateTimePicker4.Name = "kryptonDateTimePicker4";
             this.kryptonDateTimePicker4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonDateTimePicker4.Size = new System.Drawing.Size(197, 25);
+            this.kryptonDateTimePicker4.Size = new System.Drawing.Size(148, 21);
             this.kryptonDateTimePicker4.TabIndex = 4;
             // 
             // kryptonLabel1
             // 
-            this.kryptonLabel1.Location = new System.Drawing.Point(38, 54);
+            this.kryptonLabel1.Location = new System.Drawing.Point(28, 44);
+            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(147, 24);
+            this.kryptonLabel1.Size = new System.Drawing.Size(119, 20);
             this.kryptonLabel1.TabIndex = 5;
             this.kryptonLabel1.Values.Text = "PaletteMode Global";
             // 
             // kryptonLabel2
             // 
             this.kryptonLabel2.LocalCustomPalette = this.kryptonCustomPaletteBase1;
-            this.kryptonLabel2.Location = new System.Drawing.Point(38, 383);
+            this.kryptonLabel2.Location = new System.Drawing.Point(28, 311);
+            this.kryptonLabel2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonLabel2.Name = "kryptonLabel2";
             this.kryptonLabel2.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
-            this.kryptonLabel2.Size = new System.Drawing.Size(202, 24);
+            this.kryptonLabel2.Size = new System.Drawing.Size(163, 20);
             this.kryptonLabel2.TabIndex = 5;
             this.kryptonLabel2.Values.Text = "PaletteMode CustomPalette";
             // 
@@ -212,29 +254,349 @@
             // 
             // kryptonPropertyGrid1
             // 
-            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(474, 12);
+            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(685, 11);
+            this.kryptonPropertyGrid1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPropertyGrid1.Name = "kryptonPropertyGrid1";
             this.kryptonPropertyGrid1.Padding = new System.Windows.Forms.Padding(1);
             this.kryptonPropertyGrid1.SelectedObject = this.kryptonManager1;
-            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(377, 675);
+            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(250, 548);
             this.kryptonPropertyGrid1.TabIndex = 6;
             this.kryptonPropertyGrid1.Text = "kryptonPropertyGrid1";
             // 
             // kryptonPropertyGrid2
             // 
-            this.kryptonPropertyGrid2.Location = new System.Drawing.Point(866, 12);
+            this.kryptonPropertyGrid2.Location = new System.Drawing.Point(939, 11);
+            this.kryptonPropertyGrid2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPropertyGrid2.Name = "kryptonPropertyGrid2";
             this.kryptonPropertyGrid2.Padding = new System.Windows.Forms.Padding(1);
             this.kryptonPropertyGrid2.SelectedObject = this.kryptonCustomPaletteBase1;
-            this.kryptonPropertyGrid2.Size = new System.Drawing.Size(377, 675);
+            this.kryptonPropertyGrid2.Size = new System.Drawing.Size(283, 548);
             this.kryptonPropertyGrid2.TabIndex = 6;
             this.kryptonPropertyGrid2.Text = "kryptonPropertyGrid1";
             // 
+            // kryptonNumericUpDown1
+            // 
+            this.kryptonNumericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Location = new System.Drawing.Point(181, 98);
+            this.kryptonNumericUpDown1.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Name = "kryptonNumericUpDown1";
+            this.kryptonNumericUpDown1.Size = new System.Drawing.Size(120, 22);
+            this.kryptonNumericUpDown1.TabIndex = 8;
+            this.kryptonNumericUpDown1.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonNumericUpDown2
+            // 
+            this.kryptonNumericUpDown2.Enabled = false;
+            this.kryptonNumericUpDown2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Location = new System.Drawing.Point(181, 188);
+            this.kryptonNumericUpDown2.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Name = "kryptonNumericUpDown2";
+            this.kryptonNumericUpDown2.Size = new System.Drawing.Size(120, 22);
+            this.kryptonNumericUpDown2.TabIndex = 8;
+            this.kryptonNumericUpDown2.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonDomainUpDown1
+            // 
+            this.kryptonDomainUpDown1.Location = new System.Drawing.Point(181, 126);
+            this.kryptonDomainUpDown1.Name = "kryptonDomainUpDown1";
+            this.kryptonDomainUpDown1.Size = new System.Drawing.Size(120, 22);
+            this.kryptonDomainUpDown1.TabIndex = 9;
+            this.kryptonDomainUpDown1.Text = "kryptonDomainUpDown1";
+            // 
+            // kryptonDomainUpDown2
+            // 
+            this.kryptonDomainUpDown2.Enabled = false;
+            this.kryptonDomainUpDown2.Location = new System.Drawing.Point(181, 216);
+            this.kryptonDomainUpDown2.Name = "kryptonDomainUpDown2";
+            this.kryptonDomainUpDown2.Size = new System.Drawing.Size(120, 22);
+            this.kryptonDomainUpDown2.TabIndex = 9;
+            this.kryptonDomainUpDown2.Text = "kryptonDomainUpDown1";
+            // 
+            // kryptonNumericUpDown3
+            // 
+            this.kryptonNumericUpDown3.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown3.LocalCustomPalette = this.kryptonCustomPaletteBase1;
+            this.kryptonNumericUpDown3.Location = new System.Drawing.Point(181, 365);
+            this.kryptonNumericUpDown3.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown3.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown3.Name = "kryptonNumericUpDown3";
+            this.kryptonNumericUpDown3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonNumericUpDown3.Size = new System.Drawing.Size(120, 22);
+            this.kryptonNumericUpDown3.TabIndex = 8;
+            this.kryptonNumericUpDown3.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonNumericUpDown4
+            // 
+            this.kryptonNumericUpDown4.Enabled = false;
+            this.kryptonNumericUpDown4.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown4.LocalCustomPalette = this.kryptonCustomPaletteBase1;
+            this.kryptonNumericUpDown4.Location = new System.Drawing.Point(181, 455);
+            this.kryptonNumericUpDown4.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown4.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown4.Name = "kryptonNumericUpDown4";
+            this.kryptonNumericUpDown4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonNumericUpDown4.Size = new System.Drawing.Size(120, 22);
+            this.kryptonNumericUpDown4.TabIndex = 8;
+            this.kryptonNumericUpDown4.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonDomainUpDown3
+            // 
+            this.kryptonDomainUpDown3.LocalCustomPalette = this.kryptonCustomPaletteBase1;
+            this.kryptonDomainUpDown3.Location = new System.Drawing.Point(181, 393);
+            this.kryptonDomainUpDown3.Name = "kryptonDomainUpDown3";
+            this.kryptonDomainUpDown3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonDomainUpDown3.Size = new System.Drawing.Size(120, 22);
+            this.kryptonDomainUpDown3.TabIndex = 9;
+            this.kryptonDomainUpDown3.Text = "kryptonDomainUpDown1";
+            // 
+            // kryptonDomainUpDown4
+            // 
+            this.kryptonDomainUpDown4.Enabled = false;
+            this.kryptonDomainUpDown4.LocalCustomPalette = this.kryptonCustomPaletteBase1;
+            this.kryptonDomainUpDown4.Location = new System.Drawing.Point(181, 483);
+            this.kryptonDomainUpDown4.Name = "kryptonDomainUpDown4";
+            this.kryptonDomainUpDown4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonDomainUpDown4.Size = new System.Drawing.Size(120, 22);
+            this.kryptonDomainUpDown4.TabIndex = 9;
+            this.kryptonDomainUpDown4.Text = "kryptonDomainUpDown1";
+            // 
+            // kryptonDataGridView1
+            // 
+            this.kryptonDataGridView1.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.kryptonDataGridView1.ColumnHeadersHeight = 35;
+            this.kryptonDataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.Column3,
+            this.Column1,
+            this.Column2});
+            this.kryptonDataGridView1.Location = new System.Drawing.Point(307, 72);
+            this.kryptonDataGridView1.Name = "kryptonDataGridView1";
+            this.kryptonDataGridView1.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.kryptonDataGridView1.Size = new System.Drawing.Size(373, 111);
+            this.kryptonDataGridView1.TabIndex = 10;
+            // 
+            // Column3
+            // 
+            this.Column3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Column3.DropDownWidth = 121;
+            this.Column3.HeaderText = "KComboBox";
+            this.Column3.Name = "Column3";
+            this.Column3.Width = 83;
+            // 
+            // Column1
+            // 
+            this.Column1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Column1.HeaderText = "KDomainUpDown";
+            this.Column1.Name = "Column1";
+            this.Column1.Width = 112;
+            // 
+            // Column2
+            // 
+            this.Column2.AllowDecimals = false;
+            this.Column2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Column2.HeaderText = "KNumericUpDown";
+            this.Column2.Name = "Column2";
+            this.Column2.Width = 116;
+            // 
+            // kryptonDataGridView2
+            // 
+            this.kryptonDataGridView2.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.kryptonDataGridView2.ColumnHeadersHeight = 35;
+            this.kryptonDataGridView2.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.kryptonDataGridViewComboBoxColumn1,
+            this.kryptonDataGridViewDomainUpDownColumn1,
+            this.kryptonDataGridViewNumericUpDownColumn1});
+            this.kryptonDataGridView2.Enabled = false;
+            this.kryptonDataGridView2.Location = new System.Drawing.Point(307, 189);
+            this.kryptonDataGridView2.Name = "kryptonDataGridView2";
+            this.kryptonDataGridView2.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.kryptonDataGridView2.Size = new System.Drawing.Size(373, 111);
+            this.kryptonDataGridView2.TabIndex = 10;
+            // 
+            // kryptonDataGridViewComboBoxColumn1
+            // 
+            this.kryptonDataGridViewComboBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewComboBoxColumn1.DropDownWidth = 121;
+            this.kryptonDataGridViewComboBoxColumn1.HeaderText = "KComboBox";
+            this.kryptonDataGridViewComboBoxColumn1.Name = "kryptonDataGridViewComboBoxColumn1";
+            this.kryptonDataGridViewComboBoxColumn1.Width = 83;
+            // 
+            // kryptonDataGridViewDomainUpDownColumn1
+            // 
+            this.kryptonDataGridViewDomainUpDownColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewDomainUpDownColumn1.HeaderText = "KDomainUpDown";
+            this.kryptonDataGridViewDomainUpDownColumn1.Name = "kryptonDataGridViewDomainUpDownColumn1";
+            this.kryptonDataGridViewDomainUpDownColumn1.Width = 112;
+            // 
+            // kryptonDataGridViewNumericUpDownColumn1
+            // 
+            this.kryptonDataGridViewNumericUpDownColumn1.AllowDecimals = false;
+            this.kryptonDataGridViewNumericUpDownColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewNumericUpDownColumn1.HeaderText = "KNumericUpDown";
+            this.kryptonDataGridViewNumericUpDownColumn1.Name = "kryptonDataGridViewNumericUpDownColumn1";
+            this.kryptonDataGridViewNumericUpDownColumn1.Width = 116;
+            // 
+            // kryptonDataGridView3
+            // 
+            this.kryptonDataGridView3.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.kryptonDataGridView3.ColumnHeadersHeight = 35;
+            this.kryptonDataGridView3.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.kryptonDataGridViewComboBoxColumn2,
+            this.kryptonDataGridViewDomainUpDownColumn2,
+            this.kryptonDataGridViewNumericUpDownColumn2});
+            this.kryptonDataGridView3.Location = new System.Drawing.Point(307, 310);
+            this.kryptonDataGridView3.Name = "kryptonDataGridView3";
+            this.kryptonDataGridView3.Palette = this.kryptonCustomPaletteBase1;
+            this.kryptonDataGridView3.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonDataGridView3.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.kryptonDataGridView3.Size = new System.Drawing.Size(373, 111);
+            this.kryptonDataGridView3.TabIndex = 10;
+            // 
+            // kryptonDataGridViewComboBoxColumn2
+            // 
+            this.kryptonDataGridViewComboBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewComboBoxColumn2.DropDownWidth = 121;
+            this.kryptonDataGridViewComboBoxColumn2.HeaderText = "KComboBox";
+            this.kryptonDataGridViewComboBoxColumn2.Name = "kryptonDataGridViewComboBoxColumn2";
+            this.kryptonDataGridViewComboBoxColumn2.Width = 83;
+            // 
+            // kryptonDataGridViewDomainUpDownColumn2
+            // 
+            this.kryptonDataGridViewDomainUpDownColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewDomainUpDownColumn2.HeaderText = "KDomainUpDown";
+            this.kryptonDataGridViewDomainUpDownColumn2.Name = "kryptonDataGridViewDomainUpDownColumn2";
+            this.kryptonDataGridViewDomainUpDownColumn2.Width = 112;
+            // 
+            // kryptonDataGridViewNumericUpDownColumn2
+            // 
+            this.kryptonDataGridViewNumericUpDownColumn2.AllowDecimals = false;
+            this.kryptonDataGridViewNumericUpDownColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewNumericUpDownColumn2.HeaderText = "KNumericUpDown";
+            this.kryptonDataGridViewNumericUpDownColumn2.Name = "kryptonDataGridViewNumericUpDownColumn2";
+            this.kryptonDataGridViewNumericUpDownColumn2.Width = 116;
+            // 
+            // kryptonDataGridView4
+            // 
+            this.kryptonDataGridView4.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.kryptonDataGridView4.ColumnHeadersHeight = 35;
+            this.kryptonDataGridView4.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.kryptonDataGridViewComboBoxColumn3,
+            this.kryptonDataGridViewDomainUpDownColumn3,
+            this.kryptonDataGridViewNumericUpDownColumn3});
+            this.kryptonDataGridView4.Enabled = false;
+            this.kryptonDataGridView4.Location = new System.Drawing.Point(307, 427);
+            this.kryptonDataGridView4.Name = "kryptonDataGridView4";
+            this.kryptonDataGridView4.Palette = this.kryptonCustomPaletteBase1;
+            this.kryptonDataGridView4.PaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+            this.kryptonDataGridView4.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.kryptonDataGridView4.Size = new System.Drawing.Size(373, 111);
+            this.kryptonDataGridView4.TabIndex = 10;
+            // 
+            // kryptonDataGridViewComboBoxColumn3
+            // 
+            this.kryptonDataGridViewComboBoxColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewComboBoxColumn3.DropDownWidth = 121;
+            this.kryptonDataGridViewComboBoxColumn3.HeaderText = "KComboBox";
+            this.kryptonDataGridViewComboBoxColumn3.Name = "kryptonDataGridViewComboBoxColumn3";
+            this.kryptonDataGridViewComboBoxColumn3.Width = 83;
+            // 
+            // kryptonDataGridViewDomainUpDownColumn3
+            // 
+            this.kryptonDataGridViewDomainUpDownColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewDomainUpDownColumn3.HeaderText = "KDomainUpDown";
+            this.kryptonDataGridViewDomainUpDownColumn3.Name = "kryptonDataGridViewDomainUpDownColumn3";
+            this.kryptonDataGridViewDomainUpDownColumn3.Width = 112;
+            // 
+            // kryptonDataGridViewNumericUpDownColumn3
+            // 
+            this.kryptonDataGridViewNumericUpDownColumn3.AllowDecimals = false;
+            this.kryptonDataGridViewNumericUpDownColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.kryptonDataGridViewNumericUpDownColumn3.HeaderText = "KNumericUpDown";
+            this.kryptonDataGridViewNumericUpDownColumn3.Name = "kryptonDataGridViewNumericUpDownColumn3";
+            this.kryptonDataGridViewNumericUpDownColumn3.Width = 116;
+            // 
             // GlyphColors
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1245, 740);
+            this.ClientSize = new System.Drawing.Size(1233, 601);
+            this.Controls.Add(this.kryptonDataGridView4);
+            this.Controls.Add(this.kryptonDataGridView3);
+            this.Controls.Add(this.kryptonDataGridView2);
+            this.Controls.Add(this.kryptonDataGridView1);
+            this.Controls.Add(this.kryptonDomainUpDown4);
+            this.Controls.Add(this.kryptonDomainUpDown2);
+            this.Controls.Add(this.kryptonDomainUpDown3);
+            this.Controls.Add(this.kryptonDomainUpDown1);
+            this.Controls.Add(this.kryptonNumericUpDown4);
+            this.Controls.Add(this.kryptonNumericUpDown2);
+            this.Controls.Add(this.kryptonNumericUpDown3);
+            this.Controls.Add(this.kryptonNumericUpDown1);
             this.Controls.Add(this.kryptonPropertyGrid2);
             this.Controls.Add(this.kryptonPropertyGrid1);
             this.Controls.Add(this.kryptonLabel2);
@@ -251,12 +613,17 @@
             this.Controls.Add(this.kryptonDropButton3);
             this.Controls.Add(this.kryptonComboBox1);
             this.Controls.Add(this.kryptonDropButton1);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "GlyphColors";
             this.Text = "Glyph Colors";
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox3)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView3)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonDataGridView4)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -282,5 +649,29 @@
         private KryptonManager kryptonManager1;
         private KryptonPropertyGrid kryptonPropertyGrid1;
         private KryptonPropertyGrid kryptonPropertyGrid2;
+        private KryptonNumericUpDown kryptonNumericUpDown1;
+        private KryptonNumericUpDown kryptonNumericUpDown2;
+        private KryptonDomainUpDown kryptonDomainUpDown1;
+        private KryptonDomainUpDown kryptonDomainUpDown2;
+        private KryptonNumericUpDown kryptonNumericUpDown3;
+        private KryptonNumericUpDown kryptonNumericUpDown4;
+        private KryptonDomainUpDown kryptonDomainUpDown3;
+        private KryptonDomainUpDown kryptonDomainUpDown4;
+        private KryptonDataGridView kryptonDataGridView1;
+        private KryptonDataGridViewComboBoxColumn Column3;
+        private KryptonDataGridViewDomainUpDownColumn Column1;
+        private KryptonDataGridViewNumericUpDownColumn Column2;
+        private KryptonDataGridView kryptonDataGridView2;
+        private KryptonDataGridViewComboBoxColumn kryptonDataGridViewComboBoxColumn1;
+        private KryptonDataGridViewDomainUpDownColumn kryptonDataGridViewDomainUpDownColumn1;
+        private KryptonDataGridViewNumericUpDownColumn kryptonDataGridViewNumericUpDownColumn1;
+        private KryptonDataGridView kryptonDataGridView3;
+        private KryptonDataGridViewComboBoxColumn kryptonDataGridViewComboBoxColumn2;
+        private KryptonDataGridViewDomainUpDownColumn kryptonDataGridViewDomainUpDownColumn2;
+        private KryptonDataGridViewNumericUpDownColumn kryptonDataGridViewNumericUpDownColumn2;
+        private KryptonDataGridView kryptonDataGridView4;
+        private KryptonDataGridViewComboBoxColumn kryptonDataGridViewComboBoxColumn3;
+        private KryptonDataGridViewDomainUpDownColumn kryptonDataGridViewDomainUpDownColumn3;
+        private KryptonDataGridViewNumericUpDownColumn kryptonDataGridViewNumericUpDownColumn3;
     }
 }


### PR DESCRIPTION
# Using glyphs in KryptonDomainUpDown and KryptonNumericUpDown (#4049)

## Summary

For greater consistency, implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`. Feature enhancement #3663 .

## Related issues

- Closes #4049

## Type of change

- [ ] Bug fix (`Resolved`)
- [X] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- The drawing in `DrawInputControlNumericDownGlyph` and `DrawInputControlNumericUpGlyph` has been updated to follow the new glyph design. This updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
- `CreatePolygonMonochrome` draws the polygons in a single direction (downw) and then rotates them to the correct orientation. The result is polygons with a uniform shape in all directions.
- `KryptonDataGridViewCellIndicatorImage.GetOrCreate` has been adjusted to generate the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types 

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`

## Validation

- TestForm demo: `GlyphColors` (registered in `StartScreen.AddButtons()`).
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug -f net472`

## Screenshots

<img width="657" height="225" alt="image" src="https://github.com/user-attachments/assets/9f6dc393-221a-413b-b801-4dad1c011215" />

<img width="657" height="225" alt="image" src="https://github.com/user-attachments/assets/cab7054e-4ada-4120-afb6-286cd796936e" />

<img width="1193" height="479" alt="image" src="https://github.com/user-attachments/assets/09299ce4-9d04-4c1d-8952-b1b0377fa25a" />


## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
   * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
   * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
   * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

```

## Breaking changes & migration

None.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above
