### PR TITLE
Using glyphs in KryptonDomainUpDown and KryptonNumericUpDown (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,10 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+   * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
+   * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
+   * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types
 * Implemented [#4008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4008), `KryptonRichTextBox` Support for justify    
    * `KryptonRichTextBox.SelectionParagraphAlignment` adds full paragraph justify (plus Left/Center/Right) via RichEdit
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
@@ -26,7 +26,7 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
 
     // type and state of the image
     private readonly PaletteRibbonGalleryButton _paletteRibbonGalleryButton = PaletteRibbonGalleryButton.Down;
-    private readonly PaletteState _paletteState = PaletteState.Normal;
+    private PaletteState _paletteState = PaletteState.Normal;
     #endregion Fields
 
     #region Identity
@@ -168,8 +168,9 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
     /// For use by non-selected, non-highlighted, non-editing cells.
     /// </summary>
     /// <param name="size">Desired square size in pixels.</param>
+    /// <param name="cellType">Desired cell type.</param> 
     /// <returns>Bitmap image; null if renderer/palette not available.</returns>
-    internal Image? GetOrCreate(int size)
+    internal Image? GetOrCreate(int size, DataGridViewCell? cellType = null)
     {
         if (size <= 0)
         {
@@ -182,6 +183,7 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
         }
 
         PaletteBase palette = _dataGridView.GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        _paletteState = _dataGridView.Enabled ? PaletteState.Normal : PaletteState.Disabled;
         (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(palette, _paletteState);
 
         int maxSize = Math.Max(size, 1);
@@ -203,7 +205,29 @@ internal class KryptonDataGridViewCellIndicatorImage : IDisposable
             return _image;
         }
 
-        return DropDownArrowGlyphCache.GetOrCreate(glyphSize, outline, fill, DropDownArrowGlyphDirection.Down);
+        switch (cellType)
+        {
+            case KryptonDataGridViewDomainUpDownCell:
+            case KryptonDataGridViewNumericUpDownCell:
+                glyphSize = Math.Max(glyphSize, size);
+                int half = glyphSize / 2;
+                int offsetX = ((glyphSize - half) / 2) + 2;
+
+                var imageUpDown = new Bitmap(glyphSize, glyphSize, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                Image up = DropDownArrowGlyphCache.GetOrCreate(half, outline, fill, DropDownArrowGlyphDirection.Up);
+                Image down = DropDownArrowGlyphCache.GetOrCreate(half, outline, fill, DropDownArrowGlyphDirection.Down);
+
+                using (var g = Graphics.FromImage(imageUpDown))
+                {
+                    g.Clear(Color.Transparent);
+                    g.DrawImage(up, offsetX, 0, half, half);
+                    g.DrawImage(down, offsetX, half, half, half);
+                }
+                return imageUpDown;
+
+            default:
+                return DropDownArrowGlyphCache.GetOrCreate(glyphSize, outline, fill, DropDownArrowGlyphDirection.Down);
+        }
     }
     #endregion Private
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -147,7 +147,7 @@ public class KryptonDataGridViewDomainUpDownCell : KryptonDataGridViewTextBoxCel
             var righToLeft = DataGridView.RightToLeft == RightToLeft.Yes;
 
             // Use the same button width as the editor so renderer output matches
-            int buttonWidth = SystemInformation.VerticalScrollBarWidth - 2;
+            int buttonWidth = SystemInformation.VerticalScrollBarWidth + 1;
             int reservedStrip = buttonWidth + IndicatorGap;
 
             if (righToLeft)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -160,7 +160,7 @@ public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColu
     /// For internal use only.
     /// </summary>
     internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
-    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size);
+    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size, CellTemplate);
     #endregion Internal
 
     #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
@@ -352,7 +352,7 @@ public class KryptonDataGridViewNumericUpDownCell : KryptonDataGridViewTextBoxCe
             var righToLeft = DataGridView.RightToLeft == RightToLeft.Yes;
 
             // Use the same button width as the editor so renderer output matches
-            int buttonWidth = SystemInformation.VerticalScrollBarWidth - 2;
+            int buttonWidth = SystemInformation.VerticalScrollBarWidth + 1;
             int reservedStrip = buttonWidth + IndicatorGap;
 
             if (righToLeft)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
@@ -452,7 +452,7 @@ public class KryptonDataGridViewNumericUpDownColumn : KryptonDataGridViewIconCol
     /// For internal use only.
     /// </summary>
     internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
-    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size);
+    internal Image? GetIndicatorImageForSize(int size) => _kryptonDataGridViewCellIndicatorImage.GetOrCreate(size, CellTemplate);
     #endregion Internal
 
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphFactory.cs
@@ -160,7 +160,24 @@ internal static class DropDownArrowGlyphFactory
 
             g.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.None;
 
-            Point[] triangle = GetTrianglePoints(size, direction);
+            //Point[] triangle = GetTrianglePoints(size, direction);
+            //Always draw the polygon pointing downward, and then rotate and/or flip the image to the correct orientation
+            //The result is uniform polygons in all directions.
+
+            int near = Math.Max(1, size / 4);
+
+            int far = size - near - 1;
+
+            int mid = size / 2;
+
+            Point[] triangle = new[]
+            {
+                new Point(near, near),
+
+                new Point(far, near),
+
+                new Point(mid, far)
+            };
 
             if (layer == DropDownArrowGlyphLayer.Fill)
             {
@@ -176,6 +193,21 @@ internal static class DropDownArrowGlyphFactory
             }
         }
 
+        switch (direction)
+        {
+            case DropDownArrowGlyphDirection.Up:
+                bmp.RotateFlip(RotateFlipType.Rotate180FlipNone);
+                break;
+
+            case DropDownArrowGlyphDirection.Left:
+                bmp.RotateFlip(RotateFlipType.Rotate90FlipNone);
+                break;
+
+            case DropDownArrowGlyphDirection.Right:
+                bmp.RotateFlip(RotateFlipType.Rotate270FlipNone);
+                break;
+        }
+
         return bmp;
     }
 
@@ -184,7 +216,7 @@ internal static class DropDownArrowGlyphFactory
 
     private static char GetUnicodeCharacter(DropDownArrowGlyphDirection direction, int size)
     {
-        bool useSmall = size <= 12;
+        bool useSmall = size <= 4;
 
         return direction switch
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphStyleLayout.cs
@@ -13,7 +13,7 @@ internal static class DropDownArrowGlyphStyleLayout
 {
     internal static void GetLayerOffsets(DropDownArrowGlyphStyle style, int size, out Point fillOffset, out Point outlineOffset)
     {
-        if (size < 8 || style == DropDownArrowGlyphStyle.Flat)
+        if (size <= 9 || style == DropDownArrowGlyphStyle.Flat)
         {
             fillOffset = Point.Empty;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2634,20 +2634,9 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(paletteContent));
 		}
 
-		Color c1 = paletteContent.GetContentShortTextColor1(state);
-		Color c2 = paletteContent.GetContentShortTextColor2(state);
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(context, paletteContent, state);
 
-		// Find the top left starting position for drawing lines
-		var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
-		var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
-
-		using var darkPen = new Pen(c1);
-		context.Graphics.DrawLine(darkPen, xStart, yStart + 3, xStart + 4, yStart + 3);
-		context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 2, xStart + 3, yStart + 2);
-		context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
-		using var lightPen = new Pen(c2);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart + 4, yStart + 2);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart, yStart + 2);
+        DropDownArrowGlyphCache.Draw(context.Graphics, cellRect, outline, fill, DropDownArrowGlyphDirection.Up, context.Control);
 	}
 
 	/// <summary>
@@ -2677,21 +2666,10 @@ public class RenderStandard : RenderBase
 			throw new ArgumentNullException(nameof(paletteContent));
 		}
 
-		Color c1 = paletteContent.GetContentShortTextColor1(state);
-		Color c2 = paletteContent.GetContentShortTextColor2(state);
+        (Color outline, Color fill) = DropDownArrowGlyphColors.Resolve(context, paletteContent, state);
 
-		// Find the top left starting position for drawing lines
-		var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
-		var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
-
-		using var darkPen = new Pen(c1);
-		context.Graphics.DrawLine(darkPen, xStart, yStart, xStart + 4, yStart);
-		context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 1, xStart + 3, yStart + 1);
-		context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
-		using var lightPen = new Pen(c2);
-		context.Graphics.DrawLine(lightPen, xStart, yStart + 1, xStart + 2, yStart + 3);
-		context.Graphics.DrawLine(lightPen, xStart + 2, yStart + 3, xStart + 4, yStart + 1);
-	}
+        DropDownArrowGlyphCache.Draw(context.Graphics, cellRect, outline, fill, DropDownArrowGlyphDirection.Down, context.Control);
+    }
 
 	/// <summary>
 	/// Draw a drop-down grid appropriate for an input control.


### PR DESCRIPTION
# Using glyphs in KryptonDomainUpDown and KryptonNumericUpDown (#4049)

## Summary

For greater consistency, implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`. Feature enhancement #3663 .

## Related issues

- Closes #4049

## Type of change

- [ ] Bug fix (`Resolved`)
- [X] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- The drawing in `DrawInputControlNumericDownGlyph` and `DrawInputControlNumericUpGlyph` has been updated to follow the new glyph design. This updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
- `CreatePolygonMonochrome` draws the polygons in a single direction (downw) and then rotates them to the correct orientation. The result is polygons with a uniform shape in all directions.
- `KryptonDataGridViewCellIndicatorImage.GetOrCreate` has been adjusted to generate the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types 

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`

## Validation

- TestForm demo: `GlyphColors` (registered in `StartScreen.AddButtons()`).
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug -f net472`

## Screenshots

<img width="657" height="225" alt="image" src="https://github.com/user-attachments/assets/9f6dc393-221a-413b-b801-4dad1c011215" />

<img width="657" height="225" alt="image" src="https://github.com/user-attachments/assets/cab7054e-4ada-4120-afb6-286cd796936e" />

<img width="1193" height="479" alt="image" src="https://github.com/user-attachments/assets/09299ce4-9d04-4c1d-8952-b1b0377fa25a" />


## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
   * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
   * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
   * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

```

## Breaking changes & migration

None.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above
