### PR TITLE
* Fix docking indicator hit-target selection (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,7 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
-* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+* Resolved [#3999](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3999), Clarified docking indicator hit-target selection during drag feedback
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049), Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
    * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -266,14 +266,12 @@ public class DragFeedbackDocking : DragFeedback
     {
         DragTarget? matchTarget = null;
 
-        // Update each cluster so it shows/hides docking indicators based on mouse position
-        foreach (DragTarget? clusterTarget in _clusters
-                     .Select(cluster => cluster.Feedback(screenPt, _dragFeedback))
-                     .Where(clusterTarget => (clusterTarget != null) && (matchTarget == null))
-                )
+        // Update each cluster so it shows/hides docking indicators based on mouse position.
+        // Feedback must run for every cluster (side effects); keep the first hit target.
+        foreach (DockCluster cluster in _clusters)
         {
-            // TODO: Should be a better way to select the last match for this ?!?
-            matchTarget = clusterTarget;
+            DragTarget? clusterTarget = cluster.Feedback(screenPt, _dragFeedback);
+            matchTarget ??= clusterTarget;
         }
 
         // Update the solid feedback rectangle with area of the specific target

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -275,10 +275,7 @@ public class DragFeedbackDocking : DragFeedback
         }
 
         // Update the solid feedback rectangle with area of the specific target
-        if (_solid != null)
-        {
-            _solid.SolidRect = matchTarget?.DrawRect ?? Rectangle.Empty;
-        }
+        _solid?.SolidRect = matchTarget?.DrawRect ?? Rectangle.Empty;
 
         return matchTarget;
     }


### PR DESCRIPTION
Clarified the logic for selecting docking indicator hit-targets during drag feedback. The feedback method must execute for every cluster (for its side effects), but only the first valid hit target should be retained. Removed confusing LINQ query and updated comments to reflect the intended behavior. Switched from unclear 'last match' semantics to explicit 'first match' using the null-coalescing operator.