### PR TITLE
* MessageBox/Toast icon converters with MessageBoxIcon aliases (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,7 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
-* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+* Resolved [#4064](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4064), Fixed `KryptonMessageBoxIcon` and `KryptonToastIcon` design-time converters that threw when built against `MessageBoxIcon` alias values
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049), Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
    * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

--- a/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonToast/Converters/KryptonToastIconConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit.Utilities/Components/KryptonToast/Converters/KryptonToastIconConverter.cs
@@ -10,13 +10,19 @@
 namespace Krypton.Toolkit.Utilities;
 
 /// <summary>Custom type converter so that <see cref="T:KryptonToastIcon"/> values appear as neat text at design time.</summary>
+/// <remarks>
+/// <see cref="KryptonToastIcon"/> mirrors <see cref="MessageBoxIcon"/> aliases that share underlying values
+/// (<c>SystemHand</c>/<c>SystemStop</c>/<c>SystemError</c>, etc.). Those cannot share a single bi-dictionary key,
+/// so enum→string keeps one canonical display name per unique value while string→enum accepts every alias name.
+/// </remarks>
 internal class KryptonToastIconConverter : StringLookupConverter<KryptonToastIcon>
 {
     #region Static Fields
 
-    [Localizable(true)] 
-    private static readonly BiDictionary<KryptonToastIcon, string> _iconPairs =
-        new BiDictionary<KryptonToastIcon, string>(new Dictionary<KryptonToastIcon, string>
+    // One display string per unique underlying value (MessageBoxIcon aliases collapse Hand/Stop/Error, etc.).
+    [Localizable(true)]
+    private static readonly IReadOnlyDictionary<KryptonToastIcon, string> _pairsEnumToString =
+        new Dictionary<KryptonToastIcon, string>
         {
             { KryptonToastIcon.None, DesignTimeUtilities.DEFAULT_ICON_NONE },
             { KryptonToastIcon.Hand, DesignTimeUtilities.DEFAULT_ICON_HAND },
@@ -28,31 +34,57 @@ internal class KryptonToastIconConverter : StringLookupConverter<KryptonToastIco
             { KryptonToastIcon.Asterisk, DesignTimeUtilities.DEFAULT_ICON_ASTERISK },
             { KryptonToastIcon.SystemAsterisk, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ASTERISK },
             { KryptonToastIcon.Stop, DesignTimeUtilities.DEFAULT_ICON_STOP },
-            { KryptonToastIcon.SystemStop, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_STOP },
             { KryptonToastIcon.Error, DesignTimeUtilities.DEFAULT_ICON_ERROR },
-            { KryptonToastIcon.SystemError, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ERROR },
             { KryptonToastIcon.Warning, DesignTimeUtilities.DEFAULT_ICON_WARNING },
-            { KryptonToastIcon.SystemWarning, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_WARNING },
             { KryptonToastIcon.Information, DesignTimeUtilities.DEFAULT_ICON_INFORMATION },
-            { KryptonToastIcon.SystemInformation, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_INFORMATION },
             { KryptonToastIcon.Shield, DesignTimeUtilities.DEFAULT_ICON_SHIELD },
             { KryptonToastIcon.WindowsLogo, DesignTimeUtilities.DEFAULT_ICON_WINDOWS_LOGO },
             { KryptonToastIcon.Application, DesignTimeUtilities.DEFAULT_ICON_APPLICATION },
             { KryptonToastIcon.SystemApplication, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_APPLICATION },
             { KryptonToastIcon.Ok, DesignTimeUtilities.DEFAULT_ICON_OK },
             { KryptonToastIcon.Custom, DesignTimeUtilities.DEFAULT_ICON_CUSTOM }
-        });
+        };
+
+    // Alias display names (Stop/Error/Warning/Information System) map onto the shared MessageBoxIcon values.
+    [Localizable(true)]
+    private static readonly IReadOnlyDictionary<string, KryptonToastIcon> _pairsStringToEnum =
+        new Dictionary<string, KryptonToastIcon>
+        {
+            { DesignTimeUtilities.DEFAULT_ICON_NONE, KryptonToastIcon.None },
+            { DesignTimeUtilities.DEFAULT_ICON_HAND, KryptonToastIcon.Hand },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_HAND, KryptonToastIcon.SystemHand },
+            { DesignTimeUtilities.DEFAULT_ICON_QUESTION, KryptonToastIcon.Question },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_QUESTION, KryptonToastIcon.SystemQuestion },
+            { DesignTimeUtilities.DEFAULT_ICON_EXCLAMATION, KryptonToastIcon.Exclamation },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_EXCLAMATION, KryptonToastIcon.SystemExclamation },
+            { DesignTimeUtilities.DEFAULT_ICON_ASTERISK, KryptonToastIcon.Asterisk },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ASTERISK, KryptonToastIcon.SystemAsterisk },
+            { DesignTimeUtilities.DEFAULT_ICON_STOP, KryptonToastIcon.Stop },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_STOP, KryptonToastIcon.SystemStop },
+            { DesignTimeUtilities.DEFAULT_ICON_ERROR, KryptonToastIcon.Error },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ERROR, KryptonToastIcon.SystemError },
+            { DesignTimeUtilities.DEFAULT_ICON_WARNING, KryptonToastIcon.Warning },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_WARNING, KryptonToastIcon.SystemWarning },
+            { DesignTimeUtilities.DEFAULT_ICON_INFORMATION, KryptonToastIcon.Information },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_INFORMATION, KryptonToastIcon.SystemInformation },
+            { DesignTimeUtilities.DEFAULT_ICON_SHIELD, KryptonToastIcon.Shield },
+            { DesignTimeUtilities.DEFAULT_ICON_WINDOWS_LOGO, KryptonToastIcon.WindowsLogo },
+            { DesignTimeUtilities.DEFAULT_ICON_APPLICATION, KryptonToastIcon.Application },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_APPLICATION, KryptonToastIcon.SystemApplication },
+            { DesignTimeUtilities.DEFAULT_ICON_OK, KryptonToastIcon.Ok },
+            { DesignTimeUtilities.DEFAULT_ICON_CUSTOM, KryptonToastIcon.Custom }
+        };
 
     #endregion
 
     #region Protected
 
     /// <summary>Gets an array of lookup pairs.</summary>
-    protected override IReadOnlyDictionary<string, KryptonToastIcon> PairsStringToEnum => _iconPairs.SecondToFirst;
+    protected override IReadOnlyDictionary<string, KryptonToastIcon> PairsStringToEnum => _pairsStringToEnum;
 
     /// <summary>Gets the pairs enum to string.</summary>
     /// <value>The pairs enum to string.</value>
-    protected override IReadOnlyDictionary<KryptonToastIcon, string> PairsEnumToString => _iconPairs.FirstToSecond;
+    protected override IReadOnlyDictionary<KryptonToastIcon, string> PairsEnumToString => _pairsEnumToString;
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/KryptonMessageBoxIconConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/KryptonMessageBoxIconConverter.cs
@@ -10,13 +10,19 @@
 namespace Krypton.Toolkit;
 
 /// <summary>Custom type converter so that <see cref="T:KryptonMessageBoxIcon"/> values appear as neat text at design time.</summary>
+/// <remarks>
+/// <see cref="KryptonMessageBoxIcon"/> mirrors <see cref="MessageBoxIcon"/> aliases that share underlying values
+/// (<c>SystemHand</c>/<c>SystemStop</c>/<c>SystemError</c>, etc.). Those cannot share a single bi-dictionary key,
+/// so enum→string keeps one canonical display name per unique value while string→enum accepts every alias name.
+/// </remarks>
 internal class KryptonMessageBoxIconConverter : StringLookupConverter<KryptonMessageBoxIcon>
 {
     #region Static Fields
 
+    // One display string per unique underlying value (MessageBoxIcon aliases collapse Hand/Stop/Error, etc.).
     [Localizable(true)]
-    private static readonly BiDictionary<KryptonMessageBoxIcon, string> _iconPairs =
-        new BiDictionary<KryptonMessageBoxIcon, string>(new Dictionary<KryptonMessageBoxIcon, string>
+    private static readonly IReadOnlyDictionary<KryptonMessageBoxIcon, string> _pairsEnumToString =
+        new Dictionary<KryptonMessageBoxIcon, string>
         {
             { KryptonMessageBoxIcon.None, DesignTimeUtilities.DEFAULT_ICON_NONE },
             { KryptonMessageBoxIcon.Hand, DesignTimeUtilities.DEFAULT_ICON_HAND },
@@ -28,29 +34,53 @@ internal class KryptonMessageBoxIconConverter : StringLookupConverter<KryptonMes
             { KryptonMessageBoxIcon.Asterisk, DesignTimeUtilities.DEFAULT_ICON_ASTERISK },
             { KryptonMessageBoxIcon.SystemAsterisk, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ASTERISK },
             { KryptonMessageBoxIcon.Stop, DesignTimeUtilities.DEFAULT_ICON_STOP },
-            { KryptonMessageBoxIcon.SystemStop, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_STOP },
             { KryptonMessageBoxIcon.Error, DesignTimeUtilities.DEFAULT_ICON_ERROR },
-            { KryptonMessageBoxIcon.SystemError, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ERROR },
             { KryptonMessageBoxIcon.Warning, DesignTimeUtilities.DEFAULT_ICON_WARNING },
-            { KryptonMessageBoxIcon.SystemWarning, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_WARNING },
             { KryptonMessageBoxIcon.Information, DesignTimeUtilities.DEFAULT_ICON_INFORMATION },
-            { KryptonMessageBoxIcon.SystemInformation, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_INFORMATION },
             { KryptonMessageBoxIcon.Shield, DesignTimeUtilities.DEFAULT_ICON_SHIELD },
             { KryptonMessageBoxIcon.WindowsLogo, DesignTimeUtilities.DEFAULT_ICON_WINDOWS_LOGO },
             { KryptonMessageBoxIcon.Application, DesignTimeUtilities.DEFAULT_ICON_APPLICATION },
             { KryptonMessageBoxIcon.SystemApplication, DesignTimeUtilities.DEFAULT_ICON_SYSTEM_APPLICATION }
-        });
+        };
+
+    // Alias display names (Stop/Error/Warning/Information System) map onto the shared MessageBoxIcon values.
+    [Localizable(true)]
+    private static readonly IReadOnlyDictionary<string, KryptonMessageBoxIcon> _pairsStringToEnum =
+        new Dictionary<string, KryptonMessageBoxIcon>
+        {
+            { DesignTimeUtilities.DEFAULT_ICON_NONE, KryptonMessageBoxIcon.None },
+            { DesignTimeUtilities.DEFAULT_ICON_HAND, KryptonMessageBoxIcon.Hand },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_HAND, KryptonMessageBoxIcon.SystemHand },
+            { DesignTimeUtilities.DEFAULT_ICON_QUESTION, KryptonMessageBoxIcon.Question },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_QUESTION, KryptonMessageBoxIcon.SystemQuestion },
+            { DesignTimeUtilities.DEFAULT_ICON_EXCLAMATION, KryptonMessageBoxIcon.Exclamation },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_EXCLAMATION, KryptonMessageBoxIcon.SystemExclamation },
+            { DesignTimeUtilities.DEFAULT_ICON_ASTERISK, KryptonMessageBoxIcon.Asterisk },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ASTERISK, KryptonMessageBoxIcon.SystemAsterisk },
+            { DesignTimeUtilities.DEFAULT_ICON_STOP, KryptonMessageBoxIcon.Stop },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_STOP, KryptonMessageBoxIcon.SystemStop },
+            { DesignTimeUtilities.DEFAULT_ICON_ERROR, KryptonMessageBoxIcon.Error },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_ERROR, KryptonMessageBoxIcon.SystemError },
+            { DesignTimeUtilities.DEFAULT_ICON_WARNING, KryptonMessageBoxIcon.Warning },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_WARNING, KryptonMessageBoxIcon.SystemWarning },
+            { DesignTimeUtilities.DEFAULT_ICON_INFORMATION, KryptonMessageBoxIcon.Information },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_INFORMATION, KryptonMessageBoxIcon.SystemInformation },
+            { DesignTimeUtilities.DEFAULT_ICON_SHIELD, KryptonMessageBoxIcon.Shield },
+            { DesignTimeUtilities.DEFAULT_ICON_WINDOWS_LOGO, KryptonMessageBoxIcon.WindowsLogo },
+            { DesignTimeUtilities.DEFAULT_ICON_APPLICATION, KryptonMessageBoxIcon.Application },
+            { DesignTimeUtilities.DEFAULT_ICON_SYSTEM_APPLICATION, KryptonMessageBoxIcon.SystemApplication }
+        };
 
     #endregion
 
     #region Protected
 
     /// <summary>Gets an array of lookup pairs.</summary>
-    protected override IReadOnlyDictionary<string, KryptonMessageBoxIcon> PairsStringToEnum => _iconPairs.SecondToFirst;
+    protected override IReadOnlyDictionary<string, KryptonMessageBoxIcon> PairsStringToEnum => _pairsStringToEnum;
 
     /// <summary>Gets the pairs enum to string.</summary>
     /// <value>The pairs enum to string.</value>
-    protected override IReadOnlyDictionary<KryptonMessageBoxIcon, string> PairsEnumToString => _iconPairs.FirstToSecond;
+    protected override IReadOnlyDictionary<KryptonMessageBoxIcon, string> PairsEnumToString => _pairsEnumToString;
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -2269,8 +2269,7 @@ public enum MessageBoxContentAreaType
 #region Enum KryptonMessageBoxIcon
 
 /// <summary>Specifies the icon type for <see cref="T:KryptonMessageBox"/>.</summary>
-// ToDo: Fix converter, as it throws errors...
-//[TypeConverter(typeof(KryptonMessageBoxIconConverter))]
+[TypeConverter(typeof(KryptonMessageBoxIconConverter))]
 public enum KryptonMessageBoxIcon
 {
     /// <summary>Specify no icon.</summary>


### PR DESCRIPTION
# Fix: MessageBox/Toast icon converters with MessageBoxIcon aliases (#4064)

## Summary

`KryptonMessageBoxIconConverter` and `KryptonToastIconConverter` no longer throw during design-time conversion. They previously used a bi-dictionary keyed by enum values that collide because several `System*` members reuse `MessageBoxIcon` alias integers (Hand/Stop/Error, Exclamation/Warning, Asterisk/Information).

## Related issues

- Closes #4064

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `Krypton.Toolkit`: Split `KryptonMessageBoxIconConverter` into separate enum→string (unique values) and string→enum (including alias display names) maps; re-enabled `[TypeConverter]` on `KryptonMessageBoxIcon`.
- `Krypton.Toolkit.Utilities`: Applied the same pattern to `KryptonToastIconConverter`.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`, `Krypton.Toolkit.Utilities`
- TFMs verified: `net472`, `net48`, `net481`, `net8.0-windows` (Debug build of both projects and dependencies)

## Validation

- TestForm demo: N/A (design-time `TypeConverter` only; no runtime UI surface).
- Manual steps:
  1. Open a form with a property typed as `KryptonMessageBoxIcon` (or `KryptonToastIcon`) in the WinForms designer.
  2. Expand the property dropdown and confirm friendly names appear without an exception.
  3. Select values such as Hand (System); confirm round-trip to/from the property grid.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit.csproj" -c Debug` and `dotnet build ".\Source\Krypton Components\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#4064](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4064), Fixed `KryptonMessageBoxIcon` and `KryptonToastIcon` design-time converters that threw when built against `MessageBoxIcon` alias values
```

## Breaking changes & migration

None. Enum member values are unchanged; only the converters and the re-enabled `TypeConverter` attribute are updated.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [ ] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above