### PR TITLE
* Add DefaultPalette to KryptonThemeBrowserData (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,7 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
-* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+* Implemented [#4063](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4063), `KryptonThemeBrowserData.DefaultPalette` selects the initial theme by `PaletteMode` (takes precedence over `StartIndex`)
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049), Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
    * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
@@ -44,11 +44,6 @@ internal partial class VisualThemeBrowserFormRtlAware : KryptonForm
 
         StartPosition = _themeBrowserData.StartPosition ?? FormStartPosition.CenterScreen;
 
-        if (klbThemeList.Items.Count > 0)
-        {
-            klbThemeList.SelectedIndex = _themeBrowserData.StartIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
-        }
-
         klblHeader.Text = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeBrowserDescription;
 
         kbtnImport.Text = KryptonManager.Strings.MiscellaneousThemeStrings.Import;
@@ -72,7 +67,15 @@ internal partial class VisualThemeBrowserFormRtlAware : KryptonForm
             }
         }
 
-        klbThemeList.SelectedItem = _themeBrowserData.StartIndex;
+        int startIndex =
+            CommonHelperThemeSelectors.GetThemeBrowserStartIndex(_themeBrowserData, klbThemeList.Items,
+                new KryptonManager());
+        
+        if (startIndex > 0)
+        {
+            klbThemeList.SelectedIndex = startIndex;
+        }
+
     }
 
     private void klbThemeList_SelectedIndexChanged(object sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
@@ -44,8 +44,6 @@ internal partial class VisualThemeBrowserForm : KryptonForm
 
         StartPosition = _themeBrowserData.StartPosition ?? FormStartPosition.CenterScreen;
 
-        //klbThemeList.SelectedIndex = _startIndex;
-
         klblDescription.Text = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeBrowserDescription;
 
         kbtnImport.Text = KryptonManager.Strings.MiscellaneousThemeStrings.Import;
@@ -69,7 +67,14 @@ internal partial class VisualThemeBrowserForm : KryptonForm
             }
         }
 
-        klbThemeList.SelectedItem = _themeBrowserData.StartIndex;
+        int startIndex =
+            CommonHelperThemeSelectors.GetThemeBrowserStartIndex(_themeBrowserData, klbThemeList.Items,
+                new KryptonManager());
+
+        if (startIndex >= 0)
+        {
+            klbThemeList.SelectedIndex = startIndex;
+        }
     }
 
     private void kbtnOK_Click(object sender, EventArgs e) => DialogResult = DialogResult.OK;

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
@@ -6,6 +6,7 @@
  *  
  */
 #endregion
+
 namespace Krypton.Toolkit;
 
 #region Static
@@ -133,7 +134,7 @@ internal static class CommonHelperThemeSelectors
             // So, there's no need to change the index.
             if (KryptonManager.CurrentGlobalPaletteMode != PaletteMode.Global)
             {
-                result = CommonHelperThemeSelectors.GetPaletteIndex(items, KryptonManager.CurrentGlobalPaletteMode);
+                result = GetPaletteIndex(items, KryptonManager.CurrentGlobalPaletteMode);
             }
 
             // Back to norml
@@ -159,7 +160,7 @@ internal static class CommonHelperThemeSelectors
             ? manager.GlobalPaletteMode
             : defaultPalette;
                 
-        return CommonHelperThemeSelectors.GetPaletteIndex(items, pm);
+        return GetPaletteIndex(items, pm);
     }
 
     /// <summary>
@@ -185,11 +186,46 @@ internal static class CommonHelperThemeSelectors
             if (value != PaletteMode.Global)
             {
                 // Setting the index triggers OnSelectedIndexChanged()
-                result = CommonHelperThemeSelectors.GetPaletteIndex(items, defaultPalette);
+                result = GetPaletteIndex(items, defaultPalette);
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Resolves the initial theme list index for <see cref="KryptonThemeBrowser"/>.
+    /// Prefers <see cref="KryptonThemeBrowserData.DefaultPalette"/> over
+    /// <see cref="KryptonThemeBrowserData.StartIndex"/>, then the global default theme.
+    /// </summary>
+    /// <param name="themeBrowserData">Caller-supplied theme browser options.</param>
+    /// <param name="items">Populated theme list items.</param>
+    /// <param name="manager">Manager used when <see cref="PaletteMode.Global"/> is requested.</param>
+    /// <returns>A valid index into <paramref name="items"/>, or <c>-1</c> when the list is empty.</returns>
+    internal static int GetThemeBrowserStartIndex(KryptonThemeBrowserData themeBrowserData, IList items, KryptonManager manager)
+    {
+        if (items.Count == 0)
+        {
+            return -1;
+        }
+
+        if (themeBrowserData.DefaultPalette.HasValue)
+        {
+            int paletteIndex = GetInitialSelectedIndex(themeBrowserData.DefaultPalette.Value, manager, items);
+            if (paletteIndex >= 0)
+            {
+                return paletteIndex;
+            }
+        }
+
+        if (themeBrowserData.StartIndex is >= 0
+            && themeBrowserData.StartIndex.Value < items.Count)
+        {
+            return themeBrowserData.StartIndex.Value;
+        }
+
+        int fallbackIndex = GetPaletteIndex(items, GlobalStaticValues.GLOBAL_DEFAULT_PALETTE_MODE);
+        return fallbackIndex >= 0 ? fallbackIndex : 0;
     }
 }
    

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonThemeBrowserData.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonThemeBrowserData.cs
@@ -28,13 +28,23 @@ public struct KryptonThemeBrowserData
 
     /// <summary>Gets or sets the start index.</summary>
     /// <value>The start index.</value>
+    /// <remarks>
+    /// Prefer <see cref="DefaultPalette"/> when selecting by theme. When both are set,
+    /// <see cref="DefaultPalette"/> takes precedence.
+    /// </remarks>
     public int? StartIndex { get; set; }
+
+    /// <summary>Gets or sets the default palette mode to select when the theme browser opens.</summary>
+    /// <value>The default <see cref="PaletteMode"/>, or <c>null</c> to fall back to <see cref="StartIndex"/>.</value>
+    /// <remarks>
+    /// When set to <see cref="PaletteMode.Global"/>, the browser selects the current
+    /// <see cref="KryptonManager.GlobalPaletteMode"/> when that mode is a concrete theme.
+    /// </remarks>
+    public PaletteMode? DefaultPalette { get; set; }
 
     /// <summary>Gets or sets the window title.</summary>
     /// <value>The window title.</value>
     public string? WindowTitle { get; set; }
-
-    // ToDo: Add default palette mode option in V100
 
     /// <summary>Gets or sets the use RTL layout of the <see cref="KryptonThemeBrowser"/> UI.</summary>
     /// <value>The use RTL layout in an <see cref="KryptonThemeBrowser"/>.</value>


### PR DESCRIPTION
# Feature: Add DefaultPalette to KryptonThemeBrowserData (#4063)

## Summary

`KryptonThemeBrowserData` now exposes `DefaultPalette` so callers can open the theme browser on a named `PaletteMode` instead of a fragile list index. Existing `StartIndex` remains supported as a fallback.

## Related issues

- Closes #4063

## Type of change

- [x] Feature / enhancement (`Implemented`)

## Changes

- Added `KryptonThemeBrowserData.DefaultPalette` (`PaletteMode?`).
- Added `CommonHelperThemeSelectors.GetThemeBrowserStartIndex` to resolve the initial selection (`DefaultPalette` → `StartIndex` → global default).
- `VisualThemeBrowserForm` and `VisualThemeBrowserFormRtlAware` now set `SelectedIndex` correctly after the theme list is populated.
- Updated TestForm call sites (`Main`, `ThemeControlExamples`, `VisualControlsTest`) to use `DefaultPalette`.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: `net472`, `net48`, `net481`, `net8.0-windows`, `net9.0-windows`, `net10.0-windows`, `net11.0-windows`

## Validation

- TestForm demos: `Main` (theme browser button), `ThemeControlExamples`, `VisualControlsTest` (LTR and RTL theme browser buttons).
- Manual steps:
  1. Open TestForm → Theme Control Examples → Theme Browser (or Visual Controls → VisualThemeBrowserForm).
  2. Confirm the list opens with the requested default theme selected and applied.
  3. Repeat for the RTL-aware theme browser button.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Implemented [#4063](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4063), `KryptonThemeBrowserData.DefaultPalette` selects the initial theme by `PaletteMode` (takes precedence over `StartIndex`)
```

## Breaking changes & migration

None. `StartIndex` is unchanged; prefer `DefaultPalette` for new code.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above