### PR TITLE
* Fix docking indicator hit-target selection (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,7 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
-* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+* Resolved [#3999](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3999), Clarified docking indicator hit-target selection during drag feedback
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049), Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
    * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -266,21 +266,17 @@ public class DragFeedbackDocking : DragFeedback
     {
         DragTarget? matchTarget = null;
 
-        // Update each cluster so it shows/hides docking indicators based on mouse position
-        foreach (DragTarget? clusterTarget in _clusters
-                     .Select(cluster => cluster.Feedback(screenPt, _dragFeedback))
-                     .Where(clusterTarget => (clusterTarget != null) && (matchTarget == null))
-                )
+        //  Update each cluster so it shows/hides docking indicators based on mouse position.
+        // Feedback must run for every cluster (side effects); keep the first hit target.
+        foreach (DockCluster cluster in _clusters)
         {
-            // TODO: Should be a better way to select the last match for this ?!?
-            matchTarget = clusterTarget;
+            DragTarget? clusterTarget = cluster.Feedback(screenPt, _dragFeedback);
+
+            matchTarget ??= clusterTarget;
         }
 
         // Update the solid feedback rectangle with area of the specific target
-        if (_solid != null)
-        {
-            _solid.SolidRect = matchTarget?.DrawRect ?? Rectangle.Empty;
-        }
+        _solid?.SolidRect = matchTarget?.DrawRect ?? Rectangle.Empty;
 
         return matchTarget;
     }


### PR DESCRIPTION
Resolves #3999. Refactor DragFeedbackDocking to clarify logic that ensures all clusters are processed for side effects (showing/hiding indicators) while consistently selecting the first valid hit target. Replace LINQ chain with explicit foreach loop and use null-coalescing assignment. Simplify null check with null-conditional operator.