### PR TITLE
* Use typed LINQ for Ribbon QAT enumeration (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,7 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
-* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049),Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
+* Resolved [#4060](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4060), Ribbon QAT button enumeration now uses `OfType<IQuickAccessToolbarButton>()` instead of unsafe casts
+* Implemented [#4049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4049), Implement the glyphs in `KryptonDomainUpDown` and `KryptonNumericUpDown`
    * Updates the buttons for `KryptonDomainUpDown`, `KryptonNumericUpDown`, `KryptonDataGridViewDomainUpDownColumn`, and `KryptonDataGridViewNumericUpDownColumn`.
    * The polygons draws in a single direction (downw) and are rotated to the correct orientation. 
    * Adjusted the corresponding image for the `KryptonDataGridViewDomainUpDownColumn` and `KryptonDataGridViewNumericUpDownColumn` column types

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -1486,15 +1486,15 @@ public class KryptonRibbon : VisualSimple,
         }
 
         // Check each quick access toolbar button
-        foreach (IQuickAccessToolbarButton qatButton in from IQuickAccessToolbarButton qatButton in QATButtons
-                 where qatButton.GetVisible() && qatButton.GetEnabled()
-                 let shortcut = qatButton.GetShortcutKeys()
-                 where (shortcut != Keys.None) && (shortcut == keyData)
-                 select qatButton)
+        foreach (var qatButton in QATButtons.OfType<IQuickAccessToolbarButton>().Where(static qatButton => qatButton.GetVisible() && qatButton.GetEnabled()))
         {
-            // Click the button and finish processing
-            qatButton.PerformClick();
-            return true;
+            var shortcut = qatButton.GetShortcutKeys();
+            if (shortcut != Keys.None && (shortcut == keyData))
+            {
+                // Click the button and finish processing
+                qatButton.PerformClick();
+                return true;
+            }
         }
 
         // If we want to intercept key pressed for use with key tips

--- a/Source/Krypton Components/Krypton.Ribbon/General/Accessibility/KryptonRibbonAccessibleObject.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/Accessibility/KryptonRibbonAccessibleObject.cs
@@ -86,12 +86,9 @@ internal class KryptonRibbonAccessibleObject : Control.ControlAccessibleObject
     {
         var children = new List<AccessibleObject>();
 
-        foreach (IQuickAccessToolbarButton qatButton in _ribbon.QATButtons)
+        foreach (var qatButton in _ribbon.QATButtons.OfType<IQuickAccessToolbarButton>().Where(static qatButton => qatButton.GetVisible()))
         {
-            if (qatButton.GetVisible())
-            {
-                children.Add(new RibbonQATButtonAccessibleObject(this, _ribbon, qatButton));
-            }
+            children.Add(new RibbonQATButtonAccessibleObject(this, _ribbon, qatButton));
         }
 
         foreach (KryptonRibbonTab tab in _ribbon.RibbonTabs)

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATFromOverflow.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATFromOverflow.cs
@@ -59,7 +59,7 @@ internal class ViewLayoutRibbonQATFromOverflow : ViewLayoutRibbonQATContents
             var qatOverflow = new List<IQuickAccessToolbarButton>();
 
             // Scan all the defined buttons for ones to show as overflowing
-            foreach (IQuickAccessToolbarButton qatButton in Ribbon.QATButtons)
+            foreach (var qatButton in Ribbon.QATButtons.OfType<IQuickAccessToolbarButton>())
             {
                 // If the button requests to be shown...
                 if (qatButton.GetVisible())

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATMini.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATMini.cs
@@ -237,7 +237,7 @@ internal class ViewLayoutRibbonQATMini : ViewLayoutDocker
         Debug.Assert(context != null);
 
         // Scan to see if there are any visible quick access toolbar buttons
-        var visibleQATButtons = _ribbon.QATButtons.Cast<IQuickAccessToolbarButton>().Any(static qatButton => qatButton.GetVisible());
+        var visibleQATButtons = _ribbon.QATButtons.OfType<IQuickAccessToolbarButton>().Any(static qatButton => qatButton.GetVisible());
             
         // Only show the border if there are some visible contents
         _border.Visible = visibleQATButtons;


### PR DESCRIPTION
Replace unsafe Cast operations with OfType<IQuickAccessToolbarButton>() for safer enumeration of quick access toolbar buttons. This prevents potential runtime exceptions from invalid type casts and follows LINQ best practices. Changes apply across KryptonRibbon, accessibility, and view layout components.