### PR TITLE
* Improve CI restore/build and nightly change detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,12 +265,12 @@ jobs:
           path: ${{ runner.temp }}/webview2
           key: ${{ steps.webview2_cache_restore_release.outputs.cache-primary-key }}
 
-      # UseArtifactsOutput must match Build/Pack so project.assets.json lands under artifacts/obj (avoids NETSDK1005).
+      # Match build job: same dotnet restore + properties so project.assets.json lands under artifacts/obj (avoids NETSDK1005).
       - name: Restore
-        run: msbuild /m "Scripts/Build/build.proj" /t:Restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" -p:Configuration=Release -p:TFMs=all -p:UseArtifactsOutput=true
 
       # Fail early if Restore did not write assets under artifacts/obj (would surface later as NETSDK1005 in Pack).
-      - name: Verify artifacts/obj exists
+      - name: Debug: list artifacts/obj
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -278,15 +278,16 @@ jobs:
           if (-not (Test-Path -LiteralPath $objRoot)) {
             Write-Error "Artifacts obj folder missing: $objRoot"
           }
-          $assets = @(Get-ChildItem -Path $objRoot -Recurse -Filter "project.assets.json")
+          $assets = @(Get-ChildItem -Path $objRoot -Recurse -Filter "project.assets.json" -ErrorAction SilentlyContinue)
           if ($assets.Count -eq 0) {
             Write-Error "No project.assets.json found under $objRoot"
           }
           $assets | ForEach-Object { Write-Host "Found: $($_.FullName)" }
 
       # /m: multi-processor MSBuild (all runner CPUs). build.proj orchestrates Krypton.* in parallel where references allow.
+      # TFMs=all must match Restore; avoid a second restore that can rewrite assets to a different layout.
       - name: Build Release
-        run: msbuild /m "Scripts/Build/build.proj" /t:Build /restore /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true
+        run: msbuild /m "Scripts/Build/build.proj" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /p:UseArtifactsOutput=true /p:TFMs=all /p:Restore=false
 
       # No /restore here: the explicit Restore step already produced artifacts/obj; a second implicit restore
       # can write project.assets.json elsewhere / with different properties and trigger NETSDK1005.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,30 +141,20 @@ jobs:
             exit 0
           }
 
-          # Get commits from last 24 hours on alpha branch, but skip when they only touch .github
-          # (e.g. the automated .github sync from master) so CI-only changes do not trigger a release
+          # Get commits from last 24 hours on alpha that touch paths outside .github.
+          # Use rev-list pathspec (merge-aware). Per-commit git diff-tree without -m misses
+          # merge/PR commits, so Source-only merges were incorrectly treated as .github-only
+          # and skipped. Exclude .github so automated CI syncs do not trigger a release.
           $yesterday = (Get-Date).AddDays(-1).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")
-          $recentCommits = @(git rev-list --since="$yesterday" alpha)
-          $commitCount = $recentCommits.Count
+          $commitCount = [int](git rev-list --count --since="$yesterday" alpha -- . ':(exclude).github')
 
-          Write-Host "Commits in last 24 hours: $commitCount"
+          Write-Host "Commits in last 24 hours (excluding .github-only changes): $commitCount"
 
           if ($commitCount -gt 0) {
-            $changedFiles = @($recentCommits | ForEach-Object { git diff-tree --no-commit-id --name-only -r $_ } | Sort-Object -Unique)
-            $nonGitHubFiles = @($changedFiles | Where-Object { $_ -and -not ($_.Replace('\', '/') -like '.github/*') })
-
-            Write-Host "Changed files in last 24 hours: $($changedFiles.Count)"
-            Write-Host "Changed files outside .github: $($nonGitHubFiles.Count)"
-          }
-
-          if ($commitCount -gt 0 -and $nonGitHubFiles.Count -gt 0) {
             Write-Host "Changes detected - proceeding with nightly build"
             echo "has_changes=true" >> $env:GITHUB_OUTPUT
-          } elseif ($commitCount -gt 0) {
-            Write-Host "Only .github changes detected - skipping nightly build"
-            echo "has_changes=false" >> $env:GITHUB_OUTPUT
           } else {
-            Write-Host "No changes detected - skipping nightly build"
+            Write-Host "No changes detected (or only .github-only changes) - skipping nightly build"
             echo "has_changes=false" >> $env:GITHUB_OUTPUT
           }
 


### PR DESCRIPTION
Build workflow: switch Restore to dotnet restore against the solution and align restore/build properties (TFMs=all, UseArtifactsOutput=true) so project.assets.json lands under artifacts/obj and avoids NETSDK1005. Add /p:Restore=false to the msbuild Build step to prevent a second restore from rewriting assets. Hardened the artifacts/obj check (silently continue missing files) and updated comments.

Nightly workflow: replace per-commit diff-tree logic with a rev-list --count + pathspec that excludes .github to correctly detect non-.github changes (including merge commits). Simplified branching logic and improved log messages so automated .github-only syncs don't trigger nightly builds.