### PR TITLE
* Prevent empty admin suffix in form title (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Resolved [#4086](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4086), Redundant parentheses when `ShowAdministratorSuffix` is set to false
+   * Elevated `KryptonForm` titles no longer show empty `()` when `ShowAdministratorSuffix` is disabled or the Administrator string is blank
 * Resolved [#4060](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4060), Ribbon QAT button enumeration now uses `OfType<IQuickAccessToolbarButton>()` instead of unsafe casts
 * Implemented [#4063](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4063), `KryptonThemeBrowserData.DefaultPalette` selects the initial theme by `PaletteMode` (takes precedence over `StartIndex`)
 * Resolved [#4064](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4064), Fixed `KryptonMessageBoxIcon` and `KryptonToastIcon` design-time converters that threw when built against `MessageBoxIcon` alias values

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1503,10 +1503,15 @@ public class KryptonForm : VisualForm,
 		// Get the base form text
 		string titleText = Text;
 
-		// Append administrator suffix if enabled and running with elevated privileges
+		// Append administrator suffix if enabled and running with elevated privileges.
+		// Skip when the localised Administrator string is empty so we do not leave bare "()".
 		if (KryptonManager.UseAdministratorSuffix && IsInAdministratorMode)
 		{
-			titleText += $" ({KryptonManager.Strings.GeneralStrings.Administrator})";
+			string administrator = KryptonManager.Strings.GeneralStrings.Administrator;
+			if (!string.IsNullOrWhiteSpace(administrator))
+			{
+				titleText += $" ({administrator})";
+			}
 		}
 
 		return titleText;


### PR DESCRIPTION
Fix #4086 — avoid redundant empty parentheses in elevated KryptonForm titles by only appending the Administrator suffix when the localized Administrator string is non-empty. Also update the changelog entry. Changes in: KryptonForm.cs (guard against empty Administrator string) and Documents/Changelog/Changelog.md (added resolution note).