### PR TITLE
* Add bundle snapshots to backup and mirror workflows

### DIFF
--- a/.github/workflows/alpha-backup-sync.yml
+++ b/.github/workflows/alpha-backup-sync.yml
@@ -12,10 +12,15 @@
 # Discord: Set secret DISCORD_WEBHOOK_ALPHA_BACKUP to send notifications (optional).
 #
 # Separate repo backup: Set variable BACKUP_REPO (e.g. Krypton-Suite/Standard-Toolkit-Backup) and
-# secret BACKUP_REPO_TOKEN (PAT with push access). Snapshots are zipped into Source/Nightly/Standard Toolkit.
+# secret BACKUP_REPO_TOKEN (PAT with push access). Each run stores two artifacts under
+# Source/Nightly/Standard Toolkit:
+#   - *.zip    — working-tree snapshot (excludes .git; browse/extract without git)
+#   - *.bundle — git bundle of the full alpha history (disaster recovery)
+# Restore from bundle:
+#   git clone "Standard Toolkit Backup - YYYY-MM-DD.bundle" restored-repo
 # Legacy dated directories at the backup repo root are removed on each run.
 # Optional: BACKUP_DIR_PREFIX (default "Standard Toolkit Backup"), BACKUP_BRANCH (default "main"),
-# BACKUP_SNAPSHOT_KEEP (default 30 — number of newest zip snapshots to retain).
+# BACKUP_SNAPSHOT_KEEP (default 30 — newest zip and bundle snapshots to retain of each type).
 
 name: Alpha to Alpha-Backup Sync
 
@@ -170,7 +175,7 @@ jobs:
               console.warn('Could not enable auto-merge (repo may not have Allow auto-merge enabled):', err.message);
             }
 
-      - name: Push alpha snapshot to backup repository (zip)
+      - name: Push alpha snapshot to backup repository (zip + bundle)
         if: steps.kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         id: backup_repo
         env:
@@ -204,8 +209,23 @@ jobs:
           snapshot_dir="Source/Nightly/Standard Toolkit"
           today=$(date -u +%Y-%m-%d)
           zip_name="$prefix - $today.zip"
-          echo "dir_name=$snapshot_dir/$zip_name" >> "$GITHUB_OUTPUT"
-          zip -r -q "$zip_name" . -x '.git/*'
+          bundle_name="$prefix - $today.bundle"
+          echo "zip_path=$snapshot_dir/$zip_name" >> "$GITHUB_OUTPUT"
+          echo "bundle_path=$snapshot_dir/$bundle_name" >> "$GITHUB_OUTPUT"
+          echo "dir_name=$snapshot_dir" >> "$GITHUB_OUTPUT"
+
+          # Tree snapshot for browse/extract (no .git); create before the bundle so the zip
+          # does not pick up the .bundle file sitting in the working tree.
+          zip -r -q "$zip_name" . -x '.git/*' -x '*.bundle'
+
+          # Full alpha history for disaster recovery (checkout already uses fetch-depth: 0).
+          if ! git show-ref --verify --quiet refs/heads/alpha; then
+            echo "::error::Local branch 'alpha' is missing; cannot create history-preserving bundle."
+            exit 1
+          fi
+          git bundle create "$bundle_name" alpha
+          git bundle verify "$bundle_name"
+
           git clone --depth 1 "https://x-access-token:$BACKUP_REPO_TOKEN@github.com/$repo_path.git" backup-repo
           cd backup-repo
           git config user.name "github-actions[bot]"
@@ -236,25 +256,36 @@ jobs:
             done
           done
           mkdir -p "$snapshot_dir"
-          mv "../$zip_name" "$snapshot_dir/"
-          git add "$snapshot_dir/$zip_name"
-          # Retain only the newest N zip snapshots (name sorts by YYYY-MM-DD date suffix)
-          mapfile -t snapshot_zips < <(ls -1 "$snapshot_dir"/*.zip 2>/dev/null | sort -r)
-          if [ "${#snapshot_zips[@]}" -gt "$keep" ]; then
-            for old_zip in "${snapshot_zips[@]:$keep}"; do
-              git rm -f "$old_zip"
-              echo "Removed old snapshot: $old_zip"
-            done
-          fi
-          echo "Retaining up to $keep newest snapshot(s) in $snapshot_dir"
+          mv "../$zip_name" "../$bundle_name" "$snapshot_dir/"
+          git add "$snapshot_dir/$zip_name" "$snapshot_dir/$bundle_name"
+
+          # Retain only the newest N snapshots of each type (names sort by YYYY-MM-DD date suffix)
+          prune_old_snapshots() {
+            local extension="$1"
+            local label="$2"
+            local -a snapshots=()
+            mapfile -t snapshots < <(ls -1 "$snapshot_dir"/*."$extension" 2>/dev/null | sort -r)
+            if [ "${#snapshots[@]}" -gt "$keep" ]; then
+              for old_file in "${snapshots[@]:$keep}"; do
+                git rm -f "$old_file"
+                echo "Removed old $label: $old_file"
+              done
+            fi
+            echo "Retaining up to $keep newest $label(s) in $snapshot_dir"
+          }
+          prune_old_snapshots zip snapshot
+          prune_old_snapshots bundle bundle
+
           if git diff --staged --quiet; then
             echo "No backup repo changes to commit"
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: update alpha snapshots in $snapshot_dir (automated)"
+            git commit -m "chore: update alpha zip + bundle snapshots in $snapshot_dir (automated)"
             git push origin "$branch"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
-            echo "Pushed alpha snapshot to $BACKUP_REPO ($snapshot_dir/$zip_name)"
+            echo "Pushed alpha snapshots to $BACKUP_REPO:"
+            echo "  zip:    $snapshot_dir/$zip_name"
+            echo "  bundle: $snapshot_dir/$bundle_name"
           fi
 
       - name: Discord notification
@@ -266,6 +297,8 @@ jobs:
           BACKUP_PUSHED: ${{ steps.backup_repo.outputs.pushed }}
           BACKUP_REPO: ${{ vars.BACKUP_REPO }}
           BACKUP_DIR: ${{ steps.backup_repo.outputs.dir_name }}
+          BACKUP_ZIP: ${{ steps.backup_repo.outputs.zip_path }}
+          BACKUP_BUNDLE: ${{ steps.backup_repo.outputs.bundle_path }}
         run: |
           if [ -z "$DISCORD_WEBHOOK" ]; then
             echo "DISCORD_WEBHOOK_ALPHA_BACKUP not set - skipping Discord notification"
@@ -288,6 +321,8 @@ jobs:
             --arg backup_pushed "$BACKUP_PUSHED" \
             --arg backup_repo "$BACKUP_REPO" \
             --arg backup_dir "$BACKUP_DIR" \
+            --arg backup_zip "$BACKUP_ZIP" \
+            --arg backup_bundle "$BACKUP_BUNDLE" \
             --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             '{
               embeds: [{
@@ -298,7 +333,10 @@ jobs:
                     "• " + $branch,
                     (if $pr_url != "" then "• [PR #\($pr_number)](\($pr_url))" else empty end),
                     (if $backup_pushed == "true" and $backup_repo != "" then
-                      "• Pushed snapshot to backup repo: " + $backup_repo + (if $backup_dir != "" then " (`" + $backup_dir + "`)" else "" end)
+                      "• Pushed zip + bundle to backup repo: " + $backup_repo +
+                      (if $backup_dir != "" then " (`" + $backup_dir + "`)" else "" end) +
+                      (if $backup_zip != "" then "\n  • zip: `" + $backup_zip + "`" else "" end) +
+                      (if $backup_bundle != "" then "\n  • bundle: `" + $backup_bundle + "`" else "" end)
                      else empty end),
                     "• [Workflow run](\($run_url))"
                   ] | join("\n"))

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -21,6 +21,15 @@
 #   Variable  REPO_MIRROR_ON_PR_MERGE  Set to "true" to enable syncs on merged pull requests
 #   Secret    DISCORD_WEBHOOK_MIRROR  Discord webhook for mirror notifications
 #
+# Offline snapshots (optional — same BACKUP_REPO / BACKUP_REPO_TOKEN as alpha-backup-sync):
+#   After a successful non-dry-run mirror, stores a git bundle under
+#   Source/Nightly/Standard Toolkit Mirror in BACKUP_REPO:
+#   - *.bundle — git bundle of all refs in the bare source clone (full history DR)
+#   Restore from bundle:
+#     git clone "Standard Toolkit Mirror Backup - YYYY-MM-DD.bundle" restored-repo
+#   Optional: BACKUP_DIR_PREFIX (default "Standard Toolkit Mirror Backup"),
+#   BACKUP_BRANCH (default "main"), BACKUP_SNAPSHOT_KEEP (default 30).
+#
 # Testing: Actions → Repository Mirror → Run workflow → enable "Dry run" to validate
 # configuration, clone the source, and list refs without force-pushing. Use a dedicated
 # test mirror repository before pointing MIRROR_REPO at production backup storage.
@@ -383,6 +392,98 @@ jobs:
           echo "  Tags failed: $tags_failed"
           echo "  Tag prune failed: $tags_prune_failed"
 
+      - name: Push offline mirror snapshot (bundle)
+        if: steps.kill_switch.outputs.enabled == 'true' && steps.mirror.outcome == 'success'
+        id: mirror_artifacts
+        env:
+          BACKUP_REPO: ${{ vars.BACKUP_REPO }}
+          BACKUP_REPO_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
+          BACKUP_DIR_PREFIX: ${{ vars.BACKUP_DIR_PREFIX }}
+          BACKUP_BRANCH: ${{ vars.BACKUP_BRANCH }}
+          BACKUP_SNAPSHOT_KEEP: ${{ vars.BACKUP_SNAPSHOT_KEEP }}
+          DRY_RUN: ${{ steps.mirror.outputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "Dry run — skipping offline bundle snapshot."
+            exit 0
+          fi
+
+          if [ -z "${BACKUP_REPO_TOKEN:-}" ] || [ -z "${BACKUP_REPO:-}" ]; then
+            echo "BACKUP_REPO (variable) or BACKUP_REPO_TOKEN (secret) not set - skipping offline mirror snapshot"
+            exit 0
+          fi
+
+          if [ ! -d source.git ]; then
+            echo "::error::Bare clone source.git is missing; cannot create offline mirror snapshot."
+            exit 1
+          fi
+
+          repo_path="$BACKUP_REPO"
+          if [[ "$repo_path" == https://github.com/* ]] || [[ "$repo_path" == http://github.com/* ]]; then
+            repo_path="${repo_path#*github.com/}"
+            repo_path="${repo_path%.git}"
+            repo_path="${repo_path%/}"
+            echo "Normalized BACKUP_REPO from full URL to: $repo_path"
+          fi
+
+          # Prefer a mirror-specific default so alpha-backup artifacts are not overwritten
+          # when BACKUP_DIR_PREFIX is unset. If the operator sets BACKUP_DIR_PREFIX explicitly,
+          # honor it (artifacts still live in a distinct snapshot directory).
+          if [ -n "${BACKUP_DIR_PREFIX:-}" ]; then
+            prefix="$BACKUP_DIR_PREFIX"
+          else
+            prefix="Standard Toolkit Mirror Backup"
+          fi
+          branch="${BACKUP_BRANCH:-main}"
+          keep="${BACKUP_SNAPSHOT_KEEP:-14}"
+          if ! [[ "$keep" =~ ^[0-9]+$ ]] || [ "$keep" -lt 1 ]; then
+            echo "::warning:: BACKUP_SNAPSHOT_KEEP='$BACKUP_SNAPSHOT_KEEP' is invalid; using 14"
+            keep=14
+          fi
+
+          snapshot_dir="Source/Nightly/Standard Toolkit Mirror"
+          today=$(date -u +%Y-%m-%d)
+          bundle_name="$prefix - $today.bundle"
+          echo "bundle_path=$snapshot_dir/$bundle_name" >> "$GITHUB_OUTPUT"
+          echo "dir_name=$snapshot_dir" >> "$GITHUB_OUTPUT"
+
+          workspace="$PWD"
+          echo "Creating full-history bundle from bare clone (--all)..."
+          git -C source.git bundle create "${workspace}/${bundle_name}" --all
+          git bundle verify "${workspace}/${bundle_name}"
+
+          git clone --depth 1 "https://x-access-token:$BACKUP_REPO_TOKEN@github.com/$repo_path.git" backup-repo
+          cd backup-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch" 2>/dev/null || git checkout "$branch" 2>/dev/null || true
+
+          mkdir -p "$snapshot_dir"
+          mv "${workspace}/${bundle_name}" "$snapshot_dir/"
+          git add "$snapshot_dir/$bundle_name"
+
+          mapfile -t snapshot_bundles < <(ls -1 "$snapshot_dir"/*.bundle 2>/dev/null | sort -r)
+          if [ "${#snapshot_bundles[@]}" -gt "$keep" ]; then
+            for old_bundle in "${snapshot_bundles[@]:$keep}"; do
+              git rm -f "$old_bundle"
+              echo "Removed old bundle: $old_bundle"
+            done
+          fi
+          echo "Retaining up to $keep newest bundle(s) in $snapshot_dir"
+
+          if git diff --staged --quiet; then
+            echo "No backup repo changes to commit"
+          else
+            git commit -m "chore: update mirror bundle snapshot in $snapshot_dir (automated)"
+            git push origin "$branch"
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "Pushed mirror bundle to $BACKUP_REPO ($snapshot_dir/$bundle_name)"
+          fi
+
       - name: Discord notification
         if: steps.kill_switch.outputs.enabled == 'true' && always() && steps.mirror.outcome != 'skipped'
         env:
@@ -402,6 +503,10 @@ jobs:
           SOURCE_TAG_COUNT: ${{ steps.mirror.outputs.source_tag_count }}
           DRY_RUN: ${{ steps.mirror.outputs.dry_run }}
           MIRROR_REPO: ${{ steps.mirror.outputs.mirror_repo || vars.MIRROR_REPO }}
+          ARTIFACTS_PUSHED: ${{ steps.mirror_artifacts.outputs.pushed }}
+          ARTIFACT_BUNDLE: ${{ steps.mirror_artifacts.outputs.bundle_path }}
+          ARTIFACT_DIR: ${{ steps.mirror_artifacts.outputs.dir_name }}
+          BACKUP_REPO: ${{ vars.BACKUP_REPO }}
           SOURCE_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
@@ -534,6 +639,20 @@ jobs:
           fi
           if [ -n "${FAILED_BRANCHES:-}" ]; then
             add_field "❌ Failed" "$(format_ref_list "$FAILED_BRANCHES")" false
+          fi
+
+          if [ "${ARTIFACTS_PUSHED:-false}" = "true" ]; then
+            artifacts_value="_none_"
+            if [ -n "${BACKUP_REPO:-}" ]; then
+              artifacts_value="Repo: \`${BACKUP_REPO}\`"
+              if [ -n "${ARTIFACT_DIR:-}" ]; then
+                artifacts_value="${artifacts_value}"$'\n'"Dir: \`${ARTIFACT_DIR}\`"
+              fi
+              if [ -n "${ARTIFACT_BUNDLE:-}" ]; then
+                artifacts_value="${artifacts_value}"$'\n'"• bundle: \`${ARTIFACT_BUNDLE}\`"
+              fi
+            fi
+            add_field "💾 Offline bundle" "$artifacts_value" false
           fi
 
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
Update CI workflows to produce and retain git bundle artifacts for offline disaster recovery.

- .github/workflows/alpha-backup-sync.yml: create both a tree zip and a history-preserving git bundle for each run, store both under Source/Nightly/Standard Toolkit, prune oldest snapshots per type, surface zip/bundle paths as outputs, and include them in Discord notifications. Adjust default snapshot retention to 30.
- .github/workflows/repo-mirror.yml: create a full-history bundle from the bare mirror (source.git), push to BACKUP_REPO under Source/Nightly/Standard Toolkit Mirror, prune old bundles, expose outputs, and include info in notifications.

Adds validation, URL normalization, and safer ordering when creating zips/bundles for reliable backups.