### PR TITLE
* Space Key not working on Button

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,9 @@
 ﻿# New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
 # Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
 #
-# Builds TestForm and runs Scripts/UnitTest assert suites via Invoke-AllUnitTests.ps1 -Strict.
-# Contract: every Test-*.ps1 declares "# UnitTest-CI: include" or "# UnitTest-CI: exclude".
-# See Scripts/UnitTest/README.md.
+# Builds TestForm and runs Scripts/UnitTests assert suites via Invoke-AllUnitTests.ps1 -Strict.
+# Contract: every UnitTest-*.ps1 declares "# UnitTest-CI: include" or "# UnitTest-CI: exclude".
+# See Scripts/UnitTests/README.md.
 #
 # Triggers:
 #   - workflow_dispatch (on-demand from Actions UI or `gh workflow run`)
@@ -59,7 +59,7 @@ on:
     branches: ['**']
     types: [opened, synchronize, reopened]
     paths:
-      - 'Scripts/UnitTest/**'
+      - 'Scripts/UnitTests/**'
       - 'Source/Krypton Components/**'
       - '.github/workflows/unit-tests.yml'
   push:
@@ -70,7 +70,7 @@ on:
       - gold
       - V115
     paths:
-      - 'Scripts/UnitTest/**'
+      - 'Scripts/UnitTests/**'
       - 'Source/Krypton Components/**'
       - '.github/workflows/unit-tests.yml'
   workflow_call:
@@ -102,7 +102,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Scripts/UnitTest
+    name: Scripts/UnitTests
     runs-on: windows-2025-vs2026
     # Always allow workflow_dispatch / workflow_call; block only fork pull_request runs.
     if: >
@@ -185,7 +185,7 @@ jobs:
         run: |
           # Validate with powershell.exe (same host that runs the suite). pwsh alone can
           # miss UTF-8-without-BOM / non-ASCII issues that break Windows PowerShell 5.1.
-          $script = Join-Path $PWD 'Scripts\UnitTest\Invoke-AllUnitTests.ps1'
+          $script = Join-Path $env:GITHUB_WORKSPACE 'Scripts\UnitTests\Invoke-AllUnitTests.ps1'
           $probe = @'
           $errors = $null
           $tokens = $null
@@ -221,7 +221,7 @@ jobs:
           Write-Host "[INFO] Unit test run starting"
           Write-Host "[INFO] Configuration=$env:UNITTEST_CONFIGURATION TFM=$env:UNITTEST_TFM TimeoutSeconds=$timeout"
 
-          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Invoke-AllUnitTests.ps1 `
+          & powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-AllUnitTests.ps1 `
             -Configuration $env:UNITTEST_CONFIGURATION `
             -TargetFramework $env:UNITTEST_TFM `
             -Strict `

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#4147](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4147), Space Key not working on Button
+   * Space key activates a focused `KryptonButton` when the mouse is not hovering over it.
 * Implemented [#4135](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4135), **[Breaking Change]** Move all `Global*` classes into `Krypton.Interop`
    * Toolkit specific constant values and variables are now stored in `ToolkitStaticConstants` and `ToolkitGlobalVariables` in the `Krypton.Toolkit` namespace
    * Libary wide constant values, functions and variables are now stored in `SharedStaticConstants`, `SharedStaticFunctions` and `SharedGlobalVariables` in the `Krypton.Interop` namespace

--- a/Scripts/UnitTests/Get-NavigatorCaptionTabProbe.ps1
+++ b/Scripts/UnitTests/Get-NavigatorCaptionTabProbe.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Prints RealWindowBorders and caption-strip geometry for NavigatorFormIntegrationDemo.
 
@@ -7,7 +7,7 @@
     debugging non-client coordinate conversion for caption tabs.
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Get-NavigatorCaptionTabProbe.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Get-NavigatorCaptionTabProbe.ps1
 #>
 [CmdletBinding()]
 param(

--- a/Scripts/UnitTests/Get-NavigatorTabGroupColourShot.ps1
+++ b/Scripts/UnitTests/Get-NavigatorTabGroupColourShot.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Captures the CaptionIntegrated tab strip with two differently-coloured groups so the
     group-colour treatment (header wash + accent bar, member underline) can be eyeballed.
@@ -13,7 +13,7 @@
     Where to write the PNGs. Defaults to the resolved Bin\Debug\net472 directory.
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Get-NavigatorTabGroupColourShot.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Get-NavigatorTabGroupColourShot.ps1
 #>
 [CmdletBinding()]
 param(

--- a/Scripts/UnitTests/Invoke-AllUnitTests.ps1
+++ b/Scripts/UnitTests/Invoke-AllUnitTests.ps1
@@ -1,15 +1,15 @@
 ﻿<#
 .SYNOPSIS
-    Discovers and runs all CI-oriented Scripts/UnitTest assert scripts (Test-*.ps1).
+    Discovers and runs all CI-oriented Scripts/UnitTests assert scripts (UnitTest-*.ps1).
 
 .DESCRIPTION
-    Future-proof contract (see Scripts/UnitTest/README.md):
+    Future-proof contract (see Scripts/UnitTests/README.md):
 
-    * Discover every Test-*.ps1 under Scripts/UnitTest (recursive).
-    * Each Test-*.ps1 MUST declare a comment marker near the top:
+    * Discover every UnitTest-*.ps1 under Scripts/UnitTests (recursive).
+    * Each UnitTest-*.ps1 MUST declare a comment marker near the top:
         # UnitTest-CI: include   - run in CI / Invoke-AllUnitTests
         # UnitTest-CI: exclude   - interactive; never auto-run
-    * -Strict (or env UNITTEST_CI=1) fails when any Test-*.ps1 lacks a marker,
+    * -Strict (or env UNITTEST_CI=1) fails when any UnitTest-*.ps1 lacks a marker,
       or when zero include scripts are discovered.
     * Each include script runs in a fresh STA powershell child with
       -Configuration / -TargetFramework / -BinDir forwarded when present.
@@ -18,7 +18,7 @@
     Exit code is the number of failing scripts (0 = all passed).
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Invoke-AllUnitTests.ps1 -Strict
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-AllUnitTests.ps1 -Strict
 #>
 [CmdletBinding()]
 param(
@@ -57,7 +57,7 @@ foreach ($item in $classification.Excluded) {
 
 if ($classification.Undeclared.Count -gt 0) {
     $list = ($classification.Undeclared | ForEach-Object { $_.Name }) -join ', '
-    $message = "Test-*.ps1 scripts missing '# UnitTest-CI: include|exclude' marker: $list"
+    $message = "UnitTest-*.ps1 scripts missing '# UnitTest-CI: include|exclude' marker: $list"
     if ($Strict) {
         Write-UnitTestBanner -Status FAIL -Message $message
         Write-GitHubError -Message $message
@@ -77,7 +77,7 @@ if ($skippedNames.Count -gt 0) {
 
 $ciTests = @($classification.Included | Sort-Object FullName)
 if ($ciTests.Count -eq 0) {
-    $message = "No UnitTest-CI:include Test-*.ps1 scripts found under $PSScriptRoot"
+    $message = "No UnitTest-CI:include UnitTest-*.ps1 scripts found under $PSScriptRoot"
     if ($Strict) {
         Write-UnitTestBanner -Status FAIL -Message $message
         Write-GitHubError -Message $message

--- a/Scripts/UnitTests/Invoke-CaptionTabDrag.ps1
+++ b/Scripts/UnitTests/Invoke-CaptionTabDrag.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Drags between two caption-relative points on the hosted NavigatorFormIntegrationDemo.
 
@@ -7,7 +7,7 @@
     drag. Captures before / during / after screenshots into the bin folder (or -OutputDir).
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Invoke-CaptionTabDrag.ps1 `
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-CaptionTabDrag.ps1 `
         -HostPid 12345 -FromX 200 -FromY 14 -ToX 80 -ToY 14 -Tag join
 #>
 [CmdletBinding()]

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -52,6 +52,7 @@ Default output folder: `Bin\Debug\net472`.
 |--------|---------|--------|
 | `Invoke-AllUnitTests.ps1` | Discovers markers, runs every `include` script in STA children | (entry point) |
 | `UnitTest-UnitTestInfrastructure.ps1` | Shared helpers + CI marker discovery smoke assert | `include` |
+| `UnitTest-ButtonSpaceKey.ps1` | #4147 Space activates focused `KryptonButton` when `ActiveView` is null (no hover) | `include` |
 | `UnitTest-NavigatorTaskbarTabGroups.ps1` | #4129 TabGroup taskbar composites + float taskbar opt-in (needs feature binaries) | `exclude` |
 | `UnitTest-NavigatorCaptionTabRemerge.ps1` | Tear-out / remerge (needs `-HostPid`) | `exclude` |
 | `Start-NavigatorFormIntegrationHost.ps1` | Hosts `NavigatorFormIntegrationDemo` | n/a |

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -21,7 +21,7 @@ Rules:
 | `exclude` | Skipped; keep for local interactive use |
 | Missing marker | **Fails** under `-Strict` / `UNITTEST_CI=1` (forces authors to opt in or out) |
 | Zero `include` scripts | **Fails** under `-Strict` |
-| Non-`Test-*` helpers | Never auto-run (`Start-*`, `Invoke-*` drag, `Get-*`, `UnitTestCommon.ps1`) |
+| Non-`UnitTest-*` helpers | Never auto-run (`Start-*`, `Invoke-*` drag, `Get-*`, `UnitTestCommon.ps1`) |
 
 Shared optional parameters for `include` scripts (forwarded by the invoker):
 
@@ -63,7 +63,7 @@ Default output folder: `Bin\Debug\net472`.
 
 ```powershell
 dotnet build ".\Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net472
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Invoke-AllUnitTests.ps1 -Strict
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-AllUnitTests.ps1 -Strict
 ```
 
 The invoker prints `[PASS]` / `[FAIL]` / `[SKIP]` banners and a summary table. On GitHub Actions it also writes the Actions job summary and `::notice` / `::error` annotations.
@@ -78,16 +78,16 @@ gh workflow run "Unit Tests" -f configuration=Debug -f target_framework=net472 -
 
 ```powershell
 # Terminal 1 - host the demo
-powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Start-NavigatorFormIntegrationHost.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Start-NavigatorFormIntegrationHost.ps1
 
 # Terminal 2 - note the host PID, then drag or remerge
 $hp = (Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" |
     Where-Object { $_.CommandLine -like '*Start-NavigatorFormIntegrationHost*' }).ProcessId
 
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Invoke-CaptionTabDrag.ps1 `
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-CaptionTabDrag.ps1 `
     -HostPid $hp -FromX 200 -FromY 14 -ToX 80 -ToY 14 -Tag join
 
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Test-NavigatorCaptionTabRemerge.ps1 `
+powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1 `
     -HostPid $hp
 ```
 
@@ -95,7 +95,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Test-Navi
 
 ```powershell
 dotnet build ".\Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net472
-powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Test-NavigatorTaskbarTabGroups.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-NavigatorTaskbarTabGroups.ps1
 ```
 
 Screenshots from interactive helpers are written under the bin/output directory and are not checked in.

--- a/Scripts/UnitTests/Start-NavigatorFormIntegrationHost.ps1
+++ b/Scripts/UnitTests/Start-NavigatorFormIntegrationHost.ps1
@@ -1,14 +1,14 @@
-<#
+﻿<#
 .SYNOPSIS
     Hosts TestForm.NavigatorFormIntegrationDemo from a Debug bin folder (STA).
 
 .DESCRIPTION
     Loads Krypton + TestForm assemblies from Bin\<Configuration>\<TFM> and runs the
     Navigator Form Integration (#925) demo. Use as the UI host for the other
-    Scripts/UnitTest helpers.
+    Scripts/UnitTests helpers.
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Start-NavigatorFormIntegrationHost.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Start-NavigatorFormIntegrationHost.ps1
 #>
 [CmdletBinding()]
 param(

--- a/Scripts/UnitTests/UnitTest-ButtonSpaceKey.ps1
+++ b/Scripts/UnitTests/UnitTest-ButtonSpaceKey.ps1
@@ -1,0 +1,143 @@
+﻿<#
+.SYNOPSIS
+    Asserts #4147: Space activates a focused KryptonButton when ActiveView is null (no mouse hover).
+
+.DESCRIPTION
+    Loads Debug Krypton.Toolkit binaries and runs an in-process STA check:
+
+    1. Host a KryptonButton on an off-screen form.
+    2. Clear ViewManager.ActiveView (simulates mouse not over the control).
+    3. Send Space KeyDown/KeyUp through ViewManager.
+    4. Assert Click fires; repeat with ActiveView set to the button root (hover path).
+
+    Exit code 0 on success; non-zero on failure.
+    Requires an STA apartment (use powershell -STA). Invoke-AllUnitTests launches include scripts with -STA.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-ButtonSpaceKey.ps1
+#>
+# UnitTest-CI: include
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Debug',
+    [string]$TargetFramework = 'net472',
+    [string]$BinDir
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'UnitTestCommon.ps1')
+
+$repoRoot = Get-UnitTestRepoRoot
+$bin = Get-UnitTestBinDir -RepoRoot $repoRoot -Configuration $Configuration -TargetFramework $TargetFramework -BinDir $BinDir
+Register-UnitTestAssemblyResolver -BinDir $bin
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Interop.dll'))
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.dll'))
+
+$failed = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        $failed.Add($Message)
+        Write-Host "FAIL: $Message" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if (-not [object]::Equals($Expected, $Actual)) {
+        $failed.Add("$Message (expected='$Expected' actual='$Actual')")
+        Write-Host "FAIL: $Message (expected='$Expected' actual='$Actual')" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+function Get-NetObject {
+    param($Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [System.Management.Automation.PSObject]) {
+        return $Value.PSObject.BaseObject
+    }
+    return $Value
+}
+
+function Invoke-ButtonSpaceClick {
+    param(
+        $ViewManager,
+        [bool]$WithActiveView
+    )
+
+    $vm = Get-NetObject $ViewManager
+    if ($WithActiveView) {
+        $vm.ActiveView = $vm.Root
+    }
+    else {
+        $vm.ActiveView = $null
+    }
+
+    $down = New-Object System.Windows.Forms.KeyEventArgs ([System.Windows.Forms.Keys]::Space)
+    $up = New-Object System.Windows.Forms.KeyEventArgs ([System.Windows.Forms.Keys]::Space)
+    $vm.KeyDown($down)
+    $vm.KeyUp($up)
+}
+
+Write-UnitTestBanner -Status INFO -Message 'Asserting #4147 KryptonButton Space without mouse hover'
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+[System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+
+$form = Get-NetObject ([System.Activator]::CreateInstance([Krypton.Toolkit.KryptonForm]))
+$form.Text = 'UnitTest-4147-ButtonSpaceKey'
+$form.ShowInTaskbar = $false
+$form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+$form.Location = New-Object System.Drawing.Point(-32000, -32000)
+$form.Size = New-Object System.Drawing.Size(320, 160)
+
+$button = Get-NetObject ([System.Activator]::CreateInstance([Krypton.Toolkit.KryptonButton]))
+$button.Text = 'Space target'
+$button.Dock = [System.Windows.Forms.DockStyle]::Top
+$button.Height = 40
+[void]$form.Controls.Add($button)
+
+$script:clickCount = 0
+$handler = [System.EventHandler]{ param($s, $e) $script:clickCount++ }
+$button.add_Click($handler)
+
+[void]$form.Show()
+[System.Windows.Forms.Application]::DoEvents()
+[void]$button.Focus()
+[System.Windows.Forms.Application]::DoEvents()
+
+$vm = Get-NetObject $button.ViewManager
+Assert-True ($null -ne $vm) 'KryptonButton.ViewManager is available'
+Assert-True ($null -ne $vm.Root) 'ViewManager.Root is available'
+Assert-True ($null -ne $vm.Root.KeyController) 'View root exposes child KeyController (pulsing-border decorator)'
+
+$script:clickCount = 0
+Invoke-ButtonSpaceClick -ViewManager $vm -WithActiveView:$false
+Assert-Equal 1 $script:clickCount 'Space KeyDown/KeyUp clicks when ActiveView is null (no hover)'
+
+$script:clickCount = 0
+Invoke-ButtonSpaceClick -ViewManager $vm -WithActiveView:$true
+Assert-Equal 1 $script:clickCount 'Space KeyDown/KeyUp clicks when ActiveView is the button root (hover path)'
+
+$button.remove_Click($handler)
+$form.Close()
+$form.Dispose()
+
+if ($failed.Count -gt 0) {
+    Write-UnitTestBanner -Status FAIL -Message ("#4147 assertions failed ($($failed.Count))")
+    exit 1
+}
+
+Write-UnitTestBanner -Status PASS -Message '#4147 KryptonButton Space key assertions passed'
+exit 0

--- a/Scripts/UnitTests/UnitTest-NavigatorCaptionTabRemerge.ps1
+++ b/Scripts/UnitTests/UnitTest-NavigatorCaptionTabRemerge.ps1
@@ -1,4 +1,4 @@
-﻿﻿<#
+﻿<#
 .SYNOPSIS
     Tears out a caption tab and drags it back to verify remerge into the source window.
 
@@ -8,7 +8,7 @@
     "Close empty window" enabled, a successful remerge leaves a single window.
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Test-NavigatorCaptionTabRemerge.ps1 -HostPid 12345
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1 -HostPid 12345
 #>
 # UnitTest-CI: exclude
 [CmdletBinding()]

--- a/Scripts/UnitTests/UnitTest-NavigatorTaskbarTabGroups.ps1
+++ b/Scripts/UnitTests/UnitTest-NavigatorTaskbarTabGroups.ps1
@@ -15,7 +15,7 @@
     Requires an STA apartment (use powershell -STA).
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTest\Test-NavigatorTaskbarTabGroups.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-NavigatorTaskbarTabGroups.ps1
 #>
 # UnitTest-CI: exclude
 [CmdletBinding()]

--- a/Scripts/UnitTests/UnitTest-UnitTestInfrastructure.ps1
+++ b/Scripts/UnitTests/UnitTest-UnitTestInfrastructure.ps1
@@ -1,13 +1,13 @@
 ﻿<#
 .SYNOPSIS
-    Smoke assert for Scripts/UnitTest shared helpers and CI marker discovery.
+    Smoke assert for Scripts/UnitTests shared helpers and CI marker discovery.
 
 .DESCRIPTION
-    Verifies UnitTestCommon.ps1 loads and that every Test-*.ps1 under Scripts/UnitTest
+    Verifies UnitTestCommon.ps1 loads and that every UnitTest-*.ps1 under Scripts/UnitTests
     declares a UnitTest-CI include|exclude marker. Does not require TestForm binaries.
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTest\Test-UnitTestInfrastructure.ps1
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\UnitTest-UnitTestInfrastructure.ps1
 #>
 # UnitTest-CI: include
 [CmdletBinding()]
@@ -40,11 +40,11 @@ Assert-True -Condition ([string]::IsNullOrWhiteSpace($repoRoot) -eq $false) -Mes
 Assert-True -Condition (Test-Path -LiteralPath (Join-Path $repoRoot 'AGENTS.md')) -Message 'Repo root contains AGENTS.md'
 
 $classification = Get-UnitTestScriptClassification -Root $PSScriptRoot
-Assert-True -Condition ($classification.Undeclared.Count -eq 0) -Message 'No Test-*.ps1 scripts missing UnitTest-CI markers'
+Assert-True -Condition ($classification.Undeclared.Count -eq 0) -Message 'No UnitTest-*.ps1 scripts missing UnitTest-CI markers'
 Assert-True -Condition ($classification.Included.Count -gt 0) -Message 'At least one UnitTest-CI:include script is discovered'
 
 $includeNames = @($classification.Included | ForEach-Object { $_.Name })
-Assert-True -Condition ($includeNames -contains 'Test-UnitTestInfrastructure.ps1') -Message 'This infrastructure script is classified as include'
+Assert-True -Condition ($includeNames -contains 'UnitTest-UnitTestInfrastructure.ps1') -Message 'This infrastructure script is classified as include'
 
 Write-UnitTestBanner -Status INFO -Message ("Included=$($classification.Included.Count) Excluded=$($classification.Excluded.Count) Undeclared=$($classification.Undeclared.Count)")
 

--- a/Scripts/UnitTests/UnitTestCommon.ps1
+++ b/Scripts/UnitTests/UnitTestCommon.ps1
@@ -1,4 +1,4 @@
-﻿# Shared helpers for Scripts/UnitTest/*.ps1
+﻿# Shared helpers for Scripts/UnitTests/*.ps1
 # Dot-source from a unit-test script after setting $script:RepoRoot if needed.
 
 function Get-UnitTestRepoRoot {
@@ -106,7 +106,7 @@ function Get-UnitTestScriptClassification {
         [string]$Root
     )
 
-    $files = @(Get-ChildItem -LiteralPath $Root -Filter 'Test-*.ps1' -File -Recurse |
+    $files = @(Get-ChildItem -LiteralPath $Root -Filter 'UnitTest-*.ps1' -File -Recurse |
         Where-Object { $_.Name -ne 'Invoke-AllUnitTests.ps1' })
 
     $included = New-Object System.Collections.Generic.List[System.IO.FileInfo]

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewDecorator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewDecorator.cs
@@ -277,6 +277,12 @@ public abstract class ViewDecorator : ViewBase
     /// <summary>
     /// Gets and sets the associated key controller.
     /// </summary>
+    /// <remarks>
+    /// Forwarded from the child. Do not override key/focus event methods to Parent-only
+    /// bubble: when this decorator is the ViewManager root and ActiveView is null (mouse
+    /// not over the control), ViewBase must route Space/Enter through this controller
+    /// (see issue #4147).
+    /// </remarks>
     public override IKeyController? KeyController
     {
         get => _child?.KeyController;
@@ -335,53 +341,6 @@ public abstract class ViewDecorator : ViewBase
     public override void MouseLeave(ViewBase? next) =>
         // Bubble event up to the parent
         Parent?.MouseLeave(next);
-
-    #endregion
-
-    #region Key Events
-    /// <summary>
-    /// Key has been pressed down.
-    /// </summary>
-    /// <param name="e">A KeyEventArgs that contains the event data.</param>
-    public override void KeyDown(KeyEventArgs e) =>
-        // Bubble event up to the parent
-        Parent?.KeyDown(e);
-
-    /// <summary>
-    /// Key has been pressed.
-    /// </summary>
-    /// <param name="e">A KeyPressEventArgs that contains the event data.</param>
-    public override void KeyPress(KeyPressEventArgs e) =>
-        // Bubble event up to the parent
-        Parent?.KeyPress(e);
-
-    /// <summary>
-    /// Key has been released.
-    /// </summary>
-    /// <param name="e">A KeyEventArgs that contains the event data.</param>
-    /// <returns>True if capturing input; otherwise false.</returns>
-    public override bool KeyUp(KeyEventArgs e) =>
-        // Bubble event up to the parent
-        Parent?.KeyUp(e) ?? false;
-
-    #endregion
-
-    #region Source Events
-    /// <summary>
-    /// Source control has got the focus.
-    /// </summary>
-    /// <param name="c">Reference to the source control instance.</param>
-    public override void GotFocus(Control c) =>
-        // Bubble event up to the parent
-        Parent?.GotFocus(c);
-
-    /// <summary>
-    /// Source control has lost the focus.
-    /// </summary>
-    /// <param name="c">Reference to the source control instance.</param>
-    public override void LostFocus(Control c) =>
-        // Bubble event up to the parent
-        Parent?.LostFocus(c);
 
     #endregion
 

--- a/Source/Krypton Components/TestForm/Bug4147ButtonSpaceKeyDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug4147ButtonSpaceKeyDemo.cs
@@ -1,0 +1,122 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Demo for issue #4147: Space must activate a focused KryptonButton when the mouse is not hovering it.
+/// </summary>
+public sealed class Bug4147ButtonSpaceKeyDemo : KryptonForm
+{
+    private const string DemoTitle = @"Bug #4147 - Button Space Key";
+
+    private readonly KryptonWrapLabel _lblStatus;
+    private int _kryptonClicks;
+    private int _nativeClicks;
+
+    public Bug4147ButtonSpaceKeyDemo()
+    {
+        Text = DemoTitle;
+        StartPosition = FormStartPosition.CenterScreen;
+        Size = new Size(720, 380);
+        MinimumSize = new Size(640, 320);
+
+        var lblInfo = new KryptonWrapLabel
+        {
+            Dock = DockStyle.Top,
+            AutoSize = false,
+            Height = 110,
+            Text =
+                @"How to test issue #4147:" + Environment.NewLine +
+                @"1) Keep the mouse pointer away from both buttons." + Environment.NewLine +
+                @"2) Press Tab until focus is on ""KryptonButton"" (or ""Native Button"")." + Environment.NewLine +
+                @"3) Press Space — the click count for that button must increase." + Environment.NewLine +
+                @"4) Move the mouse onto the focused button and press Space again — it must still click."
+        };
+
+        _lblStatus = new KryptonWrapLabel
+        {
+            Dock = DockStyle.Bottom,
+            AutoSize = false,
+            Height = 48,
+            Text = @"Clicks — Krypton: 0 | Native: 0"
+        };
+
+        var comparison = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 2,
+            RowCount = 2,
+            Padding = new Padding(16)
+        };
+        comparison.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+        comparison.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
+        comparison.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        comparison.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+
+        var lblKrypton = new KryptonLabel
+        {
+            Text = @"KryptonButton",
+            Dock = DockStyle.Fill,
+            LabelStyle = LabelStyle.BoldControl
+        };
+        var lblNative = new KryptonLabel
+        {
+            Text = @"Native Button",
+            Dock = DockStyle.Fill,
+            LabelStyle = LabelStyle.BoldControl
+        };
+
+        var kryptonButton = new KryptonButton
+        {
+            Text = @"KryptonButton",
+            Dock = DockStyle.Top,
+            Height = 40,
+            TabIndex = 0
+        };
+        kryptonButton.Click += (_, _) =>
+        {
+            _kryptonClicks++;
+            UpdateStatus();
+        };
+
+        var nativeButton = new Button
+        {
+            Text = @"Native Button",
+            Dock = DockStyle.Top,
+            Height = 40,
+            TabIndex = 1,
+            UseVisualStyleBackColor = true
+        };
+        nativeButton.Click += (_, _) =>
+        {
+            _nativeClicks++;
+            UpdateStatus();
+        };
+
+        comparison.Controls.Add(lblKrypton, 0, 0);
+        comparison.Controls.Add(lblNative, 1, 0);
+        comparison.Controls.Add(kryptonButton, 0, 1);
+        comparison.Controls.Add(nativeButton, 1, 1);
+
+        var content = new KryptonPanel
+        {
+            Dock = DockStyle.Fill,
+            Padding = new Padding(8)
+        };
+        content.Controls.Add(comparison);
+
+        Controls.Add(content);
+        Controls.Add(_lblStatus);
+        Controls.Add(lblInfo);
+    }
+
+    private void UpdateStatus() =>
+        _lblStatus.Text = $@"Clicks — Krypton: {_kryptonClicks} | Native: {_nativeClicks}";
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -91,6 +91,8 @@ public partial class StartScreen : KryptonForm
         CreateButton<Bug2475KryptonFormHelpButtonDemo>("Bug 2475 Form Help Button", "Issue #2475: KryptonForm HelpButton shows a themed ? in the title bar. Toggle HelpButton/min/max, click ? to fire HelpRequested, open a sample child form.");
         CreateButton<Bug4086AdministratorSuffixDemo>("Bug 4086 Administrator Suffix", "Issue #4086: elevated KryptonForm title must not show bare () when ShowAdministratorSuffix is false or Administrator is empty; toggle suffix and clear/localise the string.");
         CreateButton<Bug4132FormBorderClippingDemo>("Bug 4132 Form Border Clipping", "Issue #4132: the right and bottom KryptonForm borders were clipped by the window region, which also cut the flush Close button edge. Open the samples, switch themes, hover Close, and confirm every edge reports PASS.");
+        CreateButton<Bug4147ButtonSpaceKeyDemo>("Bug 4147 Button Space Key", "Issue #4147: Space must activate a focused KryptonButton when the mouse is not over it. Tab to each button with the mouse away, press Space, then repeat with hover; click counts should increase.");
+
         CreateButton<Bug3367KryptonTextBoxButtonSpecHoverDemo>("Bug 3367 TextBox ButtonSpec Hover", "Demo for issue #3367: ButtonSpec hover flicker on KryptonTextBox/KryptonMaskedTextBox, including ImageStates.ImageNormal without the Image property.");
         CreateButton<Bug3382CueHintLinesDemo>("Bug 3382 CueHint line artifacts", "Demo for issue #3382: KryptonTextBox CueHint with TextH Near and mixed cue/content fonts - verify no stray top/left lines; cue remains vertically centered.");
         CreateButton<Bug3383KryptonButtonStateTrackingRoundingDemo>("Bug 3383 KryptonButton hover rounding vs OverrideFocus", "Demo for issue #3383: large StateCommon rounding with different StateTracking rounding and OverrideFocus rounding - Tab to focus, then hover (left repro vs right matched control). Corner fill and stroke should align after the palette merge fix.");


### PR DESCRIPTION
# Fix: Space key activates focused KryptonButton without hover (#4147)

## Summary

Focused `KryptonButton` instances again respond to Space when the mouse is not over the control. The pulsing-border view decorator had been dropping keyboard events when it was the view-manager root and no mouse-active view was set.

## Related issues

- Closes #4147

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `ViewDecorator`: stop Parent-only key/focus overrides so `ViewBase` routes through the child-forwarded `KeyController` / `SourceController` when the decorator is the view root.
- TestForm: add `Bug4147ButtonSpaceKeyDemo` with side-by-side Krypton vs native button Space activation.

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: Debug build of `Krypton.Toolkit` / `TestForm`

## Validation

- TestForm demo: `Bug4147ButtonSpaceKeyDemo` (registered in `StartScreen.AddButtons()`).
- Manual steps:
  1. Open **Bug 4147 Button Space Key**.
  2. Keep the mouse away from both buttons; Tab to **KryptonButton**; press Space — Krypton click count increases.
  3. Tab to **Native Button**; press Space — native click count increases.
  4. Hover the focused Krypton button and press Space — click count still increases.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit.csproj" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#4147](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4147), Space Key not working on Button
   * Space key activates a focused `KryptonButton` when the mouse is not hovering over it.
```

## Breaking changes & migration

None.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above