### PR TITLE
* Fix docking drag-target heuristics (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Resolved [#3858](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3858), Fix drag-target heuristics in `DragFeedbackDocking` / `DragViewController`
+   * Clarified docking drag-target priority (first hit / control edges before nested cells) and cleaned up `DragViewController` cancel path.
 * Implemented [#4088](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4088), A way to store `KryptonManager` strings into a database
    * Save/load `KryptonManager` toolkit strings via versioned `Translations.xml` (designer verbs + `KryptonManager.Strings` import/export APIs).
    * Auto-discovery: place culture-specific or default `Translations.{culture}.xml` / `.json` files in the app's output directory and the toolkit loads the best match automatically (exact → neutral → default, XML before JSON, with graceful fallback). Opt-out via `KryptonManager.AutoDiscoverTranslations = false`.

--- a/Source/Krypton Components/Krypton.Navigator/Controller/DragViewController.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controller/DragViewController.cs
@@ -299,9 +299,8 @@ public class DragViewController : GlobalId,
                     OnDragQuit();
                 }
 
-                // Recalculate if the mouse is over the button area
-                // TODO: What is this doing ? i.e. should the return value be used ?
-                return Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
+                // Capture was released; KeyUp reports whether input is still captured.
+                return Captured;
             }
         }
 
@@ -347,10 +346,6 @@ public class DragViewController : GlobalId,
                 c.Capture = false;
                 Captured = false;
             }
-
-            // Recalculate if the mouse is over the button area
-            // TODO: What is this doing ? i.e. should the return value be used ?
-            Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
         }
     }
     #endregion

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -311,10 +311,6 @@ public class DragFeedbackDocking : DragFeedback
     }
 
     private DockCluster? FindTargetCluster(DragTarget target) => _clusters.FirstOrDefault(cluster => !cluster.ExcludeCluster && cluster != null && cluster.ScreenRect.Equals(target.ScreenRect));
-
-    private DragTarget? FindTarget(Point screenPt, PageDragEndData dragEndData) =>
-        // Nothing matches
-        null;
-
+    
     #endregion
 }


### PR DESCRIPTION
Resolve #3858: clarify docking drag-target priority and tidy drag controller code. Added changelog entry. DragViewController: clean up cancel path, return Captured after capture release and remove unused mouse-over checks. DragFeedbackDocking: remove the no-op FindTarget stub so proper target discovery/heuristics are used.