### PR TITLE
* Async Form and Dialog Methods (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -49,9 +49,9 @@
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
 * Implemented [#4177](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4177), When will the Async Form Methods from .net10 (Started in .net9) actually be implemented
-   * `KryptonForm` already exposes inherited `ShowAsync` / `ShowDialogAsync` on `net9.0-windows` and newer.
-   * Added `KryptonMessageBox.ShowAsync` overloads and `KryptonTaskDialog.ShowDialogAsync` (gated to `NET9_0_OR_GREATER`).
-   * TestForm: `Async Form Methods` smoke scenario for Form, MessageBox, and TaskDialog async show.
+   * `KryptonForm` uses framework `ShowAsync` / `ShowDialogAsync` on `net9.0-windows` and newer; earlier TFMs get matching extension methods that degrade to sync show (modal) or FormClosed-backed Task (modeless).
+   * Added `KryptonMessageBox.ShowAsync` overloads and `KryptonTaskDialog.ShowDialogAsync` for all supported TFMs.
+   * TestForm: `Async Form Methods` smoke scenario for Form, MessageBox, and TaskDialog async show (same code path on every TFM).
 * Resolved [#3858](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3858), Fix drag-target heuristics in `DragFeedbackDocking` / `DragViewController`
    * Clarified docking drag-target priority (first hit / control edges before nested cells) and cleaned up `DragViewController` cancel path.
 * Implemented [#4088](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4088), A way to store `KryptonManager` strings into a database

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,10 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Implemented [#4177](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4177), When will the Async Form Methods from .net10 (Started in .net9) actually be implemented
+   * `KryptonForm` already exposes inherited `ShowAsync` / `ShowDialogAsync` on `net9.0-windows` and newer.
+   * Added `KryptonMessageBox.ShowAsync` overloads and `KryptonTaskDialog.ShowDialogAsync` (gated to `NET9_0_OR_GREATER`).
+   * TestForm: `Async Form Methods` smoke scenario for Form, MessageBox, and TaskDialog async show.
 * Resolved [#3858](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3858), Fix drag-target heuristics in `DragFeedbackDocking` / `DragViewController`
    * Clarified docking drag-target priority (first hit / control edges before nested cells) and cleaned up `DragViewController` cancel path.
 * Implemented [#4088](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4088), A way to store `KryptonManager` strings into a database

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -339,7 +339,6 @@ public static class KryptonMessageBox
             showHelpButton: displayHelpButton,
             showCloseButton: showCloseButton);
 
-#if NET9_0_OR_GREATER
     /// <summary>
     /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
     /// </summary>
@@ -647,7 +646,7 @@ public static class KryptonMessageBox
             showCtrlCopy: showCtrlCopy,
             showHelpButton: displayHelpButton,
             showCloseButton: showCloseButton);
-#endif
+
     #endregion
 
     #region Implementation
@@ -703,7 +702,6 @@ public static class KryptonMessageBox
         }
     }
 
-#if NET9_0_OR_GREATER
     /// <summary>
     /// Displays a message box asynchronously with the specified text, caption, buttons, icon, default button, options, and Help button, using the specified Help file, HelpNavigator, and Help topic.
     /// </summary>
@@ -759,7 +757,6 @@ public static class KryptonMessageBox
                 : await kmb.ShowDialogAsync(showOwner).ConfigureAwait(true);
         }
     }
-#endif
 
     #region WinForm Compatibility
     private static IWin32Window? ValidateOptions(IWin32Window? owner, MessageBoxOptions options, HelpInfo? helpInfo)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -338,6 +338,316 @@ public static class KryptonMessageBox
             showCtrlCopy: showCtrlCopy,
             showHelpButton: displayHelpButton,
             showCloseButton: showCloseButton);
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, string.Empty,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons, icon,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons, icon, defaultButton,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons, icon, defaultButton, options,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <param name="helpInfo">Contains the help data of the <see cref="KryptonMessageBox"/>.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options, HelpInfo helpInfo,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons, icon, defaultButton, options, helpInfo,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="displayHelpButton">Displays a 'Help' button, as seen in .NET 6 and higher.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(string text, string caption, KryptonMessageBoxButtons buttons, bool displayHelpButton,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(null, text, caption, buttons, icon, defaultButton, options,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: displayHelpButton,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string text,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, string.Empty,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons, icon,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons, icon, defaultButton,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons, icon, defaultButton, options,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: false,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <param name="helpInfo">Contains the help data of the <see cref="KryptonMessageBox"/>.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options, HelpInfo helpInfo,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons, icon, defaultButton, options,
+            showCtrlCopy: showCtrlCopy,
+            helpInfo: helpInfo,
+            showCloseButton: showCloseButton);
+
+    /// <summary>
+    /// Displays a message box asynchronously in front+center of the application and with the specified text, caption and buttons.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="displayHelpButton">Displays a 'Help' button, as seen in .NET 6 and higher.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    public static Task<DialogResult> ShowAsync(IWin32Window owner, string? text, string? caption, KryptonMessageBoxButtons buttons, bool displayHelpButton,
+        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options,
+        bool? showCtrlCopy = null,
+        bool? showCloseButton = null) =>
+        ShowCoreAsync(owner, text, caption, buttons, icon, defaultButton, options,
+            showCtrlCopy: showCtrlCopy,
+            showHelpButton: displayHelpButton,
+            showCloseButton: showCloseButton);
+#endif
     #endregion
 
     #region Implementation
@@ -392,6 +702,64 @@ public static class KryptonMessageBox
             return kmb.ShowDialog(showOwner);
         }
     }
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Displays a message box asynchronously with the specified text, caption, buttons, icon, default button, options, and Help button, using the specified Help file, HelpNavigator, and Help topic.
+    /// </summary>
+    /// <param name="owner">Owner of the modal dialog box.</param>
+    /// <param name="text">The text to display in the message box.</param>
+    /// <param name="caption">The text to display in the title bar of the message box.</param>
+    /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
+    /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
+    /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
+    /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
+    /// <param name="helpInfo">Contains the help data of the <see cref="KryptonMessageBox"/>.</param>
+    /// <param name="showCtrlCopy">Show extraText in title. If null (default) then only when Warning or Error icon is used.</param>
+    /// <param name="showHelpButton">Displays a 'Help' button, as seen in .NET 6 and higher.</param>
+    /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
+    /// <returns>A task that yields one of the System.Windows.Forms.DialogResult values.</returns>
+    private static async Task<DialogResult> ShowCoreAsync(IWin32Window? owner,
+        string? text, string? caption,
+        KryptonMessageBoxButtons buttons = KryptonMessageBoxButtons.OK,
+        KryptonMessageBoxIcon icon = KryptonMessageBoxIcon.None,
+        KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button1,
+        MessageBoxOptions options = 0,
+        HelpInfo? helpInfo = null,
+        bool? showCtrlCopy = null,
+        bool? showHelpButton = null,
+        bool? showCloseButton = null)
+    {
+        caption = string.IsNullOrEmpty(caption) ? @" " : caption;
+
+        IWin32Window? showOwner = ValidateOptions(owner, options, helpInfo);
+
+        // Show message box window as a modal dialog and then dispose of it after-wards
+
+        if (options is MessageBoxOptions.RightAlign or MessageBoxOptions.RtlReading)
+        {
+            using var kmbRtl = new VisualMessageBoxRtlAwareForm(showOwner, text, caption, buttons, icon,
+                defaultButton, helpInfo, showCtrlCopy, showHelpButton, showCloseButton);
+
+            kmbRtl.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
+
+            return showOwner is null
+                ? await kmbRtl.ShowDialogAsync().ConfigureAwait(true)
+                : await kmbRtl.ShowDialogAsync(showOwner).ConfigureAwait(true);
+        }
+        else
+        {
+            using var kmb = new VisualMessageBoxForm(showOwner, text, caption, buttons, icon,
+                defaultButton, helpInfo, showCtrlCopy, showHelpButton, showCloseButton);
+
+            kmb.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
+
+            return showOwner is null
+                ? await kmb.ShowDialogAsync().ConfigureAwait(true)
+                : await kmb.ShowDialogAsync(showOwner).ConfigureAwait(true);
+        }
+    }
+#endif
 
     #region WinForm Compatibility
     private static IWin32Window? ValidateOptions(IWin32Window? owner, MessageBoxOptions options, HelpInfo? helpInfo)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -274,10 +274,10 @@ public class KryptonTaskDialog : IDisposable
         return Dialog.DialogResult;
     }
 
-#if NET9_0_OR_GREATER
     /// <summary>
     /// Show as a modal dialog asynchronously.<br/>
     /// The returned task completes when the dialog has been dismissed.
+    /// On TFMs before .NET 9 this degrades to a completed task wrapping <see cref="ShowDialog"/>.
     /// </summary>
     /// <param name="owner">The parent window that launched this dialog.</param>
     /// <returns>A task that yields the DialogResult when the dialog closes.</returns>
@@ -300,7 +300,6 @@ public class KryptonTaskDialog : IDisposable
 
         return Dialog.DialogResult;
     }
-#endif
 
     /// <summary>
     /// Will close the dialog window.<br/>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/KryptonTaskDialog.cs
@@ -274,6 +274,34 @@ public class KryptonTaskDialog : IDisposable
         return Dialog.DialogResult;
     }
 
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Show as a modal dialog asynchronously.<br/>
+    /// The returned task completes when the dialog has been dismissed.
+    /// </summary>
+    /// <param name="owner">The parent window that launched this dialog.</param>
+    /// <returns>A task that yields the DialogResult when the dialog closes.</returns>
+    public async Task<DialogResult> ShowDialogAsync(IWin32Window? owner = null)
+    {
+        UpdateFormSizing();
+        UpdateFormPosition(owner);
+        ResetFormDialogResult();
+
+        // The standard form's DialogResult property always returns Cancel when e.Cancel is set to true.<br/>
+        // Before that happens the DialogResult is stored in DialogResultInternal.
+        if (owner is not null)
+        {
+            await _form.ShowDialogAsync(owner).ConfigureAwait(true);
+        }
+        else
+        {
+            await _form.ShowDialogAsync().ConfigureAwait(true);
+        }
+
+        return Dialog.DialogResult;
+    }
+#endif
+
     /// <summary>
     /// Will close the dialog window.<br/>
     /// Can be use with a modeless dialog that is controlled and updated from code.

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -36,7 +36,7 @@
 	<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	<NeutralLanguage>en</NeutralLanguage>
 	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-	<NoWarn>1701;1702</NoWarn>
+	<NoWarn>1701;1702;WFO5002</NoWarn>
 	<Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonFormAsyncExtensions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonFormAsyncExtensions.cs
@@ -1,0 +1,76 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV), Giduac, et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+#if !NET9_0_OR_GREATER
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides Form ShowDialogAsync / ShowAsync compatible APIs on TFMs before .NET 9.
+/// On .NET 9+ the framework instance methods are used instead.
+/// </summary>
+public static class KryptonFormAsyncExtensions
+{
+    /// <summary>
+    /// Displays the form as a modal dialog. Completes synchronously via <see cref="Form.ShowDialog()"/> on pre-.NET 9 TFMs.
+    /// </summary>
+    /// <param name="form">The form to show.</param>
+    /// <returns>A completed task with the dialog result.</returns>
+    public static Task<DialogResult> ShowDialogAsync(this Form form) =>
+        Task.FromResult(form.ShowDialog());
+
+    /// <summary>
+    /// Displays the form as a modal dialog. Completes synchronously via <see cref="Form.ShowDialog(IWin32Window)"/> on pre-.NET 9 TFMs.
+    /// </summary>
+    /// <param name="form">The form to show.</param>
+    /// <param name="owner">The owner window.</param>
+    /// <returns>A completed task with the dialog result.</returns>
+    public static Task<DialogResult> ShowDialogAsync(this Form form, IWin32Window? owner) =>
+        Task.FromResult(form.ShowDialog(owner));
+
+    /// <summary>
+    /// Displays the form modelessly and returns a task that completes when the form is closed.
+    /// </summary>
+    /// <param name="form">The form to show.</param>
+    /// <returns>A task that completes when the form closes.</returns>
+    public static Task ShowAsync(this Form form) => ShowAsyncCore(form, owner: null);
+
+    /// <summary>
+    /// Displays the form modelessly and returns a task that completes when the form is closed.
+    /// </summary>
+    /// <param name="form">The form to show.</param>
+    /// <param name="owner">The owner window.</param>
+    /// <returns>A task that completes when the form closes.</returns>
+    public static Task ShowAsync(this Form form, IWin32Window? owner) => ShowAsyncCore(form, owner);
+
+    private static Task ShowAsyncCore(Form form, IWin32Window? owner)
+    {
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnClosed(object? sender, FormClosedEventArgs e)
+        {
+            form.FormClosed -= OnClosed;
+            tcs.TrySetResult(null);
+        }
+
+        form.FormClosed += OnClosed;
+        if (owner is null)
+        {
+            form.Show();
+        }
+        else
+        {
+            form.Show(owner);
+        }
+
+        return tcs.Task;
+    }
+}
+
+#endif

--- a/Source/Krypton Components/TestForm/AsyncFormMethodsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/AsyncFormMethodsTest.Designer.cs
@@ -1,0 +1,129 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm
+{
+    partial class AsyncFormMethodsTest
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.klblResult = new Krypton.Toolkit.KryptonLabel();
+            this.kbtnTaskDialogShowDialogAsync = new Krypton.Toolkit.KryptonButton();
+            this.kbtnMessageBoxShowAsync = new Krypton.Toolkit.KryptonButton();
+            this.kbtnShowDialogAsync = new Krypton.Toolkit.KryptonButton();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+            this.kryptonPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // kryptonPanel1
+            // 
+            this.kryptonPanel1.Controls.Add(this.klblResult);
+            this.kryptonPanel1.Controls.Add(this.kbtnTaskDialogShowDialogAsync);
+            this.kryptonPanel1.Controls.Add(this.kbtnMessageBoxShowAsync);
+            this.kryptonPanel1.Controls.Add(this.kbtnShowDialogAsync);
+            this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Name = "kryptonPanel1";
+            this.kryptonPanel1.Size = new System.Drawing.Size(420, 160);
+            this.kryptonPanel1.TabIndex = 0;
+            // 
+            // klblResult
+            // 
+            this.klblResult.Location = new System.Drawing.Point(12, 120);
+            this.klblResult.Name = "klblResult";
+            this.klblResult.Size = new System.Drawing.Size(52, 20);
+            this.klblResult.TabIndex = 3;
+            this.klblResult.Values.Text = "Result:";
+            // 
+            // kbtnTaskDialogShowDialogAsync
+            // 
+            this.kbtnTaskDialogShowDialogAsync.Location = new System.Drawing.Point(12, 74);
+            this.kbtnTaskDialogShowDialogAsync.Name = "kbtnTaskDialogShowDialogAsync";
+            this.kbtnTaskDialogShowDialogAsync.Size = new System.Drawing.Size(390, 30);
+            this.kbtnTaskDialogShowDialogAsync.TabIndex = 2;
+            this.kbtnTaskDialogShowDialogAsync.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnTaskDialogShowDialogAsync.Values.Text = "KryptonTaskDialog.ShowDialogAsync";
+            this.kbtnTaskDialogShowDialogAsync.Click += new System.EventHandler(this.kbtnTaskDialogShowDialogAsync_Click);
+            // 
+            // kbtnMessageBoxShowAsync
+            // 
+            this.kbtnMessageBoxShowAsync.Location = new System.Drawing.Point(12, 43);
+            this.kbtnMessageBoxShowAsync.Name = "kbtnMessageBoxShowAsync";
+            this.kbtnMessageBoxShowAsync.Size = new System.Drawing.Size(390, 30);
+            this.kbtnMessageBoxShowAsync.TabIndex = 1;
+            this.kbtnMessageBoxShowAsync.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnMessageBoxShowAsync.Values.Text = "KryptonMessageBox.ShowAsync";
+            this.kbtnMessageBoxShowAsync.Click += new System.EventHandler(this.kbtnMessageBoxShowAsync_Click);
+            // 
+            // kbtnShowDialogAsync
+            // 
+            this.kbtnShowDialogAsync.Location = new System.Drawing.Point(12, 12);
+            this.kbtnShowDialogAsync.Name = "kbtnShowDialogAsync";
+            this.kbtnShowDialogAsync.Size = new System.Drawing.Size(390, 30);
+            this.kbtnShowDialogAsync.TabIndex = 0;
+            this.kbtnShowDialogAsync.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnShowDialogAsync.Values.Text = "KryptonForm.ShowDialogAsync";
+            this.kbtnShowDialogAsync.Click += new System.EventHandler(this.kbtnShowDialogAsync_Click);
+            // 
+            // AsyncFormMethodsTest
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(420, 160);
+            this.Controls.Add(this.kryptonPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "AsyncFormMethodsTest";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Async Form Methods (#4177)";
+            this.Controls.SetChildIndex(this.kryptonPanel1, 0);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+            this.kryptonPanel1.ResumeLayout(false);
+            this.kryptonPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Krypton.Toolkit.KryptonPanel kryptonPanel1;
+        private Krypton.Toolkit.KryptonButton kbtnShowDialogAsync;
+        private Krypton.Toolkit.KryptonButton kbtnMessageBoxShowAsync;
+        private Krypton.Toolkit.KryptonButton kbtnTaskDialogShowDialogAsync;
+        private Krypton.Toolkit.KryptonLabel klblResult;
+    }
+}

--- a/Source/Krypton Components/TestForm/AsyncFormMethodsTest.cs
+++ b/Source/Krypton Components/TestForm/AsyncFormMethodsTest.cs
@@ -1,0 +1,87 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+public partial class AsyncFormMethodsTest : KryptonForm
+{
+    public AsyncFormMethodsTest()
+    {
+        InitializeComponent();
+#if !NET9_0_OR_GREATER
+        kbtnShowDialogAsync.Enabled = false;
+        kbtnMessageBoxShowAsync.Enabled = false;
+        kbtnTaskDialogShowDialogAsync.Enabled = false;
+        klblResult.Text = "Async form APIs require net9.0-windows or newer.";
+#endif
+    }
+
+#if NET9_0_OR_GREATER
+    private async void kbtnShowDialogAsync_Click(object sender, EventArgs e)
+    {
+        using var dialog = new KryptonForm
+        {
+            Text = "ShowDialogAsync",
+            StartPosition = FormStartPosition.CenterParent,
+            ClientSize = new Size(320, 120),
+            FormBorderStyle = FormBorderStyle.FixedDialog,
+            MaximizeBox = false,
+            MinimizeBox = false,
+            ShowInTaskbar = false
+        };
+
+        var ok = new KryptonButton
+        {
+            DialogResult = DialogResult.OK,
+            Location = new Point(120, 40),
+            Size = new Size(80, 30)
+        };
+        ok.Values.Text = "OK";
+        dialog.Controls.Add(ok);
+        dialog.AcceptButton = ok;
+
+        var result = await dialog.ShowDialogAsync(this).ConfigureAwait(true);
+        klblResult.Text = $"KryptonForm.ShowDialogAsync => {result}";
+    }
+
+    private async void kbtnMessageBoxShowAsync_Click(object sender, EventArgs e)
+    {
+        var result = await KryptonMessageBox.ShowAsync(this, "Async message box test.", "ShowAsync",
+            KryptonMessageBoxButtons.OKCancel, KryptonMessageBoxIcon.Information).ConfigureAwait(true);
+        klblResult.Text = $"KryptonMessageBox.ShowAsync => {result}";
+    }
+
+    private async void kbtnTaskDialogShowDialogAsync_Click(object sender, EventArgs e)
+    {
+        using var taskDialog = new KryptonTaskDialog();
+        taskDialog.Heading.Text = "Async Task Dialog";
+        taskDialog.Content.Text = "Shown via ShowDialogAsync.";
+        taskDialog.FooterBar.CommonButtons.Buttons =
+            KryptonTaskDialogCommonButtonTypes.OK | KryptonTaskDialogCommonButtonTypes.Cancel;
+        taskDialog.FooterBar.CommonButtons.AcceptButton = KryptonTaskDialogCommonButtonTypes.OK;
+        taskDialog.FooterBar.CommonButtons.CancelButton = KryptonTaskDialogCommonButtonTypes.Cancel;
+        taskDialog.FooterBar.Visible = true;
+
+        var result = await taskDialog.ShowDialogAsync(this).ConfigureAwait(true);
+        klblResult.Text = $"KryptonTaskDialog.ShowDialogAsync => {result}";
+    }
+#else
+    private void kbtnShowDialogAsync_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void kbtnMessageBoxShowAsync_Click(object sender, EventArgs e)
+    {
+    }
+
+    private void kbtnTaskDialogShowDialogAsync_Click(object sender, EventArgs e)
+    {
+    }
+#endif
+}

--- a/Source/Krypton Components/TestForm/AsyncFormMethodsTest.cs
+++ b/Source/Krypton Components/TestForm/AsyncFormMethodsTest.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -14,15 +14,8 @@ public partial class AsyncFormMethodsTest : KryptonForm
     public AsyncFormMethodsTest()
     {
         InitializeComponent();
-#if !NET9_0_OR_GREATER
-        kbtnShowDialogAsync.Enabled = false;
-        kbtnMessageBoxShowAsync.Enabled = false;
-        kbtnTaskDialogShowDialogAsync.Enabled = false;
-        klblResult.Text = "Async form APIs require net9.0-windows or newer.";
-#endif
     }
 
-#if NET9_0_OR_GREATER
     private async void kbtnShowDialogAsync_Click(object sender, EventArgs e)
     {
         using var dialog = new KryptonForm
@@ -71,17 +64,4 @@ public partial class AsyncFormMethodsTest : KryptonForm
         var result = await taskDialog.ShowDialogAsync(this).ConfigureAwait(true);
         klblResult.Text = $"KryptonTaskDialog.ShowDialogAsync => {result}";
     }
-#else
-    private void kbtnShowDialogAsync_Click(object sender, EventArgs e)
-    {
-    }
-
-    private void kbtnMessageBoxShowAsync_Click(object sender, EventArgs e)
-    {
-    }
-
-    private void kbtnTaskDialogShowDialogAsync_Click(object sender, EventArgs e)
-    {
-    }
-#endif
 }

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -57,6 +57,7 @@ public partial class StartScreen : KryptonForm
     {
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
+        CreateButton<AsyncFormMethodsTest>("Async Form Methods", "Smoke test for Form.ShowDialogAsync, KryptonMessageBox.ShowAsync, and KryptonTaskDialog.ShowDialogAsync (Issue #4177, net9+/net10+).");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu with more items than fit on screen shows Scroll Up/Scroll Down rows, mouse-wheel scrolling, and keyboard navigation past visible items. Long list, mixed content, programmatic placement, and keyboard-open scenarios.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -57,7 +57,7 @@ public partial class StartScreen : KryptonForm
     {
         CreateButton<AboutBoxTest>("AboutBox", "Try this About Box for a change");
         CreateButton<AccessibilityTest>("Accessibility Test (UIA Providers)", "Comprehensive demo and test for UIA Provider implementation (Issue #762). Tests all 10 controls with accessibility support, organized by category with detailed results.");
-        CreateButton<AsyncFormMethodsTest>("Async Form Methods", "Smoke test for Form.ShowDialogAsync, KryptonMessageBox.ShowAsync, and KryptonTaskDialog.ShowDialogAsync (Issue #4177, net9+/net10+).");
+        CreateButton<AsyncFormMethodsTest>("Async Form Methods", "Smoke test for Form.ShowDialogAsync, KryptonMessageBox.ShowAsync, and KryptonTaskDialog.ShowDialogAsync (Issue #4177; all TFMs, with pre-.NET 9 degrade).");
         CreateButton<ButtonsTest>("Buttons Test", "All the buttons you want to test.");
         CreateButton<Bug3661KryptonContextMenuOverflowDemo>("Bug 3661 Context Menu Overflow", "Issue #3661: KryptonContextMenu with more items than fit on screen shows Scroll Up/Scroll Down rows, mouse-wheel scrolling, and keyboard navigation past visible items. Long list, mixed content, programmatic placement, and keyboard-open scenarios.");
         CreateButton<Bug3381KryptonButtonRoundedTextCenteringDemo>("Bug 3381 KryptonButton Rounded Text Centering", "Demo for issue #3381: vertical and horizontal text centering inside heavily rounded KryptonButton (wide pill, Cyrillic, font metrics). Includes side-by-side stress, tall narrow capsule, low-rounding baseline, and live rounding / TextV / font / height controls.");

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -13,6 +13,7 @@
     <ApplicationUseCompatibleTextRendering>false</ApplicationUseCompatibleTextRendering>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
+    <NoWarn>$(NoWarn);WFO5002</NoWarn>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
This change adds .NET 9+ async dialog support for KryptonMessageBox.ShowAsync and KryptonTaskDialog.ShowDialogAsync, matching the existing KryptonForm async APIs. It also adds the net9+ warning suppression needed for the WinForms async API analyzers and wires a new Async Form Methods smoke scenario into TestForm and the start screen.