### PR TITLE
* Disable ThemeProviderSample in TestForm

### DIFF
--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\Krypton.Toolkit.JumpList\Krypton.Toolkit.JumpList.csproj" />
     <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
     <ProjectReference Include="..\Krypton.Themes\Krypton.Themes.csproj" />
-    <ProjectReference Include="..\..\TestHarnesses\ThemeProviderSample\ThemeProviderSample.csproj" />
+    <!--<ProjectReference Include="..\..\TestHarnesses\ThemeProviderSample\ThemeProviderSample.csproj" />-->
     <ProjectReference Include="..\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj" />
     <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Temporarily removes the ThemeProviderSample project reference from the TestForm project. This keeps the sample app build focused on the core toolkit assemblies and avoids coupling the validation app to the external theme provider harness.