### PR TITLE
* Add grouped global pulsing borders

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -46,7 +46,8 @@
 ## 2026-11-xx - Build 2611 (V110 Nightly) - November 2026
 
 * Implemented [#4248](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4248), Is it possible to add `PulsingBorderValues` in `KryptonManager`
-   * Global `KryptonManager.PulsingBorderValues` so pulsing borders can be enabled and styled application-wide; per-control `PulsingBorderValues` inherit until you set a local override.
+   * Global `KryptonManager.PulsingBorderValues` is grouped by control type (`Forms`, `Buttons`, `Inputs`, `Other`). Per-control `PulsingBorderValues` inherit until you set a local override.
+   * Buttons (`KryptonButton`, `KryptonDropButton`, `KryptonColorButton`) default to a full rounded glow; inputs default to a bottom-edge glow so combo drop-down glyphs are not redrawn every frame.
 * Implemented [#1110](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1110), Where is the Krypton equivalent of a Form `MenuStrip`
    * `KryptonMenuStrip` is in the Toolbox and MenuStrip/ToolStrip/StatusStrip fonts follow the palette and `BaseFont` (`KryptonMenuStrip` first shipped in #2689).
 * Implemented [#3854](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3854), Removed unused duplicate utility types

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -26,12 +26,6 @@ namespace Krypton.Toolkit;
 [Designer(typeof(KryptonButtonDesigner))]
 public class KryptonButton : KryptonDropButton
 {
-    #region Instance Fields
-
-    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
-
-    #endregion
-
     #region Identity
     /// <summary>
     /// Initialize a new instance of the KryptonButton class.
@@ -44,29 +38,10 @@ public class KryptonButton : KryptonDropButton
 
         // Create a button controller to handle button style behaviour
         _buttonController.BecomesFixed = false;
-
-        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
-            NeedPaintDelegate,
-            () => IsButtonActive,
-            GetTripleState,
-            ViewDrawButton,
-            () => ViewDrawButton.State);
-
-        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
     }
     #endregion
 
     #region Public
-    /// <summary>
-    /// Gets access to the optional pulsing border values.
-    /// </summary>
-    [Category(@"Visuals")]
-    [Description(@"Optional pulsing border drawn around the button.")]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
-
-    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
-
     /// <summary>
     /// Gets and sets the visual orientation of the control
     /// </summary>
@@ -110,57 +85,5 @@ public class KryptonButton : KryptonDropButton
         get => base.Splitter;
         set => base.Splitter = value;
     }
-
-    /// <summary>
-    /// Request the control repaint itself and children.
-    /// </summary>
-    /// <param name="needLayout">Does the palette change require a layout.</param>
-    public override void PerformNeedPaint(bool needLayout)
-    {
-        _pulsingBorder.UpdateAnimationState();
-        base.PerformNeedPaint(needLayout);
-    }
-    #endregion
-
-    #region Protected Overrides
-    /// <summary>
-    /// Release managed and unmanaged resources.
-    /// </summary>
-    /// <param name="disposing">true to release both managed and unmanaged resources.</param>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _pulsingBorder.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-    #endregion
-
-    #region Implementation
-
-    private bool IsButtonActive
-    {
-        get
-        {
-            if (DesignMode || ContainsFocus)
-            {
-                return true;
-            }
-
-            return ViewDrawButton.State switch
-            {
-                PaletteState.Tracking => true,
-                PaletteState.Pressed => true,
-                PaletteState.CheckedTracking => true,
-                PaletteState.CheckedPressed => true,
-                _ => false
-            };
-        }
-    }
-
-    private IPaletteTriple GetTripleState() => Enabled ? ViewDrawButton.CurrentPalette : StateDisabled;
-
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckBox.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -44,6 +44,7 @@ public class KryptonCheckBox : VisualSimpleBase, IContentValues
     private bool _checked;
     private bool _threeState;
     private bool _useMnemonic;
+    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
     #endregion
 
     #region Events
@@ -168,7 +169,14 @@ public class KryptonCheckBox : VisualSimpleBase, IContentValues
         UpdateForOrientation();
 
         // Create the view manager instance
-        ViewManager = new ViewManager(this, _layoutDocker);
+        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
+            NeedPaintDelegate,
+            () => ContainsFocus || _drawCheckBox.Tracking,
+            () => null,
+            _layoutDocker,
+            () => Enabled ? PaletteState.Normal : PaletteState.Disabled,
+            InputPulsingBorderCategory.Other);
+        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
 
         // We want to be auto sized by default, but not the property default!
         AutoSize = true;
@@ -177,6 +185,26 @@ public class KryptonCheckBox : VisualSimpleBase, IContentValues
     #endregion
 
     #region Public
+    /// <summary>
+    /// Gets access to the optional pulsing border values.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Optional pulsing border drawn around the check box.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
+
+    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
+
+    /// <summary>
+    /// Request the control repaint itself and children.
+    /// </summary>
+    /// <param name="needLayout">Does the palette change require a layout.</param>
+    public override void PerformNeedPaint(bool needLayout)
+    {
+        _pulsingBorder.UpdateAnimationState();
+        base.PerformNeedPaint(needLayout);
+    }
+
     /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
@@ -845,6 +873,20 @@ public class KryptonCheckBox : VisualSimpleBase, IContentValues
         // Orientation and right to left are interconnected
         UpdateForOrientation();
         base.OnRightToLeftChanged(e);
+    }
+
+    /// <summary>
+    /// Release managed and unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pulsingBorder.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -48,6 +48,7 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
     private bool _isSelectable;
     private KryptonColorButtonCustomColorPreviewShape _customColorPreviewShape;
     private ThemeColorSortMode _themeColorSortMode;
+    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
 
     // Context menu items
     private readonly KryptonContextMenu? _kryptonContextMenu;
@@ -225,7 +226,14 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
         _buttonController.MouseSelect += OnButtonSelect;
 
         // Create the view manager instance
-        ViewManager = new ViewManager(this, _drawButton);
+        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
+            NeedPaintDelegate,
+            () => IsColorButtonActive,
+            GetColorButtonTripleState,
+            _drawButton,
+            () => _drawButton.State,
+            InputPulsingBorderCategory.Buttons);
+        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
 
         CustomColorPreviewShape = KryptonColorButtonCustomColorPreviewShape.None;
 
@@ -238,6 +246,26 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
     #endregion
 
     #region Public
+    /// <summary>
+    /// Gets access to the optional pulsing border values.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Optional pulsing border drawn around the color button.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
+
+    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
+
+    /// <summary>
+    /// Request the control repaint itself and children.
+    /// </summary>
+    /// <param name="needLayout">Does the palette change require a layout.</param>
+    public override void PerformNeedPaint(bool needLayout)
+    {
+        _pulsingBorder.UpdateAnimationState();
+        base.PerformNeedPaint(needLayout);
+    }
+
     /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
@@ -1036,6 +1064,7 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
             KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChangedForThemeColors;
             _kryptonContextMenu?.Close();
             _kryptonContextMenu?.Dispose();
+            _pulsingBorder.Dispose();
         }
 
         base.Dispose(disposing);
@@ -1290,6 +1319,28 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
     #endregion
 
     #region Implementation
+    private bool IsColorButtonActive
+    {
+        get
+        {
+            if (DesignMode || ContainsFocus)
+            {
+                return true;
+            }
+
+            return ViewDrawButton.State switch
+            {
+                PaletteState.Tracking => true,
+                PaletteState.Pressed => true,
+                PaletteState.CheckedTracking => true,
+                PaletteState.CheckedPressed => true,
+                _ => false
+            };
+        }
+    }
+
+    private IPaletteTriple GetColorButtonTripleState() => Enabled ? ViewDrawButton.CurrentPalette : StateDisabled;
+
     private void OnButtonTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -38,6 +38,7 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
     private bool _useMnemonic;
     private bool _wasEnabled;
     private bool _isSelectable;
+    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
 
     #endregion
 
@@ -129,7 +130,14 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
         _buttonController.MouseSelect += OnButtonSelect;
 
         // Create the view manager instance
-        ViewManager = new ViewManager(this, _drawButton);
+        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
+            NeedPaintDelegate,
+            () => IsButtonActive,
+            GetTripleState,
+            _drawButton,
+            () => _drawButton.State,
+            InputPulsingBorderCategory.Buttons);
+        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
 
         // Set up badge values on the button
         _drawButton.SetBadgeValues(BadgeValues, this);
@@ -137,6 +145,27 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
     #endregion
 
     #region Public
+
+    /// <summary>
+    /// Gets access to the optional pulsing border values.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Optional pulsing border drawn around the button.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
+
+    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
+
+    /// <summary>
+    /// Request the control repaint itself and children.
+    /// </summary>
+    /// <param name="needLayout">Does the palette change require a layout.</param>
+    public override void PerformNeedPaint(bool needLayout)
+    {
+        _pulsingBorder.UpdateAnimationState();
+        base.PerformNeedPaint(needLayout);
+    }
+
     /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
@@ -652,6 +681,20 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
     protected override AccessibleObject CreateAccessibilityInstance() => new KryptonDropButtonAccessibleObject(this);
 
     /// <summary>
+    /// Release managed and unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pulsingBorder.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
     /// Raises the EnabledChanged event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>
@@ -878,6 +921,28 @@ public class KryptonDropButton : VisualSimpleBase, IButtonControl, IContentValue
     #endregion
 
     #region Implementation
+
+    private bool IsButtonActive
+    {
+        get
+        {
+            if (DesignMode || ContainsFocus)
+            {
+                return true;
+            }
+
+            return ViewDrawButton.State switch
+            {
+                PaletteState.Tracking => true,
+                PaletteState.Pressed => true,
+                PaletteState.CheckedTracking => true,
+                PaletteState.CheckedPressed => true,
+                _ => false
+            };
+        }
+    }
+
+    private IPaletteTriple GetTripleState() => Enabled ? ViewDrawButton.CurrentPalette : StateDisabled;
 
     private static bool IsDialogResultValidForForm(DialogResult value)
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -361,7 +361,7 @@ public class KryptonForm : VisualForm,
 		};
 
 		_formPaletteTriple = new PaletteDoubleTripleAdapter(GetFormPaletteState);
-		_pulsingBorder = new InputPulsingBorderViewIntegration(this, NeedPaintDelegate, () => WindowActive, () => _formPaletteTriple, _drawDocker, () => _drawDocker.State);
+		_pulsingBorder = new InputPulsingBorderViewIntegration(this, NeedPaintDelegate, () => WindowActive, () => _formPaletteTriple, _drawDocker, () => _drawDocker.State, InputPulsingBorderCategory.Forms);
 
 		// Create button specification collection manager
 		_buttonManager = new ButtonSpecManagerDraw(this, Redirector, ButtonSpecs, _buttonSpecsFixed,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -34,6 +34,7 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
     private bool _useMnemonic;
     private bool _wasEnabled;
     private Control? _target;
+    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
     #endregion
 
     #region Events
@@ -82,7 +83,14 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
         };
 
         // Create the view manager instance
-        ViewManager = new ViewManager(this, _drawContent);
+        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
+            NeedPaintDelegate,
+            () => ContainsFocus,
+            () => null,
+            _drawContent,
+            () => Enabled ? PaletteState.Normal : PaletteState.Disabled,
+            InputPulsingBorderCategory.Other);
+        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
 
         // We want to be auto sized by default, but not the property default!
         AutoSize = true;
@@ -91,6 +99,26 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
     #endregion
 
     #region Public
+    /// <summary>
+    /// Gets access to the optional pulsing border values.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Optional pulsing border drawn around the label.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
+
+    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
+
+    /// <summary>
+    /// Request the control repaint itself and children.
+    /// </summary>
+    /// <param name="needLayout">Does the palette change require a layout.</param>
+    public override void PerformNeedPaint(bool needLayout)
+    {
+        _pulsingBorder.UpdateAnimationState();
+        base.PerformNeedPaint(needLayout);
+    }
+
     /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
@@ -522,6 +550,20 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
 
         // Let base class fire standard event
         base.OnEnabledChanged(e);
+    }
+
+    /// <summary>
+    /// Release managed and unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pulsingBorder.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -554,10 +554,10 @@ public sealed class KryptonManager : Component
     /// <see cref="KryptonForm"/> until they set a local override.
     /// </summary>
     [Category(@"Visuals")]
-    [Description(@"Default pulsing border settings applied globally. Unset properties on individual controls inherit these values.")]
+    [Description(@"Default pulsing border settings by control type (Forms, Buttons, Inputs, Other). Unset properties on individual controls inherit these values.")]
     [MergableProperty(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-    public InputPulsingBorderValues GlobalPulsingBorderValues => PulsingBorderValues;
+    public KryptonGlobalPulsingBorderValues GlobalPulsingBorderValues => PulsingBorderValues;
     private bool ShouldSerializeGlobalPulsingBorderValues() => !PulsingBorderValues.IsDefault;
     private void ResetGlobalPulsingBorderValues() => PulsingBorderValues.Reset();
 
@@ -943,16 +943,16 @@ public sealed class KryptonManager : Component
     public static TouchscreenSettingValues TouchscreenSettingValues { get; } = new TouchscreenSettingValues();
 
     /// <summary>
-    /// Gets the default pulsing border settings inherited by Krypton input controls and
-    /// <see cref="KryptonForm"/> until they set a local override.
+    /// Gets the default pulsing border settings grouped by control type.
     /// </summary>
     /// <remarks>
-    /// Set <c>KryptonManager.PulsingBorderValues.Enable = true</c> at startup to turn on pulsing
-    /// borders application-wide. Individual controls can still override any property, or call
+    /// Set <c>KryptonManager.PulsingBorderValues.Inputs.Enable = true</c> (or
+    /// <c>Buttons</c> / <c>Forms</c> / <c>Other</c>) at startup to turn on pulsing
+    /// borders for that group. Individual controls can still override any property, or call
     /// <see cref="InputPulsingBorderValues.Reset"/> to inherit again.
     /// </remarks>
-    public static InputPulsingBorderValues PulsingBorderValues { get; } =
-        new InputPulsingBorderValues(OnGlobalPulsingBorderNeedPaint, inheritFromGlobal: false);
+    public static KryptonGlobalPulsingBorderValues PulsingBorderValues { get; } =
+        new KryptonGlobalPulsingBorderValues(OnGlobalPulsingBorderNeedPaint);
 
     /// <summary>
     /// Gets the palette-specific values that can be used to override certain global settings for specific palettes.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -40,6 +40,7 @@ public class KryptonRadioButton : VisualSimpleBase
     private bool _checked;
     private bool _useMnemonic;
     private bool _autoCheck;
+    private readonly InputPulsingBorderViewIntegration _pulsingBorder;
     #endregion
 
     #region Events
@@ -148,7 +149,14 @@ public class KryptonRadioButton : VisualSimpleBase
         UpdateForOrientation();
 
         // Create the view manager instance
-        ViewManager = new ViewManager(this, _layoutDocker);
+        _pulsingBorder = new InputPulsingBorderViewIntegration(this,
+            NeedPaintDelegate,
+            () => ContainsFocus || _drawRadioButton.Tracking,
+            () => null,
+            _layoutDocker,
+            () => Enabled ? PaletteState.Normal : PaletteState.Disabled,
+            InputPulsingBorderCategory.Other);
+        ViewManager = new ViewManager(this, _pulsingBorder.ViewRoot);
 
         // We want to be auto sized by default, but not the property default!
         AutoSize = true;
@@ -157,6 +165,26 @@ public class KryptonRadioButton : VisualSimpleBase
     #endregion
 
     #region Public
+    /// <summary>
+    /// Gets access to the optional pulsing border values.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Optional pulsing border drawn around the radio button.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues PulsingBorderValues => _pulsingBorder.Values;
+
+    private bool ShouldSerializePulsingBorderValues() => !PulsingBorderValues.IsDefault;
+
+    /// <summary>
+    /// Request the control repaint itself and children.
+    /// </summary>
+    /// <param name="needLayout">Does the palette change require a layout.</param>
+    public override void PerformNeedPaint(bool needLayout)
+    {
+        _pulsingBorder.UpdateAnimationState();
+        base.PerformNeedPaint(needLayout);
+    }
+
     /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
@@ -633,6 +661,20 @@ public class KryptonRadioButton : VisualSimpleBase
         // Orientation and right to left are interconnected
         UpdateForOrientation();
         base.OnRightToLeftChanged(e);
+    }
+
+    /// <summary>
+    /// Release managed and unmanaged resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pulsingBorder.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -1781,6 +1781,34 @@ public enum InputPulsingBorderStyle
 }
 #endregion
 
+#region Enum InputPulsingBorderCategory
+/// <summary>
+/// Identifies which <see cref="KryptonManager.PulsingBorderValues"/> group a control inherits from.
+/// </summary>
+public enum InputPulsingBorderCategory
+{
+    /// <summary>
+    /// Text and selection inputs: TextBox, ComboBox, NumericUpDown, DateTimePicker, and similar.
+    /// </summary>
+    Inputs,
+
+    /// <summary>
+    /// Button-style controls: Button, DropButton, ColorButton, and similar.
+    /// </summary>
+    Buttons,
+
+    /// <summary>
+    /// Form chrome (<see cref="KryptonForm"/>).
+    /// </summary>
+    Forms,
+
+    /// <summary>
+    /// Other simple controls: CheckBox, RadioButton, Label, and similar.
+    /// </summary>
+    Other
+}
+#endregion
+
 #region Enum SeparatorStyle
 /// <summary>
 /// Specifies the separator style.

--- a/Source/Krypton Components/Krypton.Toolkit/General/IInputPulsingBorderProvider.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/IInputPulsingBorderProvider.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -32,7 +32,7 @@ internal interface IInputPulsingBorderProvider
     /// <summary>
     /// Gets the palette triple state used to resolve border rounding.
     /// </summary>
-    IPaletteTriple GetGlowingBorderTripleState();
+    IPaletteTriple? GetGlowingBorderTripleState();
 
     /// <summary>
     /// Gets the palette state used to resolve border rounding.

--- a/Source/Krypton Components/Krypton.Toolkit/General/InputPulsingBorderHost.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/InputPulsingBorderHost.cs
@@ -10,7 +10,7 @@
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// Hosts pulsing border values and animation for an input control.
+/// Hosts pulsing border values and animation for a control.
 /// </summary>
 internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDisposable
 {
@@ -19,7 +19,7 @@ internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDis
     private readonly Control _control;
     private readonly NeedPaintHandler _needPaint;
     private readonly Func<bool> _isActive;
-    private readonly Func<IPaletteTriple> _getTripleState;
+    private readonly Func<IPaletteTriple?> _getTripleState;
     private readonly Func<PaletteState> _getBorderState;
     private readonly InputPulsingBorderController _controller;
 
@@ -35,11 +35,13 @@ internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDis
     /// <param name="isActive">Delegate that returns whether the control is active.</param>
     /// <param name="getTripleState">Delegate that returns the current palette triple state.</param>
     /// <param name="getBorderState">Delegate that returns the current border palette state.</param>
+    /// <param name="category">Manager group this control inherits from.</param>
     public InputPulsingBorderHost(Control control,
         NeedPaintHandler needPaint,
         Func<bool> isActive,
-        Func<IPaletteTriple> getTripleState,
-        Func<PaletteState> getBorderState)
+        Func<IPaletteTriple?> getTripleState,
+        Func<PaletteState> getBorderState,
+        InputPulsingBorderCategory category)
     {
         _control = control;
         _needPaint = needPaint;
@@ -53,8 +55,8 @@ internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDis
             UpdateAnimationState();
         };
 
-        Values = new InputPulsingBorderValues(needPaintHandler);
-        _controller = new InputPulsingBorderController(Values, needPaint, () => ShouldDrawGlowingBorder());
+        Values = new InputPulsingBorderValues(needPaintHandler, category);
+        _controller = new InputPulsingBorderController(Values, OnAnimationNeedPaint, () => ShouldDrawGlowingBorder());
         KryptonManager.GlobalPulsingBorderChanged += OnGlobalPulsingBorderChanged;
         UpdateAnimationState();
     }
@@ -74,7 +76,7 @@ internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDis
         Values.Enable && _control.Enabled && ShouldShowGlowingBorder();
 
     /// <inheritdoc />
-    public IPaletteTriple GetGlowingBorderTripleState() => _getTripleState();
+    public IPaletteTriple? GetGlowingBorderTripleState() => _getTripleState();
 
     /// <inheritdoc />
     public PaletteState GetGlowingBorderState() => _getBorderState();
@@ -100,6 +102,17 @@ internal sealed class InputPulsingBorderHost : IInputPulsingBorderProvider, IDis
     #endregion
 
     #region Implementation
+
+    private void OnAnimationNeedPaint(object? sender, NeedLayoutEventArgs e)
+    {
+        if (_control.IsDisposed || !_control.IsHandleCreated)
+        {
+            return;
+        }
+
+        // Do not invalidate child HWNDs (combo drop glyph, up-down buttons, etc.).
+        _control.Invalidate(false);
+    }
 
     private void OnGlobalPulsingBorderChanged(object? sender, EventArgs e)
     {

--- a/Source/Krypton Components/Krypton.Toolkit/General/InputPulsingBorderViewIntegration.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/InputPulsingBorderViewIntegration.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -26,37 +26,28 @@ internal sealed class InputPulsingBorderViewIntegration : IDisposable
     /// <summary>
     /// Initialize a new instance of the InputPulsingBorderViewIntegration class for an input control border view.
     /// </summary>
-    /// <param name="control">Owning control.</param>
-    /// <param name="needPaint">Delegate for notifying paint requests.</param>
-    /// <param name="isActive">Delegate that returns whether the control is active for ShowWhen.Active.</param>
-    /// <param name="getTripleState">Delegate that returns the current palette triple state.</param>
-    /// <param name="borderView">Border view to decorate.</param>
     public InputPulsingBorderViewIntegration(Control control,
         NeedPaintHandler needPaint,
         Func<bool> isActive,
-        Func<IPaletteTriple> getTripleState,
-        ViewDrawDocker borderView)
-        : this(control, needPaint, isActive, getTripleState, borderView, () => borderView.State)
+        Func<IPaletteTriple?> getTripleState,
+        ViewDrawDocker borderView,
+        InputPulsingBorderCategory category = InputPulsingBorderCategory.Inputs)
+        : this(control, needPaint, isActive, getTripleState, borderView, () => borderView.State, category)
     {
     }
 
     /// <summary>
     /// Initialize a new instance of the InputPulsingBorderViewIntegration class.
     /// </summary>
-    /// <param name="control">Owning control.</param>
-    /// <param name="needPaint">Delegate for notifying paint requests.</param>
-    /// <param name="isActive">Delegate that returns whether the control is active for ShowWhen.Active.</param>
-    /// <param name="getTripleState">Delegate that returns the current palette triple state.</param>
-    /// <param name="borderView">Border view to decorate.</param>
-    /// <param name="getBorderState">Delegate that returns the current border palette state.</param>
     public InputPulsingBorderViewIntegration(Control control,
         NeedPaintHandler needPaint,
         Func<bool> isActive,
-        Func<IPaletteTriple> getTripleState,
+        Func<IPaletteTriple?> getTripleState,
         ViewBase borderView,
-        Func<PaletteState> getBorderState)
+        Func<PaletteState> getBorderState,
+        InputPulsingBorderCategory category = InputPulsingBorderCategory.Inputs)
     {
-        _host = new InputPulsingBorderHost(control, needPaint, isActive, getTripleState, getBorderState);
+        _host = new InputPulsingBorderHost(control, needPaint, isActive, getTripleState, getBorderState, category);
         _viewRoot = new ViewDecoratorInputGlow(_host, borderView);
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/InputPulsingBorderRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/InputPulsingBorderRenderer.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -22,7 +22,7 @@ internal static class InputPulsingBorderRenderer
     /// </summary>
     public static void Draw(RenderContext context,
         Rectangle bounds,
-        IPaletteBorder paletteBorder,
+        IPaletteBorder? paletteBorder,
         PaletteState state,
         float animationPhase,
         bool animate,
@@ -41,47 +41,81 @@ internal static class InputPulsingBorderRenderer
             return;
         }
 
-        using GraphicsPath path = GetGlowBorderPath(context, bounds, paletteBorder, state, style);
+        using GraphicsPath path = GetGlowBorderPath(context, bounds, paletteBorder, state);
         if (path.PointCount == 0)
         {
             return;
         }
 
-        using var antiAlias = new AntiAlias(context.Graphics);
-
+        GraphicsState? clipState = null;
         if (style == InputPulsingBorderStyle.Bottom)
         {
-            DrawBottomHalo(context.Graphics, path, animate, highlightColor);
+            float rounding = paletteBorder?.GetBorderRounding(state) ?? 0f;
+            int clipHeight = Math.Max(GlowHeight + 6, (int)Math.Ceiling(rounding) + GlowHeight);
+            clipHeight = Math.Min(clipHeight, bounds.Height);
+            clipState = context.Graphics.Save();
+            var clip = new Rectangle(bounds.X, bounds.Bottom - clipHeight, bounds.Width, clipHeight);
+            context.Graphics.SetClip(clip, CombineMode.Intersect);
         }
 
-        DrawPathGlow(context.Graphics, bounds, path, animationPhase, animate, edgeColor1, edgeColor2, highlightColor);
+        try
+        {
+            using var antiAlias = new AntiAlias(context.Graphics);
+
+            if (style == InputPulsingBorderStyle.Bottom)
+            {
+                DrawBottomHalo(context.Graphics, path, animate, highlightColor);
+            }
+
+            DrawPathGlow(context.Graphics, bounds, path, animationPhase, animate, edgeColor1, edgeColor2, highlightColor);
+        }
+        finally
+        {
+            if (clipState != null)
+            {
+                context.Graphics.Restore(clipState);
+            }
+        }
     }
 
     private static GraphicsPath GetGlowBorderPath(RenderContext context,
         Rectangle bounds,
-        IPaletteBorder paletteBorder,
-        PaletteState state,
-        InputPulsingBorderStyle style)
+        IPaletteBorder? paletteBorder,
+        PaletteState state)
     {
-        var forcedPalette = new PaletteBorderInheritForced(paletteBorder);
+        if (paletteBorder == null)
+        {
+            return CreateRoundedRectPath(bounds, 0f);
+        }
 
-        if (style == InputPulsingBorderStyle.All)
-        {
-            forcedPalette.ForceBorderEdges(PaletteDrawBorders.All);
-        }
-        else
-        {
-            float rounding = paletteBorder.GetBorderRounding(state);
-            forcedPalette.ForceBorderEdges(rounding > 0.1f
-                ? PaletteDrawBorders.BottomLeftRight
-                : PaletteDrawBorders.Bottom);
-        }
+        var forcedPalette = new PaletteBorderInheritForced(paletteBorder);
+        forcedPalette.ForceBorderEdges(PaletteDrawBorders.All);
 
         return context.Renderer!.RenderStandardBorder.GetBorderPath(context,
             bounds,
             forcedPalette,
             VisualOrientation.Top,
             state);
+    }
+
+    private static GraphicsPath CreateRoundedRectPath(Rectangle bounds, float rounding)
+    {
+        var path = new GraphicsPath();
+        if (rounding <= 0.1f)
+        {
+            path.AddRectangle(bounds);
+            return path;
+        }
+
+        float radius = Math.Min(rounding, Math.Min(bounds.Width, bounds.Height) / 2f);
+        float diameter = radius * 2f;
+        var rect = new RectangleF(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+        path.AddArc(rect.X, rect.Y, diameter, diameter, 180f, 90f);
+        path.AddArc(rect.Right - diameter, rect.Y, diameter, diameter, 270f, 90f);
+        path.AddArc(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter, 0f, 90f);
+        path.AddArc(rect.X, rect.Bottom - diameter, diameter, diameter, 90f, 90f);
+        path.CloseFigure();
+        return path;
     }
 
     private static void DrawBottomHalo(Graphics g,

--- a/Source/Krypton Components/Krypton.Toolkit/Values/InputPulsingBorderColorValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/InputPulsingBorderColorValues.cs
@@ -13,10 +13,10 @@ namespace Krypton.Toolkit;
 /// Storage for input control pulsing border colors.
 /// </summary>
 /// <remarks>
-/// Control-owned instances inherit unset colors from
-/// <see cref="KryptonManager.PulsingBorderValues"/>.Colors. Assigning a color stores a local
-/// override; <c>Reset*</c> (and <see cref="Reset"/>) clears the override so the global value is
-/// used again. The manager instance does not inherit.
+/// Control-owned instances inherit unset colors from the matching
+/// <see cref="KryptonManager.PulsingBorderValues"/> group. Assigning a color stores a local
+/// override; <c>Reset*</c> (and <see cref="Reset"/>) clears the override so the group value is
+/// used again. Manager group instances do not inherit.
 /// </remarks>
 [TypeConverter(typeof(InputPulsingBorderColorValuesConverter))]
 public class InputPulsingBorderColorValues : Storage
@@ -31,7 +31,7 @@ public class InputPulsingBorderColorValues : Storage
 
     #region Instance Fields
 
-    private readonly bool _inheritFromGlobal;
+    private readonly InputPulsingBorderCategory? _inheritCategory;
     private Color? _color1;
     private Color? _color2;
     private Color? _highlightColor;
@@ -45,7 +45,7 @@ public class InputPulsingBorderColorValues : Storage
     /// </summary>
     /// <param name="needPaint">Delegate for notifying paint requests.</param>
     public InputPulsingBorderColorValues(NeedPaintHandler? needPaint)
-        : this(needPaint, inheritFromGlobal: true)
+        : this(needPaint, InputPulsingBorderCategory.Inputs)
     {
     }
 
@@ -53,17 +53,15 @@ public class InputPulsingBorderColorValues : Storage
     /// Initialize a new instance of the <see cref="InputPulsingBorderColorValues"/> class.
     /// </summary>
     /// <param name="needPaint">Delegate for notifying paint requests.</param>
-    /// <param name="inheritFromGlobal">
-    /// When <see langword="true"/>, unset colors read from
-    /// <see cref="KryptonManager.PulsingBorderValues"/>.Colors. Pass <see langword="false"/> for
-    /// the manager's own global instance.
+    /// <param name="inheritCategory">
+    /// Manager group to inherit from, or <see langword="null"/> for a manager group instance.
     /// </param>
-    internal InputPulsingBorderColorValues(NeedPaintHandler? needPaint, bool inheritFromGlobal)
+    internal InputPulsingBorderColorValues(NeedPaintHandler? needPaint, InputPulsingBorderCategory? inheritCategory)
     {
         NeedPaint = needPaint;
-        _inheritFromGlobal = inheritFromGlobal;
+        _inheritCategory = inheritCategory;
 
-        if (!inheritFromGlobal)
+        if (!inheritCategory.HasValue)
         {
             Reset();
         }
@@ -159,8 +157,9 @@ public class InputPulsingBorderColorValues : Storage
     #region Reset
 
     /// <summary>
-    /// Resets all colors. Control instances clear local overrides and inherit from
-    /// <see cref="KryptonManager.PulsingBorderValues"/> again; the global instance restores factory defaults.
+    /// Resets all colors. Control instances clear local overrides and inherit from the
+    /// matching <see cref="KryptonManager.PulsingBorderValues"/> group again; a manager group
+    /// instance restores factory defaults.
     /// </summary>
     public void Reset()
     {
@@ -173,9 +172,11 @@ public class InputPulsingBorderColorValues : Storage
 
     #region Implementation
 
+    private bool InheritFromGlobal => _inheritCategory.HasValue;
+
     private InputPulsingBorderColorValues? InheritSource =>
-        _inheritFromGlobal && !ReferenceEquals(this, KryptonManager.PulsingBorderValues.Colors)
-            ? KryptonManager.PulsingBorderValues.Colors
+        _inheritCategory.HasValue
+            ? KryptonManager.PulsingBorderValues.Get(_inheritCategory.Value).Colors
             : null;
 
     private Color GetInherited(Color? local, Func<InputPulsingBorderColorValues, Color> read, Color factory)
@@ -190,7 +191,7 @@ public class InputPulsingBorderColorValues : Storage
     }
 
     private bool ShouldSerializeLocal(Color? local, Color effective, Color factory) =>
-        _inheritFromGlobal ? local.HasValue : effective != factory;
+        InheritFromGlobal ? local.HasValue : effective != factory;
 
     private void SetLocal(ref Color? field, Color value)
     {
@@ -203,7 +204,7 @@ public class InputPulsingBorderColorValues : Storage
 
     private void ResetLocal(ref Color? field, Color factory)
     {
-        if (_inheritFromGlobal)
+        if (InheritFromGlobal)
         {
             if (field.HasValue)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/InputPulsingBorderValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/InputPulsingBorderValues.cs
@@ -10,13 +10,13 @@
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// Storage for optional input control pulsing border settings.
+/// Storage for optional pulsing border settings.
 /// </summary>
 /// <remarks>
-/// Control-owned instances inherit unset properties from
-/// <see cref="KryptonManager.PulsingBorderValues"/>. Assigning a property stores a local
-/// override; <c>Reset*</c> (and <see cref="Reset"/>) clears the override so the global value is
-/// used again. The manager instance does not inherit.
+/// Control-owned instances inherit unset properties from the matching
+/// <see cref="KryptonManager.PulsingBorderValues"/> group. Assigning a property stores a local
+/// override; <c>Reset*</c> (and <see cref="Reset"/>) clears the override so the group value is
+/// used again. Manager group instances do not inherit.
 /// </remarks>
 [TypeConverter(typeof(InputPulsingBorderValuesConverter))]
 public class InputPulsingBorderValues : Storage
@@ -26,14 +26,14 @@ public class InputPulsingBorderValues : Storage
     private const bool DefaultEnable = false;
     private const bool DefaultAnimate = true;
     private const float DefaultAnimationSpeed = 1f;
-    private const InputPulsingBorderShowWhen DefaultShowWhen = InputPulsingBorderShowWhen.Focused;
-    private const InputPulsingBorderStyle DefaultStyle = InputPulsingBorderStyle.Bottom;
 
     #endregion
 
     #region Instance Fields
 
-    private readonly bool _inheritFromGlobal;
+    private readonly InputPulsingBorderCategory? _inheritCategory;
+    private readonly InputPulsingBorderStyle _defaultStyle;
+    private readonly InputPulsingBorderShowWhen _defaultShowWhen;
     private bool? _enable;
     private bool? _animate;
     private float? _animationSpeed;
@@ -49,7 +49,17 @@ public class InputPulsingBorderValues : Storage
     /// </summary>
     /// <param name="needPaint">Delegate for notifying paint requests.</param>
     public InputPulsingBorderValues(NeedPaintHandler? needPaint)
-        : this(needPaint, inheritFromGlobal: true)
+        : this(needPaint, InputPulsingBorderCategory.Inputs)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="InputPulsingBorderValues"/> class that inherits from a manager group.
+    /// </summary>
+    /// <param name="needPaint">Delegate for notifying paint requests.</param>
+    /// <param name="inheritCategory">Manager group to inherit unset properties from.</param>
+    internal InputPulsingBorderValues(NeedPaintHandler? needPaint, InputPulsingBorderCategory inheritCategory)
+        : this(needPaint, inheritCategory, InputPulsingBorderStyle.Bottom, InputPulsingBorderShowWhen.Focused)
     {
     }
 
@@ -57,18 +67,23 @@ public class InputPulsingBorderValues : Storage
     /// Initialize a new instance of the <see cref="InputPulsingBorderValues"/> class.
     /// </summary>
     /// <param name="needPaint">Delegate for notifying paint requests.</param>
-    /// <param name="inheritFromGlobal">
-    /// When <see langword="true"/>, unset properties read from
-    /// <see cref="KryptonManager.PulsingBorderValues"/>. Pass <see langword="false"/> for the
-    /// manager's own global instance.
+    /// <param name="inheritCategory">
+    /// Manager group to inherit from, or <see langword="null"/> for a manager group instance.
     /// </param>
-    internal InputPulsingBorderValues(NeedPaintHandler? needPaint, bool inheritFromGlobal)
+    /// <param name="defaultStyle">Factory style used when this instance does not inherit.</param>
+    /// <param name="defaultShowWhen">Factory show-when used when this instance does not inherit.</param>
+    internal InputPulsingBorderValues(NeedPaintHandler? needPaint,
+        InputPulsingBorderCategory? inheritCategory,
+        InputPulsingBorderStyle defaultStyle,
+        InputPulsingBorderShowWhen defaultShowWhen)
     {
         NeedPaint = needPaint;
-        _inheritFromGlobal = inheritFromGlobal;
-        Colors = new InputPulsingBorderColorValues(needPaint, inheritFromGlobal);
+        _inheritCategory = inheritCategory;
+        _defaultStyle = defaultStyle;
+        _defaultShowWhen = defaultShowWhen;
+        Colors = new InputPulsingBorderColorValues(needPaint, inheritCategory);
 
-        if (!inheritFromGlobal)
+        if (!inheritCategory.HasValue)
         {
             Reset();
         }
@@ -94,10 +109,10 @@ public class InputPulsingBorderValues : Storage
     #region Enable
 
     /// <summary>
-    /// Gets and sets whether the pulsing bottom border is drawn on the control.
+    /// Gets and sets whether the pulsing border is drawn on the control.
     /// </summary>
     [Category(@"Glowing Border")]
-    [Description(@"Gets and sets whether the pulsing border is drawn on the control. Unset control values inherit from KryptonManager.PulsingBorderValues.")]
+    [Description(@"Gets and sets whether the pulsing border is drawn on the control. Unset control values inherit from the matching KryptonManager.PulsingBorderValues group.")]
     [DefaultValue(DefaultEnable)]
     public bool Enable
     {
@@ -179,20 +194,20 @@ public class InputPulsingBorderValues : Storage
     /// </summary>
     [Category(@"Glowing Border")]
     [Description(@"Gets and sets when the pulsing border is shown.")]
-    [DefaultValue(DefaultShowWhen)]
+    [DefaultValue(InputPulsingBorderShowWhen.Focused)]
     public InputPulsingBorderShowWhen ShowWhen
     {
-        get => GetInherited(_showWhen, values => values.ShowWhen, DefaultShowWhen);
+        get => GetInherited(_showWhen, values => values.ShowWhen, _defaultShowWhen);
 
         set => SetLocal(ref _showWhen, value, needLayout: true);
     }
 
-    private bool ShouldSerializeShowWhen() => ShouldSerializeLocal(_showWhen, ShowWhen, DefaultShowWhen);
+    private bool ShouldSerializeShowWhen() => ShouldSerializeLocal(_showWhen, ShowWhen, _defaultShowWhen);
 
     /// <summary>
     /// Resets the ShowWhen property to its default value.
     /// </summary>
-    public void ResetShowWhen() => ResetLocal(ref _showWhen, DefaultShowWhen, needLayout: true);
+    public void ResetShowWhen() => ResetLocal(ref _showWhen, _defaultShowWhen, needLayout: true);
 
     #endregion
 
@@ -203,20 +218,20 @@ public class InputPulsingBorderValues : Storage
     /// </summary>
     [Category(@"Glowing Border")]
     [Description(@"Gets and sets whether the glow follows the bottom edge only or the entire border.")]
-    [DefaultValue(DefaultStyle)]
+    [DefaultValue(InputPulsingBorderStyle.Bottom)]
     public InputPulsingBorderStyle Style
     {
-        get => GetInherited(_style, values => values.Style, DefaultStyle);
+        get => GetInherited(_style, values => values.Style, _defaultStyle);
 
         set => SetLocal(ref _style, value, needLayout: true);
     }
 
-    private bool ShouldSerializeStyle() => ShouldSerializeLocal(_style, Style, DefaultStyle);
+    private bool ShouldSerializeStyle() => ShouldSerializeLocal(_style, Style, _defaultStyle);
 
     /// <summary>
     /// Resets the Style property to its default value.
     /// </summary>
-    public void ResetStyle() => ResetLocal(ref _style, DefaultStyle, needLayout: true);
+    public void ResetStyle() => ResetLocal(ref _style, _defaultStyle, needLayout: true);
 
     #endregion
 
@@ -237,8 +252,9 @@ public class InputPulsingBorderValues : Storage
     #region Reset
 
     /// <summary>
-    /// Resets all properties. Control instances clear local overrides and inherit from
-    /// <see cref="KryptonManager.PulsingBorderValues"/> again; the global instance restores factory defaults.
+    /// Resets all properties. Control instances clear local overrides and inherit from the
+    /// matching <see cref="KryptonManager.PulsingBorderValues"/> group again; a manager group
+    /// instance restores its factory defaults.
     /// </summary>
     public void Reset()
     {
@@ -254,9 +270,11 @@ public class InputPulsingBorderValues : Storage
 
     #region Implementation
 
+    private bool InheritFromGlobal => _inheritCategory.HasValue;
+
     private InputPulsingBorderValues? InheritSource =>
-        _inheritFromGlobal && !ReferenceEquals(this, KryptonManager.PulsingBorderValues)
-            ? KryptonManager.PulsingBorderValues
+        _inheritCategory.HasValue
+            ? KryptonManager.PulsingBorderValues.Get(_inheritCategory.Value)
             : null;
 
     private T GetInherited<T>(T? local, Func<InputPulsingBorderValues, T> read, T factory)
@@ -273,7 +291,7 @@ public class InputPulsingBorderValues : Storage
 
     private bool ShouldSerializeLocal<T>(T? local, T effective, T factory)
         where T : struct =>
-        _inheritFromGlobal ? local.HasValue : !EqualityComparer<T>.Default.Equals(effective, factory);
+        InheritFromGlobal ? local.HasValue : !EqualityComparer<T>.Default.Equals(effective, factory);
 
     private void SetLocal<T>(ref T? field, T value, bool needLayout)
         where T : struct
@@ -288,7 +306,7 @@ public class InputPulsingBorderValues : Storage
     private void ResetLocal<T>(ref T? field, T factory, bool needLayout)
         where T : struct
     {
-        if (_inheritFromGlobal)
+        if (InheritFromGlobal)
         {
             if (field.HasValue)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/KryptonGlobalPulsingBorderValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/KryptonGlobalPulsingBorderValues.cs
@@ -1,0 +1,138 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege,  KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Application-wide pulsing border defaults grouped by control type.
+/// </summary>
+/// <remarks>
+/// Each group is an independent <see cref="InputPulsingBorderValues"/> instance. Controls inherit
+/// unset properties from the matching group:
+/// <list type="bullet">
+/// <item><see cref="Forms"/> — <see cref="KryptonForm"/></item>
+/// <item><see cref="Buttons"/> — <see cref="KryptonButton"/>, <see cref="KryptonDropButton"/>, <see cref="KryptonColorButton"/></item>
+/// <item><see cref="Inputs"/> — text, combo, numeric, date, and similar input controls</item>
+/// <item><see cref="Other"/> — <see cref="KryptonCheckBox"/>, <see cref="KryptonRadioButton"/>, <see cref="KryptonLabel"/></item>
+/// </list>
+/// </remarks>
+[TypeConverter(typeof(ExpandableObjectConverter))]
+public class KryptonGlobalPulsingBorderValues : Storage
+{
+    #region Identity
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="KryptonGlobalPulsingBorderValues"/> class.
+    /// </summary>
+    /// <param name="needPaint">Delegate invoked when any group value changes.</param>
+    internal KryptonGlobalPulsingBorderValues(NeedPaintHandler? needPaint)
+    {
+        NeedPaint = needPaint;
+        Forms = CreateGroup(needPaint, InputPulsingBorderStyle.All, InputPulsingBorderShowWhen.Active);
+        Buttons = CreateGroup(needPaint, InputPulsingBorderStyle.All, InputPulsingBorderShowWhen.Active);
+        Inputs = CreateGroup(needPaint, InputPulsingBorderStyle.Bottom, InputPulsingBorderShowWhen.Focused);
+        Other = CreateGroup(needPaint, InputPulsingBorderStyle.All, InputPulsingBorderShowWhen.Active);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => !IsDefault ? @"Modified" : string.Empty;
+
+    #endregion
+
+    #region IsDefault
+
+    /// <inheritdoc />
+    public override bool IsDefault => Forms.IsDefault
+                                      && Buttons.IsDefault
+                                      && Inputs.IsDefault
+                                      && Other.IsDefault;
+
+    #endregion
+
+    #region Groups
+
+    /// <summary>
+    /// Gets the default pulsing border settings inherited by <see cref="KryptonForm"/>.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Default pulsing border for KryptonForm chrome. Unset form properties inherit these values.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues Forms { get; }
+
+    private bool ShouldSerializeForms() => !Forms.IsDefault;
+
+    /// <summary>
+    /// Gets the default pulsing border settings inherited by button-style controls.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Default pulsing border for KryptonButton, KryptonDropButton, and KryptonColorButton.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues Buttons { get; }
+
+    private bool ShouldSerializeButtons() => !Buttons.IsDefault;
+
+    /// <summary>
+    /// Gets the default pulsing border settings inherited by input controls.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Default pulsing border for TextBox, ComboBox, NumericUpDown, DateTimePicker, and similar inputs.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues Inputs { get; }
+
+    private bool ShouldSerializeInputs() => !Inputs.IsDefault;
+
+    /// <summary>
+    /// Gets the default pulsing border settings inherited by other simple controls.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Default pulsing border for KryptonCheckBox, KryptonRadioButton, and KryptonLabel.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public InputPulsingBorderValues Other { get; }
+
+    private bool ShouldSerializeOther() => !Other.IsDefault;
+
+    #endregion
+
+    #region Public
+
+    /// <summary>
+    /// Returns the global values for the specified control category.
+    /// </summary>
+    /// <param name="category">Control category.</param>
+    /// <returns>The matching global <see cref="InputPulsingBorderValues"/>.</returns>
+    public InputPulsingBorderValues Get(InputPulsingBorderCategory category) => category switch
+    {
+        InputPulsingBorderCategory.Buttons => Buttons,
+        InputPulsingBorderCategory.Forms => Forms,
+        InputPulsingBorderCategory.Other => Other,
+        _ => Inputs
+    };
+
+    /// <summary>
+    /// Restores every group to its factory defaults.
+    /// </summary>
+    public void Reset()
+    {
+        Forms.Reset();
+        Buttons.Reset();
+        Inputs.Reset();
+        Other.Reset();
+    }
+
+    #endregion
+
+    #region Implementation
+
+    private static InputPulsingBorderValues CreateGroup(NeedPaintHandler? needPaint,
+        InputPulsingBorderStyle defaultStyle,
+        InputPulsingBorderShowWhen defaultShowWhen) =>
+        new InputPulsingBorderValues(needPaint, inheritCategory: null, defaultStyle, defaultShowWhen);
+
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/View Decorator/ViewDecoratorInputGlow.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Decorator/ViewDecoratorInputGlow.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -59,14 +59,9 @@ internal sealed class ViewDecoratorInputGlow : ViewDecorator
         }
 
         InputPulsingBorderValues values = _provider.Values;
-        IPaletteTriple tripleState = _provider.GetGlowingBorderTripleState();
+        IPaletteTriple? tripleState = _provider.GetGlowingBorderTripleState();
         PaletteState state = _provider.GetGlowingBorderState();
-        IPaletteBorder? paletteBorder = tripleState.PaletteBorder;
-
-        if (paletteBorder == null)
-        {
-            return;
-        }
+        IPaletteBorder? paletteBorder = tripleState?.PaletteBorder;
 
         InputPulsingBorderRenderer.Draw(context,
             bounds,

--- a/Source/Krypton Components/TestForm/Feature3784PulsingTextBoxBorderDemo.cs
+++ b/Source/Krypton Components/TestForm/Feature3784PulsingTextBoxBorderDemo.cs
@@ -229,10 +229,11 @@ public partial class Feature3784PulsingTextBoxBorderDemo : KryptonForm
 
         if (kchkUseGlobal.Checked)
         {
-            ApplyGlowDefaults(KryptonManager.PulsingBorderValues, kchkEnable.Checked, kchkAnimate.Checked, showWhen, style, speed);
+            ApplyGlowDefaults(KryptonManager.PulsingBorderValues.Inputs, kchkEnable.Checked, kchkAnimate.Checked, showWhen, style, speed);
+            ApplyGlowDefaults(KryptonManager.PulsingBorderValues.Buttons, kchkEnable.Checked, kchkAnimate.Checked, showWhen, style, speed);
             ClearLocalGlowOverrides();
             ktxtStaticGlow.PulsingBorderValues.Enable = false;
-            SetStatus(@"Applied glow settings to KryptonManager.PulsingBorderValues. Sample controls inherit; Static TextBox is opted out.");
+            SetStatus(@"Applied glow settings to KryptonManager.PulsingBorderValues.Inputs/Buttons. Sample controls inherit; Static TextBox is opted out.");
             return;
         }
 
@@ -263,7 +264,13 @@ public partial class Feature3784PulsingTextBoxBorderDemo : KryptonForm
         {
             var showWhen = (InputPulsingBorderShowWhen)Math.Max(0, kcmbShowWhen.SelectedIndex);
             var style = kcmbStyle.SelectedIndex == 1 ? InputPulsingBorderStyle.All : InputPulsingBorderStyle.Bottom;
-            ApplyGlowDefaults(KryptonManager.PulsingBorderValues,
+            ApplyGlowDefaults(KryptonManager.PulsingBorderValues.Inputs,
+                kchkEnable.Checked,
+                kchkAnimate.Checked,
+                showWhen,
+                style,
+                (float)knudAnimationSpeed.Value);
+            ApplyGlowDefaults(KryptonManager.PulsingBorderValues.Buttons,
                 kchkEnable.Checked,
                 kchkAnimate.Checked,
                 showWhen,
@@ -271,7 +278,7 @@ public partial class Feature3784PulsingTextBoxBorderDemo : KryptonForm
                 (float)knudAnimationSpeed.Value);
             ClearLocalGlowOverrides();
             ktxtStaticGlow.PulsingBorderValues.Enable = false;
-            SetStatus(@"Global inherit on. Sample controls use KryptonManager.PulsingBorderValues; Static TextBox is opted out (Enable = false).");
+            SetStatus(@"Global inherit on. Sample controls use KryptonManager.PulsingBorderValues.Inputs/Buttons; Static TextBox is opted out (Enable = false).");
             return;
         }
 


### PR DESCRIPTION
This change introduces grouped application-wide pulsing border defaults for Forms, Buttons, Inputs, and Other controls. Each control now inherits from its matching category instead of a single global value, with button and form defaults using full-border glow and input defaults using the bottom-edge glow to avoid redraw churn. The relevant controls were updated to expose per-instance overrides and the TestForm demo was adjusted to exercise the new grouping.