### PR TITLE
* Fix Ribbon QAT extra button DPI scaling (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,8 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Implemented [#4254](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4254), DPI-scale Ribbon QAT extra button (`ViewDrawRibbonQATExtraButton`)
+   * Ribbon Quick Access Toolbar overflow/customize button now scales with DPI
 * Implemented [#3854](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3854), Removed unused duplicate utility types
   * Ribbon now uses the public Toolkit `BiDictionary`.
   * Workspace uses Interop `PI.WM_.CONTEXTMENU` instead of a local `PI` stub.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButton.cs
@@ -19,11 +19,18 @@ namespace Krypton.Ribbon;
 /// </summary>
 internal class ViewDrawRibbonQATExtraButton : ViewLeaf
 {
-    // TODO: Needs to be scaled
-    private static readonly Size _contentSize = new Size(-2, -5);
+    #region Static Fields
+
+    // 96-DPI design values. Scaled at layout/paint time (not construction) so per-monitor
+    // DPI is applied after the ribbon handle exists (issue #4254).
+    private const int ViewWidth96 = 13;
+    private const int ViewHeight96 = 22;
+    private const int ContentInflateX96 = 2;
+    private const int ContentInflateY96 = 5;
+
+    #endregion
 
     #region Instance Fields
-    private readonly Size _viewSize; // = new(13, 22);
     private readonly KryptonRibbon _ribbon;
     private IDisposable? _mementoBack;
     private readonly EventHandler? _finishDelegate;
@@ -60,7 +67,6 @@ internal class ViewDrawRibbonQATExtraButton : ViewLeaf
         MouseController = controller;
         SourceController = controller;
         KeyController = controller;
-        _viewSize = new Size((int)(13 * FactorDpiX), (int)(22 * FactorDpiY));
     }
 
     /// <summary>
@@ -122,7 +128,7 @@ internal class ViewDrawRibbonQATExtraButton : ViewLeaf
     /// Discover the preferred size of the element.
     /// </summary>
     /// <param name="context">Layout context.</param>
-    public override Size GetPreferredSize(ViewLayoutContext context) => _viewSize;
+    public override Size GetPreferredSize(ViewLayoutContext context) => new Size(ScaleDpi(ViewWidth96, FactorDpiX), ScaleDpi(ViewHeight96, FactorDpiY));
 
     /// <summary>
     /// Perform a layout of the elements.
@@ -181,7 +187,8 @@ internal class ViewDrawRibbonQATExtraButton : ViewLeaf
 
         // Find the content area inside the button rectangle
         Rectangle contentRect = ClientRectangle;
-        contentRect.Inflate(_contentSize);
+        contentRect.Inflate(-ScaleDpi(ContentInflateX96, FactorDpiX),
+            -ScaleDpi(ContentInflateY96, FactorDpiY));
 
         // Decide if we are drawing an overflow or context arrow image
         if (Overflow)
@@ -196,6 +203,11 @@ internal class ViewDrawRibbonQATExtraButton : ViewLeaf
     #endregion
 
     #region Implementation
+
+    // Round away from zero so 125% (1.25) still grows 2px design values rather than truncating to the 96-DPI size.
+    protected static int ScaleDpi(int value96, float factor) =>
+        (int)Math.Round(value96 * factor, MidpointRounding.AwayFromZero);
+
     private void ClickFinished(object? sender, EventArgs e)
     {
         // Get access to our mouse controller

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButtonMini.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButtonMini.cs
@@ -19,8 +19,14 @@ namespace Krypton.Ribbon;
 /// </summary>
 internal class ViewDrawRibbonQATExtraButtonMini : ViewDrawRibbonQATExtraButton
 {
-    private readonly int _miniButtonHeight; // = 22;
-    private readonly int _miniButtonOffset; // = 24;
+    #region Static Fields
+
+    // 96-DPI design values. Scaled in Layout so caption placement tracks per-monitor DPI (issue #4254).
+    private const int MiniButtonHeight96 = 22;
+    private const int MiniButtonOffset96 = 24;
+
+    #endregion
+
     #region Identity
     /// <summary>
     /// Initialize a new instance of the ViewDrawRibbonQATExtraButtonMini class.
@@ -31,8 +37,6 @@ internal class ViewDrawRibbonQATExtraButtonMini : ViewDrawRibbonQATExtraButton
         NeedPaintHandler needPaint)
         : base(ribbon, needPaint)
     {
-        _miniButtonHeight = (int)(22 * FactorDpiY);
-        _miniButtonOffset = (int)(24 * FactorDpiX);
     }
 
     /// <summary>
@@ -56,9 +60,10 @@ internal class ViewDrawRibbonQATExtraButtonMini : ViewDrawRibbonQATExtraButton
 
         Rectangle clientRect = context!.DisplayRectangle;
 
-        // For the minibar we have to position ourself at bottom of available area
-        clientRect.Y = clientRect.Bottom - 1 - _miniButtonOffset;
-        clientRect.Height = _miniButtonHeight;
+        // For the minibar we have to position ourself at bottom of available area.
+        // Offset stays on the X factor to match the original 96-DPI geometry.
+        clientRect.Y = clientRect.Bottom - 1 - ScaleDpi(MiniButtonOffset96, FactorDpiX);
+        clientRect.Height = ScaleDpi(MiniButtonHeight96, FactorDpiY);
 
         // Use modified size to position base class and children
         context.DisplayRectangle = clientRect;


### PR DESCRIPTION
Adjust the Ribbon Quick Access Toolbar overflow/customize button to compute its size and content inflation from the active DPI scale instead of fixed 96-DPI values. This keeps the extra button and the mini variant aligned correctly across per-monitor DPI changes, including the minibar placement geometry.