### PR TITLE
* Add BSD headers to interop helpers

### DIFF
--- a/Source/Krypton Components/Krypton.Interop/General/BoolExtensions.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/BoolExtensions.cs
@@ -1,4 +1,13 @@
-﻿namespace Krypton.Toolkit;
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
 
 /// <summary>
 /// Extension methods for working with the PI.BOOL type and standard boolean values.

--- a/Source/Krypton Components/Krypton.Interop/General/HResultExtensions.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/HResultExtensions.cs
@@ -1,4 +1,13 @@
-﻿namespace Krypton.Interop;
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Interop;
 
 internal static class HResultExtensions
 {

--- a/Source/Krypton Components/Krypton.Interop/General/Libraries.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/Libraries.cs
@@ -1,4 +1,13 @@
-﻿namespace Krypton.Toolkit;
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
 
 /// <summary>
 /// Contains string constants for Windows API library names used in Platform Invoke declarations.

--- a/Source/Krypton Components/Krypton.Interop/General/OsVersionInfo.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/OsVersionInfo.cs
@@ -1,4 +1,11 @@
-﻿
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
 
 namespace Krypton.Interop;
 

--- a/Source/Krypton Components/Krypton.Interop/General/SafeModuleHandle.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/SafeModuleHandle.cs
@@ -1,4 +1,13 @@
-﻿namespace Krypton.Toolkit;
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
 
 /// <summary>
 /// Provides a safe handle wrapper for Windows module handles (HMODULE).


### PR DESCRIPTION
Added the repository BSD license header to the General interop helper files in Krypton.Interop. This keeps the source files consistent with the project’s licensing and header conventions without changing behavior or APIs.