### PR TITLE
* Expose Rtf property on TaskDialog richtextbox

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,7 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Implemented [#4287](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4287), exposing a `Rtf` property on `KryptonTaskDialogElementRichTextBox`, allowing rich text content to be displayed in `KryptonTaskDialog`s
 * Resolved [#4255](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4255), Black frame flash and extra layout/paint cost when maximizing, minimizing, or restoring a `KryptonForm` from the caption or taskbar.
 * Implemented [#4254](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4254), DPI-scale Ribbon QAT extra button (`ViewDrawRibbonQATExtraButton`)
    * Ribbon Quick Access Toolbar overflow/customize button now scales with DPI

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementRichTextBox.cs
@@ -154,6 +154,15 @@ public class KryptonTaskDialogElementRichTextBox : KryptonTaskDialogElementBase,
         set => _richTextBox.Text = value;
     }
 
+    /// <summary>
+    /// Get or set the RTF content in the richtextbox.
+    /// </summary>
+    public string? Rtf
+    {
+        get => _richTextBox.Rtf;
+        set => _richTextBox.Rtf = value;
+    }
+
     ///<summary>
     /// Enables the textbox.
     /// </summary>


### PR DESCRIPTION
Add a nullable `Rtf` property to KryptonTaskDialogElementRichTextBox to get/set the underlying RichTextBox.Rtf, enabling rich text content in KryptonTaskDialog. Also update Documents/Changelog/Changelog.md to record issue #4287.