### PR TITLE
* Expose KryptonListView virtual mode (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,10 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Implemented [#3847](https://github.com/Krypton-Suite/Standard-Toolkit/issues/3847), `KryptonListView` virtual mode
+   * Exposed `VirtualMode` and `VirtualListSize`, and forwarded `RetrieveVirtualItem` and `CacheVirtualItems` (alongside existing `SearchForVirtualItem` / `VirtualItemsSelectionRangeChanged`).
+   * Palette item styling skips enumerating `Items` in virtual mode and applies colours on retrieve instead.
+   * TestForm: `ListView Virtual Mode` scenario with 100,000 items, cache window, type-ahead / Find, and theme change.
 * Resolved [#4252](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4252), Light Gray Office 2007, Office 2010, and Microsoft 365 themes no longer throw when drawing context-menu submenu arrows.
 * Implemented [#4287](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4287), exposing a `Rtf` property on `KryptonTaskDialogElementRichTextBox`, allowing rich text content to be displayed in `KryptonTaskDialog`s
 * Resolved [#4255](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4255), Black frame flash and extra layout/paint cost when maximizing, minimizing, or restoring a `KryptonForm` from the caption or taskbar.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -357,6 +357,16 @@ public class KryptonListView : VisualControlBase,
     [Description("ListView ItemSelectionChanged")]
     public event ListViewItemSelectionChangedEventHandler? ItemSelectionChanged;
 
+    /// <summary>Occurs when the <see cref="T:System.Windows.Forms.ListView" /> is in virtual mode and the contents of its cache need to be refreshed.</summary>
+    [Category("Action")]
+    [Description("ListView CacheVirtualItems")]
+    public event CacheVirtualItemsEventHandler? CacheVirtualItems;
+
+    /// <summary>Occurs when the <see cref="T:System.Windows.Forms.ListView" /> is in virtual mode and a <see cref="T:System.Windows.Forms.ListViewItem" /> must be provided.</summary>
+    [Category("Action")]
+    [Description("ListView RetrieveVirtualItem")]
+    public event RetrieveVirtualItemEventHandler? RetrieveVirtualItem;
+
     /// <summary>Occurs when the <see cref="T:System.Windows.Forms.ListView" /> is in virtual mode and a search is taking place.</summary>
     [Category("Action")]
     [Description("ListView SearchForVirtualItem")]
@@ -434,6 +444,8 @@ public class KryptonListView : VisualControlBase,
         _listView.KeyPress += OnListViewKeyPress;
         _listView.KeyUp += OnListViewKeyUp;
         _listView.LostFocus += OnListViewLostFocus;
+        _listView.CacheVirtualItems += OnCacheVirtualItems;
+        _listView.RetrieveVirtualItem += OnRetrieveVirtualItem;
         _listView.SearchForVirtualItem += OnSearchForVirtualItem;
         _listView.SelectedIndexChanged += OnSelectedIndexChanged;
         _listView.VirtualItemsSelectionRangeChanged += OnVirtualItemsSelectionRangeChanged;
@@ -486,6 +498,17 @@ public class KryptonListView : VisualControlBase,
     private void OnListViewKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
     private void OnListViewKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
+
+    private void OnCacheVirtualItems(object? sender, CacheVirtualItemsEventArgs e) => CacheVirtualItems?.Invoke(this, e);
+
+    private void OnRetrieveVirtualItem(object? sender, RetrieveVirtualItemEventArgs e)
+    {
+        RetrieveVirtualItem?.Invoke(this, e);
+        if (e.Item != null)
+        {
+            SetItemState(e.Item);
+        }
+    }
 
     private void OnSearchForVirtualItem(object? sender, SearchForVirtualItemEventArgs e) => SearchForVirtualItem?.Invoke(this, e);
 
@@ -1000,7 +1023,6 @@ public class KryptonListView : VisualControlBase,
         set => _listView.View = value;
     }
 
-    /* TODO: Need to wire up the virtual events as well
     /// <summary>Gets or sets the number of <see cref="T:System.Windows.Forms.ListViewItem" /> objects contained in the list when in virtual mode.</summary>
     /// <returns>The number of <see cref="T:System.Windows.Forms.ListViewItem" /> objects contained in the <see cref="T:System.Windows.Forms.ListView" /> when in virtual mode.</returns>
     /// <exception cref="T:System.ArgumentException">
@@ -1039,7 +1061,6 @@ public class KryptonListView : VisualControlBase,
         get => _listView.VirtualMode;
         set => _listView.VirtualMode = value;
     }
-    */
 
     /// <summary>Arranges items in the control when they are displayed as icons with a specified alignment setting.</summary>
     /// <param name="value">One of the <see cref="T:System.Windows.Forms.ListViewAlignment" /> values.</param>
@@ -1321,9 +1342,17 @@ public class KryptonListView : VisualControlBase,
             _drawDockerOuter.ElementState = state;
 
             _listView.BackColor = doubleState.PaletteBack.GetBackColor1(state);
-            foreach (ListViewItem li in Items)
+            if (_listView.VirtualMode)
             {
-                SetItemState(li);
+                // Enumerating Items in virtual mode retrieves every row. Visible items are styled in OnRetrieveVirtualItem.
+                _listView.Invalidate();
+            }
+            else
+            {
+                foreach (ListViewItem li in Items)
+                {
+                    SetItemState(li);
+                }
             }
         }
     }

--- a/Source/Krypton Components/TestForm/KryptonListViewVirtualModeDemo.cs
+++ b/Source/Krypton Components/TestForm/KryptonListViewVirtualModeDemo.cs
@@ -1,0 +1,243 @@
+﻿#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege, KamaniAR, Lesandro Gotardo (aka lesandrog), Jorge A. Avilés (aka mcpbcs) et al. 2026 - 2026. All rights reserved.
+ *
+ */
+#endregion
+
+namespace TestForm;
+
+/// <summary>
+/// Manual repro for issue #3847: <see cref="KryptonListView"/> virtual mode
+/// (<see cref="KryptonListView.VirtualMode"/>, <see cref="KryptonListView.VirtualListSize"/>,
+/// <see cref="KryptonListView.RetrieveVirtualItem"/>, <see cref="KryptonListView.CacheVirtualItems"/>,
+/// <see cref="KryptonListView.SearchForVirtualItem"/>).
+/// </summary>
+public sealed class KryptonListViewVirtualModeDemo : KryptonForm
+{
+    private const int ItemCount = 100000;
+
+    private readonly Dictionary<int, ListViewItem> _cache = new();
+    private readonly KryptonListView _listView;
+    private readonly KryptonLabel _status;
+    private readonly KryptonTextBox _searchBox;
+    private int _cacheStart = -1;
+    private int _cacheEnd = -1;
+    private int _lastRetrieveIndex = -1;
+
+    public KryptonListViewVirtualModeDemo()
+    {
+        Text = @"Issue #3847 — KryptonListView Virtual Mode";
+        StartPosition = FormStartPosition.CenterScreen;
+        Size = new Size(920, 620);
+        MinimumSize = new Size(640, 420);
+
+        var instructions = new KryptonWrapLabel
+        {
+            Dock = DockStyle.Top,
+            AutoSize = false,
+            Height = 92,
+            Padding = new Padding(12, 8, 12, 4),
+            Text =
+                "Issue #3847: KryptonListView now exposes VirtualMode / VirtualListSize and forwards RetrieveVirtualItem, " +
+                "CacheVirtualItems, and SearchForVirtualItem." + Environment.NewLine +
+                "Scroll the 100,000-item list, select a range, type in the list to search, use Find, and change the theme. " +
+                "The list must stay responsive and restyle visible rows without enumerating every virtual item."
+        };
+
+        _listView = new KryptonListView
+        {
+            Dock = DockStyle.Fill,
+            View = View.Details,
+            FullRowSelect = true,
+            HideSelection = false,
+            GridLines = true,
+            MultiSelect = true
+        };
+        _listView.Columns.Add("Name", 220);
+        _listView.Columns.Add("Parity", 80);
+        _listView.Columns.Add("Index", 80);
+        _listView.RetrieveVirtualItem += OnRetrieveVirtualItem;
+        _listView.CacheVirtualItems += OnCacheVirtualItems;
+        _listView.SearchForVirtualItem += OnSearchForVirtualItem;
+        _listView.SelectedIndexChanged += (_, _) => UpdateStatus();
+        _listView.VirtualItemsSelectionRangeChanged += (_, _) => UpdateStatus();
+        _listView.VirtualMode = true;
+        _listView.VirtualListSize = ItemCount;
+
+        _status = new KryptonLabel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = false
+        };
+
+        _searchBox = new KryptonTextBox
+        {
+            Dock = DockStyle.Fill,
+            CueHint = { CueHintText = @"Find (e.g. Item 12345)" }
+        };
+        _searchBox.KeyDown += OnSearchKeyDown;
+
+        var findButton = new KryptonButton
+        {
+            Dock = DockStyle.Fill,
+            Values = { Text = @"Find" }
+        };
+        findButton.Click += (_, _) => FindTypedItem();
+
+        var themeCombo = new KryptonThemeComboBox
+        {
+            Dock = DockStyle.Fill
+        };
+
+        var chrome = new TableLayoutPanel
+        {
+            Dock = DockStyle.Bottom,
+            AutoSize = true,
+            Padding = new Padding(12, 4, 12, 12),
+            ColumnCount = 4,
+            RowCount = 2
+        };
+        chrome.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        chrome.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 280F));
+        chrome.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 88F));
+        chrome.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 220F));
+        chrome.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        chrome.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        chrome.Controls.Add(_status, 0, 0);
+        chrome.SetColumnSpan(_status, 4);
+        chrome.Controls.Add(new KryptonLabel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = false,
+            Values = { Text = @"Type-ahead works in the list; Find uses SearchForVirtualItem." }
+        }, 0, 1);
+        chrome.Controls.Add(_searchBox, 1, 1);
+        chrome.Controls.Add(findButton, 2, 1);
+        chrome.Controls.Add(themeCombo, 3, 1);
+
+        Controls.Add(_listView);
+        Controls.Add(chrome);
+        Controls.Add(instructions);
+
+        UpdateStatus();
+    }
+
+    private void OnCacheVirtualItems(object? sender, CacheVirtualItemsEventArgs e)
+    {
+        if (e.StartIndex >= _cacheStart && e.EndIndex <= _cacheEnd && _cache.Count > 0)
+        {
+            UpdateStatus();
+            return;
+        }
+
+        _cache.Clear();
+        _cacheStart = e.StartIndex;
+        _cacheEnd = e.EndIndex;
+        for (int i = e.StartIndex; i <= e.EndIndex; i++)
+        {
+            _cache[i] = CreateItem(i);
+        }
+
+        UpdateStatus();
+    }
+
+    private void OnRetrieveVirtualItem(object? sender, RetrieveVirtualItemEventArgs e)
+    {
+        _lastRetrieveIndex = e.ItemIndex;
+        if (!_cache.TryGetValue(e.ItemIndex, out ListViewItem? item))
+        {
+            item = CreateItem(e.ItemIndex);
+        }
+
+        e.Item = item;
+    }
+
+    private void OnSearchForVirtualItem(object? sender, SearchForVirtualItemEventArgs e)
+    {
+        if (!e.IsTextSearch || string.IsNullOrEmpty(e.Text))
+        {
+            return;
+        }
+
+        int start = Math.Max(0, e.StartIndex);
+        for (int i = start; i < ItemCount; i++)
+        {
+            if (ItemTextMatches(i, e.Text, e.IsPrefixSearch))
+            {
+                e.Index = i;
+                return;
+            }
+        }
+
+        for (int i = 0; i < start; i++)
+        {
+            if (ItemTextMatches(i, e.Text, e.IsPrefixSearch))
+            {
+                e.Index = i;
+                return;
+            }
+        }
+    }
+
+    private void OnSearchKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Enter)
+        {
+            e.SuppressKeyPress = true;
+            FindTypedItem();
+        }
+    }
+
+    private void FindTypedItem()
+    {
+        string text = _searchBox.Text.Trim();
+        if (text.Length == 0)
+        {
+            return;
+        }
+
+        ListViewItem? match = _listView.FindItemWithText(text, false, 0, true);
+        if (match == null)
+        {
+            _status.Values.Text = $@"No match for '{text}'.";
+            return;
+        }
+
+        _listView.SelectedIndices.Clear();
+        _listView.SelectedIndices.Add(match.Index);
+        _listView.EnsureVisible(match.Index);
+        _listView.Focus();
+        UpdateStatus();
+    }
+
+    private void UpdateStatus()
+    {
+        string cache = _cacheStart < 0
+            ? "none"
+            : $"{_cacheStart}–{_cacheEnd} ({_cache.Count} items)";
+        int selected = _listView.SelectedIndices.Count;
+        _status.Values.Text =
+            $"VirtualListSize={ItemCount:N0}; last retrieve={_lastRetrieveIndex}; cache={cache}; selected={selected}.";
+    }
+
+    private static bool ItemTextMatches(int index, string text, bool prefix)
+    {
+        string itemText = FormatName(index);
+        return prefix
+            ? itemText.StartsWith(text, StringComparison.CurrentCultureIgnoreCase)
+            : string.Equals(itemText, text, StringComparison.CurrentCultureIgnoreCase);
+    }
+
+    private static ListViewItem CreateItem(int index) =>
+        new(new[]
+        {
+            FormatName(index),
+            (index % 2) == 0 ? "Even" : "Odd",
+            index.ToString(CultureInfo.InvariantCulture)
+        });
+
+    private static string FormatName(int index) => $"Item {index}";
+}

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -85,6 +85,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<CalendarTest>("Calendar", string.Empty);
         CreateButton<ComboBoxDateTimePickerConsistencyDemo>("ComboBox/DateTimePicker Consistency", "Comprehensive demonstration of KComboBox and KDateTimePicker consistency fix (Issue #1651). Shows drop-down buttons stretching to full height and centered text.");
         CreateButton<ControlsTest>("Controls Test", string.Empty);
+        CreateButton<KryptonListViewVirtualModeDemo>("ListView Virtual Mode", "Issue #3847: KryptonListView VirtualMode / VirtualListSize with RetrieveVirtualItem, CacheVirtualItems, and SearchForVirtualItem (100,000 items).");
         CreateButton<DataGridViewDemo>("KryptonDataGridView Demo", string.Empty);
         CreateButton<FadeFormTest>("FadeForm", string.Empty);
         CreateButton<GroupBoxTest>("GroupBox", string.Empty);


### PR DESCRIPTION
Expose and forward virtual-mode events (RetrieveVirtualItem, CacheVirtualItems) from the underlying ListView and wire them into KryptonListView. Palette styling avoids enumerating all Items in virtual mode and instead styles visible rows on retrieve (Invalidate used). Adds a TestForm demo (KryptonListViewVirtualModeDemo) with a 100,000-item virtual list, search/caching, and updates StartScreen and the Changelog to document the feature.