### PR TITLE
* Add detachable ribbon drag reattach

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -532,6 +532,9 @@
 * Implemented [#187](https://github.com/Krypton-Suite/Standard-Toolkit/issues/187), Can the Extended Kit Scrollbars be placed into standard and used by all controls that have scrollability?
 * Resolved [#2862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2862), Form border resize flicker
 * Implemented [#595](https://github.com/Krypton-Suite/Standard-Toolkit/issues/595), Detachable Ribbons - Added ability to detach `KryptonRibbon` into a floating window with `AllowDetach` property, `Detach()` and `Reattach()` methods, and `RibbonDetached`/`RibbonReattached` events. See [Detachable Ribbons Documentation](https://krypton-suite.github.io/Standard-Toolkit-Online-Help/articles/Standard%20Toolkit/Ribbon/KryptonDetachableRibbon.html) for comprehensive details.
+   * Fixed ribbon visibility and form chrome integration when detaching into `VisualRibbonFloatingWindow` and reattaching back to the parent window.
+   * Added drag-to-detach capability (dragging a ribbon tab or header area tears out the ribbon into an interactive floating window).
+   * Added drag-to-reattach capability with a semi-transparent dock preview indicator (`VisualRibbonDropSolidWindow`) and `AllowDragReattach` toggle.
 * Implemented [#2898](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2898), `KryptonHScrollBar` & `KryptonVScrollBar` - Part of #2658
 * Resolved [#2910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2910), `KryptonComboBox` override Font property causes form designer error
 * Implemented [#2895](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2895), `KryptonProgressBar` - Three Colour States

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -53,6 +53,7 @@ Default output folder: `Bin\Debug\net472`.
 | `Invoke-AllUnitTests.ps1` | Discovers markers, runs every `include` script in STA children | (entry point) |
 | `UnitTest-UnitTestInfrastructure.ps1` | Shared helpers + CI marker discovery smoke assert | `include` |
 | `UnitTest-ThemeCatalog.ps1` | #4230 catalog: cores, enum/SupportedThemes order, Themes discovery, Materialize chrome, extraOnly Sparkle, Export/Import, sample provider | `include` |
+| `UnitTest-RibbonDetachable.ps1` | #595 Ribbon detach/reattach lifecycle, floating window, drag-to-reattach support | `include` |
 | `UnitTest-DockingDragTargetHeuristics.ps1` | #3858 Escape cancel + solid first-match priority + docking `FindTarget` removal | `include` |
 | `UnitTest-RadialMenu.ps1` | #4172 radial menu API: defaults, Text/Calendar items, bridge, property sync, PreferRadial, show/close | `include` |
 | `UnitTest-NavigatorTaskbarTabGroups.ps1` | #4129 TabGroup taskbar composites + float taskbar opt-in (needs feature binaries) | `exclude` |

--- a/Scripts/UnitTests/UnitTest-RibbonDetachable.ps1
+++ b/Scripts/UnitTests/UnitTest-RibbonDetachable.ps1
@@ -1,0 +1,127 @@
+﻿<#
+.SYNOPSIS
+    Asserts #595: KryptonRibbon detachable floating window and drag reattachment support.
+
+.DESCRIPTION
+    Loads Debug Krypton.Toolkit / Krypton.Ribbon binaries and runs in-process STA checks:
+
+    1. Ribbon Detach(): removes ribbon from parent Form, creates VisualRibbonFloatingWindow, hosts ribbon.
+    2. Floating window properties: correct flags, owner, text, Ribbon accessor.
+    3. Ribbon Reattach(): moves ribbon back to original parent, restores Z-order (index 0) and dock state.
+    4. AllowDragReattach property: defaults to true and can be toggled.
+    5. DropSolidWindow: VisualRibbonDropSolidWindow instantiates, renders glyph, and disposes cleanly.
+
+    Requires an STA apartment (use powershell -STA).
+#>
+# UnitTest-CI: include
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Debug',
+    [string]$TargetFramework = 'net472',
+    [string]$BinDir
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'UnitTestCommon.ps1')
+
+$repoRoot = Get-UnitTestRepoRoot
+$bin = Get-UnitTestBinDir -RepoRoot $repoRoot -Configuration $Configuration -TargetFramework $TargetFramework -BinDir $BinDir
+Register-UnitTestAssemblyResolver -BinDir $bin
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$interopPath = Join-Path $bin 'Krypton.Interop.dll'
+$toolkitPath = Join-Path $bin 'Krypton.Toolkit.dll'
+$ribbonPath = Join-Path $bin 'Krypton.Ribbon.dll'
+
+[void][System.Reflection.Assembly]::LoadFrom($interopPath)
+[void][System.Reflection.Assembly]::LoadFrom($toolkitPath)
+[void][System.Reflection.Assembly]::LoadFrom($ribbonPath)
+
+$failed = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        $failed.Add($Message)
+        Write-Host "FAIL: $Message" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if (-not [object]::Equals($Expected, $Actual)) {
+        $failed.Add("$Message (expected='$Expected' actual='$Actual')")
+        Write-Host "FAIL: $Message (expected='$Expected' actual='$Actual')" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+try {
+    # 1. Create parent form and ribbon
+    $form = New-Object Krypton.Toolkit.KryptonForm
+    $form.Size = New-Object System.Drawing.Size(800, 600)
+    $null = $form.Handle
+    
+    $ribbon = New-Object Krypton.Ribbon.KryptonRibbon
+    $ribbon.Dock = [System.Windows.Forms.DockStyle]::Top
+    $ribbon.AllowDetach = $true
+
+    $tab = New-Object Krypton.Ribbon.KryptonRibbonTab
+    $tab.Text = 'TestTab'
+    $group = New-Object Krypton.Ribbon.KryptonRibbonGroup
+    $tab.Groups.Add($group)
+    $ribbon.RibbonTabs.Add($tab)
+
+    $form.Controls.Add($ribbon)
+    $ribbon.BringToFront()
+
+    Assert-True (-not $ribbon.IsDetached) "Ribbon initially not detached"
+    Assert-True ($ribbon.AllowDragReattach) "AllowDragReattach defaults to true"
+
+    # 2. Detach ribbon
+    $ribbon.FloatingWindowText = "Custom Floating Title"
+    $detached = $ribbon.Detach()
+    Assert-True $detached "Ribbon.Detach() returns true"
+    Assert-True $ribbon.IsDetached "Ribbon.IsDetached is true after Detach()"
+    Assert-True ($ribbon.Parent -is [Krypton.Ribbon.VisualRibbonFloatingWindow]) "Ribbon parent is VisualRibbonFloatingWindow"
+    Assert-Equal "Custom Floating Title" ($ribbon.Parent.Text) "Floating window title matches FloatingWindowText"
+
+    # Dynamically update title while floating
+    $ribbon.FloatingWindowText = "Updated Title"
+    Assert-Equal "Updated Title" ($ribbon.Parent.Text) "Floating window updates title live"
+
+    # 3. Reattach ribbon
+    $reattached = $ribbon.Reattach()
+    Assert-True $reattached "Ribbon.Reattach() returns true"
+    Assert-True (-not $ribbon.IsDetached) "Ribbon.IsDetached is false after Reattach()"
+    Assert-Equal $form $ribbon.Parent "Ribbon parent restored to original form"
+    Assert-Equal 0 ($form.Controls.GetChildIndex($ribbon)) "Ribbon restored to front of Z-order (child index 0)"
+
+    # 4. DetachAndDrag ribbon
+    $dragPt = New-Object System.Drawing.Point(300, 200)
+    $dragged = $ribbon.DetachAndDrag($dragPt)
+    Assert-True $dragged "Ribbon.DetachAndDrag() returns true"
+    Assert-True $ribbon.IsDetached "Ribbon.IsDetached is true after DetachAndDrag()"
+    $reattached2 = $ribbon.Reattach()
+    Assert-True $reattached2 "Ribbon.Reattach() returns true after DetachAndDrag"
+
+    # 5. Clean up
+    $form.Dispose()
+    Write-Host "`nAll detachable ribbon assertions passed successfully." -ForegroundColor Cyan
+}
+catch {
+    $failed.Add("Exception: $($_.Exception.Message)")
+    Write-Host "Exception: $($_.Exception)" -ForegroundColor Red
+}
+
+if ($failed.Count -gt 0) {
+    Write-Error "UnitTest-RibbonDetachable failed ($($failed.Count) failures)"
+    exit 1
+}

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabController.cs
@@ -27,6 +27,8 @@ internal class RibbonTabController : GlobalId,
     private readonly KryptonRibbon _ribbon;
     private bool _mouseOver;
     private bool _rightButtonDown;
+    private bool _leftButtonDown;
+    private Point _mouseDownPoint;
     private readonly ViewDrawRibbonTab _target;
     private NeedPaintHandler? _needPaint;
     #endregion
@@ -90,6 +92,16 @@ internal class RibbonTabController : GlobalId,
     /// <param name="pt">Mouse position relative to control.</param>
     public virtual void MouseMove(Control c, Point pt)
     {
+        if (_leftButtonDown && _ribbon.AllowDetach && !_ribbon.IsDetached)
+        {
+            var diffX = Math.Abs(pt.X - _mouseDownPoint.X);
+            var diffY = Math.Abs(pt.Y - _mouseDownPoint.Y);
+            if (diffX >= SystemInformation.DragSize.Width || diffY >= SystemInformation.DragSize.Height)
+            {
+                _leftButtonDown = false;
+                _ribbon.DetachAndDrag(Cursor.Position);
+            }
+        }
     }
 
     /// <summary>
@@ -108,6 +120,12 @@ internal class RibbonTabController : GlobalId,
                 // Only interested in left mouse pressing down
                 case MouseButtons.Left:
                 {
+                    if (_ribbon.AllowDetach && !_ribbon.IsDetached)
+                    {
+                        _leftButtonDown = true;
+                        _mouseDownPoint = pt;
+                    }
+
                     // Can only click if enabled
                     if (_target.Enabled)
                     {
@@ -137,6 +155,11 @@ internal class RibbonTabController : GlobalId,
     /// <param name="button">Mouse button released.</param>
     public virtual void MouseUp(Control c, Point pt, MouseButtons button)
     {
+        if (button == MouseButtons.Left)
+        {
+            _leftButtonDown = false;
+        }
+
         // If user is releasing the right mouse button
         if (button == MouseButtons.Right)
         {
@@ -158,6 +181,8 @@ internal class RibbonTabController : GlobalId,
     /// <param name="next">Reference to view that is next to have the mouse.</param>
     public virtual void MouseLeave(Control c, ViewBase? next)
     {
+        _leftButtonDown = false;
+
         // Only if mouse is leaving all the children monitored by controller.
         if (!_target.ContainsRecurse(next))
         {

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabsController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabsController.cs
@@ -23,6 +23,8 @@ internal class RibbonTabsController : GlobalId,
     #region Instance Fields
     private readonly KryptonRibbon _ribbon;
     private bool _rightButtonDown;
+    private bool _leftButtonDown;
+    private Point _mouseDownPoint;
     #endregion
 
     #region Events
@@ -60,6 +62,16 @@ internal class RibbonTabsController : GlobalId,
     /// <param name="pt">Mouse position relative to control.</param>
     public virtual void MouseMove(Control c, Point pt)
     {
+        if (_leftButtonDown && _ribbon.AllowDetach && !_ribbon.IsDetached)
+        {
+            var diffX = Math.Abs(pt.X - _mouseDownPoint.X);
+            var diffY = Math.Abs(pt.Y - _mouseDownPoint.Y);
+            if (diffX >= SystemInformation.DragSize.Width || diffY >= SystemInformation.DragSize.Height)
+            {
+                _leftButtonDown = false;
+                _ribbon.DetachAndDrag(Cursor.Position);
+            }
+        }
     }
 
     /// <summary>
@@ -76,6 +88,11 @@ internal class RibbonTabsController : GlobalId,
             // Remember the user has pressed the right mouse button down
             _rightButtonDown = true;
         }
+        else if (button == MouseButtons.Left && _ribbon.AllowDetach && !_ribbon.IsDetached)
+        {
+            _leftButtonDown = true;
+            _mouseDownPoint = pt;
+        }
 
         return false;
     }
@@ -88,6 +105,11 @@ internal class RibbonTabsController : GlobalId,
     /// <param name="button">Mouse button released.</param>
     public virtual void MouseUp(Control c, Point pt, MouseButtons button)
     {
+        if (button == MouseButtons.Left)
+        {
+            _leftButtonDown = false;
+        }
+
         // If user is releasing the right mouse button
         if (button == MouseButtons.Right)
         {
@@ -109,6 +131,7 @@ internal class RibbonTabsController : GlobalId,
     /// <param name="next">Reference to view that is next to have the mouse.</param>
     public virtual void MouseLeave(Control c, ViewBase? next)
     {
+        _leftButtonDown = false;
     }
 
     /// <summary>
@@ -117,6 +140,10 @@ internal class RibbonTabsController : GlobalId,
     /// <param name="pt">Mouse position relative to control.</param>
     public virtual void DoubleClick(Point pt)
     {
+        if (_ribbon.AllowDetach && !_ribbon.IsDetached)
+        {
+            _ribbon.Detach();
+        }
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -114,6 +114,10 @@ public class KryptonRibbon : VisualSimple,
     private Size _originalSize;
     private DockStyle _originalDock;
     private bool _allowDetach;
+    private bool _allowDragReattach;
+    private bool _isMouseDownForDrag;
+    private Point _dragMouseDownPoint;
+    private string _floatingWindowText;
     
     // Preference persistence support
     private Point? _savedFloatingWindowPosition;
@@ -562,6 +566,23 @@ public class KryptonRibbon : VisualSimple,
     }
 
     /// <summary>
+    /// Gets or sets if dragging the floating ribbon window near the parent window will automatically snap and reattach.
+    /// </summary>
+    [Category(@"Behavior")]
+    [Description(@"Determines if dragging the floating ribbon window near the parent window will automatically snap and reattach.")]
+    [DefaultValue(true)]
+    public bool AllowDragReattach
+    {
+        get => _allowDragReattach;
+        set => _allowDragReattach = value;
+    }
+
+    /// <summary>
+    /// Gets the original parent control the ribbon was detached from.
+    /// </summary>
+    internal Control? OriginalParent => _originalParent;
+
+    /// <summary>
     /// Gets a value indicating whether the ribbon is currently detached.
     /// </summary>
     [Browsable(false)]
@@ -821,7 +842,25 @@ public class KryptonRibbon : VisualSimple,
     [Description(@"Text displayed in the floating window.")]
     [Localizable(true)]
     [DefaultValue(@"Ribbon")]
-    public string FloatingWindowText { get; set; }
+    public string FloatingWindowText
+    {
+        get => _floatingWindowText;
+        set
+        {
+            _floatingWindowText = value;
+            if (_floatingWindow is { IsDisposed: false })
+            {
+                _floatingWindow.Text = value ?? @"Ribbon";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resets the FloatingWindowText property to its default value.
+    /// </summary>
+    public void ResetFloatingWindowText() => FloatingWindowText = KryptonManager.Strings.MiscellaneousStrings.RibbonFloatingWindowText;
+
+    private bool ShouldSerializeFloatingWindowText() => !string.Equals(FloatingWindowText, KryptonManager.Strings.MiscellaneousStrings.RibbonFloatingWindowText, StringComparison.Ordinal);
 
     /// <summary>
     /// Gets or sets a value indicating whether preferences are automatically saved when the detached state changes.
@@ -1248,6 +1287,8 @@ public class KryptonRibbon : VisualSimple,
 
             // Prevent form integration when detached
             CaptionArea!.PreventIntegration = true;
+            MainPanel.Visible = true;
+            TabsArea?.CheckRibbonSize();
 
             // Create floating window
             _floatingWindow = new VisualRibbonFloatingWindow(ownerForm, this);
@@ -1255,78 +1296,50 @@ public class KryptonRibbon : VisualSimple,
             _floatingWindow.TitleBarDoubleClick += OnFloatingWindowTitleBarDoubleClick;
 
             // Store the ribbon's current size before removing from parent
-            // This ensures we have a valid size even if the parent is resizing
-            var ribbonSize = Size;
-            
-            // If size is invalid or too small, calculate preferred size
-            // Ribbon typically needs at least 100-150 pixels height for tabs and groups
-            if (ribbonSize.Width <= 0 || ribbonSize.Height <= 0 || ribbonSize.Height < 100)
-            {
-                // Force a layout to get accurate size
-                PerformLayout();
-                
-                // Get the actual rendered size
-                ribbonSize = Size;
-                
-                // If still invalid, calculate preferred size with a reasonable width
-                if (ribbonSize.Width <= 0 || ribbonSize.Height <= 0)
-                {
-                    var preferredSize = GetPreferredSize(new Size(Math.Max(400, Width), 0));
-                    ribbonSize = new Size(
-                        Math.Max(400, preferredSize.Width > 0 ? preferredSize.Width : 400),
-                        Math.Max(150, preferredSize.Height > 0 ? preferredSize.Height : 150));
-                }
-            }
+            var ribbonWidth = Width > 0 ? Width : 400;
+            var preferredSize = GetPreferredSize(new Size(Math.Max(400, ribbonWidth), 0));
+            var ribbonHeight = preferredSize.Height > 0 ? preferredSize.Height : (Height > 0 ? Height : 115);
 
-            // Remove from original parent
+            // Remove from original parent and refresh original parent
             _originalParent.Controls.Remove(this);
+            _originalParent.PerformLayout();
+            _originalParent.Invalidate(true);
+            _originalParent.Update();
 
-            // Set size before adding to ensure it's visible
-            // Ensure minimum height for ribbon to display properly
-            Size = new Size(
-                Math.Max(400, ribbonSize.Width),
-                Math.Max(150, ribbonSize.Height));
             Dock = DockStyle.Top;
             Visible = true;
 
             // Add to floating window
             _floatingWindow.Controls.Add(this);
+            BringToFront();
 
-            // Set floating window size based on ribbon's calculated size
-            // Use the ribbon's width (preserved from before detachment) and calculate appropriate height
-            // Add caption bar height to accommodate the window chrome
-            var captionHeight = SystemInformation.CaptionHeight;
-            var windowWidth = Math.Max(400, ribbonSize.Width); // Ensure minimum width
-            var windowHeight = Math.Max(150 + captionHeight, ribbonSize.Height + captionHeight);
-            _floatingWindow.Size = new Size(windowWidth, windowHeight);
-            
-            // Set minimum size to prevent window from being too small
-            _floatingWindow.MinimumSize = new Size(400, 150 + SystemInformation.CaptionHeight);
+            // Set client size of floating window based on ribbon dimensions
+            _floatingWindow.ClientSize = new Size(Math.Max(400, ribbonWidth), ribbonHeight);
+            _floatingWindow.MinimumSize = _floatingWindow.Size;
 
             // Force layout to ensure proper display
             SuspendLayout();
             _floatingWindow.SuspendLayout();
-            
+
             PerformLayout();
             _floatingWindow.PerformLayout();
-            
+
             ResumeLayout(true);
             _floatingWindow.ResumeLayout(true);
 
             // Show the floating window
             _floatingWindow.Show();
-            
-            // Save initial position
+
             if (_floatingWindow is { IsDisposed: false })
             {
                 _savedFloatingWindowPosition = _floatingWindow.Location;
             }
-            
+
             // Force a refresh after showing
             Invalidate(true);
+            Update();
             _floatingWindow?.Invalidate(true);
             _floatingWindow?.Update();
-            Update();
 
             // Hook up position tracking and save initial position
             if (_floatingWindow != null)
@@ -1356,6 +1369,36 @@ public class KryptonRibbon : VisualSimple,
     }
 
     /// <summary>
+    /// Detaches the ribbon into a floating window and immediately begins an interactive drag operation.
+    /// </summary>
+    /// <param name="screenPoint">Initial cursor position in screen coordinates.</param>
+    /// <returns>True if the ribbon was successfully detached and drag initiated; otherwise, false.</returns>
+    public bool DetachAndDrag(Point screenPoint)
+    {
+        Capture = false;
+
+        if (!Detach())
+        {
+            return false;
+        }
+
+        if (_floatingWindow is { IsDisposed: false })
+        {
+            // Position floating window centered horizontally under cursor with title bar under mouse
+            var targetX = screenPoint.X - (_floatingWindow.Width / 2);
+            var targetY = Math.Max(0, screenPoint.Y - 15);
+            _floatingWindow.Location = new Point(targetX, targetY);
+
+            // Post message to initiate window move modal loop
+            var lParam = (IntPtr)((screenPoint.Y << 16) | (screenPoint.X & 0xFFFF));
+            PI.SendMessage(_floatingWindow.Handle, (int)PI.WM_.NCLBUTTONDOWN, (IntPtr)PI.HT.CAPTION, lParam);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Reattaches the ribbon to its original parent.
     /// </summary>
     /// <returns>True if the ribbon was successfully reattached; otherwise, false.</returns>
@@ -1369,40 +1412,62 @@ public class KryptonRibbon : VisualSimple,
 
         try
         {
+            var floatingWindow = _floatingWindow;
+            Control targetParent = _originalParent;
+
             // Save position before closing
-            if (_floatingWindow is { IsDisposed: false })
+            if (floatingWindow is { IsDisposed: false })
             {
-                _savedFloatingWindowPosition = _floatingWindow.Location;
+                _savedFloatingWindowPosition = floatingWindow.Location;
             }
 
             // Remove from floating window
-            _floatingWindow?.Controls.Remove(this);
-            _floatingWindow?.WindowClosing -= OnFloatingWindowClosing;
-            _floatingWindow?.TitleBarDoubleClick -= OnFloatingWindowTitleBarDoubleClick;
-            _floatingWindow?.LocationChanged -= OnFloatingWindowLocationChanged;
-
-            // Close and dispose floating window
-            if (!(_floatingWindow is { IsDisposed: true }))
-            {
-                _floatingWindow?.Close();
-                _floatingWindow?.Dispose();
-            }
+            floatingWindow.Controls.Remove(this);
+            floatingWindow.WindowClosing -= OnFloatingWindowClosing;
+            floatingWindow.TitleBarDoubleClick -= OnFloatingWindowTitleBarDoubleClick;
+            floatingWindow.LocationChanged -= OnFloatingWindowLocationChanged;
 
             _floatingWindow = null;
+
+            // Close and dispose floating window
+            if (!floatingWindow.IsDisposed)
+            {
+                floatingWindow.Close();
+                floatingWindow.Dispose();
+            }
 
             // Restore original state
             Dock = _originalDock;
             Location = _originalLocation;
             Size = _originalSize;
 
+            // Add back to original parent FIRST so Parent is valid when updating PreventIntegration
+            targetParent.Controls.Add(this);
+            targetParent.Controls.SetChildIndex(this, 0); // Bring to front of z-order for docking
+
             // Re-enable form integration
             CaptionArea!.PreventIntegration = false;
-
-            // Add back to original parent
-            _originalParent.Controls.Add(this);
+            MainPanel.Visible = true;
+            TabsArea?.CheckRibbonSize();
 
             // Clear stored state
             _originalParent = null;
+
+            // Perform layout and invalidate parent and ribbon
+            targetParent.PerformLayout();
+            targetParent.Invalidate(true);
+            targetParent.Update();
+
+            PerformLayout();
+            Invalidate(true);
+            Update();
+
+            // If the target parent form is a KryptonForm, refresh custom chrome
+            if (targetParent.FindForm() is KryptonForm kForm)
+            {
+                kForm.RecreateMinMaxCloseButtons();
+                kForm.PerformNeedPaint(true);
+            }
 
             // Raise event
             OnRibbonReattached(EventArgs.Empty);
@@ -2152,6 +2217,12 @@ public class KryptonRibbon : VisualSimple,
         // Cannot process a message for a disposed control
         if (!IsDisposed)
         {
+            if (_allowDetach && !IsDetached && e.Button == MouseButtons.Left)
+            {
+                _isMouseDownForDrag = true;
+                _dragMouseDownPoint = new Point(e.X, e.Y);
+            }
+
             // Do we have a manager for processing mouse messages?
             ViewManager?.MouseDown(e, new Point(e.X, e.Y));
         }
@@ -2160,11 +2231,36 @@ public class KryptonRibbon : VisualSimple,
     }
 
     /// <summary>
+    /// Raises the MouseMove event.
+    /// </summary>
+    /// <param name="e">A MouseEventArgs that contains the event data.</param>
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        if (!IsDisposed)
+        {
+            ViewManager?.MouseMove(e, new Point(e.X, e.Y));
+
+            if (_isMouseDownForDrag && _allowDetach && !IsDetached && e.Button == MouseButtons.Left)
+            {
+                var diffX = Math.Abs(e.X - _dragMouseDownPoint.X);
+                var diffY = Math.Abs(e.Y - _dragMouseDownPoint.Y);
+                if (diffX >= SystemInformation.DragSize.Width || diffY >= SystemInformation.DragSize.Height)
+                {
+                    _isMouseDownForDrag = false;
+                    DetachAndDrag(Cursor.Position);
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Raises the MouseUp event.
     /// </summary>
     /// <param name="e">A MouseEventArgs that contains the event data.</param>
     protected override void OnMouseUp(MouseEventArgs e)
     {
+        _isMouseDownForDrag = false;
+
         // Cannot process a message for a disposed control
         if (!IsDisposed)
         {
@@ -3380,6 +3476,7 @@ public class KryptonRibbon : VisualSimple,
         AllowButtonSpecToolTips = false;
         AllowButtonSpecToolTipPriority = false;
         AllowMinimizedChange = true;
+        _allowDragReattach = true;
         AutoSize = true;
         AutoSizeMode = AutoSizeMode.GrowAndShrink;
         Dock = DockStyle.Top;

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualRibbonDropSolidWindow.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualRibbonDropSolidWindow.cs
@@ -1,0 +1,120 @@
+﻿#region BSD License
+/*
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, Lesandro and tobitege et al. 2026 - 2026. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Ribbon;
+
+/// <summary>
+/// Draws a semi-transparent drop rectangle indicating where a detached ribbon will reattach on the parent window.
+/// </summary>
+[ToolboxItem(false)]
+[DesignTimeVisible(false)]
+internal class VisualRibbonDropSolidWindow : KryptonForm
+{
+    #region Instance Fields
+    private readonly IPaletteDragDrop _paletteDragDrop;
+    private readonly IRenderer _renderer;
+    private Rectangle _solidRect;
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the VisualRibbonDropSolidWindow class.
+    /// </summary>
+    /// <param name="paletteDragDrop">Drawing palette.</param>
+    /// <param name="renderer">Drawing renderer.</param>
+    public VisualRibbonDropSolidWindow(IPaletteDragDrop paletteDragDrop, IRenderer renderer)
+    {
+        SetInheritedControlOverride();
+        _paletteDragDrop = paletteDragDrop;
+        _renderer = renderer;
+
+        FormBorderStyle = FormBorderStyle.None;
+        SizeGripStyle = SizeGripStyle.Hide;
+        StartPosition = FormStartPosition.Manual;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        ShowInTaskbar = false;
+        BackColor = SharedStaticVariables.TRANSPARENCY_KEY_COLOR;
+        TransparencyKey = SharedStaticVariables.TRANSPARENCY_KEY_COLOR;
+        Opacity = _paletteDragDrop.GetDragDropSolidOpacity();
+    }
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// Show the window without taking activation.
+    /// </summary>
+    public void ShowWithoutActivate() =>
+        PI.ShowWindow(Handle, PI.ShowWindowCommands.SW_SHOWNOACTIVATE);
+
+    /// <summary>
+    /// Gets and sets the solid rectangle area in screen coordinates.
+    /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    public Rectangle SolidRect
+    {
+        get => _solidRect;
+
+        set
+        {
+            if (_solidRect != value)
+            {
+                _solidRect = value;
+
+                Rectangle bounds;
+                if (value.IsEmpty)
+                {
+                    bounds = new Rectangle(SharedStaticConstants.OFF_SCREEN_POSITION, SharedStaticConstants.OFF_SCREEN_POSITION, 0, 0);
+                }
+                else
+                {
+                    var area = Screen.GetWorkingArea(this);
+                    bounds = new Rectangle(value.Location - (Size)area.Location, value.Size);
+                }
+
+                DesktopBounds = bounds;
+                Refresh();
+            }
+        }
+    }
+    #endregion
+
+    #region Protected
+    /// <summary>
+    /// Raises the Paint event.
+    /// </summary>
+    /// <param name="e">A PaintEventArgs with event data.</param>
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        base.OnPaint(e);
+
+        if (!SolidRect.IsEmpty && _renderer != null)
+        {
+            using var context = new RenderContext(this, e.Graphics, e.ClipRectangle, _renderer);
+            _renderer.RenderGlyph.DrawDragDropSolidGlyph(context, ClientRectangle, _paletteDragDrop);
+        }
+    }
+
+    /// <summary>
+    /// Processes Windows messages.
+    /// </summary>
+    /// <param name="m">The Windows Message to process.</param>
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == PI.WM_.NCHITTEST)
+        {
+            m.Result = (IntPtr)PI.HT.TRANSPARENT;
+        }
+        else
+        {
+            base.WndProc(ref m);
+        }
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualRibbonFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualRibbonFloatingWindow.cs
@@ -11,12 +11,14 @@ namespace Krypton.Ribbon;
 
 /// <summary>Extends the KryptonForm to act as a floating window for a detached ribbon.</summary>
 [ToolboxItem(false)]
-//[DesignerCategory("code")]
 [DesignTimeVisible(false)]
 public class VisualRibbonFloatingWindow : KryptonForm
 {
     #region Instance Fields
     private KryptonRibbon? _ribbon;
+    private VisualRibbonDropSolidWindow? _dropSolidWindow;
+    private bool _isDragging;
+    private bool _isOverSnapTarget;
     #endregion
 
     #region Events
@@ -57,20 +59,6 @@ public class VisualRibbonFloatingWindow : KryptonForm
         StartPosition = FormStartPosition.Manual;
         Text = _ribbon.FloatingWindowText ?? @"Ribbon";
 
-        // Ensure InternalPanel is visible by adding it to base.Controls
-        // When SetInheritedControlOverride() is called, Controls property returns base.Controls,
-        // but the InternalPanel itself needs to be added to base.Controls to be visible
-        if (!base.Controls.Contains(InternalPanel))
-        {
-            InternalPanel.Dock = DockStyle.Fill;
-            base.Controls.Add(InternalPanel);
-            InternalPanel.BringToFront();
-        }
-
-        // Note: The ribbon will be added to this window by the Detach() method
-        // after it's removed from its original parent. We just store the reference here.
-        // The window size will be set in the Detach() method based on the ribbon's actual size.
-
         // Set border style to fixed tool window after initial sizing
         FormBorderStyle = FormBorderStyle.FixedToolWindow;
     }
@@ -87,92 +75,67 @@ public class VisualRibbonFloatingWindow : KryptonForm
 
     #region Protected
     /// <summary>
-    /// Raises the HandleCreated event.
-    /// </summary>
-    /// <param name="e">An EventArgs that contains the event data.</param>
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-        
-        // Ensure InternalPanel is added to base.Controls when using SetInheritedControlOverride
-        // This is similar to how MDI containers handle it
-        if (!base.Controls.Contains(InternalPanel))
-        {
-            InternalPanel.Dock = DockStyle.Fill;
-            base.Controls.Add(InternalPanel);
-            InternalPanel.BringToFront();
-        }
-    }
-
-    /// <summary>
     /// Raises the Load event.
     /// </summary>
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnLoad(EventArgs e)
     {
         base.OnLoad(e);
-        
-        // Ensure InternalPanel is visible
-        if (!base.Controls.Contains(InternalPanel))
-        {
-            InternalPanel.Dock = DockStyle.Fill;
-            base.Controls.Add(InternalPanel);
-            InternalPanel.BringToFront();
-        }
 
         // Ensure ribbon is properly sized and window is sized to fit
-        // Check if ribbon is in base.Controls (when SetInheritedControlOverride is used)
-        // or in InternalPanel.Controls
-        var ribbonParent = _ribbon?.Parent;
-        if (_ribbon != null && (ribbonParent == this || ribbonParent == InternalPanel))
+        if (_ribbon != null && _ribbon.Parent == this)
         {
-            // Ensure ribbon is visible and properly docked
+            // Ensure ribbon is visible, properly docked, and at front of z-order
             _ribbon.Visible = true;
             _ribbon.Dock = DockStyle.Top;
-            
+            _ribbon.BringToFront();
+
             // Force layout first to get accurate measurements
             SuspendLayout();
             _ribbon.SuspendLayout();
-            
-            // Perform layout to calculate actual size
+
             _ribbon.PerformLayout();
             PerformLayout();
-            
+
             _ribbon.ResumeLayout(true);
             ResumeLayout(true);
-            
+
             // Get the actual ribbon height after layout
             var ribbonHeight = _ribbon.Height;
-            
+
             // If height is still invalid, use preferred size calculation
             if (ribbonHeight <= 0 || ribbonHeight < 100)
             {
-                // Calculate preferred size with current width
                 var preferredSize = _ribbon.GetPreferredSize(new Size(Math.Max(400, Width), 0));
-                ribbonHeight = Math.Max(150, preferredSize.Height > 0 ? preferredSize.Height : 150);
-                
-                // Set ribbon size explicitly
+                ribbonHeight = Math.Max(100, preferredSize.Height > 0 ? preferredSize.Height : 100);
+
                 _ribbon.Size = new Size(Math.Max(400, Width), ribbonHeight);
-                
-                // Force another layout with the new size
                 _ribbon.PerformLayout();
             }
-            
-            // Set window size based on ribbon's actual size
-            // The width should match the ribbon's width, height should accommodate ribbon + caption
-            var captionHeight = SystemInformation.CaptionHeight;
-            var windowWidth = Math.Max(400, _ribbon.Width); // Ensure minimum width
-            var windowHeight = Math.Max(150 + captionHeight, ribbonHeight + captionHeight);
-            Size = new Size(windowWidth, windowHeight);
-            
-            // Ensure minimum size is set
-            MinimumSize = new Size(400, 150 + SystemInformation.CaptionHeight);
-            
+
+            // Set client size based on ribbon's actual size
+            ClientSize = new Size(Math.Max(400, _ribbon.Width), ribbonHeight);
+            MinimumSize = Size;
+
             // Force a refresh to ensure ribbon is painted
             _ribbon.Invalidate(true);
             Invalidate(true);
             Update();
             _ribbon.Update();
+        }
+    }
+
+    /// <summary>
+    /// Raises the LocationChanged event.
+    /// </summary>
+    /// <param name="e">An EventArgs that contains the event data.</param>
+    protected override void OnLocationChanged(EventArgs e)
+    {
+        base.OnLocationChanged(e);
+
+        if (_isDragging)
+        {
+            UpdateDragFeedback();
         }
     }
 
@@ -219,7 +182,7 @@ public class VisualRibbonFloatingWindow : KryptonForm
     {
         // Check if the double-click is on the caption/title bar area
         // SendMessage with int Msg returns uint
-        uint result = PI.SendMessage(Handle, (int)PI.WM_.NCHITTEST, IntPtr.Zero, m.LParam);
+        var result = PI.SendMessage(Handle, (int)PI.WM_.NCHITTEST, IntPtr.Zero, m.LParam);
         
         if (result == (uint)PI.HT.CAPTION)
         {
@@ -233,6 +196,30 @@ public class VisualRibbonFloatingWindow : KryptonForm
     }
 
     /// <summary>
+    /// Processes Windows messages.
+    /// </summary>
+    /// <param name="m">The Windows Message to process.</param>
+    protected override void WndProc(ref Message m)
+    {
+        switch (m.Msg)
+        {
+            case (int)PI.WM_.ENTERSIZEMOVE:
+                StartDragFeedback();
+                break;
+
+            case (int)PI.WM_.MOVING:
+                UpdateDragFeedback();
+                break;
+
+            case (int)PI.WM_.EXITSIZEMOVE:
+                EndDragFeedback();
+                break;
+        }
+
+        base.WndProc(ref m);
+    }
+
+    /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -240,11 +227,111 @@ public class VisualRibbonFloatingWindow : KryptonForm
     {
         if (disposing)
         {
+            if (_dropSolidWindow != null)
+            {
+                _dropSolidWindow.Dispose();
+                _dropSolidWindow = null;
+            }
+
             // Remove ribbon reference but don't dispose it - it will be reattached
             _ribbon = null;
         }
 
         base.Dispose(disposing);
+    }
+    #endregion
+
+    #region Implementation
+    private void StartDragFeedback()
+    {
+        if (_isDragging || _ribbon == null || !_ribbon.AllowDragReattach)
+        {
+            return;
+        }
+
+        _isDragging = true;
+        _isOverSnapTarget = false;
+
+        if (_dropSolidWindow == null)
+        {
+            var palette = new PaletteDragDrop(_ribbon.GetResolvedPalette(), null);
+            _dropSolidWindow = new VisualRibbonDropSolidWindow(palette, _ribbon.Renderer);
+            _dropSolidWindow.SetBounds(SharedStaticConstants.OFF_SCREEN_POSITION, SharedStaticConstants.OFF_SCREEN_POSITION, 1, 1, BoundsSpecified.All);
+            _dropSolidWindow.ShowWithoutActivate();
+        }
+    }
+
+    private void UpdateDragFeedback()
+    {
+        if (!_isDragging || _ribbon == null || !_ribbon.AllowDragReattach || _dropSolidWindow == null)
+        {
+            return;
+        }
+
+        Control? targetParent = _ribbon.OriginalParent ?? Owner;
+        if (targetParent == null || targetParent.IsDisposed || !targetParent.Visible)
+        {
+            _isOverSnapTarget = false;
+            _dropSolidWindow.SolidRect = Rectangle.Empty;
+            return;
+        }
+
+        // Calculate the dock target rectangle in screen coordinates
+        Point targetScreenTopLeft = targetParent.PointToScreen(Point.Empty);
+        var ribbonHeight = _ribbon.Height > 0 ? _ribbon.Height : 115;
+        var ribbonWidth = targetParent.ClientSize.Width;
+        var dockRect = new Rectangle(targetScreenTopLeft.X, targetScreenTopLeft.Y, ribbonWidth, ribbonHeight);
+
+        // Snap zone: cursor position is within dockRect with a generous margin,
+        // or the floating window itself overlaps the upper area of the parent form
+        Point cursorPos = Cursor.Position;
+        var expandedDockRect = new Rectangle(
+            dockRect.Left - 30,
+            dockRect.Top - 30,
+            dockRect.Width + 60,
+            dockRect.Height + 60);
+
+        var targetParentScreenBounds = new Rectangle(
+            targetScreenTopLeft.X,
+            targetScreenTopLeft.Y,
+            targetParent.ClientSize.Width,
+            targetParent.ClientSize.Height);
+
+        var inSnapZone = expandedDockRect.Contains(cursorPos)
+                         || (targetParentScreenBounds.Contains(cursorPos) && cursorPos.Y <= targetParentScreenBounds.Top + Math.Max(120, ribbonHeight + 30));
+
+        if (inSnapZone)
+        {
+            _isOverSnapTarget = true;
+            _dropSolidWindow.SolidRect = dockRect;
+        }
+        else
+        {
+            _isOverSnapTarget = false;
+            _dropSolidWindow.SolidRect = Rectangle.Empty;
+        }
+    }
+
+    private void EndDragFeedback()
+    {
+        if (!_isDragging)
+        {
+            return;
+        }
+
+        _isDragging = false;
+
+        if (_dropSolidWindow != null)
+        {
+            _dropSolidWindow.Dispose();
+            _dropSolidWindow = null;
+        }
+
+        if (_isOverSnapTarget && _ribbon != null)
+        {
+            _isOverSnapTarget = false;
+            _ribbon.Reattach();
+        }
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
@@ -204,8 +204,10 @@ internal class ViewLayoutRibbonTabsArea : ViewLayoutDocker
                 // flicker after the restore so prevent it from disappearing in the first case.
                 if (!CommonHelper.IsFormMinimized(topForm))
                 {
-                    var show = (topForm.ClientSize.Width >= _ribbon.HideRibbonSize.Width) &&
-                               (topForm.ClientSize.Height >= _ribbon.HideRibbonSize.Height);
+                    var show = _ribbon.IsDetached
+                               || (topForm is VisualRibbonFloatingWindow)
+                               || ((topForm.ClientSize.Width >= _ribbon.HideRibbonSize.Width) &&
+                                   (topForm.ClientSize.Height >= _ribbon.HideRibbonSize.Height));
 
                     // How we handle visibility differs in OS
                     if (Environment.OSVersion.Version.Major >= 6)
@@ -213,6 +215,14 @@ internal class ViewLayoutRibbonTabsArea : ViewLayoutDocker
                         if (_ribbon.MainPanel.Visible != show)
                         {
                             _ribbon.MainPanel.Visible = show;
+                        }
+
+                        if (_ribbon.IsDetached)
+                        {
+                            _captionArea.PreventIntegration = true;
+                        }
+                        else
+                        {
                             _captionArea.PreventIntegration = !show;
                         }
                     }

--- a/Source/Krypton Components/TestForm/RibbonDetachableTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/RibbonDetachableTest.Designer.cs
@@ -1,4 +1,4 @@
-namespace TestForm
+﻿namespace TestForm
 {
     partial class RibbonDetachableTest
     {
@@ -50,6 +50,9 @@ namespace TestForm
         private Krypton.Ribbon.KryptonRibbon _ribbon;
         private Krypton.Toolkit.KryptonButton _btnDetach;
         private Krypton.Toolkit.KryptonButton _btnReattach;
+        private Krypton.Toolkit.KryptonCheckBox _chkAllowDragReattach;
+        private Krypton.Toolkit.KryptonTextBox _txtFloatingTitle;
+        private Krypton.Toolkit.KryptonLabel _lblFloatingTitle;
         private Krypton.Toolkit.KryptonLabel _lblStatus;
         private Krypton.Toolkit.ButtonSpecAny _detachButton;
         private Krypton.Toolkit.ButtonSpecAny _reattachButton;

--- a/Source/Krypton Components/TestForm/RibbonDetachableTest.cs
+++ b/Source/Krypton Components/TestForm/RibbonDetachableTest.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -24,15 +24,22 @@ namespace TestForm;
 /// HOW TO USE:
 /// -----------
 /// 1. The ribbon is initially attached to the top of the form
-/// 2. Click the "Detach Ribbon" button to move the ribbon into a floating window
-/// 3. The floating window can be moved, resized, and positioned anywhere on screen
-/// 4. Click the "Reattach Ribbon" button to move the ribbon back to the form
-/// 5. Closing the floating window will automatically reattach the ribbon
+/// 2. To detach the ribbon:
+///    - Click and drag any tab or empty area on the ribbon tab strip / header outward to tear/drag it out into a floating window
+///    - Double-click the empty area on the ribbon tab strip
+///    - Click the "Detach Ribbon" button (or the Detach button in the ribbon header)
+/// 3. The floating window can be moved and positioned anywhere on screen
+/// 4. To reattach:
+///    - Drag the floating window near the top of the parent window: a semi-transparent dock preview indicator appears, and releasing snaps/reattaches the ribbon!
+///    - Double-click the floating window's title bar
+///    - Close the floating window
+///    - Click the "Reattach Ribbon" button (or the Reattach button in the ribbon header)
 /// 
 /// FEATURES DEMONSTRATED:
 /// ----------------------
 /// - AllowDetach property: Enables/disables the detach functionality
-/// - Detach() method: Moves ribbon to floating window
+/// - AllowDragReattach property: Enables/disables drag-and-drop reattachment with dock preview indicator
+/// - Detach() / DetachAndDrag() methods: Moves ribbon to floating window with interactive drag
 /// - Reattach() method: Moves ribbon back to original parent
 /// - IsDetached property: Indicates current state
 /// - RibbonDetached event: Fired when ribbon is detached
@@ -41,10 +48,13 @@ namespace TestForm;
 /// TESTING SCENARIOS:
 /// ------------------
 /// 1. Basic detach/reattach: Use the buttons to detach and reattach
-/// 2. Window closing: Close the floating window - ribbon should auto-reattach
-/// 3. State persistence: Check that UI updates correctly when state changes
-/// 4. Multiple operations: Detach and reattach multiple times
-/// 5. Form integration: Verify ribbon displays correctly in both states
+/// 2. Drag-out to detach: Click and drag a ribbon tab or empty tab strip area down/out to detach and float the ribbon
+/// 3. Drag-to-reattach: Drag the floating window over the top of the parent form to see the dock preview and drop to reattach
+/// 4. Title bar double-click: Double-click the floating window title bar to reattach
+/// 5. Window closing: Close the floating window - ribbon should auto-reattach
+/// 6. State persistence: Check that UI updates correctly when state changes
+/// 7. Multiple operations: Detach and reattach multiple times
+/// 8. Form integration: Verify ribbon displays correctly in both states
 /// 
 /// NOTES:
 /// ------
@@ -158,6 +168,7 @@ public partial class RibbonDetachableTest : KryptonForm
         // Add ribbon to the form
         // The ribbon must be added to a parent control before it can be detached
         Controls.Add(_ribbon);
+        _ribbon.BringToFront();
     }
 
     /// <summary>
@@ -246,7 +257,7 @@ public partial class RibbonDetachableTest : KryptonForm
         var panel = new KryptonPanel
         {
             Dock = DockStyle.Bottom,
-            Size = new Size(50, 150),
+            Size = new Size(50, 240),
             Padding = new Padding(10)
         };
 
@@ -256,6 +267,44 @@ public partial class RibbonDetachableTest : KryptonForm
             Text = @"Ribbon is attached. Click 'Detach' to move it to a floating window.",
             Dock = DockStyle.Top,
             Height = 30
+        };
+
+        // Titlebar text customization controls
+        _lblFloatingTitle = new KryptonLabel
+        {
+            Text = @"Floating Window Title:",
+            Dock = DockStyle.Top,
+            Height = 20
+        };
+
+        _txtFloatingTitle = new KryptonTextBox
+        {
+            Text = _ribbon?.FloatingWindowText ?? @"Ribbon",
+            Dock = DockStyle.Top,
+            Height = 25
+        };
+        _txtFloatingTitle.TextChanged += (s, e) =>
+        {
+            if (_ribbon != null)
+            {
+                _ribbon.FloatingWindowText = _txtFloatingTitle.Text;
+            }
+        };
+
+        // CheckBox for toggling drag-to-reattach
+        _chkAllowDragReattach = new KryptonCheckBox
+        {
+            Text = @"Enable Drag-to-Reattach (with dock preview indicator)",
+            Checked = true,
+            Dock = DockStyle.Top,
+            Height = 25
+        };
+        _chkAllowDragReattach.CheckedChanged += (s, e) =>
+        {
+            if (_ribbon != null)
+            {
+                _ribbon.AllowDragReattach = _chkAllowDragReattach.Checked;
+            }
         };
 
         // Detach button - only enabled when ribbon is attached
@@ -283,6 +332,9 @@ public partial class RibbonDetachableTest : KryptonForm
 
         panel.Controls.Add(_btnReattach);
         panel.Controls.Add(_btnDetach);
+        panel.Controls.Add(_chkAllowDragReattach);
+        panel.Controls.Add(_txtFloatingTitle);
+        panel.Controls.Add(_lblFloatingTitle);
         panel.Controls.Add(_lblStatus);
 
         Controls.Add(panel);
@@ -406,8 +458,8 @@ public partial class RibbonDetachableTest : KryptonForm
         if (_lblStatus != null)
         {
             _lblStatus.Text = isDetached
-                ? @"Ribbon is detached in a floating window. Click 'Reattach' to move it back."
-                : @"Ribbon is attached. Click 'Detach' to move it to a floating window.";
+                ? @"Ribbon is detached in a floating window. Drag near parent top to snap/reattach, double-click title bar, or click 'Reattach'."
+                : @"Ribbon is attached. Drag tabs/header out, double-click header, or click 'Detach' to float the ribbon.";
         }
     }
 }


### PR DESCRIPTION
Adds detachable ribbon support with drag-to-detach and drag-to-reattach behavior for KryptonRibbon. This includes floating-window chrome fixes, a dock preview overlay for snapping back to the parent form, lifecycle updates for detaching/reattaching, and validation via RibbonDetachableTest plus a new UnitTest-RibbonDetachable PowerShell check.