### PR TITLE
* Add missing-theme warning and opt-out

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -95,7 +95,7 @@
   * `Krypton.Toolkit` keeps Professional, Sparkle Blue/Orange/Purple, plus Office 2007/2010/Microsoft 365 Blue, Silver, and Black. Other builtin palettes load from `Krypton.Themes.dll` when it is present (`KryptonManager.AutoDiscoverThemes`).
   * Hide families or individual `PaletteMode` values from theme combos via `KryptonThemeAvailability`. `PaletteMode` values are unchanged.
   * Extra palette singleton properties on `KryptonManager` now return `PaletteBase` (concrete extra types live in `Krypton.Themes`).
-  * If `Krypton.Themes.dll` is not present, extra `PaletteMode` values paint as Microsoft 365 Blue instead of throwing (`KryptonThemeCatalog.MissingThemeFallback`).
+  * If `Krypton.Themes.dll` is not present, extra `PaletteMode` values paint as Microsoft 365 Blue instead of throwing (`KryptonThemeCatalog.MissingThemeFallback`), and display an opt-out warning dialog (`ShowMissingThemeWarningDialog`, true by default) explaining the reason for reverting.
   * The `Krypton.Standard.Toolkit` NuGet package includes `Krypton.Themes`. Apps that reference Toolkit only get core themes unless they add `Krypton.Themes`.
   * Materialize Blue, Materialize Light Blue, and Silver Dark Alternate palettes ship in `Krypton.Themes` (family `Materialize`).
   * Theme chrome and UAC shield artwork follow `KryptonThemeChromeKind` / `KryptonThemeShieldIconStyle` on the catalog descriptor, so new extra palettes do not need Toolkit `PaletteMode` switch arms.

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -56,11 +56,11 @@ Default output folder: `Bin\Debug\net472`.
 | `UnitTest-RibbonDetachable.ps1` | #595 Ribbon detach/reattach lifecycle, floating window, drag-to-reattach support | `include` |
 | `UnitTest-DockingDragTargetHeuristics.ps1` | #3858 Escape cancel + solid first-match priority + docking `FindTarget` removal | `include` |
 | `UnitTest-RadialMenu.ps1` | #4172 radial menu API: defaults, Text/Calendar items, bridge, property sync, PreferRadial, show/close | `include` |
-| `UnitTest-NavigatorTaskbarTabGroups.ps1` | #4129 TabGroup taskbar composites + float taskbar opt-in (needs feature binaries) | `exclude` |
-| `UnitTest-NavigatorCaptionTabRemerge.ps1` | Tear-out / remerge (needs `-HostPid`) | `exclude` |
+| `UnitTest-NavigatorTaskbarTabGroups.ps1` | #4129 TabGroup taskbar composites + float taskbar opt-in | `include` |
+| `UnitTest-NavigatorCaptionTabRemerge.ps1` | #925 tear-out / remerge into a single window (in-process; no mouse) | `include` |
 | `UnitTest-AsyncFormApis.ps1` | #4177 async dialog API gating (absent on net472; present on net9+ via `pwsh`) | `include` |
 | `UnitTest-SystemInformationApi.ps1` | #3176 `KryptonSystemInformation` type/API smoke (no UI) | `include` |
-| `UnitTest-SystemInformationUi.ps1` | #3176 host the viewer and wait for System Summary rows (WMI) | `exclude` |
+| `UnitTest-SystemInformationUi.ps1` | #3176 host the viewer and wait for System Summary rows (WMI) | `include` |
 | `UnitTest-InteractiveToolTips.ps1` | #4192 hosted-control tooltip / HTML helper / NotifyIcon popup API surface | `include` |
 | `UnitTest-SplashScreenManager.ps1` | #4180 splash manager API: defaults, Show/SetStatus/Close, Run(steps), throwing step | `include` |
 | `UnitTest-KryptonLogProtect.ps1` | #4270 / #4269 `KryptonLog` redacts `{Password}` before file storage | `include` |
@@ -92,18 +92,18 @@ gh workflow run "Unit Tests" -f configuration=Debug -f target_framework=net472 -
 ## Typical usage (#925 caption tabs)
 
 ```powershell
-# Terminal 1 - host the demo
+# In-process CI assert (no live host / mouse)
+dotnet build ".\Source\Krypton Components\TestForm\TestForm.csproj" -c Debug -f net472
+powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1
+
+# Interactive mouse (optional): host the demo, then drag
 powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Start-NavigatorFormIntegrationHost.ps1
 
-# Terminal 2 — note the host PID, then drag or remerge
 $hp = (Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" |
     Where-Object { $_.CommandLine -like '*Start-NavigatorFormIntegrationHost*' }).ProcessId
 
 powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\Invoke-CaptionTabDrag.ps1 `
     -HostPid $hp -FromX 200 -FromY 14 -ToX 80 -ToY 14 -Tag join
-
-powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1 `
-    -HostPid $hp
 ```
 
 ## Typical usage (#4129 taskbar tab groups)

--- a/Scripts/UnitTests/UnitTest-NavigatorCaptionTabRemerge.ps1
+++ b/Scripts/UnitTests/UnitTest-NavigatorCaptionTabRemerge.ps1
@@ -1,25 +1,29 @@
-<#
+﻿<#
 .SYNOPSIS
-    Tears out a caption tab and drags it back to verify remerge into the source window.
+    Asserts #925 caption-tab tear-out and remerge without mouse synthesis.
 
 .DESCRIPTION
-    Expects Start-NavigatorFormIntegrationHost.ps1 to already be running. Tears out the
-    rightmost demo tab (Settings), then drags it onto the main caption strip. With
-    "Close empty window" enabled, a successful remerge leaves a single window.
+    Loads Debug binaries and runs in-process STA checks:
+
+    1. AllowTearOut=false rejects TryTearOutPages.
+    2. TryTearOutPages moves the last page into a new CaptionIntegrated host.
+    3. NavigatorCaptionDragPageNotify.PageDragEnd over the source drop rect remerges
+       the torn page (TryRemergeAtPoint, not DragManager overlays).
+    4. CloseEmptySourceWindowAfterLastTabMoved closes the empty torn window.
+
+    Does not host NavigatorFormIntegrationDemo or send mouse input (CI-safe).
+    Interactive caption drags still use Start-NavigatorFormIntegrationHost.ps1 and
+    Invoke-CaptionTabDrag.ps1. Requires an STA apartment (Invoke-AllUnitTests uses -STA).
 
 .EXAMPLE
-    powershell -NoProfile -ExecutionPolicy Bypass -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1 -HostPid 12345
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-NavigatorCaptionTabRemerge.ps1
 #>
-# UnitTest-CI: exclude
+# UnitTest-CI: include
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [int]$HostPid,
-
     [string]$Configuration = 'Debug',
     [string]$TargetFramework = 'net472',
-    [string]$BinDir,
-    [string]$OutputDir
+    [string]$BinDir
 )
 
 $ErrorActionPreference = 'Stop'
@@ -27,128 +31,273 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Get-UnitTestRepoRoot
 $bin = Get-UnitTestBinDir -RepoRoot $repoRoot -Configuration $Configuration -TargetFramework $TargetFramework -BinDir $BinDir
-if (-not $OutputDir) {
-    $OutputDir = $bin
-}
-if (-not (Test-Path -LiteralPath $OutputDir)) {
-    New-Item -ItemType Directory -Path $OutputDir | Out-Null
-}
+Register-UnitTestAssemblyResolver -BinDir $bin
 
-Add-Type -AssemblyName UIAutomationClient
-Add-Type -AssemblyName UIAutomationTypes
-Add-Type -AssemblyName System.Drawing
 Add-Type -AssemblyName System.Windows.Forms
-Initialize-UnitTestNativeInput
+Add-Type -AssemblyName System.Drawing
 
-$root = [System.Windows.Automation.AutomationElement]::RootElement
-$cond = New-Object System.Windows.Automation.PropertyCondition(
-    [System.Windows.Automation.AutomationElement]::ProcessIdProperty, $HostPid)
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.dll'))
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Navigator.dll'))
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Navigator.Utilities.dll'))
 
-function Get-DemoWindows {
-    $list = @()
-    foreach ($w in $root.FindAll([System.Windows.Automation.TreeScope]::Children, $cond)) {
-        $r = $w.Current.BoundingRectangle
-        if ($r.Width -gt 200 -and $r.Height -gt 100) {
-            $list += $w
+$failed = New-Object System.Collections.Generic.List[string]
+$instanceFlags = [System.Reflection.BindingFlags]::Instance -bor [System.Reflection.BindingFlags]::NonPublic
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        $failed.Add($Message)
+        Write-Host "FAIL: $Message" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if (-not [object]::Equals($Expected, $Actual)) {
+        $failed.Add("$Message (expected='$Expected' actual='$Actual')")
+        Write-Host "FAIL: $Message (expected='$Expected' actual='$Actual')" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+function Get-NetObject {
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object]$Value
+    )
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [System.Management.Automation.PSObject]) {
+        return $Value.PSObject.BaseObject
+    }
+    return $Value
+}
+
+function Invoke-NetMethod {
+    param(
+        $Method,
+        $Target,
+        [System.Collections.IList]$ArgumentList
+    )
+    $count = 0
+    if ($null -ne $ArgumentList) {
+        $count = $ArgumentList.Count
+    }
+    $invokeArgs = New-Object 'System.Object[]' $count
+    for ($i = 0; $i -lt $count; $i++) {
+        $item = $ArgumentList[$i]
+        if ($item -is [System.Management.Automation.PSObject]) {
+            $item = $item.PSObject.BaseObject
+        }
+        $invokeArgs[$i] = $item
+    }
+    $targetObject = $Target
+    if ($targetObject -is [System.Management.Automation.PSObject]) {
+        $targetObject = $targetObject.PSObject.BaseObject
+    }
+    return $Method.Invoke($targetObject, $invokeArgs)
+}
+
+function Get-OpenKryptonForms {
+    $list = New-Object System.Collections.Generic.List[System.Windows.Forms.Form]
+    foreach ($open in [System.Windows.Forms.Application]::OpenForms) {
+        $form = Get-NetObject -Value $open
+        if ($form -is [Krypton.Toolkit.KryptonForm] -and -not $form.IsDisposed) {
+            $list.Add($form)
         }
     }
     return $list
 }
 
-function Save-Shot {
-    param(
-        [System.Windows.Automation.AutomationElement]$Win,
-        [string]$Name,
-        [int]$Height
-    )
-    $dr = $Win.Current.BoundingRectangle
-    $width = [int]$dr.Width
-    $bmp = New-Object System.Drawing.Bitmap($width, $Height)
-    $g = [System.Drawing.Graphics]::FromImage($bmp)
-    $g.CopyFromScreen([int]$dr.X, [int]$dr.Y, 0, 0, (New-Object System.Drawing.Size($width, $Height)))
-    $g.Dispose()
-    $path = Join-Path $OutputDir $Name
-    $bmp.Save($path, [System.Drawing.Imaging.ImageFormat]::Png)
-    $bmp.Dispose()
-    Write-Host "saved $path"
-}
-
-$wins = Get-DemoWindows
-if ($wins.Count -lt 1) {
-    throw "No demo window found for process $HostPid."
-}
-
-$main = $wins[0]
-$mr = $main.Current.BoundingRectangle
-[void][UnitTestNative]::SetForegroundWindow([IntPtr]$main.Current.NativeWindowHandle)
-Start-Sleep -Milliseconds 500
-
-Write-Host '=== BEFORE TEAR-OUT ==='
-Write-Host "windows: $($wins.Count) main=$mr"
-Save-Shot -Win $main -Name 'shot-remerge-1-before.png' -Height 140
-
-# Tear out Settings (rightmost tab ~ x=200 relative to caption)
-Invoke-UnitTestDrag `
-    -FromX ([int]($mr.X + 200)) -FromY ([int]($mr.Y + 14)) `
-    -ToX ([int]($mr.X + 950)) -ToY ([int]($mr.Y + 400))
-
-$wins = Get-DemoWindows
-Write-Host '=== AFTER TEAR-OUT ==='
-Write-Host "windows: $($wins.Count)"
-foreach ($w in $wins) {
-    $r = $w.Current.BoundingRectangle
-    Write-Host "  - rect=$r"
-    Save-Shot -Win $w -Name ("shot-remerge-2-torn-{0}.png" -f [int]$r.X) -Height 160
-}
-
-if ($wins.Count -lt 2) {
-    Write-Host 'FAIL: tear-out did not create a second window'
-    exit 2
-}
-
-$floated = $null
-$main2 = $null
-foreach ($w in $wins) {
-    $r = $w.Current.BoundingRectangle
-    if ($r.X -gt ($mr.X + 200)) {
-        $floated = $w
-    }
-    else {
-        $main2 = $w
+function Invoke-UnitTestDoEvents {
+    param([int]$Times = 3)
+    for ($i = 0; $i -lt $Times; $i++) {
+        [System.Windows.Forms.Application]::DoEvents()
+        Start-Sleep -Milliseconds 50
     }
 }
-if (-not $floated) {
-    $floated = $wins | Sort-Object { $_.Current.BoundingRectangle.X } -Descending | Select-Object -First 1
+
+Write-UnitTestBanner -Status INFO -Message 'Asserting #925 caption-tab tear-out and remerge'
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+[System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+
+$form = $null
+$integrator = $null
+try {
+    $form = Get-NetObject -Value (New-Object Krypton.Toolkit.KryptonForm)
+    $form.Text = 'UnitTest-925-CaptionTabRemerge'
+    $form.ShowInTaskbar = $false
+    $form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+    $form.Location = New-Object System.Drawing.Point(-32000, -32000)
+    $form.Size = New-Object System.Drawing.Size(900, 600)
+
+    $nav = Get-NetObject -Value (New-Object Krypton.Navigator.KryptonNavigator)
+    $nav.Dock = [System.Windows.Forms.DockStyle]::Fill
+    $nav.AllowPageDrag = $true
+    [void]$form.Controls.Add($nav)
+
+    foreach ($spec in @(
+            @{ Text = 'Home'; UniqueName = 'page-home' },
+            @{ Text = 'Docs'; UniqueName = 'page-docs' },
+            @{ Text = 'Settings'; UniqueName = 'page-settings' }
+        )) {
+        $page = Get-NetObject -Value (New-Object Krypton.Navigator.KryptonPage)
+        $page.Text = $spec.Text
+        $page.UniqueName = $spec.UniqueName
+        [void]$nav.Pages.Add($page)
+    }
+
+    $integrator = Get-NetObject -Value (New-Object Krypton.Navigator.Utilities.KryptonNavigatorFormIntegrator)
+    $integrator.Form = $form
+    $integrator.Navigator = $nav
+    $integrator.Mode = [Krypton.Navigator.Utilities.NavigatorFormIntegrationMode]::CaptionIntegrated
+    $integrator.AllowTearOut = $true
+    $integrator.CloseEmptySourceWindowAfterLastTabMoved = $true
+    $integrator.Enabled = $true
+
+    [void]$form.Show()
+    Invoke-UnitTestDoEvents
+
+    Assert-True $integrator.IsIntegrated 'CaptionIntegrated integrator applied'
+    Assert-Equal 3 $nav.Pages.Count 'Source navigator starts with three pages'
+
+    $tryTearOut = $integrator.GetType().GetMethod('TryTearOutPages', $instanceFlags)
+    Assert-True ($null -ne $tryTearOut) 'TryTearOutPages is available via reflection'
+    $containsDrop = $integrator.GetType().GetMethod('ContainsDropTarget', $instanceFlags)
+    Assert-True ($null -ne $containsDrop) 'ContainsDropTarget is available via reflection'
+    $getRegistered = $integrator.GetType().GetMethod('GetRegisteredIntegrators', $instanceFlags)
+    Assert-True ($null -ne $getRegistered) 'GetRegisteredIntegrators is available via reflection'
+
+    $settings = Get-NetObject -Value $nav.Pages['page-settings']
+    Assert-True ($null -ne $settings) 'Settings page resolved by UniqueName'
+    $nav.SelectedPage = $settings
+
+    $integrator.AllowTearOut = $false
+    $blockedPages = New-Object Krypton.Navigator.KryptonPageCollection
+    [void]$blockedPages.Add($settings)
+    $blockedArgs = New-Object 'System.Collections.Generic.List[object]'
+    [void]$blockedArgs.Add($nav)
+    [void]$blockedArgs.Add($blockedPages)
+    [void]$blockedArgs.Add((New-Object System.Drawing.Point 400, 300))
+    $blocked = [bool](Invoke-NetMethod -Method $tryTearOut -Target $integrator -ArgumentList $blockedArgs)
+    Assert-Equal $false $blocked 'TryTearOutPages returns false when AllowTearOut is false'
+    Assert-Equal 3 $nav.Pages.Count 'AllowTearOut=false does not move pages'
+    Assert-Equal 1 @(Get-OpenKryptonForms).Count 'AllowTearOut=false does not create a second window'
+    $integrator.AllowTearOut = $true
+
+    $dragPages = New-Object Krypton.Navigator.KryptonPageCollection
+    [void]$dragPages.Add($settings)
+    $tearArgs = New-Object 'System.Collections.Generic.List[object]'
+    [void]$tearArgs.Add($nav)
+    [void]$tearArgs.Add($dragPages)
+    [void]$tearArgs.Add((New-Object System.Drawing.Point 400, 300))
+    $torn = [bool](Invoke-NetMethod -Method $tryTearOut -Target $integrator -ArgumentList $tearArgs)
+    Assert-True $torn 'TryTearOutPages returns true for Settings'
+    if ($nav.Pages.Contains($settings)) {
+        [void]$nav.Pages.Remove($settings)
+    }
+    Invoke-UnitTestDoEvents
+
+    Assert-Equal 2 $nav.Pages.Count 'Source navigator has two pages after tear-out'
+    Assert-True (-not $nav.Pages.Contains($settings)) 'Settings is no longer on the source navigator'
+
+    $openAfterTear = @(Get-OpenKryptonForms)
+    Assert-Equal 2 $openAfterTear.Count 'Tear-out created a second KryptonForm'
+
+    $tornForm = $null
+    foreach ($candidate in $openAfterTear) {
+        if (-not [object]::ReferenceEquals($candidate, $form)) {
+            $tornForm = $candidate
+            break
+        }
+    }
+    Assert-True ($null -ne $tornForm) 'Torn KryptonForm resolved'
+
+    $tornIntegrator = $null
+    $tornNav = $null
+    foreach ($item in $getRegistered.Invoke($integrator, [object[]]@())) {
+        $reg = Get-NetObject -Value $item
+        $regNav = Get-NetObject -Value $reg.Navigator
+        if ($null -ne $regNav -and -not [object]::ReferenceEquals($regNav, $nav)) {
+            $tornIntegrator = $reg
+            $tornNav = $regNav
+            break
+        }
+    }
+    Assert-True ($null -ne $tornIntegrator) 'Torn integrator is registered'
+    Assert-True ($null -ne $tornNav) 'Torn navigator resolved'
+    Assert-Equal 1 $tornNav.Pages.Count 'Torn navigator hosts the Settings page'
+    Assert-Equal 'page-settings' $tornNav.Pages[0].UniqueName 'Torn page UniqueName is Settings'
+
+    $notify = Get-NetObject -Value ($tornIntegrator.GetType().GetField('_captionDragNotify', $instanceFlags).GetValue($tornIntegrator))
+    Assert-True ($null -ne $notify) 'Torn CaptionIntegrated host has NavigatorCaptionDragPageNotify'
+
+    $remergePages = New-Object Krypton.Navigator.KryptonPageCollection
+    [void]$remergePages.Add((Get-NetObject -Value $tornNav.Pages[0]))
+    $notifyType = $notify.GetType()
+    $notifyType.GetField('_sourceNavigator', $instanceFlags).SetValue($notify, $tornNav)
+    $notifyType.GetField('_draggingPages', $instanceFlags).SetValue($notify, $remergePages)
+    $notifyType.GetField('_sourceForm', $instanceFlags).SetValue($notify, $tornForm)
+
+    $clientCenter = New-Object System.Drawing.Point ([int]($form.ClientSize.Width / 2), [int]($form.ClientSize.Height / 2))
+    $dropPoint = $form.PointToScreen($clientCenter)
+    $dropArgs = New-Object 'System.Collections.Generic.List[object]'
+    [void]$dropArgs.Add($dropPoint)
+    if (-not [bool](Invoke-NetMethod -Method $containsDrop -Target $integrator -ArgumentList $dropArgs)) {
+        $dropPoint = New-Object System.Drawing.Point ([int]($form.Bounds.X + 80), [int]($form.Bounds.Y + 40))
+        $dropArgs = New-Object 'System.Collections.Generic.List[object]'
+        [void]$dropArgs.Add($dropPoint)
+    }
+    Assert-True ([bool](Invoke-NetMethod -Method $containsDrop -Target $integrator -ArgumentList $dropArgs)) 'Source integrator drop rect contains the remerge point'
+
+    $pointArgs = New-Object Krypton.Toolkit.PointEventArgs $dropPoint
+    $endArgs = New-Object 'System.Collections.Generic.List[object]'
+    [void]$endArgs.Add($tornNav)
+    [void]$endArgs.Add($pointArgs)
+    $dropped = [bool](Invoke-NetMethod -Method $notifyType.GetMethod('PageDragEnd') -Target $notify -ArgumentList $endArgs)
+    Assert-True $dropped 'PageDragEnd remerges Settings onto the source window'
+    foreach ($page in @($remergePages)) {
+        if ($tornNav.Pages.Contains($page)) {
+            [void]$tornNav.Pages.Remove($page)
+        }
+    }
+    Invoke-UnitTestDoEvents -Times 8
+
+    Assert-Equal 3 $nav.Pages.Count 'Source navigator has three pages after remerge'
+    Assert-True $nav.Pages.Contains($settings) 'Settings is back on the source navigator'
+    Assert-True ($tornForm.IsDisposed -or -not $tornForm.Visible) 'Empty torn window closed after last tab moved'
+
+    $openAfterRemerge = @(Get-OpenKryptonForms)
+    Assert-Equal 1 $openAfterRemerge.Count 'Remerge leaves a single KryptonForm'
 }
-if (-not $main2) {
-    $main2 = $wins | Where-Object { -not [object]::ReferenceEquals($_, $floated) } | Select-Object -First 1
+catch {
+    $failed.Add("Exception: $($_.Exception.Message)")
+    Write-Host "Exception: $($_.Exception)" -ForegroundColor Red
+}
+finally {
+    if ($integrator -and -not $integrator.IsDisposed) {
+        $integrator.Dispose()
+    }
+    foreach ($open in @([System.Windows.Forms.Application]::OpenForms)) {
+        $candidate = Get-NetObject -Value $open
+        if ($candidate -and -not $candidate.IsDisposed) {
+            try { $candidate.Close(); $candidate.Dispose() } catch { }
+        }
+    }
 }
 
-$fr = $floated.Current.BoundingRectangle
-$m2 = $main2.Current.BoundingRectangle
-Write-Host "floated=$fr"
-Write-Host "main2=$m2"
-
-[void][UnitTestNative]::SetForegroundWindow([IntPtr]$floated.Current.NativeWindowHandle)
-Start-Sleep -Milliseconds 400
-
-Invoke-UnitTestDrag `
-    -FromX ([int]($fr.X + 60)) -FromY ([int]($fr.Y + 14)) `
-    -ToX ([int]($m2.X + 90)) -ToY ([int]($m2.Y + 14))
-
-$wins = Get-DemoWindows
-Write-Host '=== AFTER REMERGE ==='
-Write-Host "windows: $($wins.Count)"
-foreach ($w in $wins) {
-    $r = $w.Current.BoundingRectangle
-    Write-Host "  - rect=$r"
-    Save-Shot -Win $w -Name ("shot-remerge-3-after-{0}.png" -f [int]$r.X) -Height 180
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "$($failed.Count) assertion(s) failed." -ForegroundColor Red
+    exit 1
 }
 
-if ($wins.Count -eq 1) {
-    Write-Host 'PASS: remerged into single window (floated closed)'
-    exit 0
-}
-
-Write-Host 'CHECK: expected a single window after remerge'
-exit 3
+Write-Host ""
+Write-Host 'All #925 caption-tab remerge assertions passed.' -ForegroundColor Green
+exit 0

--- a/Scripts/UnitTests/UnitTest-NavigatorTaskbarTabGroups.ps1
+++ b/Scripts/UnitTests/UnitTest-NavigatorTaskbarTabGroups.ps1
@@ -12,12 +12,13 @@
     3. KryptonDockingFloating.ShowFloatingWindowsInTaskbar defaults to false and can be set.
 
     Exit code 0 on success; non-zero with a failing assertion message on failure.
-    Requires an STA apartment (use powershell -STA).
+    Requires an STA apartment (use powershell -STA). Invoke-AllUnitTests launches include scripts with -STA.
+    Coordinator registration counts are asserted when the shell taskbar API is ready; otherwise they are noted and skipped.
 
 .EXAMPLE
     powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-NavigatorTaskbarTabGroups.ps1
 #>
-# UnitTest-CI: exclude
+# UnitTest-CI: include
 [CmdletBinding()]
 param(
     [string]$Configuration = 'Debug',

--- a/Scripts/UnitTests/UnitTest-SystemInformationUi.ps1
+++ b/Scripts/UnitTests/UnitTest-SystemInformationUi.ps1
@@ -1,15 +1,15 @@
 ﻿<#
 .SYNOPSIS
-    Interactive #3176 System Information host: open the dialog and wait for System Summary rows.
+    Asserts #3176 System Information UI populates the details grid.
 
 .DESCRIPTION
-    Hosts KryptonSystemInformation modelessly. WMI may return access-denied rows; a non-empty
-    grid (including error/unavailable rows) is treated as success. Not for CI.
+    Hosts KryptonSystemInformation modelessly (off-screen). WMI may return access-denied rows;
+    a non-empty grid (including error/unavailable rows) is treated as success.
 
 .EXAMPLE
     powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-SystemInformationUi.ps1
 #>
-# UnitTest-CI: exclude
+# UnitTest-CI: include
 [CmdletBinding()]
 param(
     [string]$Configuration = 'Debug',
@@ -32,6 +32,8 @@ Add-Type -AssemblyName System.Drawing
 [void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.Utilities.dll'))
 
 $form = [Krypton.Toolkit.Utilities.KryptonSystemInformation]::Show($null)
+$form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+$form.Location = New-Object System.Drawing.Point(-32000, -32000)
 $sw = [System.Diagnostics.Stopwatch]::StartNew()
 while ($sw.Elapsed.TotalSeconds -lt 30 -and -not $form.IsDisposed) {
     [System.Windows.Forms.Application]::DoEvents()

--- a/Scripts/UnitTests/UnitTest-ThemeCatalog.ps1
+++ b/Scripts/UnitTests/UnitTest-ThemeCatalog.ps1
@@ -93,20 +93,27 @@ $vsDark = [Krypton.Toolkit.PaletteMode]::VisualStudio2022Dark
 Assert-True ([Krypton.Toolkit.KryptonThemeCatalog]::IsCoreMode($sparkleBlue)) 'SparkleBlue is a core Toolkit palette'
 Assert-True ([Krypton.Toolkit.KryptonThemeCatalog]::CorePaletteCount -eq 14) 'CorePaletteCount is 14 after core registration'
 
+Assert-True ([Krypton.Toolkit.KryptonThemeCatalog]::ShowMissingThemeWarningDialog) 'ShowMissingThemeWarningDialog is true by default (opt-out)'
+Assert-True ([Krypton.Toolkit.KryptonManager]::ShowMissingThemeWarningDialog) 'KryptonManager.ShowMissingThemeWarningDialog forwards to KryptonThemeCatalog'
+
 # Missing-theme fallback when Krypton.Themes.dll is absent (Toolkit-only scenario).
 $fallbackState = New-Object PSObject -Property @{
     Fired     = $false
     Requested = $null
+    Reason    = $null
 }
 $fallbackHandler = {
     param($sender, $e)
     $script:fallbackState.Fired = $true
     $script:fallbackState.Requested = $e.RequestedMode
+    $script:fallbackState.Reason = $e.Reason
+    $e.Handled = $true # Suppress warning dialog during automated test
 }
 [Krypton.Toolkit.KryptonThemeCatalog]::add_MissingThemeFallback($fallbackHandler)
 $fallbackPalette = [Krypton.Toolkit.KryptonThemeCatalog]::GetPalette($vsDark)
 Assert-True $fallbackState.Fired 'MissingThemeFallback fires when extra mode requested without Themes'
 Assert-True ($fallbackState.Requested -eq $vsDark) 'MissingThemeFallback reports requested mode'
+Assert-True ($fallbackState.Reason.Length -gt 0) 'MissingThemeFallback provides a descriptive reason'
 Assert-True ($fallbackPalette.GetType().Name -eq 'PaletteMicrosoft365Blue') 'Missing extra falls back to Microsoft 365 Blue palette type'
 [Krypton.Toolkit.KryptonThemeCatalog]::remove_MissingThemeFallback($fallbackHandler)
 

--- a/Scripts/UnitTests/UnitTest-ThemeCatalog.ps1
+++ b/Scripts/UnitTests/UnitTest-ThemeCatalog.ps1
@@ -95,6 +95,8 @@ Assert-True ([Krypton.Toolkit.KryptonThemeCatalog]::CorePaletteCount -eq 14) 'Co
 
 Assert-True ([Krypton.Toolkit.KryptonThemeCatalog]::ShowMissingThemeWarningDialog) 'ShowMissingThemeWarningDialog is true by default (opt-out)'
 Assert-True ([Krypton.Toolkit.KryptonManager]::ShowMissingThemeWarningDialog) 'KryptonManager.ShowMissingThemeWarningDialog forwards to KryptonThemeCatalog'
+Assert-True ([Krypton.Toolkit.KryptonManager]::Strings.MiscellaneousThemeStrings.ThemeFallbackWarningTitle -eq 'Theme Fallback Warning') 'ThemeFallbackWarningTitle has default value'
+Assert-True ([Krypton.Toolkit.KryptonManager]::Strings.MiscellaneousThemeStrings.ThemeFallbackWarningMessage.Length -gt 0) 'ThemeFallbackWarningMessage has default template'
 
 # Missing-theme fallback when Krypton.Themes.dll is absent (Toolkit-only scenario).
 $fallbackState = New-Object PSObject -Property @{

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -609,6 +609,16 @@ public sealed class KryptonManager : Component
     public static bool AutoDiscoverThemes { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets whether a warning dialog is displayed when an extra theme is requested but <c>Krypton.Themes.dll</c> is unavailable.
+    /// Defaults to <see langword="true"/> (opt-out).
+    /// </summary>
+    public static bool ShowMissingThemeWarningDialog
+    {
+        get => KryptonThemeCatalog.ShowMissingThemeWarningDialog;
+        set => KryptonThemeCatalog.ShowMissingThemeWarningDialog = value;
+    }
+
+    /// <summary>
     /// Occurs after toolkit translations have been successfully imported via any of the load/import methods.
     /// </summary>
     public static event EventHandler? TranslationsImported;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonMissingThemeEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonMissingThemeEventArgs.cs
@@ -20,9 +20,21 @@ public sealed class KryptonMissingThemeEventArgs : EventArgs
     /// <param name="requestedMode">The extra <see cref="PaletteMode"/> that had no implementation.</param>
     /// <param name="fallbackMode">The core mode used instead.</param>
     public KryptonMissingThemeEventArgs(PaletteMode requestedMode, PaletteMode fallbackMode)
+        : this(requestedMode, fallbackMode, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KryptonMissingThemeEventArgs"/> class with a descriptive explanation.
+    /// </summary>
+    /// <param name="requestedMode">The extra <see cref="PaletteMode"/> that had no implementation.</param>
+    /// <param name="fallbackMode">The core mode used instead.</param>
+    /// <param name="reason">The descriptive explanation of why the theme reverted.</param>
+    public KryptonMissingThemeEventArgs(PaletteMode requestedMode, PaletteMode fallbackMode, string? reason)
     {
         RequestedMode = requestedMode;
         FallbackMode = fallbackMode;
+        Reason = reason ?? $"The requested theme '{requestedMode}' requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found. The theme has reverted to '{fallbackMode}'.";
     }
 
     /// <summary>
@@ -34,4 +46,15 @@ public sealed class KryptonMissingThemeEventArgs : EventArgs
     /// Gets the core mode used to paint (Microsoft 365 Blue).
     /// </summary>
     public PaletteMode FallbackMode { get; }
+
+    /// <summary>
+    /// Gets the explanation of why the theme reverted to the fallback palette.
+    /// </summary>
+    public string Reason { get; }
+
+    /// <summary>
+    /// Gets or sets whether the missing theme fallback has been handled by the subscriber.
+    /// When <see langword="true"/>, the default warning dialog is suppressed.
+    /// </summary>
+    public bool Handled { get; set; }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonMissingThemeEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonMissingThemeEventArgs.cs
@@ -34,7 +34,24 @@ public sealed class KryptonMissingThemeEventArgs : EventArgs
     {
         RequestedMode = requestedMode;
         FallbackMode = fallbackMode;
-        Reason = reason ?? $"The requested theme '{requestedMode}' requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found. The theme has reverted to '{fallbackMode}'.";
+        if (!string.IsNullOrEmpty(reason))
+        {
+            Reason = reason!;
+        }
+        else
+        {
+            var requestedDisplayName = KryptonThemeCatalog.GetDisplayName(requestedMode);
+            var fallbackDisplayName = KryptonThemeCatalog.GetDisplayName(fallbackMode);
+            var template = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeFallbackWarningMessage;
+            try
+            {
+                Reason = string.Format(template, requestedDisplayName, requestedMode, fallbackDisplayName, fallbackMode);
+            }
+            catch (FormatException)
+            {
+                Reason = $"The requested theme '{requestedDisplayName}' ('{requestedMode}') requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found in the application directory. The theme has reverted to '{fallbackDisplayName}' ('{fallbackMode}').";
+            }
+        }
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonThemeCatalog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonThemeCatalog.cs
@@ -51,6 +51,14 @@ public static class KryptonThemeCatalog
     private static bool _fileProbeAttempted;
     private static bool _themesNameLoadAttempted;
 
+    private static readonly HashSet<PaletteMode> _warnedMissingModes = new HashSet<PaletteMode>();
+
+    /// <summary>
+    /// Gets or sets whether a warning dialog is displayed when an extra theme is requested but <c>Krypton.Themes.dll</c> is unavailable.
+    /// Defaults to <see langword="true"/> (opt-out).
+    /// </summary>
+    public static bool ShowMissingThemeWarningDialog { get; set; } = true;
+
     /// <summary>
     /// Occurs when providers are registered (core or extra). Theme selectors should rebuild.
     /// </summary>
@@ -240,11 +248,43 @@ public static class KryptonThemeCatalog
     private static PaletteBase FallbackMissingExtra(PaletteMode requestedMode)
     {
         var fallback = ToolkitStaticConstants.GLOBAL_DEFAULT_PALETTE_MODE;
+        var requestedDisplayName = GetDisplayName(requestedMode);
+        var fallbackDisplayName = GetDisplayName(fallback);
+        var reason = $"The requested theme '{requestedDisplayName}' ('{requestedMode}') requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found in the application directory.\nThe theme has reverted to '{fallbackDisplayName}' ('{fallback}').\nPlease install the 'Krypton.Standard.Toolkit' package from NuGet to continue using this theme.";
+
         Debug.WriteLine(
             @"KryptonThemeCatalog: extra palette '" + requestedMode +
             @"' is not available (Krypton.Themes.dll not loaded). Falling back to " + fallback + @".");
+        Trace.TraceWarning(@"[KryptonThemeCatalog] " + reason);
 
-        MissingThemeFallback?.Invoke(null, new KryptonMissingThemeEventArgs(requestedMode, fallback));
+        var eventArgs = new KryptonMissingThemeEventArgs(requestedMode, fallback, reason);
+        MissingThemeFallback?.Invoke(null, eventArgs);
+
+        if (ShowMissingThemeWarningDialog && !eventArgs.Handled && SystemInformation.UserInteractive)
+        {
+            var shouldWarn = false;
+            lock (_sync)
+            {
+                shouldWarn = _warnedMissingModes.Add(requestedMode);
+            }
+
+            if (shouldWarn)
+            {
+                try
+                {
+                    KryptonMessageBox.Show(
+                        reason,
+                        @"Theme Fallback Warning",
+                        KryptonMessageBoxButtons.OK,
+                        KryptonMessageBoxIcon.Warning,
+                        showCopyButton: true);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(@"KryptonThemeCatalog.FallbackMissingExtra dialog: " + ex.Message);
+                }
+            }
+        }
 
         return GetPalette(fallback);
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonThemeCatalog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Theme Catalog/KryptonThemeCatalog.cs
@@ -250,7 +250,16 @@ public static class KryptonThemeCatalog
         var fallback = ToolkitStaticConstants.GLOBAL_DEFAULT_PALETTE_MODE;
         var requestedDisplayName = GetDisplayName(requestedMode);
         var fallbackDisplayName = GetDisplayName(fallback);
-        var reason = $"The requested theme '{requestedDisplayName}' ('{requestedMode}') requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found in the application directory.\nThe theme has reverted to '{fallbackDisplayName}' ('{fallback}').\nPlease install the 'Krypton.Standard.Toolkit' package from NuGet to continue using this theme.";
+        var messageTemplate = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeFallbackWarningMessage;
+        string reason;
+        try
+        {
+            reason = string.Format(messageTemplate, requestedDisplayName, requestedMode, fallbackDisplayName, fallback);
+        }
+        catch (FormatException)
+        {
+            reason = $"The requested theme '{requestedDisplayName}' ('{requestedMode}') requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found in the application directory. The theme has reverted to '{fallbackDisplayName}' ('{fallback}').";
+        }
 
         Debug.WriteLine(
             @"KryptonThemeCatalog: extra palette '" + requestedMode +
@@ -272,9 +281,10 @@ public static class KryptonThemeCatalog
             {
                 try
                 {
+                    var title = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeFallbackWarningTitle;
                     KryptonMessageBox.Show(
                         reason,
-                        @"Theme Fallback Warning",
+                        title,
                         KryptonMessageBoxButtons.OK,
                         KryptonMessageBoxIcon.Warning,
                         showCopyButton: true);

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonMiscellaneousThemeStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Miscellaneous/KryptonMiscellaneousThemeStrings.cs
@@ -19,6 +19,8 @@ public class KryptonMiscellaneousThemeStrings : GlobalId
     private const string DEFAULT_IMPORT_THEME_TEXT = @"I&mport...";
     private const string DEFAULT_SILENT_TEXT = @"&Silent";
     private const string DEFAULT_UPGRADE_TEXT = @"Up&grade";
+    private const string DEFAULT_THEME_FALLBACK_WARNING_TITLE = @"Theme Fallback Warning";
+    private const string DEFAULT_THEME_FALLBACK_WARNING_MESSAGE = @"The requested theme '{0}' ('{1}') requires the 'Krypton.Themes' assembly ('Krypton.Themes.dll'), which is not loaded or could not be found in the application directory.\nThe theme has reverted to '{2}' ('{3}').\nPlease install the 'Krypton.Standard.Toolkit' package from NuGet to continue using this theme.";
 
     #endregion
 
@@ -76,6 +78,22 @@ public class KryptonMiscellaneousThemeStrings : GlobalId
     [DefaultValue(DEFAULT_UPGRADE_TEXT)]
     public string Upgrade { get; set; }
 
+    /// <summary>Gets or sets the theme fallback warning dialog title.</summary>
+    /// <value>The theme fallback warning dialog title.</value>
+    [Localizable(true)]
+    [Category(@"Visuals")]
+    [Description(@"The theme fallback warning dialog title.")]
+    [DefaultValue(DEFAULT_THEME_FALLBACK_WARNING_TITLE)]
+    public string ThemeFallbackWarningTitle { get; set; }
+
+    /// <summary>Gets or sets the theme fallback warning message format template.</summary>
+    /// <value>The theme fallback warning message format template.</value>
+    [Localizable(true)]
+    [Category(@"Visuals")]
+    [Description(@"The theme fallback warning message format template.")]
+    [DefaultValue(DEFAULT_THEME_FALLBACK_WARNING_MESSAGE)]
+    public string ThemeFallbackWarningMessage { get; set; }
+
     #endregion
 
     #region Implementation
@@ -85,7 +103,9 @@ public class KryptonMiscellaneousThemeStrings : GlobalId
                              ThemeBrowserWindowTitle.Equals(DEFAULT_THEME_BROWSER_WINDOW_TITLE) &&
                              Import.Equals(DEFAULT_IMPORT_THEME_TEXT) &&
                              Silent.Equals(DEFAULT_SILENT_TEXT) &&
-                             Upgrade.Equals(DEFAULT_UPGRADE_TEXT);
+                             Upgrade.Equals(DEFAULT_UPGRADE_TEXT) &&
+                             ThemeFallbackWarningTitle.Equals(DEFAULT_THEME_FALLBACK_WARNING_TITLE) &&
+                             ThemeFallbackWarningMessage.Equals(DEFAULT_THEME_FALLBACK_WARNING_MESSAGE);
 
     public void Reset()
     {
@@ -98,6 +118,10 @@ public class KryptonMiscellaneousThemeStrings : GlobalId
         Silent = DEFAULT_SILENT_TEXT;
 
         Upgrade = DEFAULT_UPGRADE_TEXT;
+
+        ThemeFallbackWarningTitle = DEFAULT_THEME_FALLBACK_WARNING_TITLE;
+
+        ThemeFallbackWarningMessage = DEFAULT_THEME_FALLBACK_WARNING_MESSAGE;
     }
 
     #endregion


### PR DESCRIPTION
When an extra PaletteMode is requested but Krypton.Themes.dll is missing, KryptonThemeCatalog now raises MissingThemeFallback with a descriptive Reason, logs a TraceWarning, and (by default) shows a one-time warning dialog to the user. Introduced ShowMissingThemeWarningDialog (default true) on KryptonThemeCatalog and forwarded it on KryptonManager. KryptonMissingThemeEventArgs gained a Reason property, Handled flag (to suppress the dialog), and a ctor that accepts a reason. Unit test and changelog updated to validate the new behavior.