### PR TITLE
* Add scheduled publish day support to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,12 @@
 # build (scheduled or manual), or enable the skip_change_check workflow_dispatch input for a one-off run.
 # Either override forces a build even when there are no commits, or only .github-only commits, in the
 # last 24 hours.
+#
+# SCHEDULED PUBLISH DAYS: In addition to the daily 24-hour change check, the workflow can also publish
+# on 1 January and on UTC days of the year whose number ends in 0 (e.g. 10, 20, 30, 100, 300, 310),
+# even when there are no qualifying commits. Enable each rule via repository variables:
+#   NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED=true
+#   NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED=true
 
 name: Nightly Release
 
@@ -131,6 +137,8 @@ jobs:
         env:
           SKIP_CHANGE_CHECK_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_change_check == true && 'true' || 'false' }}
           SKIP_NIGHTLY_24_HOUR_CHECK: ${{ vars.SKIP_NIGHTLY_24_HOUR_CHECK }}
+          NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED: ${{ vars.NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED }}
+          NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED: ${{ vars.NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -150,18 +158,45 @@ jobs:
 
           Write-Host "Commits in last 24 hours (excluding .github-only changes): $commitCount"
 
-          if ($commitCount -gt 0) {
-            Write-Host "Changes detected - proceeding with nightly build"
+          $todayUtc = (Get-Date).ToUniversalTime()
+          $dayOfYear = $todayUtc.DayOfYear
+          $jan1PublishEnabled = $env:NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED -eq 'true'
+          $dayEndsZeroPublishEnabled = $env:NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED -eq 'true'
+          $forcedPublishDay = $false
+          $forcedPublishReason = $null
+
+          if ($jan1PublishEnabled -and $todayUtc.Month -eq 1 -and $todayUtc.Day -eq 1) {
+            $forcedPublishDay = $true
+            $forcedPublishReason = 'scheduled publish day (1 January; NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED=true)'
+          } elseif ($dayEndsZeroPublishEnabled -and ($dayOfYear % 10 -eq 0)) {
+            $forcedPublishDay = $true
+            $forcedPublishReason = "scheduled publish day (day $dayOfYear of year ends in 0; NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED=true)"
+          }
+
+          if ($forcedPublishDay) {
+            Write-Host "Scheduled publish day matched: $forcedPublishReason"
+          } elseif ($todayUtc.Month -eq 1 -and $todayUtc.Day -eq 1) {
+            Write-Host '1 January matched, but NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED is not true - scheduled publish skipped'
+          } elseif ($dayOfYear % 10 -eq 0) {
+            Write-Host "Day $dayOfYear of year ends in 0, but NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED is not true - scheduled publish skipped"
+          }
+
+          if ($commitCount -gt 0 -or $forcedPublishDay) {
+            if ($commitCount -gt 0) {
+              Write-Host "Changes detected - proceeding with nightly build"
+            } else {
+              Write-Host "No recent changes, but scheduled publish day - proceeding with nightly build"
+            }
             echo "has_changes=true" >> $env:GITHUB_OUTPUT
           } else {
-            Write-Host "No changes detected (or only .github-only changes) - skipping nightly build"
+            Write-Host "No changes detected (or only .github-only changes) and not a scheduled publish day - skipping nightly build"
             echo "has_changes=false" >> $env:GITHUB_OUTPUT
           }
 
       - name: Skip notification
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'false'
         run: |
-          Write-Host "::notice::No commits (other than .github-only changes) in the last 24 hours. Skipping nightly build and publish."
+          Write-Host "::notice::No commits (other than .github-only changes) in the last 24 hours and not a scheduled publish day. Skipping nightly build and publish."
 
       # .NET 9 and 10; .NET 11 for net11.0-windows (DOTNET_PREVIEW_SETUP_VERSION when set, else 11.0.x).
       - name: Setup .NET (9 and 10)


### PR DESCRIPTION
Enable scheduled publishes even when no recent commits by adding two repo-variable flags and logic to the nightly workflow. Expose NIGHTLY_SCHEDULED_PUBLISH_JAN1_ENABLED and NIGHTLY_SCHEDULED_PUBLISH_DAY_ENDS_ZERO_ENABLED as env vars, compute UTC day-of-year and force a publish on 1 Jan or when the day-of-year ends in 0. Emit has_changes=true for scheduled publishes, improve logging, and update the skip-notice wording to reflect scheduled-publish checks.