### PR TITLE
* Designer has lots of Modified entries (V105 LTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Repository Guidelines
+﻿# Repository Guidelines
 
 ## Environment
 - OS: Windows
@@ -45,9 +45,38 @@
 - WinForms: `UseWindowsForms=true`; prefer designer-friendly patterns and keep partial classes tidy
 - WinForms designer: keep object declarations at file bottom; initialize in `*.Designer.cs` `InitializeComponent()`
 - Constraint: do not use `yield return` inside `catch` blocks
+- WinForms designer serialization: follow **Designer Serialization Defaults** below. A new or changed Toolbox control / `Storage` type must not show **Modified** on a fresh drop.
+
+### Designer Serialization Defaults
+
+Nested objects that inherit `Storage` show **"Modified"** in the Visual Studio property grid when `IsDefault` is false (`Storage.ToString()`). A freshly constructed Toolbox control must look unedited. This is issue [#4325](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4325).
+
+When a constructor (or a helper it calls) writes a real value that is that type's factory look — combo `TextH = Near`, progress-bar green `Color1`, command-link alignments, scrollbar colours, stock images, `EnableToolTips = true` on a specific control — record it as the designer default. Do not leave it as an Inherit/Empty mismatch.
+
+**Required per designer-visible property**
+
+| Kind | Rule |
+|---|---|
+| Simple value | `[DefaultValue(x)]` **or** `ShouldSerializeXxx()` / `ResetXxx()`, matching the constructor. `ShouldSerializeXxx` must match the property name. |
+| Nested `Storage` (`DesignerSerializationVisibility.Content`) | `IsDefault` is the AND of every child `ShouldSerialize`; parent has `ShouldSerializeFoo() => !Foo.IsDefault`. |
+| Constructor factory value (not Inherit/Empty/`null`) | After writing it, call `CaptureFactoryDefaults()` on that storage (or `SetFactory*` / `SetDefault*` where those exist). Then `ShouldSerialize` compares to the captured factory, not to Inherit/Empty. |
+| Runtime inherit vs designer default | Palette `GetXxx` must still treat Inherit/`Color.Empty`/`null` as inherit. Do not reuse `ShouldSerializeXxx()` as the inherit test once a factory default is non-inherit. |
+| `Color` | Use `Color` + `[KryptonDefaultColor]` or `ShouldSerialize` vs `Color.Empty`. Do not use `Color?` with `[DefaultValue(typeof(Color), "Empty")]` — the types do not match and `"Empty"` often fails to parse. |
+| `decimal` | `[DefaultValue(typeof(decimal), "1")]`, not `[DefaultValue(1.0d)]` (double vs decimal never compares equal). |
+| `IsDefault` | Implement it. `public override bool IsDefault { get; }` is always `false` (bool default) and permanently shows **Modified**. |
+| Hidden from the designer | `[Browsable(false)]` does **not** stop serialization. Also set `[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]`, or add `ShouldSerialize` / `[DefaultValue]`. Subclass `new` properties need this too: private `ShouldSerialize` on the base type is not found on the derived type. |
+
+`[DefaultValue]` takes precedence over `ShouldSerializeXxx`. If both exist and the attribute is wrong, the designer ignores the method. For per-instance factory defaults (Green vs Empty depending on the control), omit `[DefaultValue]` and use only `ShouldSerialize` / `Reset` against the captured factory.
+
+Do not call public setters in a constructor if those setters allocate override storage unless you then `CaptureFactoryDefaults()`. `PopulateFromBase` / `Reset` must restore inherit sentinels or the captured factory, not stamp resolved theme colours.
+
+After a drop, only site properties should serialize (`Name`, `Location`, `Size`, `TabIndex`, and `Text` when the designer copies the control name). `Values.Text` showing **Modified** because the designer set `kryptonButton1` is expected. Extra children on `Values` / `StateCommon` / `ToolTipValues` must not also be dirty.
+
+**Check:** after adding or changing a Toolbox control or `Storage` type, build Debug `net472` and run `Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1` (STA). Extend `$corePrefixes` in that script when adding a new core drop target. See `Scripts/UnitTests/README.md`.
 
 ## Testing Guidelines
 - No formal unit test suite. Validate changes via `TestForm` scenarios and harnesses under `Source/TestHarnesses`
+- When adding or changing a Toolbox control or `Storage` type, run `Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1` (STA, Debug `net472`) so fresh drops do not show **Modified**. Extend `$corePrefixes` for new core drop targets.
 - When fixing a bug, add/adjust a minimal repro in `TestForm` or a harness and describe manual steps in the PR
 
 ## Commit & Pull Request Guidelines

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,11 @@
 
 ## 2026-10-26 - Build 2610 (Version 105-LTS - Patch 4) - October 2026
 
+* Resolved [#4325](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4325), When using Fresh dragged objects onto a form, the designer has lots of `Modified` entries
+  * Freshly dropped toolbox controls no longer show nested palette/values objects as **Modified** in the Visual Studio Properties window.
+  * Constructor factory values (combo `TextH`, progress-bar fill, command-link alignments, form chrome hint, stock images, and similar) are recorded as designer defaults via `CaptureFactoryDefaults` / `SetFactory*` and matching `ShouldSerialize` / `IsDefault`.
+  * `[DefaultValue]` mismatches (`ToolTipValues.ShowIntervalDelay`, `Color? DropDownArrowColor`, decimal NUD values, scrollbar colours, wrap-label style) were aligned with actual constructor defaults.
+  * Regression: `Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1` (STA, Debug `net472`).
 * Resolved [#1870](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1870), `KryptonCustomPaletteBase`, Unable to Set / Change the color table (help to migrate to v90.)
   * `KryptonCustomPaletteBase.BasePaletteMode` now switches the inherited color table (Office 2010 Silver and other builtin themes no longer stay stuck on Microsoft 365 Blue).
   * The designer `ColorTable` shows the resolved colors; assigning a builtin palette to `BasePalette` keeps the matching `BasePaletteMode` instead of forcing `Custom`.

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -1,0 +1,14 @@
+﻿# Unit test scripts
+
+## Designer serialization defaults (`UnitTest-DesignerSerializationDefaults.ps1`)
+
+Fresh Toolbox controls must not show nested `Storage` objects as **Modified** (issue #4325).
+
+Requires Debug `net472` output (`Bin\Debug\net472\Krypton.Toolkit.dll`).
+
+```cmd
+dotnet build "Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug -f net472
+powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-DesignerSerializationDefaults.ps1
+```
+
+The script instantiates toolbox controls, walks `TypeDescriptor` content properties, and fails if core drop targets have `IsDefault == false` or unexpected `ShouldSerializeValue == true`.

--- a/Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1
+++ b/Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1
@@ -1,0 +1,428 @@
+﻿# Requires STA (WinForms TypeDescriptor). Fresh Toolbox controls must not show
+# nested Storage as "Modified" (issue #4325).
+# Usage (from repo root):
+#   powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-DesignerSerializationDefaults.ps1
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if (-not (Test-Path -LiteralPath (Join-Path $repoRoot 'Source'))) {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+}
+
+$tfm = 'net472'
+$config = 'Debug'
+$toolkitDll = Join-Path $repoRoot "Bin\$config\$tfm\Krypton.Toolkit.dll"
+if (-not (Test-Path -LiteralPath $toolkitDll)) {
+    Write-Error "Build Debug $tfm first. Missing: $toolkitDll"
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$binDir = Split-Path -Parent $toolkitDll
+$resolveHandler = [System.ResolveEventHandler] {
+    param($sender, $e)
+    $simple = (New-Object System.Reflection.AssemblyName $e.Name).Name
+    $candidate = Join-Path $binDir ($simple + '.dll')
+    if (Test-Path -LiteralPath $candidate) {
+        return [System.Reflection.Assembly]::LoadFrom($candidate)
+    }
+    return $null
+}
+[AppDomain]::CurrentDomain.add_AssemblyResolve($resolveHandler)
+
+Get-ChildItem -LiteralPath $binDir -Filter '*.dll' | ForEach-Object {
+    try { [void][System.Reflection.Assembly]::LoadFrom($_.FullName) } catch { }
+}
+
+Add-Type -Path $toolkitDll
+
+$auditor = @'
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Windows.Forms;
+
+public static class DesignerDefaultAuditor
+{
+    static readonly Hashtable SkipNames = CreateSkipNames();
+    static readonly string[] CorePrefixes = new string[]
+    {
+        "KryptonButton.",
+        "KryptonDropButton.",
+        "KryptonCheckButton.",
+        "KryptonColorButton.",
+        "KryptonCommandLinkButton.",
+        "KryptonCheckBox.",
+        "KryptonRadioButton.",
+        "KryptonLabel.",
+        "KryptonLinkLabel.",
+        "KryptonWrapLabel.",
+        "KryptonLinkWrapLabel.",
+        "KryptonComboBox.",
+        "KryptonTextBox.",
+        "KryptonMaskedTextBox.",
+        "KryptonRichTextBox.",
+        "KryptonNumericUpDown.",
+        "KryptonDomainUpDown.",
+        "KryptonProgressBar.",
+        "KryptonTrackBar.",
+        "KryptonPanel.",
+        "KryptonGroup.",
+        "KryptonGroupBox.",
+        "KryptonHeader.",
+        "KryptonHeaderGroup.",
+        "KryptonBorderEdge.",
+        "KryptonSeparator.",
+        "KryptonSplitContainer.",
+        "KryptonBreadCrumb.",
+        "KryptonDateTimePicker.",
+        "KryptonMonthCalendar.",
+        "KryptonTreeView.",
+        "KryptonListBox.",
+        "KryptonCheckedListBox.",
+        "KryptonListView.",
+        "KryptonDataGridView.",
+        "KryptonPropertyGrid.",
+        "KryptonToggleSwitch.",
+        "KryptonHScrollBar.",
+        "KryptonVScrollBar.",
+        "KryptonScrollBar.",
+        "KryptonForm."
+    };
+
+    static Hashtable CreateSkipNames()
+    {
+        Hashtable table = new Hashtable(StringComparer.Ordinal);
+        string[] names = new string[]
+        {
+            "Name", "Location", "Size", "Bounds", "ClientSize", "MaximumSize", "MinimumSize",
+            "TabIndex", "TabStop", "WindowTarget", "DataBindings", "Controls", "Site", "Container",
+            "Handle", "Region", "AccessibilityObject", "CompanyName", "ProductName", "ProductVersion",
+            "Tag", "Cursor", "ImeMode", "Parent", "TopLevelControl", "BindingContext", "ContextMenuStrip",
+            "Anchor", "Dock", "Margin", "Padding", "AutoScrollMargin", "AutoScrollMinSize",
+            "Owner", "Capacity", "UniqueName", "DefaultDataSourceUpdateMode", "CurrentPath",
+        "Visible", "TransparencyKey", "UseCompatibleTextRendering"
+        };
+        for (int i = 0; i < names.Length; i++)
+        {
+            table[names[i]] = true;
+        }
+        return table;
+    }
+
+    public static int Run(Assembly toolkit)
+    {
+        ArrayList modified = new ArrayList();
+        ArrayList dirty = new ArrayList();
+        ArrayList instantiateFails = new ArrayList();
+        int instantiated = 0;
+        Type[] types;
+        try
+        {
+            types = toolkit.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types;
+        }
+
+        for (int t = 0; t < types.Length; t++)
+        {
+            Type type = types[t];
+            if (type == null || !type.IsPublic || type.IsAbstract || type.IsGenericType)
+            {
+                continue;
+            }
+            if (!typeof(Component).IsAssignableFrom(type))
+            {
+                continue;
+            }
+            if (type.GetConstructor(Type.EmptyTypes) == null)
+            {
+                continue;
+            }
+
+            bool toolboxFalse = false;
+            object[] toolbox = type.GetCustomAttributes(typeof(ToolboxItemAttribute), true);
+            if (toolbox != null)
+            {
+                for (int a = 0; a < toolbox.Length; a++)
+                {
+                    ToolboxItemAttribute tia = (ToolboxItemAttribute)toolbox[a];
+                    if (tia.Equals(ToolboxItemAttribute.None))
+                    {
+                        toolboxFalse = true;
+                    }
+                }
+            }
+
+            bool isForm = typeof(Form).IsAssignableFrom(type) && type.Name == "KryptonForm";
+            bool isControl = typeof(Control).IsAssignableFrom(type);
+            if (!isForm)
+            {
+                if (toolboxFalse)
+                {
+                    continue;
+                }
+                if (!isControl)
+                {
+                    continue;
+                }
+                if (typeof(Form).IsAssignableFrom(type))
+                {
+                    continue;
+                }
+            }
+
+            string name = type.Name;
+            if (name.IndexOf("Dialog", StringComparison.Ordinal) >= 0
+                || name.IndexOf("Manager", StringComparison.Ordinal) >= 0
+                || name.IndexOf("Palette", StringComparison.Ordinal) >= 0
+                || (name.IndexOf("Command", StringComparison.Ordinal) >= 0 && name != "KryptonCommandLinkButton")
+                || name == "KryptonContextMenu"
+                || name == "KryptonToastNotificationManager"
+                || name == "KryptonCheckSet")
+            {
+                continue;
+            }
+
+            object instance;
+            try
+            {
+                instance = Activator.CreateInstance(type);
+                instantiated++;
+            }
+            catch (Exception ex)
+            {
+                instantiateFails.Add(name + ": " + Unwrap(ex));
+                continue;
+            }
+
+            try
+            {
+                Walk(name, instance, modified, dirty, new Hashtable(), 0);
+            }
+            catch (Exception ex)
+            {
+                instantiateFails.Add(name + " walk: " + Unwrap(ex));
+            }
+
+            IDisposable disposable = instance as IDisposable;
+            if (disposable != null)
+            {
+                try { disposable.Dispose(); }
+                catch { }
+            }
+        }
+
+        modified.Sort(StringComparer.Ordinal);
+        dirty.Sort(StringComparer.Ordinal);
+
+        Console.WriteLine("Instantiated: " + instantiated);
+        Console.WriteLine("Modified storage paths: " + modified.Count);
+        for (int i = 0; i < modified.Count; i++)
+        {
+            Console.WriteLine("  " + modified[i]);
+        }
+        Console.WriteLine("Dirty designer paths: " + dirty.Count);
+        for (int i = 0; i < dirty.Count; i++)
+        {
+            Console.WriteLine("  " + dirty[i]);
+        }
+        if (instantiateFails.Count > 0)
+        {
+            Console.WriteLine("Instantiate/walk failures: " + instantiateFails.Count);
+            for (int i = 0; i < instantiateFails.Count; i++)
+            {
+                Console.WriteLine("  " + instantiateFails[i]);
+            }
+        }
+
+        ArrayList coreHits = new ArrayList();
+        for (int i = 0; i < modified.Count; i++)
+        {
+            string line = (string)modified[i];
+            if (IsCore(line))
+            {
+                coreHits.Add("Modified " + line);
+            }
+        }
+        for (int i = 0; i < dirty.Count; i++)
+        {
+            string line = (string)dirty[i];
+            if (IsCore(line))
+            {
+                coreHits.Add("Dirty " + line);
+            }
+        }
+
+        if (coreHits.Count > 0)
+        {
+            Console.WriteLine("FAIL: core Toolbox drops still look modified (" + coreHits.Count + ")");
+            for (int i = 0; i < coreHits.Count; i++)
+            {
+                Console.WriteLine("  " + coreHits[i]);
+            }
+            return 1;
+        }
+
+        Console.WriteLine("PASS: core Toolbox drops have no unexpected Modified/ShouldSerialize hits.");
+        return 0;
+    }
+
+    static bool IsCore(string path)
+    {
+        for (int i = 0; i < CorePrefixes.Length; i++)
+        {
+            string prefix = CorePrefixes[i];
+            if (path.StartsWith(prefix, StringComparison.Ordinal) || path == prefix.TrimEnd('.'))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void Walk(string path, object instance, ArrayList modified, ArrayList dirty, Hashtable seen, int depth)
+    {
+        if (instance == null || depth > 12)
+        {
+            return;
+        }
+        if (seen.Contains(instance))
+        {
+            return;
+        }
+        seen.Add(instance, true);
+
+        PropertyInfo isDefaultProp = instance.GetType().GetProperty("IsDefault", BindingFlags.Instance | BindingFlags.Public);
+        if (isDefaultProp != null && isDefaultProp.PropertyType == typeof(bool) && isDefaultProp.GetIndexParameters().Length == 0)
+        {
+            try
+            {
+                object val = isDefaultProp.GetValue(instance, null);
+                if (val is bool && !((bool)val))
+                {
+                    modified.Add(path + " => Modified");
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        PropertyDescriptorCollection props;
+        try
+        {
+            props = TypeDescriptor.GetProperties(instance);
+        }
+        catch
+        {
+            return;
+        }
+
+        for (int p = 0; p < props.Count; p++)
+        {
+            PropertyDescriptor pd = props[p];
+            if (pd == null || SkipNames.Contains(pd.Name))
+            {
+                continue;
+            }
+            if (pd.IsReadOnly && pd.SerializationVisibility != DesignerSerializationVisibility.Content)
+            {
+                continue;
+            }
+            if (pd.SerializationVisibility == DesignerSerializationVisibility.Hidden)
+            {
+                continue;
+            }
+
+            string childPath = path + "." + pd.Name;
+            if (childPath.IndexOf("DataBindings", StringComparison.Ordinal) >= 0
+                || childPath.IndexOf("ToolkitStrings", StringComparison.Ordinal) >= 0
+                || childPath.IndexOf("Strings.", StringComparison.Ordinal) >= 0
+                || childPath.EndsWith(".RootItem.ShortText", StringComparison.Ordinal)
+                || childPath.EndsWith(".Text", StringComparison.Ordinal) && path.IndexOf("RichTextBox", StringComparison.Ordinal) >= 0
+                || childPath.IndexOf("KryptonContextMenu", StringComparison.Ordinal) >= 0)
+            {
+                continue;
+            }
+
+            object child = null;
+            try
+            {
+                child = pd.GetValue(instance);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (pd.SerializationVisibility == DesignerSerializationVisibility.Content && child != null && !pd.PropertyType.IsValueType && pd.PropertyType != typeof(string))
+            {
+                Walk(childPath, child, modified, dirty, seen, depth + 1);
+                continue;
+            }
+
+            if (pd.SerializationVisibility == DesignerSerializationVisibility.Visible)
+            {
+                bool should;
+                try
+                {
+                    should = pd.ShouldSerializeValue(instance);
+                }
+                catch
+                {
+                    continue;
+                }
+                if (should)
+                {
+                    dirty.Add(childPath + " = " + FormatValue(child));
+                }
+            }
+        }
+    }
+
+    static string FormatValue(object value)
+    {
+        if (value == null)
+        {
+            return "null";
+        }
+        string text = Convert.ToString(value);
+        if (text == null)
+        {
+            return value.GetType().Name;
+        }
+        if (text.Length > 80)
+        {
+            text = text.Substring(0, 80) + "...";
+        }
+        return text.Replace("\r", " ").Replace("\n", " ");
+    }
+
+    static string Unwrap(Exception ex)
+    {
+        Exception inner = ex;
+        while (inner.InnerException != null)
+        {
+            inner = inner.InnerException;
+        }
+        return inner.GetType().Name + ": " + inner.Message;
+    }
+}
+'@
+
+$refs = @(
+    'System.Windows.Forms.dll',
+    'System.Drawing.dll',
+    'System.dll',
+    'System.Core.dll'
+)
+Add-Type -TypeDefinition $auditor -ReferencedAssemblies $refs -ErrorAction Stop
+
+$code = [DesignerDefaultAuditor]::Run([Krypton.Toolkit.KryptonButton].Assembly)
+exit $code

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -100,6 +100,7 @@ public class KryptonBreadCrumb : VisualSimpleBase,
         _buttonStyle = ButtonStyle.BreadCrumb;
         RootItem = new KryptonBreadCrumbItem("Root");
         RootItem.PropertyChanged += OnCrumbItemChanged;
+        AutoSize = true;
         AllowButtonSpecToolTips = false;
         AllowButtonSpecToolTipPriority = false;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCalcInput.cs
@@ -537,7 +537,7 @@ public class KryptonCalcInput : VisualControlBase, IContainedInputControl
     /// </summary>
     [Category(@"Appearance")]
     [Description(@"The current value of the numeric up-down control.")]
-    [DefaultValue(0.0d)]
+    [DefaultValue(typeof(decimal), "0")]
     [Bindable(true)]
     public decimal Value
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -228,6 +228,7 @@ public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValu
         ViewManager = new ViewManager(this, _drawButton);
 
         CustomColorPreviewShape = KryptonColorButtonCustomColorPreviewShape.None;
+        Values.SetFactoryImage(Values.Image);
 
         // Defaults for dynamic theme color mapping
         _themeColorSortMode = ThemeColorSortMode.OKLCH;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -105,6 +105,7 @@ public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
         contentShortText.TextV = PaletteRelativeAlign.Center;
         StateCommon.Content.LongText.TextH = PaletteRelativeAlign.Near;
         StateCommon.Content.LongText.TextV = PaletteRelativeAlign.Far;
+        StateCommon.Content.CaptureFactoryDefaults();
 
         StateDisabled = new PaletteTriple(StateCommon, NeedPaintDelegate);
         StateNormal = new PaletteTriple(StateCommon, NeedPaintDelegate);
@@ -115,6 +116,7 @@ public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
         OverrideFocus.Border.Draw = InheritBool.True;
         OverrideFocus.Border.DrawBorders = PaletteDrawBorders.All;
         OverrideFocus.Border.GraphicsHint = PaletteGraphicsHint.AntiAlias;
+        OverrideFocus.Border.CaptureFactoryDefaults();
         // Force style update
         ButtonStyle = ButtonStyle.Command;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -292,18 +292,15 @@ public class KryptonDataGridView : DataGridView
         set => base.BackgroundColor = value;
     }
 
-    ///// <summary>
-    ///// Gets or sets the border style for the DataGridView.
-    ///// </summary>
-    //[Browsable(false)]
-    //[EditorBrowsable(EditorBrowsableState.Never)]
-    //[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    // Disable as part of https://github.com/Krypton-Suite/Standard-Toolkit/issues/989
-    //public new BorderStyle BorderStyle
-    //{
-    //    get => base.BorderStyle;
-    //    set { /* Do nothing, we do not allow a border style change! */ }
-    //}
+    /// <summary>
+    /// Gets or sets the border style for the DataGridView.
+    /// </summary>
+    [DefaultValue(BorderStyle.None)]
+    public new BorderStyle BorderStyle
+    {
+        get => base.BorderStyle;
+        set => base.BorderStyle = value;
+    }
 
     /// <summary>
     /// Gets the cell border style for the DataGridView.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -81,6 +81,7 @@ public class KryptonLinkWrapLabel : LinkLabel
         _redirector = CreateRedirector();
 
         // Default properties
+        _labelStyle = LabelStyle.NormalPanel;
         SetLabelStyle(LabelStyle.NormalPanel);
         AutoSize = true;
         TabStop = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1174,7 +1174,7 @@ public class KryptonNumericUpDown : VisualControlBase,
     /// </summary>
     [Category(@"Data")]
     [Description(@"Indicates the amount to increment or decrement one each button click.")]
-    [DefaultValue(1.0d)]
+    [DefaultValue(typeof(decimal), "1")]
     public decimal Increment
     {
         get => _numericUpDown.Increment;
@@ -1187,7 +1187,7 @@ public class KryptonNumericUpDown : VisualControlBase,
     [Category(@"Data")]
     [Description(@"Indicates the maximum value for the numeric up-down control.")]
     [RefreshProperties(RefreshProperties.All)]
-    [DefaultValue(100.0d)]
+    [DefaultValue(typeof(decimal), "100")]
     public decimal Maximum
     {
         get => _numericUpDown.Maximum;
@@ -1200,7 +1200,7 @@ public class KryptonNumericUpDown : VisualControlBase,
     [Category(@"Data")]
     [Description(@"Indicates the minimum value for the numeric up-down control.")]
     [RefreshProperties(RefreshProperties.All)]
-    [DefaultValue(0.0d)]
+    [DefaultValue(typeof(decimal), "0")]
     public decimal Minimum
     {
         get => _numericUpDown.Minimum;
@@ -1225,7 +1225,7 @@ public class KryptonNumericUpDown : VisualControlBase,
     /// </summary>
     [Category(@"Appearance")]
     [Description(@"The current value of the numeric up-down control.")]
-    [DefaultValue(0.0d)]
+    [DefaultValue(typeof(decimal), "0")]
     [Bindable(true)]
     public decimal Value
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPoweredByButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPoweredByButton.cs
@@ -66,9 +66,8 @@ public class KryptonPoweredByButton : KryptonButton
     /// <summary>Initializes a new instance of the <see cref="KryptonPoweredByButton" /> class.</summary>
     public KryptonPoweredByButton()
     {
-        Values.Text = @$"{KryptonManager.Strings.MiscellaneousStrings.PoweredByText} Krypton";
-
-        Values.Image = ButtonImageResources.Krypton_Stable_Button;
+        Values.SetFactoryText($"{KryptonManager.Strings.MiscellaneousStrings.PoweredByText} Krypton");
+        Values.SetFactoryImage(ButtonImageResources.Krypton_Stable_Button);
 
         Size = new Size(153, 25);
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -95,10 +95,8 @@ public class KryptonProgressBar : Control, IContentValues
         }
 
         // Create content storage
-        Values = new LabelValues(OnNeedPaintHandler)
-        {
-            Text = string.Empty
-        };
+        Values = new LabelValues(OnNeedPaintHandler);
+        Values.SetFactoryText(string.Empty);
         Values.TextChanged += OnLabelTextChanged;
 
         // We want to be notified whenever the global palette changes
@@ -120,10 +118,13 @@ public class KryptonProgressBar : Control, IContentValues
                 Color1 = Color.Green
             }
         };
+        StateCommon.Back.CaptureFactoryDefaults();
         StateDisabled = new PaletteTriple(StateCommon, OnNeedPaintHandler);
         ((PaletteBack)StateDisabled.PaletteBack).ColorStyle = PaletteColorStyle.OneNote;
+        ((PaletteBack)StateDisabled.PaletteBack).CaptureFactoryDefaults();
         StateNormal = new PaletteTriple(StateCommon, OnNeedPaintHandler);
         ((PaletteBack)StateNormal.PaletteBack).ColorStyle = PaletteColorStyle.OneNote;
+        ((PaletteBack)StateNormal.PaletteBack).CaptureFactoryDefaults();
         _stateBackValue = new PaletteTriple(StateCommon, OnNeedPaintHandler).Back;
         _stateBackValue.ColorStyle = PaletteColorStyle.GlassNormalFull;
         _blockCount = 0; // 0 = automatic sizing
@@ -202,11 +203,7 @@ public class KryptonProgressBar : Control, IContentValues
 
     private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
 
-    private void ResetStateCommon()
-    {
-        StateCommon.PopulateFromBase(PaletteState.Normal);
-        StateCommon.Back.Color1 = Color.Green;
-    }
+    private void ResetStateCommon() => StateCommon.Back.Color1 = Color.Green;
 
     /// <summary>
     /// Gets access to the disabled ProgressBar appearance entries.
@@ -323,7 +320,7 @@ public class KryptonProgressBar : Control, IContentValues
 
     [Category(@"Visuals")]
     [Description(@"Shadow color for the text; Empty for automatic.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
+    [KryptonDefaultColor]
     public Color TextShadowColor
     {
         get => _textShadowColor;
@@ -361,7 +358,7 @@ public class KryptonProgressBar : Control, IContentValues
 
     [Category(@"Visuals")]
     [Description(@"Backdrop color for the text; Empty for automatic semi-transparent.")]
-    [DefaultValue(typeof(Color), nameof(Color.Empty))]
+    [KryptonDefaultColor]
     public Color TextBackdropColor
     {
         get => _textBackdropColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
@@ -110,6 +110,7 @@ public class KryptonScrollBar : Control
     /// <summary>Gets or sets the width of the scroll bar.</summary>
     /// <value>The width of the scroll bar.</value>
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [DefaultValue(19)]
     public int ScrollBarWidth
     {
         get => Width; 
@@ -414,7 +415,6 @@ public class KryptonScrollBar : Control
     /// </summary>
     [Category(@"Appearance")]
     [Description(@"Gets or sets the border color.")]
-    [DefaultValue(typeof(Color), "Color.FromARGB(93, 140, 201)")]
     public Color BorderColor
     {
         get => _borderColor;
@@ -426,13 +426,14 @@ public class KryptonScrollBar : Control
             Invalidate();
         }
     }
+    private bool ShouldSerializeBorderColor() => _borderColor != Color.FromArgb(93, 140, 201);
+    private void ResetBorderColor() => BorderColor = Color.FromArgb(93, 140, 201);
 
     /// <summary>
     /// Gets or sets the border color in disabled state.
     /// </summary>
     [Category(@"Appearance")]
     [Description(@"Gets or sets the border color in disabled state.")]
-    [DefaultValue(typeof(Color), "Color.Gray")]
     public Color DisabledBorderColor
     {
         get => _disabledBorderColor;
@@ -444,13 +445,15 @@ public class KryptonScrollBar : Control
             Invalidate();
         }
     }
+    private bool ShouldSerializeDisabledBorderColor() => _disabledBorderColor != Color.Gray;
+    private void ResetDisabledBorderColor() => DisabledBorderColor = Color.Gray;
 
     /// <summary>
     /// Gets or sets the opacity of the context menu (from 0 - 1).
     /// </summary>
     [Category(@"Appearance")]
     [Description(@"Gets or sets the opacity of the context menu (from 0 - 1).")]
-    [DefaultValue(1)]
+    [DefaultValue(1.0)]
     public double Opacity
     {
         get => _contextMenu.Opacity;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
@@ -449,10 +449,10 @@ public class KryptonScrollBar : Control
     private void ResetDisabledBorderColor() => DisabledBorderColor = Color.Gray;
 
     /// <summary>
-    /// Gets or sets the opacity of the context menu (from 0 - 1).
+    /// Gets or sets the opacity of the context menu (from 0 - 1.0).
     /// </summary>
     [Category(@"Appearance")]
-    [Description(@"Gets or sets the opacity of the context menu (from 0 - 1).")]
+    [Description(@"Gets or sets the opacity of the context menu (from 0 - 1.0).")]
     [DefaultValue(1.0)]
     public double Opacity
     {
@@ -466,7 +466,7 @@ public class KryptonScrollBar : Control
                 return;
             }
 
-            _contextMenu.AllowTransparency = value != 1;
+            _contextMenu.AllowTransparency = value != 1.0;
 
             _contextMenu.Opacity = value;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
@@ -25,8 +25,9 @@ public class KryptonStatusStrip : StatusStrip,
 
     #region Properties
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [Description(@"The progress bars to display on the status strip.")]
     [DefaultValue(null)]
-    public ToolStripProgressBar[] ProgressBars { get; set; }
+    public ToolStripProgressBar[]? ProgressBars { get; set; }
     #endregion
 
     #region Constructor

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
@@ -25,6 +25,7 @@ public class KryptonStatusStrip : StatusStrip,
 
     #region Properties
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [DefaultValue(null)]
     public ToolStripProgressBar[] ProgressBars { get; set; }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToolkitPoweredByControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonToolkitPoweredByControl.cs
@@ -50,7 +50,7 @@ public partial class KryptonToolkitPoweredByControl : UserControl
 
     /// <summary>Gets or sets the type of the toolkit.</summary>
     /// <value>The type of the toolkit.</value>
-    [DefaultValue(typeof(ToolkitSupportType), @"ToolkitSupportType.Stable"), Description(@"Changes the icon based on the type of toolkit you are using.")]
+    [DefaultValue(ToolkitSupportType.Stable), Description(@"Changes the icon based on the type of toolkit you are using.")]
     public ToolkitSupportType ToolkitSupportType { get => _ToolkitSupportType; set { _ToolkitSupportType = value; SetLogo(value); } }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -83,6 +83,7 @@ public class KryptonWrapLabel : Label
         _redirector = CreateRedirector();
 
         // Default properties
+        _labelStyle = LabelStyle.NormalPanel;
         SetLabelStyle(LabelStyle.NormalPanel);
         AutoSize = true;
         TabStop = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBack.cs
@@ -68,6 +68,16 @@ public class PaletteBack : Storage,
     #region Instance Fields
     private IPaletteBack? _inherit;
     private InternalStorage? _storage;
+    private InheritBool _factoryDraw = InheritBool.Inherit;
+    private PaletteGraphicsHint _factoryGraphicsHint = PaletteGraphicsHint.Inherit;
+    private Color _factoryColor1 = GlobalStaticValues.EMPTY_COLOR;
+    private Color _factoryColor2 = GlobalStaticValues.EMPTY_COLOR;
+    private PaletteColorStyle _factoryColorStyle = PaletteColorStyle.Inherit;
+    private PaletteRectangleAlign _factoryColorAlign = PaletteRectangleAlign.Inherit;
+    private float _factoryColorAngle = -1;
+    private Image? _factoryImage;
+    private PaletteImageStyle _factoryImageStyle = PaletteImageStyle.Inherit;
+    private PaletteRectangleAlign _factoryImageAlign = PaletteRectangleAlign.Inherit;
     #endregion
 
     #region Events
@@ -102,7 +112,34 @@ public class PaletteBack : Storage,
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => (_storage == null) || _storage.IsDefault;
+    public override bool IsDefault =>
+        Draw == _factoryDraw &&
+        GraphicsHint == _factoryGraphicsHint &&
+        Color1.Equals(_factoryColor1) &&
+        Color2.Equals(_factoryColor2) &&
+        ColorStyle == _factoryColorStyle &&
+        ColorAlign == _factoryColorAlign &&
+        ColorAngle.Equals(_factoryColorAngle) &&
+        Image == _factoryImage &&
+        ImageStyle == _factoryImageStyle &&
+        ImageAlign == _factoryImageAlign;
+
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        _factoryDraw = Draw;
+        _factoryGraphicsHint = GraphicsHint;
+        _factoryColor1 = Color1;
+        _factoryColor2 = Color2;
+        _factoryColorStyle = ColorStyle;
+        _factoryColorAlign = ColorAlign;
+        _factoryColorAngle = ColorAngle;
+        _factoryImage = Image;
+        _factoryImageStyle = ImageStyle;
+        _factoryImageAlign = ImageAlign;
+    }
 
     #endregion
 
@@ -141,7 +178,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Should background be drawn.")]
-    [DefaultValue(InheritBool.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public InheritBool Draw
     {
@@ -188,7 +224,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Hint for drawing graphics.")]
-    [DefaultValue(PaletteGraphicsHint.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteGraphicsHint GraphicsHint
     {
@@ -236,7 +271,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Main background color.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color Color1
     {
@@ -283,7 +317,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Secondary background color.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color Color2
     {
@@ -330,7 +363,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background color drawing style.")]
-    [DefaultValue(PaletteColorStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteColorStyle ColorStyle
     {
@@ -377,7 +409,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background color alignment style.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteRectangleAlign ColorAlign
     {
@@ -425,7 +456,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background color angle.")]
-    [DefaultValue(-1f)]
     [RefreshProperties(RefreshProperties.All)]
     public float ColorAngle
     {
@@ -473,7 +503,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background image.")]
-    [DefaultValue(null)]
     [RefreshProperties(RefreshProperties.All)]
     public Image? Image
     {
@@ -520,7 +549,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background image style.")]
-    [DefaultValue(PaletteImageStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteImageStyle ImageStyle
     {
@@ -569,7 +597,6 @@ public class PaletteBack : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Background image alignment style.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteRectangleAlign ImageAlign
     {
@@ -608,6 +635,29 @@ public class PaletteBack : Storage,
     /// <returns>Image alignment style.</returns>
     public PaletteRectangleAlign GetBackImageAlign(PaletteState state) =>
         ImageAlign != PaletteRectangleAlign.Inherit ? ImageAlign : _inherit!.GetBackImageAlign(state);
+    #endregion
+
+    #region ShouldSerialize
+    private bool ShouldSerializeDraw() => Draw != _factoryDraw;
+    private void ResetDraw() => Draw = _factoryDraw;
+    private bool ShouldSerializeGraphicsHint() => GraphicsHint != _factoryGraphicsHint;
+    private void ResetGraphicsHint() => GraphicsHint = _factoryGraphicsHint;
+    private bool ShouldSerializeColor1() => !Color1.Equals(_factoryColor1);
+    private void ResetColor1() => Color1 = _factoryColor1;
+    private bool ShouldSerializeColor2() => !Color2.Equals(_factoryColor2);
+    private void ResetColor2() => Color2 = _factoryColor2;
+    private bool ShouldSerializeColorStyle() => ColorStyle != _factoryColorStyle;
+    private void ResetColorStyle() => ColorStyle = _factoryColorStyle;
+    private bool ShouldSerializeColorAlign() => ColorAlign != _factoryColorAlign;
+    private void ResetColorAlign() => ColorAlign = _factoryColorAlign;
+    private bool ShouldSerializeColorAngle() => !ColorAngle.Equals(_factoryColorAngle);
+    private void ResetColorAngle() => ColorAngle = _factoryColorAngle;
+    private bool ShouldSerializeImage() => Image != _factoryImage;
+    private void ResetImage() => Image = _factoryImage;
+    private bool ShouldSerializeImageStyle() => ImageStyle != _factoryImageStyle;
+    private void ResetImageStyle() => ImageStyle = _factoryImageStyle;
+    private bool ShouldSerializeImageAlign() => ImageAlign != _factoryImageAlign;
+    private void ResetImageAlign() => ImageAlign = _factoryImageAlign;
     #endregion
 
     #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackColor1.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackColor1.cs
@@ -45,6 +45,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets a value indicating if background should be drawn.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new InheritBool Draw
     {
         get => base.Draw;
@@ -57,6 +58,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets the graphics hint for drawing the background.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new PaletteGraphicsHint GraphicsHint
     {
         get => base.GraphicsHint;
@@ -69,6 +71,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and sets the second background color.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new Color Color2
     {
         get => base.Color2;
@@ -81,6 +84,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and sets the color drawing style.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new PaletteColorStyle ColorStyle
     {
         get => base.ColorStyle;
@@ -93,6 +97,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and set the color alignment.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new PaletteRectangleAlign ColorAlign
     {
         get => base.ColorAlign;
@@ -105,6 +110,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and sets the color angle.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new float ColorAngle
     {
         get => base.ColorAngle;
@@ -117,6 +123,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and sets the background image.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new Image? Image
     {
         get => base.Image;
@@ -129,6 +136,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and sets the background image style.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new PaletteImageStyle ImageStyle
     {
         get => base.ImageStyle;
@@ -141,6 +149,7 @@ public class PaletteBackColor1 : PaletteBack
     /// Gets and set the image alignment.
     /// </summary>
     [Browsable(false)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public new PaletteRectangleAlign ImageAlign
     {
         get => base.ImageAlign;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -77,6 +77,19 @@ public class PaletteBorder : Storage,
     #region Instance Fields
     private IPaletteBorder _inherit;
     private InternalStorage? _storage;
+    private InheritBool _factoryDraw = InheritBool.Inherit;
+    private PaletteDrawBorders _factoryDrawBorders = PaletteDrawBorders.Inherit;
+    private PaletteGraphicsHint _factoryGraphicsHint = PaletteGraphicsHint.Inherit;
+    private Color _factoryColor1 = GlobalStaticValues.EMPTY_COLOR;
+    private Color _factoryColor2 = GlobalStaticValues.EMPTY_COLOR;
+    private PaletteColorStyle _factoryColorStyle = PaletteColorStyle.Inherit;
+    private PaletteRectangleAlign _factoryColorAlign = PaletteRectangleAlign.Inherit;
+    private float _factoryColorAngle = -1;
+    private int _factoryWidth = -1;
+    private float _factoryRounding = GlobalStaticValues.DEFAULT_PRIMARY_CORNER_ROUNDING_VALUE;
+    private Image? _factoryImage;
+    private PaletteImageStyle _factoryImageStyle = PaletteImageStyle.Inherit;
+    private PaletteRectangleAlign _factoryImageAlign = PaletteRectangleAlign.Inherit;
     #endregion
 
     #region Events
@@ -113,7 +126,40 @@ public class PaletteBorder : Storage,
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => (_storage == null) || _storage.IsDefault;
+    public override bool IsDefault =>
+        Draw == _factoryDraw &&
+        DrawBorders == _factoryDrawBorders &&
+        GraphicsHint == _factoryGraphicsHint &&
+        Color1.Equals(_factoryColor1) &&
+        Color2.Equals(_factoryColor2) &&
+        ColorStyle == _factoryColorStyle &&
+        ColorAlign == _factoryColorAlign &&
+        ColorAngle.Equals(_factoryColorAngle) &&
+        Width == _factoryWidth &&
+        Rounding.Equals(_factoryRounding) &&
+        Image == _factoryImage &&
+        ImageStyle == _factoryImageStyle &&
+        ImageAlign == _factoryImageAlign;
+
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        _factoryDraw = Draw;
+        _factoryDrawBorders = DrawBorders;
+        _factoryGraphicsHint = GraphicsHint;
+        _factoryColor1 = Color1;
+        _factoryColor2 = Color2;
+        _factoryColorStyle = ColorStyle;
+        _factoryColorAlign = ColorAlign;
+        _factoryColorAngle = ColorAngle;
+        _factoryWidth = Width;
+        _factoryRounding = Rounding;
+        _factoryImage = Image;
+        _factoryImageStyle = ImageStyle;
+        _factoryImageAlign = ImageAlign;
+    }
 
     #endregion
 
@@ -155,7 +201,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Should border be drawn.")]
-    [DefaultValue(InheritBool.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual InheritBool Draw
     {
@@ -202,7 +247,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Specify which borders should be drawn.")]
-    [DefaultValue(PaletteDrawBorders.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     [Editor(typeof(PaletteDrawBordersEditor), typeof(UITypeEditor))]
     public PaletteDrawBorders DrawBorders
@@ -235,7 +279,8 @@ public class PaletteBorder : Storage,
         }
     }
 
-    private bool ShouldSerializeDrawBorders() => DrawBorders != PaletteDrawBorders.Inherit;
+    private bool ShouldSerializeDrawBorders() => DrawBorders != _factoryDrawBorders;
+    private void ResetDrawBorders() => DrawBorders = _factoryDrawBorders;
 
     /// <summary>
     /// Gets the actual borders to draw value.
@@ -260,7 +305,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Hint for drawing graphics.")]
-    [DefaultValue(PaletteGraphicsHint.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteGraphicsHint GraphicsHint
     {
@@ -308,7 +352,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Main border color.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color Color1
     {
@@ -366,7 +409,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Secondary border color.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public Color Color2
     {
@@ -413,7 +455,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border color drawing style.")]
-    [DefaultValue(PaletteColorStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteColorStyle ColorStyle
     {
@@ -462,7 +503,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border color alignment style.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteRectangleAlign ColorAlign
     {
@@ -510,7 +550,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border color angle.")]
-    [DefaultValue(-1f)]
     [RefreshProperties(RefreshProperties.All)]
     public float ColorAngle
     {
@@ -557,7 +596,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border width.")]
-    [DefaultValue(-1)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual int Width
     {
@@ -604,7 +642,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"How much to round the border corners.")]
-    [DefaultValue(GlobalStaticValues.DEFAULT_PRIMARY_CORNER_ROUNDING_VALUE)]
     [RefreshProperties(RefreshProperties.All)]
     public float Rounding
     {
@@ -647,8 +684,8 @@ public class PaletteBorder : Storage,
         }
     }
 
-    private void ResetRounding() => Rounding = GlobalStaticValues.DEFAULT_PRIMARY_CORNER_ROUNDING_VALUE;
-    private bool ShouldSerializeRounding() => Rounding != GlobalStaticValues.DEFAULT_PRIMARY_CORNER_ROUNDING_VALUE;
+    private bool ShouldSerializeRounding() => !Rounding.Equals(_factoryRounding);
+    private void ResetRounding() => Rounding = _factoryRounding;
 
     /// <summary>
     /// Gets the border rounding.
@@ -665,7 +702,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border image.")]
-    [DefaultValue(null)]
     [RefreshProperties(RefreshProperties.All)]
     public Image? Image
     {
@@ -712,7 +748,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border image style.")]
-    [DefaultValue(PaletteImageStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteImageStyle ImageStyle
     {
@@ -744,7 +779,8 @@ public class PaletteBorder : Storage,
         }
     }
 
-    private bool ShouldSerializeImageStyle() => ImageStyle != PaletteImageStyle.Inherit;
+    private bool ShouldSerializeImageStyle() => ImageStyle != _factoryImageStyle;
+    private void ResetImageStyle() => ImageStyle = _factoryImageStyle;
 
     /// <summary>
     /// Gets the border image style.
@@ -763,7 +799,6 @@ public class PaletteBorder : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Border image alignment style.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public PaletteRectangleAlign ImageAlign
     {
@@ -802,6 +837,29 @@ public class PaletteBorder : Storage,
     /// <returns>Image alignment style.</returns>
     public PaletteRectangleAlign GetBorderImageAlign(PaletteState state) =>
         ImageAlign != PaletteRectangleAlign.Inherit ? ImageAlign : _inherit.GetBorderImageAlign(state);
+    #endregion
+
+    #region ShouldSerialize
+    private bool ShouldSerializeDraw() => Draw != _factoryDraw;
+    private void ResetDraw() => Draw = _factoryDraw;
+    private bool ShouldSerializeGraphicsHint() => GraphicsHint != _factoryGraphicsHint;
+    private void ResetGraphicsHint() => GraphicsHint = _factoryGraphicsHint;
+    private bool ShouldSerializeColor1() => !Color1.Equals(_factoryColor1);
+    private void ResetColor1() => Color1 = _factoryColor1;
+    private bool ShouldSerializeColor2() => !Color2.Equals(_factoryColor2);
+    private void ResetColor2() => Color2 = _factoryColor2;
+    private bool ShouldSerializeColorStyle() => ColorStyle != _factoryColorStyle;
+    private void ResetColorStyle() => ColorStyle = _factoryColorStyle;
+    private bool ShouldSerializeColorAlign() => ColorAlign != _factoryColorAlign;
+    private void ResetColorAlign() => ColorAlign = _factoryColorAlign;
+    private bool ShouldSerializeColorAngle() => !ColorAngle.Equals(_factoryColorAngle);
+    private void ResetColorAngle() => ColorAngle = _factoryColorAngle;
+    private bool ShouldSerializeWidth() => Width != _factoryWidth;
+    private void ResetWidth() => Width = _factoryWidth;
+    private bool ShouldSerializeImage() => Image != _factoryImage;
+    private void ResetImage() => Image = _factoryImage;
+    private bool ShouldSerializeImageAlign() => ImageAlign != _factoryImageAlign;
+    private void ResetImageAlign() => ImageAlign = _factoryImageAlign;
     #endregion
 
     #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteFormBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteFormBorder.cs
@@ -29,6 +29,7 @@ public class PaletteFormBorder : PaletteBorder
         : base(inherit, needPaint)
     {
         _ownerForm = ownerForm;
+        CaptureFactoryDefaults();
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
@@ -107,6 +107,15 @@ public class PaletteContent : Storage,
                                       _longText.IsDefault &&
                                       ((_storage == null) || _storage.IsDefault);
 
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        _shortText.CaptureFactoryDefaults();
+        _longText.CaptureFactoryDefaults();
+    }
+
     #endregion
 
     #region SetInherit

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
@@ -81,6 +81,22 @@ public class PaletteContentText : Storage
 
     #region Instance Fields
     private InternalStorage? _storage;
+    private Font? _factoryFont;
+    private PaletteTextHint _factoryHint = PaletteTextHint.Inherit;
+    private PaletteTextTrim _factoryTrim = PaletteTextTrim.Inherit;
+    private PaletteTextHotkeyPrefix _factoryPrefix = PaletteTextHotkeyPrefix.Inherit;
+    private PaletteRelativeAlign _factoryTextH = PaletteRelativeAlign.Inherit;
+    private PaletteRelativeAlign _factoryTextV = PaletteRelativeAlign.Inherit;
+    private PaletteRelativeAlign _factoryMultiLineH = PaletteRelativeAlign.Inherit;
+    private InheritBool _factoryMultiLine = InheritBool.Inherit;
+    private Color _factoryColor1 = GlobalStaticValues.EMPTY_COLOR;
+    private Color _factoryColor2 = GlobalStaticValues.EMPTY_COLOR;
+    private PaletteColorStyle _factoryColorStyle = PaletteColorStyle.Inherit;
+    private PaletteRectangleAlign _factoryColorAlign = PaletteRectangleAlign.Inherit;
+    private float _factoryColorAngle = -1;
+    private Image? _factoryImage;
+    private PaletteImageStyle _factoryImageStyle = PaletteImageStyle.Inherit;
+    private PaletteRectangleAlign _factoryImageAlign = PaletteRectangleAlign.Inherit;
     #endregion
 
     #region Events
@@ -109,7 +125,46 @@ public class PaletteContentText : Storage
     /// </summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault => (_storage == null) || _storage.IsDefault;
+    public override bool IsDefault =>
+        Font == _factoryFont &&
+        Hint == _factoryHint &&
+        Trim == _factoryTrim &&
+        Prefix == _factoryPrefix &&
+        TextH == _factoryTextH &&
+        TextV == _factoryTextV &&
+        MultiLineH == _factoryMultiLineH &&
+        MultiLine == _factoryMultiLine &&
+        Color1.Equals(_factoryColor1) &&
+        Color2.Equals(_factoryColor2) &&
+        ColorStyle == _factoryColorStyle &&
+        ColorAlign == _factoryColorAlign &&
+        ColorAngle.Equals(_factoryColorAngle) &&
+        Image == _factoryImage &&
+        ImageStyle == _factoryImageStyle &&
+        ImageAlign == _factoryImageAlign;
+
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        _factoryFont = Font;
+        _factoryHint = Hint;
+        _factoryTrim = Trim;
+        _factoryPrefix = Prefix;
+        _factoryTextH = TextH;
+        _factoryTextV = TextV;
+        _factoryMultiLineH = MultiLineH;
+        _factoryMultiLine = MultiLine;
+        _factoryColor1 = Color1;
+        _factoryColor2 = Color2;
+        _factoryColorStyle = ColorStyle;
+        _factoryColorAlign = ColorAlign;
+        _factoryColorAngle = ColorAngle;
+        _factoryImage = Image;
+        _factoryImageStyle = ImageStyle;
+        _factoryImageAlign = ImageAlign;
+    }
 
     #endregion
 
@@ -120,7 +175,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Font for drawing the content text.")]
-    [DefaultValue(null)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Font? Font
     {
@@ -160,7 +214,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Text rendering hint for the content text.")]
-    [DefaultValue(PaletteTextHint.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteTextHint Hint
     {
@@ -200,7 +253,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Text trimming style for the content text.")]
-    [DefaultValue(PaletteTextTrim.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteTextTrim Trim
     {
@@ -240,7 +292,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"How to draw prefix characters for the content text.")]
-    [DefaultValue(PaletteTextHotkeyPrefix.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteTextHotkeyPrefix Prefix
     {
@@ -280,7 +331,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Relative horizontal alignment of content text.")]
-    [DefaultValue(PaletteRelativeAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteRelativeAlign TextH
     {
@@ -320,7 +370,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Relative vertical alignment of content text.")]
-    [DefaultValue(PaletteRelativeAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteRelativeAlign TextV
     {
@@ -360,7 +409,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Relative horizontal alignment of multiline content text.")]
-    [DefaultValue(PaletteRelativeAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteRelativeAlign MultiLineH
     {
@@ -400,7 +448,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Flag indicating if multiline text is allowed..")]
-    [DefaultValue(InheritBool.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual InheritBool MultiLine
     {
@@ -440,7 +487,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Main color for the text.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color1
     {
@@ -480,7 +526,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Secondary color for the text.")]
-    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color2
     {
@@ -520,7 +565,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Color drawing style for the text.")]
-    [DefaultValue(PaletteColorStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteColorStyle ColorStyle
     {
@@ -560,7 +604,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Color alignment style for the text.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteRectangleAlign ColorAlign
     {
@@ -600,7 +643,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Color angle for the text.")]
-    [DefaultValue(-1f)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual float ColorAngle
     {
@@ -640,7 +682,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Image for the text.")]
-    [DefaultValue(null)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Image? Image
     {
@@ -680,7 +721,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Image style for the text.")]
-    [DefaultValue(PaletteImageStyle.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteImageStyle ImageStyle
     {
@@ -720,7 +760,6 @@ public class PaletteContentText : Storage
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Image alignment style for the text.")]
-    [DefaultValue(PaletteRectangleAlign.Inherit)]
     [RefreshProperties(RefreshProperties.All)]
     public virtual PaletteRectangleAlign ImageAlign
     {
@@ -751,6 +790,41 @@ public class PaletteContentText : Storage
             }
         }
     }
+    #endregion
+
+    #region ShouldSerialize
+    private bool ShouldSerializeFont() => Font != _factoryFont;
+    private void ResetFont() => Font = _factoryFont;
+    private bool ShouldSerializeHint() => Hint != _factoryHint;
+    private void ResetHint() => Hint = _factoryHint;
+    private bool ShouldSerializeTrim() => Trim != _factoryTrim;
+    private void ResetTrim() => Trim = _factoryTrim;
+    private bool ShouldSerializePrefix() => Prefix != _factoryPrefix;
+    private void ResetPrefix() => Prefix = _factoryPrefix;
+    private bool ShouldSerializeTextH() => TextH != _factoryTextH;
+    private void ResetTextH() => TextH = _factoryTextH;
+    private bool ShouldSerializeTextV() => TextV != _factoryTextV;
+    private void ResetTextV() => TextV = _factoryTextV;
+    private bool ShouldSerializeMultiLineH() => MultiLineH != _factoryMultiLineH;
+    private void ResetMultiLineH() => MultiLineH = _factoryMultiLineH;
+    private bool ShouldSerializeMultiLine() => MultiLine != _factoryMultiLine;
+    private void ResetMultiLine() => MultiLine = _factoryMultiLine;
+    private bool ShouldSerializeColor1() => !Color1.Equals(_factoryColor1);
+    private void ResetColor1() => Color1 = _factoryColor1;
+    private bool ShouldSerializeColor2() => !Color2.Equals(_factoryColor2);
+    private void ResetColor2() => Color2 = _factoryColor2;
+    private bool ShouldSerializeColorStyle() => ColorStyle != _factoryColorStyle;
+    private void ResetColorStyle() => ColorStyle = _factoryColorStyle;
+    private bool ShouldSerializeColorAlign() => ColorAlign != _factoryColorAlign;
+    private void ResetColorAlign() => ColorAlign = _factoryColorAlign;
+    private bool ShouldSerializeColorAngle() => !ColorAngle.Equals(_factoryColorAngle);
+    private void ResetColorAngle() => ColorAngle = _factoryColorAngle;
+    private bool ShouldSerializeImage() => Image != _factoryImage;
+    private void ResetImage() => Image = _factoryImage;
+    private bool ShouldSerializeImageStyle() => ImageStyle != _factoryImageStyle;
+    private void ResetImageStyle() => ImageStyle = _factoryImageStyle;
+    private bool ShouldSerializeImageAlign() => ImageAlign != _factoryImageAlign;
+    private void ResetImageAlign() => ImageAlign = _factoryImageAlign;
     #endregion
 
     #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColor.cs
@@ -94,7 +94,7 @@ public class PaletteElementColor : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"First element color.")]
-    [DefaultValue(typeof(Color), "Empty")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color1
     {
@@ -132,7 +132,7 @@ public class PaletteElementColor : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Second element color.")]
-    [DefaultValue(typeof(Color), "Empty")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color2
     {
@@ -170,7 +170,7 @@ public class PaletteElementColor : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Third element color.")]
-    [DefaultValue(typeof(Color), "Empty")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color3
     {
@@ -208,7 +208,7 @@ public class PaletteElementColor : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Fourth element color.")]
-    [DefaultValue(typeof(Color), "Empty")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color4
     {
@@ -246,7 +246,7 @@ public class PaletteElementColor : Storage,
     [KryptonPersist(false)]
     [Category(@"Visuals")]
     [Description(@"Fifth element color.")]
-    [DefaultValue(typeof(Color), "Empty")]
+    [KryptonDefaultColor]
     [RefreshProperties(RefreshProperties.All)]
     public virtual Color Color5
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTriple.cs
@@ -63,6 +63,16 @@ public class PaletteTriple : Storage,
                                       Border.IsDefault &&
                                       Content.IsDefault;
 
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        Back.CaptureFactoryDefaults();
+        Border.CaptureFactoryDefaults();
+        Content.CaptureFactoryDefaults();
+    }
+
     #endregion
 
     #region SetInherit

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
@@ -93,6 +93,16 @@ public class PaletteTripleRedirect : Storage,
                                       Border.IsDefault &&
                                       Content.IsDefault;
 
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        Back.CaptureFactoryDefaults();
+        Border.CaptureFactoryDefaults();
+        Content.CaptureFactoryDefaults();
+    }
+
     #endregion
 
     #region SetRedirector

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteImagesIntegratedToolBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteImagesIntegratedToolBar.cs
@@ -68,7 +68,22 @@ public class KryptonPaletteImagesIntegratedToolBar : Storage
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public override bool IsDefault { get; }
+    public override bool IsDefault =>
+        (_copy == null) &&
+        (_cut == null) &&
+        (_help == null) &&
+        (_paste == null) &&
+        (_new == null) &&
+        (_open == null) &&
+        (_pageSetup == null) &&
+        (_printPreview == null) &&
+        (_print == null) &&
+        (_quickPrint == null) &&
+        (_redo == null) &&
+        (_undo == null) &&
+        (_saveAll == null) &&
+        (_saveAs == null) &&
+        (_save == null);
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteComboBoxRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteComboBoxRedirect.cs
@@ -55,6 +55,7 @@ public class PaletteComboBoxRedirect : Storage
                 _shortTextH = PaletteRelativeAlign.Near
             }
         };
+        ComboBox.Content.CaptureFactoryDefaults();
 
         _dropBackRedirect = new PaletteDoubleRedirect(redirect!, 
             PaletteBackStyle.ControlClient, 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewRedirect.cs
@@ -79,6 +79,7 @@ public class PaletteDataGridViewRedirect : Storage
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public PaletteBackStyle BackStyle
     {
         get => _background.BackStyle;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
@@ -23,6 +23,7 @@ public class PaletteInputControlContentStates : Storage,
     private Font? _font;
     private Color _color1;
     internal Padding _padding;
+    private PaletteRelativeAlign _factoryTextH = PaletteRelativeAlign.Inherit;
     internal PaletteRelativeAlign _shortTextH;
 
     #endregion
@@ -62,6 +63,11 @@ public class PaletteInputControlContentStates : Storage,
                                          (Color1.IsEmpty) &&
                                          Padding.Equals(CommonHelper.InheritPadding)
                                          && !ShouldSerializeTextH();
+
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults() => _factoryTextH = _shortTextH;
 
     #endregion
 
@@ -209,7 +215,6 @@ public class PaletteInputControlContentStates : Storage,
     [Category(@"Visuals")]
     [Description(@"Relative horizontal Content text alignment\nIn order to get this into the designer.cs you must also modify another value in this area!")]
     [RefreshProperties(RefreshProperties.All)]
-    [DefaultValue(PaletteRelativeAlign.Inherit)]
     public PaletteRelativeAlign TextH
     {
         get => _shortTextH;
@@ -224,16 +229,17 @@ public class PaletteInputControlContentStates : Storage,
         }
     }
 
-    private bool ShouldSerializeTextH() => _shortTextH != PaletteRelativeAlign.Inherit;
+    private bool ShouldSerializeTextH() => _shortTextH != _factoryTextH;
 
-    private void ResetTextH() => _shortTextH = PaletteRelativeAlign.Inherit;
+    private void ResetTextH() => _shortTextH = _factoryTextH;
 
     /// <summary>
     /// Gets the actual content short text horizontal alignment value.
     /// </summary>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>RelativeAlignment value.</returns>
-    public virtual PaletteRelativeAlign GetContentShortTextH(PaletteState state) => ShouldSerializeTextH() ? _shortTextH : Inherit.GetContentShortTextH(state);
+    public virtual PaletteRelativeAlign GetContentShortTextH(PaletteState state) =>
+        _shortTextH != PaletteRelativeAlign.Inherit ? _shortTextH : Inherit.GetContentShortTextH(state);
 
     /// <summary>
     /// Gets the actual content short text vertical alignment value.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
@@ -70,6 +70,15 @@ public class PaletteInputControlTripleRedirect : Storage,
                                       Border.IsDefault &&
                                       Content.IsDefault;
 
+    /// <summary>
+    /// Treats the current values as the unset designer default.
+    /// </summary>
+    public void CaptureFactoryDefaults()
+    {
+        Border.CaptureFactoryDefaults();
+        Content.CaptureFactoryDefaults();
+    }
+
     #endregion
 
     #region SetRedirector

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/DropDownArrowGlyphColors.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
@@ -96,12 +96,12 @@ internal static class DropDownArrowGlyphColors
 
         if (context?.Control is KryptonDropButton dropButton)
         {
-            Color? arrowColor = dropButton.Values.DropDownArrowColor;
+            Color arrowColor = dropButton.Values.DropDownArrowColor;
 
-            if (arrowColor.HasValue && arrowColor.Value != Color.Empty)
+            if (!arrowColor.IsEmpty)
             {
 
-                color = arrowColor.Value;
+                color = arrowColor;
 
                 return true;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Storage/Colors/KryptonColorStorage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Storage/Colors/KryptonColorStorage.cs
@@ -12,7 +12,7 @@ namespace Krypton.Toolkit;
 [TypeConverter(typeof(ExpandableObjectConverter))]
 public class KryptonColorStorage : Storage
 {
-    public override bool IsDefault { get; }
+    public override bool IsDefault => true;
 
     public void Reset()
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonImageStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonImageStates.cs
@@ -171,6 +171,7 @@ public class ButtonImageStates : Storage
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public virtual Image? ImageCheckedNormal
     {
         get => null;
@@ -185,6 +186,7 @@ public class ButtonImageStates : Storage
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public virtual Image? ImageCheckedPressed
     {
         get => null;
@@ -198,6 +200,7 @@ public class ButtonImageStates : Storage
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public virtual Image? ImageCheckedTracking
     {
         get => null;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
@@ -32,10 +32,12 @@ public class ButtonValues : Storage,
     private IconSelectionStrategy _iconSelectionStrategy;
     private Image? _image;
     private Color _transparent;
-    private Color? _dropDownArrowColor;
+    private Color _dropDownArrowColor;
     private string? _text;
     private string _extraText;
     private Size? _customIconSize;
+    private string _defaultText = DEFAULT_TEXT;
+    private Image? _defaultImage;
 
     #endregion
 
@@ -79,15 +81,33 @@ public class ButtonValues : Storage,
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override bool IsDefault => ImageStates.IsDefault &&
-                                      (Image == null) &&
+                                      (Image == _defaultImage) &&
                                       (UseAsADialogButton == false) &&
                                       (UseAsUACElevationButton == false) &&
                                       (ShowSplitOption == false) &&
                                       (DropDownArrowColor == GlobalStaticValues.EMPTY_COLOR) &&
                                       //(UACShieldIconSize == UACShieldIconSize.ExtraSmall)
                                       (ImageTransparentColor == GlobalStaticValues.EMPTY_COLOR) &&
-                                      (Text == DEFAULT_TEXT) &&
+                                      (Text == _defaultText) &&
                                       (ExtraText == _defaultExtraText);
+
+    /// <summary>
+    /// Treats <paramref name="text"/> as the unset designer default for <see cref="Text"/>.
+    /// </summary>
+    internal void SetFactoryText(string text)
+    {
+        _defaultText = text ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
+        _text = _defaultText;
+    }
+
+    /// <summary>
+    /// Treats <paramref name="image"/> as the unset designer default for <see cref="Image"/>.
+    /// </summary>
+    internal void SetFactoryImage(Image? image)
+    {
+        _defaultImage = image;
+        _image = image;
+    }
 
     #endregion
 
@@ -113,12 +133,12 @@ public class ButtonValues : Storage,
         }
     }
 
-    private bool ShouldSerializeImage() => Image != null;
+    private bool ShouldSerializeImage() => Image != _defaultImage;
 
     /// <summary>
     /// Resets the Image property to its default value.
     /// </summary>
-    public void ResetImage() => Image = null;
+    public void ResetImage() => Image = _defaultImage;
     #endregion
 
     #region ImageTransparentColor
@@ -198,12 +218,12 @@ public class ButtonValues : Storage,
         }
     }
 
-    private bool ShouldSerializeText() => Text != DEFAULT_TEXT;
+    private bool ShouldSerializeText() => Text != _defaultText;
 
     /// <summary>
     /// Resets the Text property to its default value.
     /// </summary>
-    public void ResetText() => Text = DEFAULT_TEXT;
+    public void ResetText() => Text = _defaultText;
     #endregion
 
     #region ExtraText
@@ -380,8 +400,8 @@ public class ButtonValues : Storage,
     /// <value>The color of the drop-down arrow.</value>
     [Category(@"Visuals")]
     [Description(@"Sets the drop-down arrow color.")]
-    [DefaultValue(typeof(Color), @"Empty")]
-    public Color? DropDownArrowColor
+    [KryptonDefaultColor]
+    public Color DropDownArrowColor
     {
         get => _dropDownArrowColor;
 
@@ -389,14 +409,13 @@ public class ButtonValues : Storage,
         {
             if (_dropDownArrowColor != value)
             {
-                _dropDownArrowColor = value ?? GlobalStaticValues.EMPTY_COLOR;
-
+                _dropDownArrowColor = value;
                 PerformNeedPaint(true);
             }
         }
     }
-    private void ResetDropDownArrowColor() => _dropDownArrowColor = GlobalStaticValues.EMPTY_COLOR;
-    private bool ShouldSerializeDropDownArrowColor() => _dropDownArrowColor != GlobalStaticValues.EMPTY_COLOR;
+    private void ResetDropDownArrowColor() => DropDownArrowColor = GlobalStaticValues.EMPTY_COLOR;
+    private bool ShouldSerializeDropDownArrowColor() => DropDownArrowColor != GlobalStaticValues.EMPTY_COLOR;
     #endregion
 
     #region CreateImageStates

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
@@ -22,10 +22,10 @@ public class ColorButtonValues : Storage,
 
     private readonly string _defaultText = KryptonManager.Strings.ColorStrings.Color;
     private static readonly string _defaultExtraText = GlobalStaticValues.DEFAULT_EMPTY_STRING;
-    private static readonly Image? _defaultImage = GenericImageResources.ButtonColorImageSmall;
     #endregion
 
     #region Instance Fields
+    private Image? _defaultImage = GenericImageResources.ButtonColorImageSmall;
     private Image? _image;
     private Image? _sourceImage;
     private Image? _compositeImage;
@@ -82,6 +82,15 @@ public class ColorButtonValues : Storage,
                                       (ExtraText == _defaultExtraText)
                                       && (_roundedCorners == 0)
     ;
+
+    /// <summary>
+    /// Treats <paramref name="image"/> as the unset designer default for <see cref="Image"/>.
+    /// </summary>
+    internal void SetFactoryImage(Image? image)
+    {
+        _defaultImage = image;
+        _image = image;
+    }
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/CommandLinkTextValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/CommandLinkTextValues.cs
@@ -90,6 +90,8 @@ public class CommandLinkTextValues : CaptionValues
 
     #region Protected
 
+    protected override Image? GetImageDefault() => DEFAULT_IMAGE;
+
     /// <inheritdoc />
     protected override string GetDescriptionDefault() => DEFAULT_DESCRIPTION;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/LabelValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/LabelValues.cs
@@ -28,6 +28,7 @@ public class LabelValues : Storage,
     private Color _transparent;
     private string? _text;
     private string _extraText;
+    private string _defaultText = DEFAULT_TEXT;
     #endregion
 
     #region Events
@@ -63,8 +64,17 @@ public class LabelValues : Storage,
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override bool IsDefault => (Image == null) &&
                                       (ImageTransparentColor == GlobalStaticValues.EMPTY_COLOR) &&
-                                      (Text == DEFAULT_TEXT) &&
+                                      (Text == _defaultText) &&
                                       (ExtraText == _defaultExtraText);
+
+    /// <summary>
+    /// Treats <paramref name="text"/> as the unset designer default for <see cref="Text"/>.
+    /// </summary>
+    internal void SetFactoryText(string text)
+    {
+        _defaultText = text ?? GlobalStaticValues.DEFAULT_EMPTY_STRING;
+        _text = _defaultText;
+    }
 
     #endregion
 
@@ -170,12 +180,12 @@ public class LabelValues : Storage,
         }
     }
 
-    private bool ShouldSerializeText() => Text != DEFAULT_TEXT;
+    private bool ShouldSerializeText() => Text != _defaultText;
 
     /// <summary>
     /// Resets the Text property to its default value.
     /// </summary>
-    public void ResetText() => Text = DEFAULT_TEXT;
+    public void ResetText() => Text = _defaultText;
 
     /// <summary>
     /// Gets the content short text.

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
@@ -128,7 +128,7 @@ public class ToolTipValues : HeaderValues
     /// </summary>
     [Category(@"ToolTip")]
     [Description("Hover interval (in millisecs) before a tooltip is shown\n[Currently ONLY designer values used]")]
-    [DefaultValue(5000)]
+    [DefaultValue(500)]
     public int ShowIntervalDelay
     {
         get => _showIntervalDelay;

--- a/Source/Krypton Components/TestForm/KryptonTaskDialogDemo/KryptonTaskDialogDemoResources.Designer.cs
+++ b/Source/Krypton Components/TestForm/KryptonTaskDialogDemo/KryptonTaskDialogDemoResources.Designer.cs
@@ -19,7 +19,7 @@ namespace TestForm.KryptonTaskDialogDemo {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class KryptonTaskDialogDemoResources {


### PR DESCRIPTION
# Fix: Fresh toolbox drops no longer show Modified nested properties (#4325)

## Summary

Freshly dropped Krypton controls no longer show nested palette and values objects as **Modified** in the Visual Studio Properties window until the user actually changes them. Constructor factory values (combo `TextH`, progress-bar green fill, scrollbar border colours, command-link alignments, and similar) are now treated as designer defaults via `ShouldSerialize` / `IsDefault`.

## Related issues

- Closes #4325

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- Shared palette storage (`PaletteBack`, `PaletteBorder`, `PaletteContentText`, input-control content) records constructor factory defaults with `CaptureFactoryDefaults()`.
- Combo box `TextH = Near`, progress bar fill/style, command-link text alignment, form chrome `GraphicsHint`, color-button stock image, powered-by text/image, wrap-label style, and related constructors now capture those values as unset defaults.
- `[DefaultValue]` mismatches fixed for tooltip hover delay, `DropDownArrowColor` (`Color` not `Color?`), decimal numeric values, scrollbar colours, and related properties.
- Regression script: `Scripts/UnitTests/UnitTest-DesignerSerializationDefaults.ps1`.

## Test plan

- [ ] Run `UnitTest-DesignerSerializationDefaults.ps1` (STA, Debug net472) — expect `PASS`.
- [ ] New WinForms project, `KryptonForm`, drag `KryptonButton`, `KryptonComboBox`, `KryptonTextBox`, `KryptonLabel`, `KryptonProgressBar`, `KryptonCommandLinkButton`. Properties window Visuals nodes should be blank except `Values` when the designer assigned `Text`.
- [ ] Change a nested property, save, confirm it serializes; Reset should restore the factory look without leftover **Modified**.