### PR TITLE
* KryptonForm RTL caption chrome

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -561,6 +561,9 @@
 * Resolved [#2886](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2886), Jump list support
 * Implemented [#2882](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2882), `KryptonPrintPreviewDialog` - Part of #2658
 * Resolved [#2103](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2103), Ensure that `KryptonForm` properly supports RTL/LTR
+  * `KryptonForm` RTL caption text is no longer mirrored, and resizing from the left or right edge follows the grabbed side.
+  * RTL + `RightToLeftLayout` no longer clips the left window frame (window region was mirrored off the physical left edge).
+  * Caption icon under RTL layout is inset from the frame. Extra space is `KryptonForm.CaptionIconPadding` (default `2`; `Empty` keeps only the frame inset).
 * Resolved [#2457](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2457), `KryptonForm` RTL border bug
 * Implemented [#2792](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2792), `KryptonNotifyIcon` - Part of #2658
 * Implemented [#2791](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2791), `KryptonFlowLayoutPanel` - Part of #2658

--- a/Scripts/UnitTests/Invoke-KryptonFormRtlScreenshot.ps1
+++ b/Scripts/UnitTests/Invoke-KryptonFormRtlScreenshot.ps1
@@ -1,0 +1,70 @@
+﻿<#
+.SYNOPSIS
+    Hosts RTLFormBorderTest and writes a PNG of RTL+layout caption chrome.
+
+.DESCRIPTION
+    Loads TestForm in-process (STA), shows RTLFormBorderTest with RightToLeft +
+    RightToLeftLayout, and captures Documents/PR/2103-kryptonform-rtl-layout.png.
+
+    # UnitTest-CI: exclude
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\Invoke-KryptonFormRtlScreenshot.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Debug',
+    [string]$TargetFramework = 'net472',
+    [string]$BinDir,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'UnitTestCommon.ps1')
+
+$repoRoot = Get-UnitTestRepoRoot
+$bin = Get-UnitTestBinDir -RepoRoot $repoRoot -Configuration $Configuration -TargetFramework $TargetFramework -BinDir $BinDir
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $repoRoot 'Documents\PR\2103-kryptonform-rtl-layout.png'
+}
+
+$outDir = Split-Path -Parent $OutputPath
+if (-not (Test-Path -LiteralPath $outDir)) {
+    New-Item -ItemType Directory -Path $outDir | Out-Null
+}
+
+Register-UnitTestAssemblyResolver -BinDir $bin
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.dll'))
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.Utilities.dll'))
+$asm = [System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'TestForm.exe'))
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+$formType = $asm.GetType('TestForm.RTLFormBorderTest')
+if (-not $formType) {
+    throw 'Type TestForm.RTLFormBorderTest was not found in TestForm.exe.'
+}
+
+$form = [System.Activator]::CreateInstance($formType)
+$form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+$form.Location = New-Object System.Drawing.Point 80, 80
+$form.TopMost = $true
+$form.Show()
+$form.Activate()
+$form.BringToFront()
+[System.Windows.Forms.Application]::DoEvents()
+Start-Sleep -Milliseconds 500
+[System.Windows.Forms.Application]::DoEvents()
+
+$bounds = $form.Bounds
+$bmp = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+$g.Dispose()
+$bmp.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
+$bmp.Dispose()
+
+$form.Close()
+$form.Dispose()
+Write-Host "Wrote $OutputPath"

--- a/Scripts/UnitTests/README.md
+++ b/Scripts/UnitTests/README.md
@@ -66,6 +66,7 @@ Default output folder: `Bin\Debug\net472`.
 | `UnitTest-KryptonLogProtect.ps1` | #4270 / #4269 `KryptonLog` redacts `{Password}` before file storage | `include` |
 | `UnitTest-CommandLinkArrow.ps1` | #4264 default command-link arrow: helper returns 32x32 image; Windows 7 embedded resource is packaged | `include` |
 | `UnitTest-CustomPaletteBasePaletteMode.ps1` | #1870 `KryptonCustomPaletteBase.BasePaletteMode` inherits the builtin colour table; builtin `BasePalette` keeps catalog mode | `include` |
+| `UnitTest-KryptonFormRtl.ps1` | #2103 `KryptonForm` RTL: `ScreenToWindow` stays physical; Close hit-tests on the right in LTR and the left with `RightToLeftLayout`; window region includes both physical left and right chrome | `include` |
 | `UnitTest-ContextMenuSubMenuImage.ps1` | #4252 Light Gray Office 2007/2010/Microsoft 365 `GetContextMenuSubMenuImage` returns an image; all catalog palettes must not throw | `include` |
 | `Start-AsyncFormsDemoHost.ps1` | Hosts `Feature4177AsyncFormsDemo` | n/a |
 | `Start-SplashScreenManagerHost.ps1` | Hosts `Feature4180SplashScreenManagerDemo` (#4180) | n/a |
@@ -76,6 +77,7 @@ Default output folder: `Bin\Debug\net472`.
 | `Start-RadialMenuDemoHost.ps1` | Hosts `RadialMenuDemo` (#4172) | n/a |
 | `Invoke-RadialMenuScreenshot.ps1` | Opens radial menu and writes `Documents/PR/4172-radial-menu-native.png` | `exclude` |
 | `Invoke-SchemeStripTextScreenshot.ps1` | Hosts `SchemeStripTextDemo` (#1100) and writes default/contrast PNGs under `Documents/PR/` | `exclude` |
+| `Invoke-KryptonFormRtlScreenshot.ps1` | Hosts `RTLFormBorderTest` (#2103) and writes `Documents/PR/2103-kryptonform-rtl-layout.png` | `exclude` |
 
 ## Run all CI assert tests (on demand)
 

--- a/Scripts/UnitTests/UnitTest-KryptonFormRtl.ps1
+++ b/Scripts/UnitTests/UnitTest-KryptonFormRtl.ps1
@@ -1,0 +1,157 @@
+﻿<#
+.SYNOPSIS
+    Asserts #2103 KryptonForm RTL chrome coordinates (close button side + ScreenToWindow).
+
+.DESCRIPTION
+    Shows a KryptonForm in LTR and RTL+RightToLeftLayout, then checks that ScreenToWindow
+    uses the physical top-left origin, HitTestCloseButton matches native chrome placement
+    (right in LTR, left in RTL layout), and the realized window region includes both
+    physical left and right chrome (RTL must not clip the left frame).
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -STA -File .\Scripts\UnitTests\UnitTest-KryptonFormRtl.ps1
+#>
+# UnitTest-CI: include
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Debug',
+    [string]$TargetFramework = 'net472',
+    [string]$BinDir
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'UnitTestCommon.ps1')
+
+$repoRoot = Get-UnitTestRepoRoot
+$bin = Get-UnitTestBinDir -RepoRoot $repoRoot -Configuration $Configuration -TargetFramework $TargetFramework -BinDir $BinDir
+Register-UnitTestAssemblyResolver -BinDir $bin
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class KryptonFormRtlNative {
+    [DllImport("user32.dll")] public static extern int GetWindowRgn(IntPtr hWnd, IntPtr hRgn);
+    [DllImport("gdi32.dll")] public static extern IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
+    [DllImport("gdi32.dll")] public static extern bool DeleteObject(IntPtr hObject);
+    [DllImport("gdi32.dll")] public static extern bool PtInRegion(IntPtr hrgn, int x, int y);
+    public const int ERROR = 0;
+    public const int NULLREGION = 1;
+    public const int SIMPLEREGION = 2;
+    public const int COMPLEXREGION = 3;
+}
+"@
+
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Interop.dll'))
+[void][System.Reflection.Assembly]::LoadFrom((Join-Path $bin 'Krypton.Toolkit.dll'))
+
+$failed = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        $failed.Add($Message)
+        Write-Host "FAIL: $Message" -ForegroundColor Red
+    }
+    else {
+        Write-Host "PASS: $Message" -ForegroundColor Green
+    }
+}
+
+$screenToWindow = [Krypton.Toolkit.VisualForm].GetMethod(
+    'ScreenToWindow',
+    [System.Reflection.BindingFlags]'Instance,NonPublic')
+Assert-True ($null -ne $screenToWindow) 'VisualForm.ScreenToWindow is available'
+
+function Test-FormRtlChrome {
+    param(
+        [bool]$RtlLayout,
+        [string]$Label
+    )
+
+    $form = New-Object Krypton.Toolkit.KryptonForm
+    try {
+        $form.Text = 'Caption Test ABC'
+        $form.ControlBox = $true
+        $form.MinimizeBox = $true
+        $form.MaximizeBox = $true
+        $form.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::Sizable
+        $form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+        $form.Location = New-Object System.Drawing.Point 80, 80
+        $form.Size = New-Object System.Drawing.Size 480, 280
+        if ($RtlLayout) {
+            $form.RightToLeft = [System.Windows.Forms.RightToLeft]::Yes
+            $form.RightToLeftLayout = $true
+        }
+        else {
+            $form.RightToLeft = [System.Windows.Forms.RightToLeft]::No
+            $form.RightToLeftLayout = $false
+        }
+
+        $form.Show()
+        $form.Activate()
+        [System.Windows.Forms.Application]::DoEvents()
+        Start-Sleep -Milliseconds 200
+        [System.Windows.Forms.Application]::DoEvents()
+
+        $leftScreen = New-Object System.Drawing.Point ($form.Left + 2), ($form.Top + 40)
+        $windowPt = $screenToWindow.Invoke($form, @($leftScreen))
+        Assert-True ($windowPt.X -lt 40) "$Label ScreenToWindow(physical left) X=$($windowPt.X) is near 0, not mirrored to Width"
+
+        $closeXs = New-Object System.Collections.Generic.List[int]
+        for ($scanY = 8; $scanY -le 36; $scanY += 4) {
+            for ($scanX = 0; $scanX -lt $form.Width; $scanX += 4) {
+                if ($form.HitTestCloseButton((New-Object System.Drawing.Point $scanX, $scanY))) {
+                    $closeXs.Add($scanX)
+                }
+            }
+        }
+        $closeCount = $closeXs.Count
+        Assert-True ($closeCount -gt 0) "$Label Close button has a non-empty hit area (scanned caption)"
+        if ($closeCount -gt 0) {
+            $avgX = ($closeXs | Measure-Object -Average).Average
+            $mid = $form.Width / 2.0
+            Write-Host "$Label Close hit X average=$([int]$avgX) width=$($form.Width) samples=$closeCount"
+            if ($RtlLayout) {
+                Assert-True ($avgX -lt $mid) "$Label Close is on the physical left (avg X=$([int]$avgX))"
+            }
+            else {
+                Assert-True ($avgX -gt $mid) "$Label Close is on the physical right (avg X=$([int]$avgX))"
+            }
+        }
+
+        $hrgn = [KryptonFormRtlNative]::CreateRectRgn(0, 0, 0, 0)
+        try {
+            $rgnType = [KryptonFormRtlNative]::GetWindowRgn($form.Handle, $hrgn)
+            $leftChrome = ($rgnType -eq [KryptonFormRtlNative]::ERROR) -or [KryptonFormRtlNative]::PtInRegion($hrgn, 0, 12)
+            $rightChrome = ($rgnType -eq [KryptonFormRtlNative]::ERROR) -or [KryptonFormRtlNative]::PtInRegion($hrgn, $form.Width - 1, 12)
+            Write-Host "$Label GetWindowRgn type=$rgnType leftPt=$leftChrome rightPt=$rightChrome"
+            Assert-True $leftChrome "$Label window region includes physical left chrome (x=0)"
+            Assert-True $rightChrome "$Label window region includes physical right chrome (x=Width-1)"
+        }
+        finally {
+            if ($hrgn -ne [IntPtr]::Zero) {
+                [void][KryptonFormRtlNative]::DeleteObject($hrgn)
+            }
+        }
+    }
+    finally {
+        if ($form) {
+            $form.Close()
+            $form.Dispose()
+        }
+    }
+}
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+Test-FormRtlChrome -RtlLayout $false -Label 'LTR'
+Test-FormRtlChrome -RtlLayout $true -Label 'RTL+Layout'
+
+if ($failed.Count -gt 0) {
+    Write-Host ("{0} assertion(s) failed." -f $failed.Count) -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'KryptonForm RTL chrome assertions passed.'
+exit 0

--- a/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Interop/General/PlatformInvoke.cs
@@ -2802,6 +2802,23 @@ No 	                    No 	                    Show text only
             PALETTEWINDOW = WINDOWEDGE + TOOLWINDOW + TOPMOST;
     }
 
+    /// <summary>
+    /// GDI device-context layout flags for <see cref="GetLayout"/> / <see cref="SetLayout"/>.
+    /// </summary>
+    internal struct LAYOUT_
+    {
+        public const uint
+            RTL = 0x00000001,
+            BTT = 0x00000002,
+            VBH = 0x00000004,
+            BITMAPORIENTATIONPRESERVED = 0x00000008;
+    }
+
+    /// <summary>
+    /// Win32 <c>GDI_ERROR</c> return from GDI functions such as <see cref="GetLayout"/>.
+    /// </summary>
+    internal const uint GDI_ERROR = 0xFFFFFFFF;
+
     internal enum MF_ : uint
     {
         INSERT = 0x00000000,
@@ -4563,6 +4580,24 @@ No 	                    No 	                    Show text only
     [DllImport(Libraries.Gdi32, CharSet = CharSet.Auto)]
     internal static extern int BitBlt(IntPtr hDestDC, int x, int y, int nWidth, int nHeight, IntPtr hSrcDC, int xSrc,
         int ySrc, int dwRop);
+    #endif
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    #if NET8_0_OR_GREATER
+    [LibraryImport(Libraries.Gdi32)]
+    internal static partial uint GetLayout(IntPtr hdc);
+    #else
+
+    [DllImport(Libraries.Gdi32)]
+    internal static extern uint GetLayout(IntPtr hdc);
+    #endif
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    #if NET8_0_OR_GREATER
+    [LibraryImport(Libraries.Gdi32)]
+    internal static partial uint SetLayout(IntPtr hdc, uint dwLayout);
+    #else
+
+    [DllImport(Libraries.Gdi32)]
+    internal static extern uint SetLayout(IntPtr hdc, uint dwLayout);
     #endif
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     #if NET8_0_OR_GREATER

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -917,11 +917,11 @@ public abstract class ButtonSpecManagerBase : GlobalId
     /// <param name="spec">Button spec instance.</param>
     /// <returns>Dock style to assign before RTL mirroring.</returns>
     /// <remarks>
-    /// Maps palette Near/Far edge to Left/Right dock. Form chrome relies on
-    /// <see cref="KryptonForm.FormPaletteRedirect.GetButtonSpecEdge(PaletteButtonSpecStyle)"/> to move standard Far-edge buttons to the
-    /// physical left in RTL (Far→Near remap) rather than depending on
-    /// <see cref="ViewDrawDocker.CalculateDock"/> alone, which does not consistently mirror
-    /// caption button specs (issue #3786).
+    /// Maps palette Near/Far edge to Left/Right dock. Form chrome then relies on
+    /// <see cref="ViewDrawDocker.CalculateDock"/> to flip Left/Right in RTL. Native Near-edge
+    /// traffic lights are remapped Near→Far by
+    /// <see cref="KryptonForm.FormPaletteRedirect.GetButtonSpecEdge(PaletteButtonSpecStyle)"/>
+    /// so they remain on the physical left (issue #2103 / #3786).
     /// </remarks>
     protected virtual ViewDockStyle GetButtonSpecDockStyle(ButtonSpec spec)
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -40,7 +40,6 @@ public class KryptonForm : VisualForm,
 
 		public override PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state)
 		{
-			// Handle header styles
 			if (style is PaletteContentStyle.HeaderForm
 				or PaletteContentStyle.HeaderPrimary
 				or PaletteContentStyle.HeaderDockInactive
@@ -50,15 +49,8 @@ public class KryptonForm : VisualForm,
 				or PaletteContentStyle.HeaderCustom2
 				or PaletteContentStyle.HeaderCustom3)
 			{
-				// RTL caption reading order (physical left → right):
-				// [Control box] [TextExtra] [Title] [Icon]
-				// Title is Far so it sits on the physical right, immediately before the icon.
-				if (_kryptonForm.RightToLeft == RightToLeft.Yes && _kryptonForm.RightToLeftLayout)
-				{
-					return PaletteRelativeAlign.Far;
-				}
-
-				// Use custom title align if set, otherwise use base
+				// Palette Near/Far is logical. RenderStandard.RightToLeftIndex maps them to
+				// physical cells, so do not invert here (that put the icon on the leading edge).
 				return _kryptonForm._formTitleAlign != PaletteRelativeAlign.Inherit
 					? _kryptonForm._formTitleAlign
 					: base.GetContentShortTextH(style, state);
@@ -67,48 +59,27 @@ public class KryptonForm : VisualForm,
 			return base.GetContentShortTextH(style, state);
 		}
 
-		public override PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state)
+		/// <inheritdoc/>
+		public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style, PaletteState state)
 		{
-			// Handle header styles
-			if (style is PaletteContentStyle.HeaderForm
-				or PaletteContentStyle.HeaderPrimary
-				or PaletteContentStyle.HeaderDockInactive
-				or PaletteContentStyle.HeaderDockActive
-				or PaletteContentStyle.HeaderSecondary
-				or PaletteContentStyle.HeaderCustom1
-				or PaletteContentStyle.HeaderCustom2
-				or PaletteContentStyle.HeaderCustom3)
-			{
-				// TextExtra uses Near so it follows the control box on the physical left in RTL.
-				if (_kryptonForm.RightToLeft == RightToLeft.Yes && _kryptonForm.RightToLeftLayout)
-				{
-					return PaletteRelativeAlign.Near;
-				}
-			}
-
-			return base.GetContentLongTextH(style, state);
+			Padding padding = base.GetBorderContentPadding(owningForm, style, state);
+			return style == PaletteContentStyle.HeaderForm
+				? CommonHelper.GetFormHeaderContentPadding(_kryptonForm, padding)
+				: padding;
 		}
 
-		public override PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state)
+		/// <inheritdoc/>
+		public override int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state)
 		{
-			// Icon uses Far in RTL so it anchors on the physical right of the caption.
-			if (_kryptonForm.RightToLeft == RightToLeft.Yes && _kryptonForm.RightToLeftLayout)
+			int gap = base.GetContentAdjacentGap(style, state);
+			if (style != PaletteContentStyle.HeaderForm
+				|| !_kryptonForm.UsesRtlFormButtonLayout()
+				|| gap < 0)
 			{
-				return style switch
-				{
-					PaletteContentStyle.HeaderForm
-						or PaletteContentStyle.HeaderPrimary
-						or PaletteContentStyle.HeaderDockInactive
-						or PaletteContentStyle.HeaderDockActive
-						or PaletteContentStyle.HeaderSecondary
-						or PaletteContentStyle.HeaderCustom1
-						or PaletteContentStyle.HeaderCustom2
-						or PaletteContentStyle.HeaderCustom3 => PaletteRelativeAlign.Far,
-					_ => base.GetContentImageH(style, state)
-				};
+				return gap;
 			}
 
-			return base.GetContentImageH(style, state);
+			return Math.Max(gap, 4);
 		}
 
 		/// <inheritdoc/>
@@ -127,9 +98,11 @@ public class KryptonForm : VisualForm,
 		/// <item>
 		/// <description>
 		/// <b>View dock</b> — <see cref="ButtonSpecManagerBase"/> maps that edge to
-		/// <see cref="ViewDockStyle"/> Left/Right. Custom form chrome does not rely on
-		/// <see cref="ViewDrawDocker.CalculateDock"/> mirroring for Far-edge buttons in RTL, so this
-		/// redirector remaps palette Far → Near when RTL is active (issue #3786).
+		/// <see cref="ViewDockStyle"/> Left/Right. <see cref="ViewDrawDocker.CalculateDock"/> then
+		/// flips Left/Right when RTL layout is active. Non-client chrome is painted in physical
+		/// coordinates (issue #2103), so Far-edge (Windows) buttons rely on that flip to land on
+		/// the physical left. Native Near-edge (traffic light) buttons would be flipped to the
+		/// physical right; this redirector maps Near → Far in RTL so they stay on the left.
 		/// </description>
 		/// </item>
 		/// </list>
@@ -142,14 +115,9 @@ public class KryptonForm : VisualForm,
 		/// </remarks>
 		public override PaletteRelativeEdgeAlign GetButtonSpecEdge(PaletteButtonSpecStyle style)
 		{
-			// Per-form override wins (e.g. macOS palette with FormTrafficLightEdge = Far keeps a
-			// Windows-style control box on the Far side without the RTL Far→Near remap below).
-			if (_kryptonForm._formTrafficLightEdge != PaletteRelativeEdgeAlign.Inherit && IsFormWindowButtonSpecStyle(style))
-			{
-				return _kryptonForm._formTrafficLightEdge;
-			}
-
-			var edge = base.GetButtonSpecEdge(style);
+			var edge = _kryptonForm._formTrafficLightEdge != PaletteRelativeEdgeAlign.Inherit && IsFormWindowButtonSpecStyle(style)
+				? _kryptonForm._formTrafficLightEdge
+				: base.GetButtonSpecEdge(style);
 
 			if (!IsFormWindowButtonSpecStyle(style)
 				|| !_kryptonForm.UsesRtlFormButtonLayout())
@@ -157,12 +125,10 @@ public class KryptonForm : VisualForm,
 				return edge;
 			}
 
-			// Standard palettes: FormClose/Min/Max are Far in LTR (physical right).
-			// In RTL the control box must move to the physical left (leading edge). Remap Far→Near
-			// so ButtonSpecManagerDraw docks Left. Do not remap native Near-edge palettes (macOS
-			// traffic lights) — they must stay on the physical left in both LTR and RTL.
-			return edge == PaletteRelativeEdgeAlign.Far
-				? PaletteRelativeEdgeAlign.Near
+			// CalculateDock flips Left/Right. Near (traffic lights) would land on the physical
+			// right; map Near→Far so they dock Right then flip back to the physical left.
+			return edge == PaletteRelativeEdgeAlign.Near
+				? PaletteRelativeEdgeAlign.Far
 				: edge;
 		}
 	}
@@ -205,6 +171,7 @@ public class KryptonForm : VisualForm,
 
 	#region Static Fields
 	private static readonly Size CAPTION_ICON_SIZE = new Size(16, 16);
+	private static readonly Padding DefaultCaptionIconPadding = new Padding(2);
 
 	private const int HT_CORNER = 8;
 
@@ -229,6 +196,7 @@ public class KryptonForm : VisualForm,
 	private HeaderStyle _headerStyle;
 	private PaletteRelativeAlign _formTitleAlign;
 	private PaletteRelativeEdgeAlign _formTrafficLightEdge;
+	private Padding _captionIconPadding;
 	private HeaderStyle _headerStylePrev;
 	private FormWindowState _regionWindowState;
 	private FormWindowState _lastWindowState;
@@ -281,6 +249,7 @@ public class KryptonForm : VisualForm,
 		_headerStyle = HeaderStyle.Form;
 		_formTitleAlign = PaletteRelativeAlign.Near;
 		_formTrafficLightEdge = PaletteRelativeEdgeAlign.Inherit;
+		_captionIconPadding = DefaultCaptionIconPadding;
 		_headerStylePrev = _headerStyle;
 		AllowButtonSpecToolTips = false;
 		_allowFormChrome = true;
@@ -1118,15 +1087,51 @@ public class KryptonForm : VisualForm,
 	private void ResetFormTitleAlign() => _formTitleAlign = PaletteRelativeAlign.Near;
 
 	/// <summary>
+	/// Gets and sets extra padding around the caption icon, in addition to the window-frame inset.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Values are physical Left, Top, Right, and Bottom. Under
+	/// <see cref="Control.RightToLeft"/> + <see cref="Form.RightToLeftLayout"/> the palette's
+	/// frame inset is moved onto the icon (right) side first; this padding is then added.
+	/// </para>
+	/// <para>
+	/// Default is <c>2, 2, 2, 2</c>. Set to <see cref="Padding.Empty"/> for only the frame inset.
+	/// Per-side header content padding can still be overridden via
+	/// <see cref="StateCommon"/> Header.Content.Padding.
+	/// </para>
+	/// </remarks>
+	[Category(@"Visuals")]
+	[Description(@"Extra padding around the caption icon, added after the window-frame inset.")]
+	[DefaultValue(typeof(Padding), "2, 2, 2, 2")]
+	public Padding CaptionIconPadding
+	{
+		get => _captionIconPadding;
+
+		set
+		{
+			if (_captionIconPadding != value)
+			{
+				_captionIconPadding = value;
+				PerformNeedPaint(true);
+			}
+		}
+	}
+
+	private bool ShouldSerializeCaptionIconPadding() => _captionIconPadding != DefaultCaptionIconPadding;
+	private void ResetCaptionIconPadding() => CaptionIconPadding = DefaultCaptionIconPadding;
+
+	/// <summary>
 	/// Gets and sets where form minimize/maximize/close buttons are placed for macOS-style palettes.
 	/// </summary>
 	/// <remarks>
 	/// <see cref="PaletteRelativeEdgeAlign.Inherit"/> uses the palette default (Near / traffic lights for
 	/// macOS and OS X Aqua). <see cref="PaletteRelativeEdgeAlign.Far"/> forces a standard Windows
-	/// control box on the Far edge (physical right in LTR). When set to Far, the RTL Far→Near remap in
-	/// <see cref="KryptonForm.FormPaletteRedirect.GetButtonSpecEdge(PaletteButtonSpecStyle)"/> is bypassed so the developer controls edge
-	/// explicitly. <see cref="PaletteRelativeEdgeAlign.Near"/> forces traffic-light placement on the
-	/// Near edge regardless of palette.
+	/// control box on the Far edge (physical right in LTR). When set to Far, the RTL Near→Far remap in
+	/// <see cref="KryptonForm.FormPaletteRedirect.GetButtonSpecEdge(PaletteButtonSpecStyle)"/> is not applied
+	/// (Far is left unchanged so <see cref="ViewDrawDocker.CalculateDock"/> can move the control box
+	/// to the physical left). <see cref="PaletteRelativeEdgeAlign.Near"/> forces traffic-light placement on the
+	/// Near edge regardless of palette; that Near value is remapped to Far under RTL so the lights stay left.
 	/// </remarks>
 	[Category(@"Visuals")]
 	[Description(@"Placement of form traffic-light buttons. Inherit uses the palette; Far places them on the right like a standard Windows application.")]
@@ -1524,6 +1529,26 @@ public class KryptonForm : VisualForm,
 				OnRightToLeftChanged(EventArgs.Empty);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Gets and sets whether the form mirrors its layout when <see cref="Control.RightToLeft"/> is <see cref="System.Windows.Forms.RightToLeft.Yes"/>.
+	/// </summary>
+	/// <remarks>
+	/// Matches native <see cref="Form"/>: caption chrome and client docking flip only when both
+	/// <see cref="Control.RightToLeft"/> is <see cref="System.Windows.Forms.RightToLeft.Yes"/> and this property is <see langword="true"/>.
+	/// </remarks>
+	[Browsable(true)]
+	[DefaultValue(false)]
+	[Localizable(true)]
+	[EditorBrowsable(EditorBrowsableState.Always)]
+	[DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+	[Category(@"Appearance")]
+	[Description(@"Indicates whether to use RTL layout when RightToLeft is Yes.")]
+	public override bool RightToLeftLayout
+	{
+		get => base.RightToLeftLayout;
+		set => base.RightToLeftLayout = value;
 	}
 
 	#endregion
@@ -2122,7 +2147,7 @@ public class KryptonForm : VisualForm,
 		if (_drawContent.IsImageDisplayed(context))
 		{
 			// Extract the point in screen coordinates
-			var screenPoint = new Point((int)m.LParam.ToInt64());
+			var screenPoint = PointFromMessageLParam(m.LParam);
 
 			// Convert to window coordinates
 			Point windowPoint = ScreenToWindow(screenPoint);
@@ -2168,6 +2193,7 @@ public class KryptonForm : VisualForm,
 			return;
 		}
 
+		uint previousLayout = BeginPhysicalWindowDcLayout(hDC);
 		try
 		{
 			// Restrict drawing strictly to the grip rectangle in window coordinates
@@ -2180,6 +2206,7 @@ public class KryptonForm : VisualForm,
 		}
 		finally
 		{
+			EndPhysicalWindowDcLayout(hDC, previousLayout);
 			PI.ReleaseDC(Handle, hDC);
 		}
 	}
@@ -2323,10 +2350,15 @@ public class KryptonForm : VisualForm,
 			return rect;
 		}
 
-		// Close owns the top-right corner; min/max only grow upward into their own column.
-		return ReferenceEquals(buttonSpec, ButtonSpecClose)
-			? Rectangle.FromLTRB(rect.Left, 0, Width, rect.Bottom)
-			: Rectangle.FromLTRB(rect.Left, 0, rect.Right, rect.Bottom);
+		// Close owns the leading top corner; min/max only grow upward into their own column.
+		if (ReferenceEquals(buttonSpec, ButtonSpecClose))
+		{
+			return UsesRtlFormButtonLayout()
+				? Rectangle.FromLTRB(0, 0, rect.Right, rect.Bottom)
+				: Rectangle.FromLTRB(rect.Left, 0, Width, rect.Bottom);
+		}
+
+		return Rectangle.FromLTRB(rect.Left, 0, rect.Right, rect.Bottom);
 	}
 
 	/// <summary>
@@ -2606,7 +2638,7 @@ public class KryptonForm : VisualForm,
 	/// <returns>True if the message was processed; otherwise false.</returns>
 	protected override bool OnWM_NCRBUTTONDOWN(ref Message m)
 	{
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 		Point windowPoint = ScreenToWindow(screenPoint);
 
 		// Caption strip (including injected tabs): never let DefWndProc open the system menu.
@@ -2627,7 +2659,7 @@ public class KryptonForm : VisualForm,
 	/// <returns>True if the message was processed; otherwise false.</returns>
 	protected override bool OnWM_NCRBUTTONUP(ref Message m)
 	{
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 		Point windowPoint = ScreenToWindow(screenPoint);
 
 		if (IsInTitleBarArea(screenPoint) || IsOverInteractiveChromeView(windowPoint))
@@ -2652,7 +2684,7 @@ public class KryptonForm : VisualForm,
 		if (_drawContent.IsImageDisplayed(context))
 		{
 			// Extract the point in screen coordinates
-			var screenPoint = new Point((int)m.LParam.ToInt64());
+			var screenPoint = PointFromMessageLParam(m.LParam);
 
 			// Convert to window coordinates
 			Point windowPoint = ScreenToWindow(screenPoint);
@@ -3023,15 +3055,27 @@ public class KryptonForm : VisualForm,
 					{
 						// Track the window state at the time the region is created
 						_regionWindowState = WindowState;
-						// Get the path for the border, so we can shape the form using it
-						using var context = new RenderContext(this, null, Bounds, Renderer);
-						using GraphicsPath? path = _drawDocker.GetOuterBorderPath(context);
+
+						// WS_EX_LAYOUTRTL mirrors SetWindowRgn into logical coordinates, which
+						// shifts the realized region by about the frame width and clips the
+						// physical left chrome (issue #2103). Same workaround as maximized RTL (#2457).
+						Region? newRegion = null;
+						if (!UsesRtlFormButtonLayout())
+						{
+							using var context = new RenderContext(this, null, Bounds, Renderer);
+							using GraphicsPath? path = _drawDocker.GetOuterBorderPath(context);
+							if (path != null)
+							{
+								newRegion = new Region(path);
+							}
+						}
+
 						if (!_firstCheckView)
 						{
 							SuspendPaint();
 						}
 
-						UpdateBorderRegion(path != null ? new Region(path) : null);
+						UpdateBorderRegion(newRegion);
 
 						if (!_firstCheckView)
 						{
@@ -3366,9 +3410,9 @@ public class KryptonForm : VisualForm,
 	/// </summary>
 	/// <remarks>
 	/// Uses the palette's <em>native</em> edge from <see cref="PaletteBase.GetButtonSpecEdge"/>,
-	/// not <see cref="VisualForm.Redirector"/>. After issue #3786, the redirector remaps Far→Near for standard
-	/// palettes in RTL; consulting the redirector here would mis-classify RTL Office forms as
-	/// traffic-light layouts and apply the wrong collection order.
+	/// not <see cref="VisualForm.Redirector"/>. After issue #2103, the redirector remaps Near→Far for traffic-light
+	/// palettes in RTL so <see cref="ViewDrawDocker.CalculateDock"/> keeps them on the physical left; consulting the
+	/// redirector here would mis-classify RTL Office forms as traffic-light layouts and apply the wrong collection order.
 	/// </remarks>
 	private bool UsesLeftTrafficLightFormButtons()
 	{
@@ -3400,7 +3444,7 @@ public class KryptonForm : VisualForm,
 	/// <item>
 	/// <description>
 	/// <b>Far-edge / Windows control box</b> — collection [min, max, close] for both LTR and RTL.
-	/// LTR (dock right): Min → Max → Close. RTL (dock left after Far→Near remap): Close → Max → Min.
+	/// LTR (dock right): Min → Max → Close. RTL (dock left after CalculateDock flip): Close → Max → Min.
 	/// </description>
 	/// </item>
 	/// <item>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSystemMenuListener.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSystemMenuListener.cs
@@ -151,12 +151,17 @@ internal class KryptonSystemMenuListener : NativeWindow
 
     private Point ScreenToWindow(Point screenPoint)
     {
-        // First of all convert to client coordinates
+        if (_form.IsHandleCreated)
+        {
+            var windowRect = new PI.RECT();
+            if (PI.GetWindowRect(_form.Handle, ref windowRect))
+            {
+                return new Point(screenPoint.X - windowRect.left, screenPoint.Y - windowRect.top);
+            }
+        }
+
         Point clientPoint = _form.PointToClient(screenPoint);
-
-        // Now adjust to take into account the top and left borders
         clientPoint.Offset(_form.RealWindowBorders.Left, _form.RealWindowBorders.Top);
-
         return clientPoint;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -802,16 +802,66 @@ public abstract class VisualForm : Form,
 	/// </summary>
 	/// <param name="screenPt">Screen point.</param>
 	/// <returns>Point in window coordinates.</returns>
+	/// <remarks>
+	/// Uses <see cref="PI.GetWindowRect"/> so the origin is the physical top-left of the window.
+	/// <see cref="Control.PointToClient"/> mirrors X when <c>WS_EX_LAYOUTRTL</c> is set, which
+	/// inverted left/right resize and mouse mapping for custom chrome (issue #2103).
+	/// </remarks>
 	protected Point ScreenToWindow(Point screenPt)
 	{
-		// First of all convert to client coordinates
-		Point clientPt = PointToClient(screenPt);
+		if (IsHandleCreated)
+		{
+			var windowRect = new PI.RECT();
+			if (PI.GetWindowRect(Handle, ref windowRect))
+			{
+				return new Point(screenPt.X - windowRect.left, screenPt.Y - windowRect.top);
+			}
+		}
 
-		// Now adjust to take into account the top and left borders
+		Point clientPt = PointToClient(screenPt);
 		Padding borders = RealWindowBorders;
 		clientPt.Offset(borders.Left, borders.Top);
-
 		return clientPt;
+	}
+
+	/// <summary>
+	/// Unpacks a packed mouse <c>lParam</c> into a point using signed 16-bit coordinates.
+	/// </summary>
+	/// <param name="lParam">Message <c>lParam</c>.</param>
+	/// <returns>Point with signed X/Y (required on monitors with negative origin).</returns>
+	protected static Point PointFromMessageLParam(IntPtr lParam)
+	{
+		long packed = lParam.ToInt64();
+		return new Point((short)(packed & 0xFFFF), (short)((packed >> 16) & 0xFFFF));
+	}
+
+	/// <summary>
+	/// Clears <see cref="PI.LAYOUT_.RTL"/> on a window DC so GDI drawing and <c>BitBlt</c> use physical coordinates.
+	/// </summary>
+	/// <param name="hdc">Device context from <c>GetWindowDC</c>.</param>
+	/// <returns>Previous layout flags, or <see cref="PI.GDI_ERROR"/> if they could not be read.</returns>
+	internal static uint BeginPhysicalWindowDcLayout(IntPtr hdc)
+	{
+		uint previous = PI.GetLayout(hdc);
+		if (previous != PI.GDI_ERROR && (previous & PI.LAYOUT_.RTL) != 0)
+		{
+			PI.SetLayout(hdc, previous & ~PI.LAYOUT_.RTL);
+		}
+
+		return previous;
+	}
+
+	/// <summary>
+	/// Restores layout flags saved by <see cref="BeginPhysicalWindowDcLayout"/>.
+	/// </summary>
+	/// <param name="hdc">Device context whose layout should be restored.</param>
+	/// <param name="previous">Value returned from <see cref="BeginPhysicalWindowDcLayout"/>.</param>
+	internal static void EndPhysicalWindowDcLayout(IntPtr hdc, uint previous)
+	{
+		if (previous != PI.GDI_ERROR)
+		{
+			PI.SetLayout(hdc, previous);
+		}
 	}
 
 	/// <summary>
@@ -1802,7 +1852,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_NCHITTEST(ref Message m)
 	{
 		// Extract the point in screen coordinates
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to window coordinates
 		Point windowPoint = ScreenToWindow(screenPoint);
@@ -1892,7 +1942,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_NCMOUSEMOVE(ref Message m)
 	{
 		// Extract the point in screen coordinates
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to window coordinates
 		Point windowPoint = ScreenToWindow(screenPoint);
@@ -1938,7 +1988,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_NCLBUTTONDOWN(ref Message m)
 	{
 		// Extract the point in screen coordinates
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to window coordinates
 		Point windowPoint = ScreenToWindow(screenPoint);
@@ -1955,7 +2005,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_NCLBUTTONUP(ref Message m)
 	{
 		// Extract the point in screen coordinates
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to window coordinates
 		Point windowPoint = ScreenToWindow(screenPoint);
@@ -1971,7 +2021,7 @@ public abstract class VisualForm : Form,
 	/// <returns>True if the message was processed; otherwise false.</returns>
 	protected virtual bool OnWM_NCRBUTTONDOWN(ref Message m)
 	{
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 		Point windowPoint = ScreenToWindow(screenPoint);
 
 		// Always route through the view first so caption tabs / button specs can handle RightClick.
@@ -1995,7 +2045,7 @@ public abstract class VisualForm : Form,
 	/// <returns>True if the message was processed; otherwise false.</returns>
 	protected virtual bool OnWM_NCRBUTTONUP(ref Message m)
 	{
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 		Point windowPoint = ScreenToWindow(screenPoint);
 
 		WindowChromeRightMouseUp(windowPoint);
@@ -2043,7 +2093,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_MOUSEMOVE(ref Message m)
 	{
 		// Extract the point in client coordinates
-		var clientPoint = new Point((int)m.LParam);
+		var clientPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to screen coordinates
 		Point screenPoint = PointToScreen(clientPoint);
@@ -2072,7 +2122,7 @@ public abstract class VisualForm : Form,
 		_trackingMouse = false;
 
 		// Extract the point in client coordinates
-		var clientPoint = new Point((int)m.LParam);
+		var clientPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to screen coordinates
 		Point screenPoint = PointToScreen(clientPoint);
@@ -2100,7 +2150,7 @@ public abstract class VisualForm : Form,
 	protected virtual bool OnWM_NCLBUTTONDBLCLK(ref Message m)
 	{
 		// Extract the point in screen coordinates
-		var screenPoint = new Point((int)m.LParam.ToInt64());
+		var screenPoint = PointFromMessageLParam(m.LParam);
 
 		// Convert to window coordinates
 		Point windowPoint = ScreenToWindow(screenPoint);
@@ -2132,6 +2182,7 @@ public abstract class VisualForm : Form,
 			// If we managed to get a device context
 			if (hDC != IntPtr.Zero)
 			{
+				uint previousLayout = BeginPhysicalWindowDcLayout(hDC);
 				try
 				{
 					// Find the rectangle that covers the client area of the form
@@ -2159,8 +2210,9 @@ public abstract class VisualForm : Form,
 						// If we managed to get a compatible bitmap
 						if (hBitmap != IntPtr.Zero)
 						{
-							// Must use the screen device context for the bitmap when drawing into the
-							// bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
+							// Draw into a display-compatible memory DC so opacity works. The window DC
+							// has LAYOUT_RTL cleared for this paint so BitBlt does not mirror glyphs
+							// (issue #2103).
 							// Select the new bitmap into the screen DC
 							IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
 
@@ -2199,6 +2251,8 @@ public abstract class VisualForm : Form,
 				}
 				finally
 				{
+					EndPhysicalWindowDcLayout(hDC, previousLayout);
+
 					// Must always release the device context
 					PI.ReleaseDC(Handle, hDC);
 				}

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -560,7 +560,7 @@ public static class CommonHelper
     /// <param name="owningForm">Form providing non-client border metrics.</param>
     /// <returns>Pixel inset from the right chrome edge.</returns>
     public static int GetFormHeaderButtonEdgeInsetRight(KryptonForm? owningForm) =>
-        owningForm == null ? 0 : Math.Max(2, owningForm.RealWindowBorders.Right);
+        owningForm == null ? 0 : Math.Max(2, WindowBorderThickness(owningForm.RealWindowBorders.Right));
 
     /// <summary>
     /// HeaderForm content padding with the frame inset on the icon side, plus
@@ -578,13 +578,28 @@ public static class CommonHelper
         Padding padding = palettePadding;
         if (owningForm != null && IsRightToLeftLayout(owningForm))
         {
-            int frameInset = Math.Max(palettePadding.Left, palettePadding.Right);
+            // Thickness only: AdjustWindowRectEx can return a signed side (RTL exstyle).
+            // Screen origin (primary monitor on the right) is not part of this metric.
+            int frameInset = Math.Max(
+                WindowBorderThickness(palettePadding.Left),
+                WindowBorderThickness(palettePadding.Right));
             if (frameInset < 2)
             {
-                frameInset = Math.Max(2, owningForm.RealWindowBorders.Right);
+                Padding borders = owningForm.RealWindowBorders;
+                frameInset = Math.Max(
+                    WindowBorderThickness(borders.Left),
+                    WindowBorderThickness(borders.Right));
+                if (frameInset < 2)
+                {
+                    frameInset = 2;
+                }
             }
 
-            padding = new Padding(palettePadding.Right, palettePadding.Top, frameInset, palettePadding.Bottom);
+            padding = new Padding(
+                WindowBorderThickness(palettePadding.Right),
+                palettePadding.Top,
+                frameInset,
+                palettePadding.Bottom);
         }
 
         if (owningForm == null)
@@ -597,6 +612,19 @@ public static class CommonHelper
             ? padding
             : new Padding(padding.Left + extra.Left, padding.Top + extra.Top, padding.Right + extra.Right, padding.Bottom + extra.Bottom);
     }
+
+    /// <summary>
+    /// Absolute pixel width of one window-frame side from <see cref="GetWindowBorders"/>.
+    /// </summary>
+    /// <param name="sideMetric">A <see cref="Padding"/> Left/Right/Top/Bottom from border metrics.</param>
+    /// <returns>Non-negative thickness in pixels.</returns>
+    /// <remarks>
+    /// <see cref="GetWindowBorders"/> uses a zero <c>RECT</c> with <c>AdjustWindowRectEx</c>, so the
+    /// result is chrome thickness, not screen position. A primary monitor placed on the right (negative
+    /// virtual-screen X) does not change it. <c>WS_EX_LAYOUTRTL</c> can still make a side negative;
+    /// callers must use the magnitude as a width.
+    /// </remarks>
+    private static int WindowBorderThickness(int sideMetric) => Math.Abs(sideMetric);
 
     /// <summary>
     /// Gets a value indicating if the provided value is an override state but excludes one value.

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -563,6 +563,42 @@ public static class CommonHelper
         owningForm == null ? 0 : Math.Max(2, owningForm.RealWindowBorders.Right);
 
     /// <summary>
+    /// HeaderForm content padding with the frame inset on the icon side, plus
+    /// <see cref="KryptonForm.CaptionIconPadding"/>.
+    /// </summary>
+    /// <param name="owningForm">Form whose RTL layout, border metrics, and icon padding are used.</param>
+    /// <param name="palettePadding">Padding from the palette (Left = LTR icon inset, Right = 0).</param>
+    /// <returns>
+    /// Palette padding in LTR, plus <see cref="KryptonForm.CaptionIconPadding"/>. Under RTL layout
+    /// the icon is Near on the physical right, so the frame inset moves to <see cref="Padding.Right"/>
+    /// before the extra padding is applied.
+    /// </returns>
+    public static Padding GetFormHeaderContentPadding(KryptonForm? owningForm, Padding palettePadding)
+    {
+        Padding padding = palettePadding;
+        if (owningForm != null && IsRightToLeftLayout(owningForm))
+        {
+            int frameInset = Math.Max(palettePadding.Left, palettePadding.Right);
+            if (frameInset < 2)
+            {
+                frameInset = Math.Max(2, owningForm.RealWindowBorders.Right);
+            }
+
+            padding = new Padding(palettePadding.Right, palettePadding.Top, frameInset, palettePadding.Bottom);
+        }
+
+        if (owningForm == null)
+        {
+            return padding;
+        }
+
+        Padding extra = owningForm.CaptionIconPadding;
+        return extra.Equals(Padding.Empty)
+            ? padding
+            : new Padding(padding.Left + extra.Left, padding.Top + extra.Top, padding.Right + extra.Right, padding.Bottom + extra.Bottom);
+    }
+
+    /// <summary>
     /// Gets a value indicating if the provided value is an override state but excludes one value.
     /// </summary>
     /// <param name="state">Specific state.</param>

--- a/Source/Krypton Components/TestForm/Bug3786ControlBoxOrderDemo.cs
+++ b/Source/Krypton Components/TestForm/Bug3786ControlBoxOrderDemo.cs
@@ -18,7 +18,7 @@ namespace TestForm;
 /// </para>
 /// <list type="number">
 /// <item><description>Collection order — <c>_buttonSpecsFixed</c> sequence (min/max/close vs traffic-light).</description></item>
-/// <item><description>Edge placement — <see cref="KryptonForm.FormTrafficLightEdge"/> and palette Near/Far, with RTL Far→Near remap.</description></item>
+/// <item><description>Edge placement — <see cref="KryptonForm.FormTrafficLightEdge"/> and palette Near/Far, with RTL Near→Far remap for traffic lights.</description></item>
 /// <item><description>Runtime RTL — <see cref="Control.RightToLeft"/> + <see cref="RightToLeftLayout"/>.</description></item>
 /// </list>
 /// <para>

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -183,7 +183,7 @@ public partial class StartScreen : KryptonForm
         CreateButton<RichTextBoxFormattingTest>("RichTextBox Formatting Test", "Tests fix for RichTextBox formatting preservation when palette changes (Issue #2832)");
         CreateButton<Feature4008RichTextBoxJustifyDemo>("Feature 4008 RichTextBox Justify", "Issue #4008: KryptonRichTextBox.SelectionParagraphAlignment with Left/Center/Right/Justify. Compare with native RichTextBox SelectionAlignment (no Justify). Resize the form to see justified word spacing.");
         CreateButton<Bug3343RichTextBoxEditLossDemo>("Bug 3343 RichTextBox mouse leave", "Issue #3343: type in KryptonRichTextBox, move the mouse out without changing focus; text and TextLength must not reset. Includes KryptonTextBox for comparison.");
-        CreateButton<RTLFormBorderTest>("RTL Layout Test", "Test for RTL compliance");
+        CreateButton<RTLFormBorderTest>("RTL Layout Test", "Issue #2103: KryptonForm RightToLeft / RightToLeftLayout. Caption must stay readable, control box on the left, icon on the right, and left/right resize must follow the grabbed edge. CaptionIconPadding controls extra space around the caption icon. Includes a native Form comparison.");
         CreateButton<ToastNotificationTestChoice>("Toast", "For breakfast....?");
         CreateButton<Feature3959WorkspacePageTagPersistDemo>("Feature 3959 Workspace Page.Tag", "Issue #3959: persist KryptonPage.Tag via TypeConverter (string/int) on workspace save/load; use PageSaving/PageLoading for non-convertible custom Tag objects.");
         CreateButton<WorkspaceTest>("WorkspaceTest", string.Empty);

--- a/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.Designer.cs
@@ -30,7 +30,14 @@
         {
             this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
             this.buttonSpecAny2 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kwlblInstructions = new Krypton.Toolkit.KryptonWrapLabel();
+            this.klblMode = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbRtlMode = new Krypton.Toolkit.KryptonComboBox();
             this.kchkbtnSwitchLayout = new Krypton.Toolkit.KryptonCheckButton();
+            this.kbtnOpenNativeForm = new Krypton.Toolkit.KryptonButton();
+            this.klblCaptionIconPadding = new Krypton.Toolkit.KryptonLabel();
+            this.knudCaptionIconPadding = new Krypton.Toolkit.KryptonNumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbRtlMode)).BeginInit();
             this.SuspendLayout();
             // 
             // buttonSpecAny1
@@ -43,19 +50,84 @@
             this.buttonSpecAny2.Type = Krypton.Toolkit.PaletteButtonSpecStyle.Previous;
             this.buttonSpecAny2.UniqueName = "13edbb23e5f1489cb15b33880c16b496";
             // 
+            // kwlblInstructions
+            // 
+            this.kwlblInstructions.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.kwlblInstructions.Location = new System.Drawing.Point(12, 12);
+            this.kwlblInstructions.Name = "kwlblInstructions";
+            this.kwlblInstructions.Size = new System.Drawing.Size(680, 120);
+            this.kwlblInstructions.Text = "Issue #2103 — native WinForms: RightToLeft alone does not flip the title bar; RightToLeft + RightToLeftLayout moves min/max/close to the left and the icon to the right. Caption text must stay readable (not glyph-mirrored). Drag the left and right borders: the grabbed edge must move. Open a native Form to compare. CaptionIconPadding adds extra space around the caption icon (designer: Visuals).";
+            // 
+            // klblMode
+            // 
+            this.klblMode.Location = new System.Drawing.Point(12, 140);
+            this.klblMode.Name = "klblMode";
+            this.klblMode.Size = new System.Drawing.Size(90, 20);
+            this.klblMode.TabIndex = 0;
+            this.klblMode.Values.Text = "RTL mode";
+            // 
+            // kcmbRtlMode
+            // 
+            this.kcmbRtlMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbRtlMode.DropDownWidth = 280;
+            this.kcmbRtlMode.IntegralHeight = false;
+            this.kcmbRtlMode.Location = new System.Drawing.Point(12, 166);
+            this.kcmbRtlMode.Name = "kcmbRtlMode";
+            this.kcmbRtlMode.Size = new System.Drawing.Size(280, 25);
+            this.kcmbRtlMode.TabIndex = 1;
+            this.kcmbRtlMode.Items.AddRange(new object[] {
+            "Left to right",
+            "RightToLeft only (caption stays LTR)",
+            "RightToLeft + RightToLeftLayout"});
+            this.kcmbRtlMode.SelectedIndexChanged += new System.EventHandler(this.kcmbRtlMode_SelectedIndexChanged);
+            // 
             // kchkbtnSwitchLayout
             // 
-            this.kchkbtnSwitchLayout.AccessibleDescription = "Toggles the form between right-to-left and left-to-right layout.";
+            this.kchkbtnSwitchLayout.AccessibleDescription = "Toggles the form between right-to-left layout and left-to-right.";
             this.kchkbtnSwitchLayout.AccessibleName = "Switch layout";
             this.kchkbtnSwitchLayout.AccessibleRole = System.Windows.Forms.AccessibleRole.CheckButton;
-            this.kchkbtnSwitchLayout.Location = new System.Drawing.Point(317, 150);
+            this.kchkbtnSwitchLayout.Location = new System.Drawing.Point(308, 166);
             this.kchkbtnSwitchLayout.Name = "kchkbtnSwitchLayout";
-            this.kchkbtnSwitchLayout.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.kchkbtnSwitchLayout.Size = new System.Drawing.Size(90, 25);
-            this.kchkbtnSwitchLayout.TabIndex = 1;
+            this.kchkbtnSwitchLayout.Size = new System.Drawing.Size(120, 25);
+            this.kchkbtnSwitchLayout.TabIndex = 2;
             this.kchkbtnSwitchLayout.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kchkbtnSwitchLayout.Values.Text = "Switch Layout";
             this.kchkbtnSwitchLayout.Click += new System.EventHandler(this.kchkbtnSwitchLayout_Click);
+            // 
+            // kbtnOpenNativeForm
+            // 
+            this.kbtnOpenNativeForm.Location = new System.Drawing.Point(444, 166);
+            this.kbtnOpenNativeForm.Name = "kbtnOpenNativeForm";
+            this.kbtnOpenNativeForm.Size = new System.Drawing.Size(140, 25);
+            this.kbtnOpenNativeForm.TabIndex = 3;
+            this.kbtnOpenNativeForm.Values.Text = "Open native Form";
+            this.kbtnOpenNativeForm.Click += new System.EventHandler(this.kbtnOpenNativeForm_Click);
+            // 
+            // klblCaptionIconPadding
+            // 
+            this.klblCaptionIconPadding.Location = new System.Drawing.Point(12, 204);
+            this.klblCaptionIconPadding.Name = "klblCaptionIconPadding";
+            this.klblCaptionIconPadding.Size = new System.Drawing.Size(280, 20);
+            this.klblCaptionIconPadding.TabIndex = 4;
+            this.klblCaptionIconPadding.Values.Text = "CaptionIconPadding (all sides)";
+            // 
+            // knudCaptionIconPadding
+            // 
+            this.knudCaptionIconPadding.Location = new System.Drawing.Point(12, 230);
+            this.knudCaptionIconPadding.Maximum = new decimal(new int[] {
+            32,
+            0,
+            0,
+            0});
+            this.knudCaptionIconPadding.Name = "knudCaptionIconPadding";
+            this.knudCaptionIconPadding.Size = new System.Drawing.Size(80, 22);
+            this.knudCaptionIconPadding.TabIndex = 5;
+            this.knudCaptionIconPadding.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.knudCaptionIconPadding.ValueChanged += new System.EventHandler(this.knudCaptionIconPadding_ValueChanged);
             // 
             // RTLFormBorderTest
             // 
@@ -64,13 +136,21 @@
             this.ButtonSpecs.Add(this.buttonSpecAny1);
             this.ButtonSpecs.Add(this.buttonSpecAny2);
             this.ClientSize = new System.Drawing.Size(705, 414);
+            this.Controls.Add(this.knudCaptionIconPadding);
+            this.Controls.Add(this.klblCaptionIconPadding);
+            this.Controls.Add(this.kbtnOpenNativeForm);
             this.Controls.Add(this.kchkbtnSwitchLayout);
+            this.Controls.Add(this.kcmbRtlMode);
+            this.Controls.Add(this.klblMode);
+            this.Controls.Add(this.kwlblInstructions);
             this.Name = "RTLFormBorderTest";
             this.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.RightToLeftLayout = true;
-            this.Text = "RTLFormBorderTest";
+            this.Text = "Caption Test ABC";
             this.TextExtra = "Test Text";
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbRtlMode)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -78,6 +158,12 @@
 
         private ButtonSpecAny buttonSpecAny1;
         private ButtonSpecAny buttonSpecAny2;
+        private KryptonWrapLabel kwlblInstructions;
+        private KryptonLabel klblMode;
+        private KryptonComboBox kcmbRtlMode;
         private KryptonCheckButton kchkbtnSwitchLayout;
+        private KryptonButton kbtnOpenNativeForm;
+        private KryptonLabel klblCaptionIconPadding;
+        private KryptonNumericUpDown knudCaptionIconPadding;
     }
 }

--- a/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.cs
+++ b/Source/Krypton Components/TestForm/User Experience/RTL Tests/RTLFormBorderTest.cs
@@ -9,27 +9,83 @@
 
 namespace TestForm;
 
+/// <summary>
+/// Issue #2103: KryptonForm RightToLeft / RightToLeftLayout caption chrome vs native Form.
+/// </summary>
 public partial class RTLFormBorderTest : KryptonForm
 {
+    private const int ModeLeftToRight = 0;
+    private const int ModeRightToLeftOnly = 1;
+    private const int ModeRightToLeftLayout = 2;
+
     public RTLFormBorderTest()
     {
         InitializeComponent();
-
-        kchkbtnSwitchLayout.Checked = true;
+        kcmbRtlMode.SelectedIndex = ModeRightToLeftLayout;
+        ApplySelectedMode();
     }
 
     private void kchkbtnSwitchLayout_Click(object sender, EventArgs e)
     {
-        if (kchkbtnSwitchLayout.Checked)
-        {
-            RightToLeftLayout = true;
+        kcmbRtlMode.SelectedIndex = kchkbtnSwitchLayout.Checked
+            ? ModeRightToLeftLayout
+            : ModeLeftToRight;
+        ApplySelectedMode();
+    }
 
-            RightToLeft = RightToLeft.Yes;
-        }
-        else
+    private void kcmbRtlMode_SelectedIndexChanged(object sender, EventArgs e) => ApplySelectedMode();
+
+    private void kbtnOpenNativeForm_Click(object sender, EventArgs e)
+    {
+        var native = new Form
         {
-            RightToLeftLayout = false;
-            RightToLeft = RightToLeft.No;
+            Text = Text,
+            Size = Size,
+            StartPosition = FormStartPosition.CenterParent,
+            FormBorderStyle = FormBorderStyle.Sizable,
+            RightToLeft = RightToLeft,
+            RightToLeftLayout = RightToLeftLayout
+        };
+        native.Controls.Add(new Label
+        {
+            AutoSize = false,
+            Dock = DockStyle.Fill,
+            Padding = new Padding(12),
+            Text = "Native Form with the same RightToLeft / RightToLeftLayout. Compare caption glyphs, min/max/close side, and left/right resize."
+        });
+        native.Show(this);
+    }
+
+    private void ApplySelectedMode()
+    {
+        int index = kcmbRtlMode.SelectedIndex;
+        if (index < 0)
+        {
+            return;
         }
+
+        switch (index)
+        {
+            case ModeRightToLeftOnly:
+                RightToLeft = RightToLeft.Yes;
+                RightToLeftLayout = false;
+                break;
+            case ModeRightToLeftLayout:
+                RightToLeft = RightToLeft.Yes;
+                RightToLeftLayout = true;
+                break;
+            default:
+                RightToLeft = RightToLeft.No;
+                RightToLeftLayout = false;
+                break;
+        }
+
+        kchkbtnSwitchLayout.Checked = RightToLeftLayout;
+    }
+
+    private void knudCaptionIconPadding_ValueChanged(object sender, EventArgs e)
+    {
+        int extra = (int)knudCaptionIconPadding.Value;
+        CaptionIconPadding = new Padding(extra);
     }
 }


### PR DESCRIPTION
# Fix: KryptonForm RTL caption chrome (#2103)

## Summary

`KryptonForm` custom chrome now paints and hit-tests in physical window coordinates when `RightToLeft` + `RightToLeftLayout` are on. Caption text stays readable (not glyph-mirrored), min/max/close stay on the left with the icon on the right, both window frames stay visible, and dragging the left or right border resizes that edge.

## Related issues

- Closes #2103

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `VisualForm` clears `LAYOUT_RTL` on the window DC during non-client paint/`BitBlt`, and maps screen points through `GetWindowRect` instead of `PointToClient`.
- `KryptonForm.FormPaletteRedirect` maps traffic-light Near→Far under RTL so `ViewDrawDocker.CalculateDock` keeps them on the physical left; Windows Far-edge buttons rely on that dock flip.
- Restored-state `KryptonForm` does not apply the outer-border `Region` when RTL layout is on. `WS_EX_LAYOUTRTL` mirrors `SetWindowRgn`, which shifted the realized region and clipped the physical left frame (same workaround as maximized RTL / #2457).
- HeaderForm content padding under RTL moves the frame inset to the physical right (icon side). Extra space around the glyph is `KryptonForm.CaptionIconPadding` (default `2`).
- `RightToLeftLayout` is browsable and serializable on `KryptonForm`. Maximized Close hit band expands to the leading edge in RTL.
- TestForm `RTLFormBorderTest` covers LTR, RightToLeft-only, and RightToLeft+layout, with a native `Form` comparison.

## Affected packages & target frameworks

- Packages: `Krypton.Interop`, `Krypton.Toolkit`
- TFMs verified: `net472`

## Validation

- TestForm demo: `RTLFormBorderTest` (StartScreen: **RTL Layout Test**).
- Manual steps:
  1. Open **RTL Layout Test**. Confirm caption reads `Caption Test ABC` (not mirrored).
  2. Control box on the left, icon on the right; Close clicks on the left.
  3. Left and right window frames are both visible; Close is not clipped.
  4. Drag the left border: the left edge moves. Drag the right border: the right edge moves.
  5. Combo: **RightToLeft only** — caption stays LTR. **Left to right** — Windows control box on the right.
  6. **Open native Form** and compare the same three combinations.
  7. Change **CaptionIconPadding (all sides)** and confirm the caption icon inset updates.
- Build: `dotnet build ".\Source\Krypton Components\TestForm\TestForm.csproj" -c Debug`
- Script: `powershell -STA -File .\Scripts\UnitTests\UnitTest-KryptonFormRtl.ps1`

## Screenshots / GIFs

<img width="721" height="453" alt="2103-kryptonform-rtl-layout" src="https://github.com/user-attachments/assets/5b7d17af-f409-4006-93e2-d158f7db7bbb" />

Caption under `RightToLeft` + `RightToLeftLayout`: readable title, control box on the left, icon on the right, left and right frames visible.

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#2103](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2103), `KryptonForm` RTL caption text is no longer mirrored, and resizing from the left or right edge follows the grabbed side.
  * RTL + `RightToLeftLayout` no longer clips the left window frame (window region was mirrored off the physical left edge).
  * Caption icon under RTL layout is inset from the frame. Extra space is `KryptonForm.CaptionIconPadding` (default `2`; `Empty` keeps only the frame inset).
```

## Breaking changes & migration

None. `RightToLeft` + `RightToLeftLayout` still follow native WinForms. Chrome coordinates are now physical, so caption glyphs and left/right resize match a standard `Form`.

## Developer documentation

Omitted (bug fix of existing RTL chrome).

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [x] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [x] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above