### PR TITLE
* Add commit links to workflow notifications

### DIFF
--- a/.github/workflows/alpha-backup-sync.yml
+++ b/.github/workflows/alpha-backup-sync.yml
@@ -314,6 +314,9 @@ jobs:
           if [ "$BRANCH_CREATED" = "true" ]; then
             branch_msg="alpha-backup branch was created (did not exist)"
           fi
+          sha="$(git rev-parse HEAD)"
+          short_sha="${sha:0:7}"
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${sha}"
           payload=$(jq -n \
             --arg branch "$branch_msg" \
             --arg pr_url "$pr_url" \
@@ -324,13 +327,17 @@ jobs:
             --arg backup_zip "$BACKUP_ZIP" \
             --arg backup_bundle "$BACKUP_BUNDLE" \
             --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg commit_url "$commit_url" \
+            --arg short_sha "$short_sha" \
             '{
               embeds: [{
                 title: "📦 Alpha → Alpha-Backup Sync",
+                url: $commit_url,
                 description: (
                   "Alpha had commits in the last 24 hours. Sync workflow ran.\n\n" +
                   ([
                     "• " + $branch,
+                    "• [Commit `\($short_sha)`](\($commit_url))",
                     (if $pr_url != "" then "• [PR #\($pr_number)](\($pr_url))" else empty end),
                     (if $backup_pushed == "true" and $backup_repo != "" then
                       "• Pushed zip + bundle to backup repo: " + $backup_repo +

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -95,7 +95,7 @@ jobs:
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
 
           $missing = New-Object System.Collections.Generic.List[string]
@@ -224,7 +224,7 @@ jobs:
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
 
           $missing = New-Object System.Collections.Generic.List[string]

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -95,7 +95,7 @@ jobs:
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
 
           $missing = New-Object System.Collections.Generic.List[string]
@@ -224,7 +224,7 @@ jobs:
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
 
           $missing = New-Object System.Collections.Generic.List[string]

--- a/.github/workflows/build-testform.yml
+++ b/.github/workflows/build-testform.yml
@@ -93,12 +93,24 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
+          $missing = New-Object System.Collections.Generic.List[string]
+          # master/gold/V105: TestForm\KryptonTaskDialogDemo
+          # alpha/canary (V110): TestForm\KryptonToolkit\Feature\KryptonTaskDialogDemo
+          $taskDialogResxCandidates = @(
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+          )
+          $taskDialogResx = $taskDialogResxCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+          if (-not $taskDialogResx) {
+            $missing.Add("Missing .resx file: KryptonTaskDialogDemoResources.resx (tried: $($taskDialogResxCandidates -join '; '))")
+          }
+
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
-
-          $missing = New-Object System.Collections.Generic.List[string]
+          if ($taskDialogResx) {
+            $resxFiles += $taskDialogResx
+          }
           foreach ($resxPath in $resxFiles) {
             if (-not (Test-Path -LiteralPath $resxPath)) {
               $missing.Add("Missing .resx file: $resxPath")
@@ -222,12 +234,24 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $projectDir = Join-Path $env:GITHUB_WORKSPACE 'Source\Krypton Components\TestForm'
+          $missing = New-Object System.Collections.Generic.List[string]
+          # master/gold/V105: TestForm\KryptonTaskDialogDemo
+          # alpha/canary (V110): TestForm\KryptonToolkit\Feature\KryptonTaskDialogDemo
+          $taskDialogResxCandidates = @(
+            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+            Join-Path $projectDir 'KryptonToolkit\Feature\KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
+          )
+          $taskDialogResx = $taskDialogResxCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+          if (-not $taskDialogResx) {
+            $missing.Add("Missing .resx file: KryptonTaskDialogDemoResources.resx (tried: $($taskDialogResxCandidates -join '; '))")
+          }
+
           $resxFiles = @(
             Join-Path $projectDir 'Properties\Resources.resx'
-            Join-Path $projectDir 'KryptonTaskDialogDemo\KryptonTaskDialogDemoResources.resx'
           )
-
-          $missing = New-Object System.Collections.Generic.List[string]
+          if ($taskDialogResx) {
+            $resxFiles += $taskDialogResx
+          }
           foreach ($resxPath in $resxFiles) {
             if (-not (Test-Path -LiteralPath $resxPath)) {
               $missing.Add("Missing .resx file: $resxPath")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,6 +314,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Get Version
         id: get_version
         shell: pwsh

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -384,16 +384,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🐤 Krypton Toolkit Canary LTS Release"
+                url = $commitUrl
                 description = "A new canary pre-release from the V105-LTS branch is now available!"
                 color = 16776960
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{

--- a/.github/workflows/canary-lts-release.yml
+++ b/.github/workflows/canary-lts-release.yml
@@ -266,6 +266,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration Canary -PackageSearchPaths 'Artefacts/Packages/Canary/*.nupkg' -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.canary_lts_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration Canary -PackageSearchPaths 'Artefacts/Packages/Canary/*.nupkg' -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Push NuGet Packages to nuget.org
         if: steps.canary_lts_kill_switch.outputs.enabled == 'true'
         id: push_nuget

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -288,6 +288,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration Canary -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.canary_release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration Canary -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Save NuGet cache
         if: success() && steps.canary_release_kill_switch.outputs.enabled == 'true'
         uses: actions/cache/save@v6

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -418,16 +418,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🐤 Krypton Toolkit Canary Release"
+                url = $commitUrl
                 description = "A new canary pre-release is now available for early testing!"
                 color = 16776960
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -509,16 +509,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🚀 Krypton Toolkit Nightly Release"
+                url = $commitUrl
                 description = "A new nightly build is now available for bleeding-edge testing!"
                 color = 10181046
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -373,6 +373,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration Nightly -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration Nightly -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Push NuGet Packages to nuget.org
         if: steps.nightly_release_kill_switch.outputs.enabled == 'true' && steps.check_changes.outputs.has_changes == 'true'
         id: push_nuget

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -418,16 +418,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🥇 Krypton Toolkit Release Candidate"
+                url = $commitUrl
                 description = "A new release candidate is now available. These are prerelease versions of the stable package IDs (include prerelease to install)."
                 color = 16766720
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}-rc``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -289,6 +289,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration RC -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.rc_release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration RC -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Save NuGet cache
         if: success() && steps.rc_release_kill_switch.outputs.enabled == 'true'
         uses: actions/cache/save@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,16 +360,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🎉 Krypton Toolkit Stable Release"
+                url = $commitUrl
                 description = "A new stable release is now available!"
                 color = 7863670
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{
@@ -725,16 +735,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🎉 Krypton Toolkit Stable Release"
+                url = $commitUrl
                 description = "A new stable release is now available!"
                 color = 7863670
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{
@@ -1109,16 +1129,26 @@ jobs:
             exit 0
           }
 
+          $sha = (git rev-parse HEAD).Trim()
+          $shortSha = $sha.Substring(0, [Math]::Min(7, $sha.Length))
+          $commitUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/commit/$sha"
+
           $payload = @{
             embeds = @(
               @{
                 title = "🐤 Krypton Toolkit Canary Release"
+                url = $commitUrl
                 description = "A new canary pre-release is now available for early testing!"
                 color = 16776960
                 fields = @(
                   @{
                     name = "📌 Version"
                     value = "``${{ steps.get_version.outputs.version }}``"
+                    inline = $true
+                  }
+                  @{
+                    name = "🔗 Commit"
+                    value = "[``$shortSha``]($commitUrl)"
                     inline = $true
                   }
                   @{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,15 @@ jobs:
           . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonInteropInPackages.ps1')
           Test-KryptonInteropInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfInteropProjectMissing
 
+      - name: Verify WinForms Designer SDK in NuGet packages
+        if: steps.release_kill_switch.outputs.enabled == 'true' && steps.krypton_major_version.outputs.major >= 110
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repoRoot = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+          . (Join-Path $repoRoot 'Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1')
+          Test-KryptonDesignerSdkInPackages -Configuration Release -MinimumMajorVersion 110 -SkipIfDesignerSdkProjectMissing
+
       - name: Save NuGet cache
         # Kill switch check
         if: success() && steps.release_kill_switch.outputs.enabled == 'true'

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -656,9 +656,9 @@ jobs:
 
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           links="[Workflow run](${run_url})"
-          if [ "$EVENT_NAME" = "push" ] && [ -n "${SHA:-}" ]; then
+          if [ -n "${SHA:-}" ]; then
             short_sha="${SHA:0:7}"
-            links="${links} · [Trigger commit](${source_url}/commit/${SHA}) (\`${short_sha}\`)"
+            links="${links} · [Commit](${source_url}/commit/${SHA}) (\`${short_sha}\`)"
           fi
           add_field "🔗 Links" "$links" false
 

--- a/.github/workflows/scan-code-todos.yml
+++ b/.github/workflows/scan-code-todos.yml
@@ -1233,6 +1233,7 @@ jobs:
           JOB_STATUS: ${{ job.status }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ -z "$DISCORD_WEBHOOK" ]; then
@@ -1240,11 +1241,20 @@ jobs:
             exit 0
           fi
 
+          sha="${SHA:-${GITHUB_SHA:-}}"
+          if git rev-parse HEAD >/dev/null 2>&1; then
+            sha="$(git rev-parse HEAD)"
+          fi
+          short_sha="${sha:0:7}"
+          commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${sha}"
+
           if [ -f scan-summary.json ]; then
             payload="$(jq -n \
               --arg repo "$REPOSITORY" \
               --arg run_url "$RUN_URL" \
               --arg job_status "$JOB_STATUS" \
+              --arg short_sha "$short_sha" \
+              --arg commit_url "$commit_url" \
               --argjson summary "$(cat scan-summary.json)" \
               '
               def n($v): if $v == null then "n/a" else ($v|tostring) end;
@@ -1254,9 +1264,11 @@ jobs:
               {
                 embeds: [{
                   title: ("📝 Code TODO scan" + $dry),
+                  url: $commit_url,
                   description: (
                     "**Repository:** " + $repo + "\n" +
                     "**Branch:** `" + ($summary.branch // "unknown") + "`\n" +
+                    "**Commit:** [`" + $short_sha + "`](" + $commit_url + ")\n" +
                     "**Marker mode:** " + $mode + "\n" +
                     "**Job status:** " + $job_status + "\n\n" +
                     "**Scan**\n" +
@@ -1287,12 +1299,16 @@ jobs:
               --arg repo "$REPOSITORY" \
               --arg run_url "$RUN_URL" \
               --arg job_status "$JOB_STATUS" \
+              --arg short_sha "$short_sha" \
+              --arg commit_url "$commit_url" \
               '
               {
                 embeds: [{
                   title: "📝 Code TODO scan",
+                  url: $commit_url,
                   description: (
                     "**Repository:** " + $repo + "\n" +
+                    "**Commit:** [`" + $short_sha + "`](" + $commit_url + ")\n" +
                     "**Job status:** " + $job_status + "\n\n" +
                     "The workflow did not complete the issue sync step (no scan summary was produced).\n\n" +
                     "[View workflow run](" + $run_url + ")"

--- a/Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1‎
+++ b/Scripts/CI/Test-KryptonDesignerSdkInPackages.ps1‎
@@ -1,0 +1,323 @@
+# Verifies packable Krypton module .nupkg files include WinForms Designer Extensibility SDK
+# assemblies under lib/<tfm>/Design/WinForms/ (issue #593).
+# Dot-source this script, then call Test-KryptonDesignerSdkInPackages after msbuild Pack.
+#
+# Parameters:
+#   -Configuration          Release, Canary, Nightly, etc. (searches artifacts/packages and Bin/Packages)
+#   -PackageSearchPaths     Additional glob paths for .nupkg files
+#   -SkipIfDesignerSdkProjectMissing  Exit 0 when Krypton.Toolkit.Design.csproj is absent
+#   -MinimumMajorVersion    Exit 0 when the evaluated toolkit major version is below this value (V110+)
+
+function Get-KryptonToolkitMajorVersionForDesignerSdk {
+    param(
+        [string]$Configuration = 'Release',
+        [string]$RepoRoot = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        $RepoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') {
+            $env:GITHUB_WORKSPACE
+        }
+        else {
+            (Get-Location).Path
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Configuration)) {
+        $Configuration = 'Release'
+    }
+
+    $proj = Join-Path $RepoRoot 'Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj'
+    if (-not (Test-Path -LiteralPath $proj)) {
+        Write-Error "Krypton.Toolkit project not found at '$proj'."
+    }
+
+    $versionProperties = @('LibraryVersion', 'AssemblyVersion', 'Version')
+    foreach ($property in $versionProperties) {
+        $evaluated = (& dotnet msbuild $proj -getProperty:$property -p:Configuration=$Configuration -nologo -v:q).Trim()
+        if ($evaluated -match '^(\d+)\.') {
+            return [int]$Matches[1]
+        }
+    }
+
+    Write-Error "Could not resolve Krypton toolkit major version from MSBuild (tried: $($versionProperties -join ', '))."
+}
+
+function Test-IsModernWinFormsLibFolder {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LibFolderName
+    )
+
+    return $LibFolderName -match '^(net[8-9]|net1[0-9])'
+}
+
+function Get-DesignerSdkPackageKind {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageFileName
+    )
+
+    if ($PackageFileName -match '\.snupkg$') {
+        return $null
+    }
+
+    $packageId = [System.IO.Path]::GetFileNameWithoutExtension($PackageFileName)
+
+    $skipRoots = @(
+        'Krypton.Docking',
+        'Krypton.Themes',
+        'Krypton.Toolkit.JumpList',
+        'Krypton.Interop'
+    )
+
+    foreach ($root in $skipRoots) {
+        if ($packageId.Equals($root, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $packageId.StartsWith("$root.", [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $null
+        }
+    }
+
+    if ($packageId.Equals('Krypton.Standard.Toolkit', [System.StringComparison]::OrdinalIgnoreCase) -or
+        $packageId.StartsWith('Krypton.Standard.Toolkit.', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'Standard'
+    }
+
+    $kinds = @(
+        @{ Root = 'Krypton.Workspace'; Kind = 'Workspace' },
+        @{ Root = 'Krypton.Navigator'; Kind = 'Navigator' },
+        @{ Root = 'Krypton.Ribbon'; Kind = 'Ribbon' },
+        @{ Root = 'Krypton.Toolkit'; Kind = 'Toolkit' }
+    )
+
+    foreach ($entry in $kinds) {
+        if ($packageId.Equals($entry.Root, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $packageId.StartsWith("$($entry.Root).", [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $entry.Kind
+        }
+    }
+
+    return $null
+}
+
+function Get-DesignerSdkExpectedRelativePaths {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Kind
+    )
+
+    $server = [System.Collections.Generic.List[string]]::new()
+    $client = @(
+        'Krypton.Toolkit.Design.Client.dll',
+        'Krypton.Toolkit.Design.Protocol.dll'
+    )
+
+    switch ($Kind) {
+        'Toolkit' {
+            [void]$server.Add('Krypton.Toolkit.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Design.Protocol.dll')
+        }
+        'Ribbon' {
+            [void]$server.Add('Krypton.Ribbon.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Design.Protocol.dll')
+        }
+        'Navigator' {
+            [void]$server.Add('Krypton.Navigator.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Design.Protocol.dll')
+        }
+        'Workspace' {
+            [void]$server.Add('Krypton.Workspace.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Design.Protocol.dll')
+        }
+        'Standard' {
+            [void]$server.Add('Krypton.Toolkit.Design.dll')
+            [void]$server.Add('Krypton.Ribbon.Design.dll')
+            [void]$server.Add('Krypton.Navigator.Design.dll')
+            [void]$server.Add('Krypton.Workspace.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Utilities.Design.dll')
+            [void]$server.Add('Krypton.Navigator.Utilities.Design.dll')
+            [void]$server.Add('Krypton.Toolkit.Design.Protocol.dll')
+        }
+        default {
+            return @()
+        }
+    }
+
+    $paths = [System.Collections.Generic.List[string]]::new()
+    foreach ($name in $server) {
+        [void]$paths.Add("Design/WinForms/Server/$name")
+    }
+    foreach ($name in $client) {
+        [void]$paths.Add("Design/WinForms/$name")
+    }
+
+    return @($paths)
+}
+
+function Test-NupkgContainsDesignerSdk {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$Package,
+        [Parameter(Mandatory = $true)]
+        [string]$Kind
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $expectedRelative = Get-DesignerSdkExpectedRelativePaths -Kind $Kind
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Package.FullName)
+    try {
+        $entryNames = @($zip.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+
+        $sdkLeak = @(
+            $entryNames |
+                Where-Object { $_ -match '(?i)Microsoft\.WinForms\.Designer\.SDK\.dll$' }
+        )
+        if ($sdkLeak.Count -gt 0) {
+            return @{
+                Ok      = $false
+                Message = "$($Package.Name) contains Microsoft.WinForms.Designer.SDK.dll (must not leak into consumer packages)"
+            }
+        }
+
+        $libFolders = @(
+            $entryNames |
+                ForEach-Object {
+                    if ($_ -match '^lib/([^/]+)/') { $Matches[1] }
+                } |
+                Select-Object -Unique
+        )
+
+        $modernFolders = @($libFolders | Where-Object { Test-IsModernWinFormsLibFolder -LibFolderName $_ })
+        if ($modernFolders.Count -eq 0) {
+            return @{
+                Ok      = $true
+                Message = "$($Package.Name) has no modern Windows lib folders; Designer SDK packing not required"
+            }
+        }
+
+        $missing = [System.Collections.Generic.List[string]]::new()
+        foreach ($tfm in $modernFolders) {
+            foreach ($relative in $expectedRelative) {
+                $full = "lib/$tfm/$relative"
+                $found = $entryNames | Where-Object { $_.Equals($full, [System.StringComparison]::OrdinalIgnoreCase) }
+                if (-not $found) {
+                    [void]$missing.Add($full)
+                }
+            }
+        }
+
+        if ($missing.Count -gt 0) {
+            return @{
+                Ok      = $false
+                Message = "$($Package.Name) missing Designer SDK files: $($missing -join ', ')"
+            }
+        }
+
+        return @{
+            Ok      = $true
+            Message = "$($Package.Name) contains Design/WinForms assemblies for $($modernFolders.Count) modern TFM folder(s)"
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
+
+function Test-KryptonDesignerSdkInPackages {
+    param(
+        [string]$Configuration = '',
+        [string[]]$PackageSearchPaths = @(),
+        [switch]$SkipIfDesignerSdkProjectMissing,
+        [int]$MinimumMajorVersion = 0
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    $repoRoot = if ($null -ne $env:GITHUB_WORKSPACE -and $env:GITHUB_WORKSPACE -ne '') {
+        $env:GITHUB_WORKSPACE
+    }
+    else {
+        (Get-Location).Path
+    }
+
+    $msbuildConfiguration = if ([string]::IsNullOrWhiteSpace($Configuration)) { 'Release' } else { $Configuration }
+
+    if ($MinimumMajorVersion -gt 0) {
+        $major = Get-KryptonToolkitMajorVersionForDesignerSdk -Configuration $msbuildConfiguration -RepoRoot $repoRoot
+        if ($major -lt $MinimumMajorVersion) {
+            Write-Host "::notice:: Major version $major is below $MinimumMajorVersion; skipping WinForms Designer SDK NuGet package verification."
+            return
+        }
+    }
+
+    $designProject = Join-Path $repoRoot 'Source/Krypton Components/Krypton.Toolkit.Design/Krypton.Toolkit.Design.csproj'
+    if ($SkipIfDesignerSdkProjectMissing -and -not (Test-Path -LiteralPath $designProject)) {
+        Write-Host '::notice:: Krypton.Toolkit.Design project not present; skipping NuGet package verification.'
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $designProject)) {
+        Write-Error "Krypton.Toolkit.Design project not found at '$designProject'."
+    }
+
+    $searchPaths = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrWhiteSpace($Configuration)) {
+        $searchPaths.Add("artifacts/packages/$Configuration/*.nupkg")
+        $searchPaths.Add("Bin/Packages/$Configuration/*.nupkg")
+        $searchPaths.Add("Artefacts/Packages/$Configuration/*.nupkg")
+    }
+
+    foreach ($path in $PackageSearchPaths) {
+        if (-not [string]::IsNullOrWhiteSpace($path)) {
+            $searchPaths.Add($path)
+        }
+    }
+
+    if ($searchPaths.Count -eq 0) {
+        $searchPaths.Add('artifacts/packages/*/*.nupkg')
+        $searchPaths.Add('Bin/Packages/*/*.nupkg')
+        $searchPaths.Add('Artefacts/Packages/*/*.nupkg')
+    }
+
+    $packages = @()
+    foreach ($pattern in $searchPaths) {
+        $packages += Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue
+    }
+
+    $packages = @($packages | Where-Object { $_ -ne $null } | Sort-Object FullName -Unique)
+
+    if ($packages.Count -eq 0) {
+        Write-Error "No .nupkg files found. Searched: $($searchPaths -join '; ')"
+    }
+
+    $requiredPackages = @()
+    foreach ($package in $packages) {
+        $kind = Get-DesignerSdkPackageKind -PackageFileName $package.Name
+        if ($null -ne $kind) {
+            $requiredPackages += [pscustomobject]@{ Package = $package; Kind = $kind }
+        }
+    }
+
+    if ($requiredPackages.Count -eq 0) {
+        Write-Error "Found $($packages.Count) .nupkg file(s), but none match packable Krypton module package IDs that must include Designer SDK assemblies."
+    }
+
+    $failures = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in $requiredPackages) {
+        $result = Test-NupkgContainsDesignerSdk -Package $item.Package -Kind $item.Kind
+        if ($result.Ok) {
+            Write-Host "OK: $($result.Message)"
+            continue
+        }
+
+        $failures.Add($item.Package.Name)
+        Write-Host "::error file=$($item.Package.FullName)::$($result.Message)"
+    }
+
+    if ($failures.Count -gt 0) {
+        throw "WinForms Designer SDK NuGet verification failed for $($failures.Count) package(s): $($failures -join ', ')"
+    }
+
+    Write-Host "Verified WinForms Designer SDK assemblies in $($requiredPackages.Count) Krypton module package(s)."
+}


### PR DESCRIPTION
Include full SHA, short SHA and commit URL in multiple GitHub Actions notification payloads so Discord embeds link to the triggering commit. Updated workflows: .github/workflows/alpha-backup-sync.yml, canary.yml, canary-lts-release.yml, nightly.yml, release.yml, release-candidate.yml, scan-code-todos.yml (also expose SHA env var). Minor wording change in repo-mirror.yml links. Additionally fix TestForm resx path in build-testform.yml. This improves CI notification traceability by surfacing the exact commit.