### PR TITLE
* Update demo copyright years

### DIFF
--- a/Source/Krypton Components/TestForm/KryptonToolkit/Feature/BorderlessFormDemo.cs
+++ b/Source/Krypton Components/TestForm/KryptonToolkit/Feature/BorderlessFormDemo.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/TestForm/KryptonToolkit/Feature/BorderlessMdiHostDemo.cs
+++ b/Source/Krypton Components/TestForm/KryptonToolkit/Feature/BorderlessMdiHostDemo.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2026. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2026 - 2026. All rights reserved.
  *
  */
 #endregion


### PR DESCRIPTION
Refresh the copyright ranges in the borderless form and borderless MDI host demo headers to reflect 2026.