### PR TITLE
* Correct RC package identifiers

### DIFF
--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -239,11 +239,11 @@
 
 		<When Condition="'$(Configuration)' == 'RC'">
 			<PropertyGroup>
-				<PackageId Condition="'$(TFMs)' == 'lite' And '$(PackageId)' != ''">$(PackageId).Lite</PackageId>
+				<PackageId Condition="'$(TFMs)' == 'lite' And '$(PackageId)' != ''">$(PackageId).RC.Lite</PackageId>
 
 				<Description Condition="'$(TFMs)' == 'lite'">An update to Component factory's krypton toolkit to support .NET Framework 4.8 - 4.8.1 and .NET 8 - 11. $(Description) This package supports all .NET Framework versions starting .NET Framework 4.8 - 4.8.1, .NET 6 - 8. Also, all libraries are included targeting each specific framework version for performance purposes. To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md To find out what's new, please visit: https://github.com/Krypton-Suite/Standard-Toolkit/blob/gold/Documents/Changelog/Changelog.md This is a release candidate of the stable package. Include prerelease packages to consume it; the matching stable version replaces it at GA.</Description>
 
-				<PackageId Condition="'$(TFMs)' == 'all' And '$(PackageId)' != ''">$(PackageId)</PackageId>
+				<PackageId Condition="'$(TFMs)' == 'all' And '$(PackageId)' != ''">$(PackageId).RC</PackageId>
 				<Description Condition="'$(TFMs)' == 'all'">An update to Component factory's krypton toolkit to support .NET Framework 4.7.2 - 4.8.1 and .NET 8 - 11. $(Description) This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8.1 and .NET 8 - 11. Also, all libraries are included targeting each specific framework version for performance purposes. To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md To find out what's new, please visit: https://github.com/Krypton-Suite/Standard-Toolkit/blob/gold/Documents/Changelog/Changelog.md This is a release candidate of the stable package. Include prerelease packages to consume it; the matching stable version replaces it at GA.</Description>
 			</PropertyGroup>
 		</When>


### PR DESCRIPTION
Update release-candidate package IDs to include the `.RC` suffix for both `all` and `lite` target framework configurations, preventing RC packages from colliding with stable package names.