### PR TITLE
* Remove obsolete Office 2013 TODOs

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,7 @@
 
 ## 2026-11-30 - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#4404](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4404), Removed obsolete Office 2013 "render dynamically" TODOs now covered by `KryptonColorSchemeBase`
 * Resolved [#4373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4373), Toolstrip controls are unreadable with certain themes
   * ToolStrip item text stays readable on themes where the historic ColorTable alias did not contrast with the strip (Office White, Office 2007 Black, Visual Studio 2010 variations).
   * `KryptonWrapLabel` / `KryptonLinkWrapLabel` no longer throw `ArgumentException` (`Parameter is not valid`) from `DrawString` after a theme change. Palette fonts are cloned before assignment to `Control.Font`.

--- a/Source/Krypton Components/Krypton.Themes/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Themes/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -255,8 +255,6 @@ public abstract class PaletteOffice2013Base : PaletteBase
 
     #endregion
 
-    //TODO Dynamically render
-    //public static Color baseUserColor = Color.FromArgb(255, 248, 56);
     #endregion
 
     #region Identity

--- a/Source/Krypton Components/Krypton.Themes/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
+++ b/Source/Krypton Components/Krypton.Themes/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
@@ -226,9 +226,6 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
 
-    //TODO rendre dynamique
-    //public static Color baseUserColor = Color.FromArgb(255, 248, 56);
-
     #endregion Instance Fields
 
     #region Identity


### PR DESCRIPTION
Deletes obsolete dynamic-rendering TODO comments from the Office 2013 palette bases and records the cleanup in the changelog for issue #4404.