### PR TITLE
* Keep KryptonComboBox drop-down width tracking control width (V110)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -45,6 +45,8 @@
 
 ## 2026-11-30 - Build 2611 (V110 Nightly) - November 2026
 
+* Resolved [#4425](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4425), Keep KryptonComboBox drop-down width tracking control width
+  * `KryptonComboBox` keeps the drop-down list width in sync with the control when `DropDownWidth` has not been set explicitly (removed the leftover Content-palette sync TODO from [#1704](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1704)).
 * Resolved [#4373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4373), Toolstrip controls are unreadable with certain themes
   * ToolStrip item text stays readable on themes where the historic ColorTable alias did not contrast with the strip (Office White, Office 2007 Black, Visual Studio 2010 variations).
   * `KryptonWrapLabel` / `KryptonLinkWrapLabel` no longer throw `ArgumentException` (`Parameter is not valid`) from `DrawString` after a theme change. Palette fonts are cloned before assignment to `Control.Font`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3724,10 +3724,11 @@ public class KryptonComboBox : VisualControlBase,
     /// </summary>
     private void SynchronizeNativeDropDownWidth()
     {
-        if (!_dropDownWidthSet)
+        _comboBox.DropDownWidth = _dropDownWidthSet switch
         {
-            _comboBox.DropDownWidth = Width;
-        }
+            false => Width,
+            _ => _comboBox.DropDownWidth
+        };
     }
 
     private void OnComboBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2952,12 +2952,6 @@ public class KryptonComboBox : VisualControlBase,
             ForceControlLayout();
         }
 
-        // ToDo: Create a new API for this in a later version
-        //if (StateCommon.ComboBox.Content.SynchronizeDropDownWidth)
-        //{
-        //    DropDownWidth = Size.Width;
-        //}
-
         base.OnPaint(e);
         Paint?.Invoke(this, e!);
     }
@@ -2970,6 +2964,9 @@ public class KryptonComboBox : VisualControlBase,
     {
         // Let base class raise events
         base.OnResize(e);
+
+        // Keep the native drop-down width aligned when DropDownWidth has not been set explicitly.
+        SynchronizeNativeDropDownWidth();
 
         // We must have a layout calculation
         ForceControlLayout();
@@ -3712,10 +3709,25 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxDropDown(object? sender, EventArgs e)
     {
+        // Ensure the list uses the current control width when DropDownWidth is still tracking.
+        SynchronizeNativeDropDownWidth();
+
         _comboBox.Dropped = true;
         _hoverIndex = -1;
         Refresh();
         OnDropDown(e);
+    }
+
+    /// <summary>
+    /// Updates the inner ComboBox drop-down width to match this control when <see cref="DropDownWidth"/>
+    /// has not been assigned explicitly (WinForms-compatible tracking).
+    /// </summary>
+    private void SynchronizeNativeDropDownWidth()
+    {
+        if (!_dropDownWidthSet)
+        {
+            _comboBox.DropDownWidth = Width;
+        }
     }
 
     private void OnComboBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);


### PR DESCRIPTION
# Fix: Keep KryptonComboBox drop-down width tracking control width (#4425)

## Summary

Completes the leftover `#1704` TODO in `KryptonComboBox` by syncing the native drop-down width on resize and before drop-down when `DropDownWidth` has not been set explicitly. No new Content-palette API is added (that placement was wrong and already removed).

## Related issues

- Closes #4425
- Related: #1704, #3123

## Type of change

- [x] Bug fix (`Resolved`)
- [ ] Feature / enhancement (`Implemented`)
- [ ] **Breaking change** (API removal/rename, behavior change requiring migration, assembly/namespace move)
- [ ] Documentation only

## Changes

- `Krypton.Toolkit` / `KryptonComboBox`:
  - Removed the commented `StateCommon.ComboBox.Content.SynchronizeDropDownWidth` paint-path TODO.
  - Added `SynchronizeNativeDropDownWidth()` and call it from `OnResize` and `OnComboBoxDropDown` when `!_dropDownWidthSet` (does not use the public `DropDownWidth` setter).

## Affected packages & target frameworks

- Packages: `Krypton.Toolkit`
- TFMs verified: build of `Krypton.Toolkit` Debug (as available locally)

## Validation

- Manual steps:
  1. Place a `KryptonComboBox` with no designer `DropDownWidth` assignment; resize wider then narrower; open the list — list width matches the control.
  2. Set `DropDownWidth` to a fixed value (e.g. larger than the control); resize the control; open the list — list width stays at the explicit value.
  3. Call `ResetDropDownWidth()`; resize again — tracking resumes.
- Build: `dotnet build ".\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" -c Debug`

## Changelog

- Entry added to `Documents/Changelog/Changelog.md`:

```markdown
* Resolved [#4425](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4425), Keep KryptonComboBox drop-down width tracking control width
  * `KryptonComboBox` keeps the drop-down list width in sync with the control when `DropDownWidth` has not been set explicitly (removed the leftover Content-palette sync TODO from [#1704](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1704)).
```

## Breaking changes & migration

None.

## Checklist

- [x] Builds for `net472` and is C# 7.3 compatible where required
- [x] New compiler/analyzer warnings in touched code addressed
- [x] `Documents/Changelog/Changelog.md` updated
- [ ] TestForm demo added or updated (features / observable bug fixes)
- [ ] `Documents/Development/` guide added (substantial features)
- [ ] Screenshots/GIFs included (UI changes)
- [x] Breaking-change impact and TFM notes documented above
- [ ] New unit tests have been added