### PR TITLE
* Sync KryptonComboBox drop-down width (V105 LTS)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -48,6 +48,8 @@
 
 ## 2026-11-10 - Build 2611 (Version 105-LTS - Patch 4) - November 2026
 
+* Resolved [#4425](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4425), Keep KryptonComboBox drop-down width tracking control width
+  * `KryptonComboBox` keeps the drop-down list width in sync with the control when `DropDownWidth` has not been set explicitly (removed the leftover Content-palette sync TODO from [#1704](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1704)).
 * Resolved [#4373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/4373), Toolstrip controls are unreadable with certain themes
   * ToolStrip item text is unreadable on Office White, Office 2007 Black, and Visual Studio 2010 themes.
   * ColorTable `ToolStripText` now picks a scheme colour that contrasts with the tool-strip background (WCAG AA 4.5:1) instead of always reusing status-strip or button text.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2756,12 +2756,6 @@ public class KryptonComboBox : VisualControlBase,
             ForceControlLayout();
         }
 
-        // ToDo: Create a new API for this in a later version
-        //if (StateCommon.ComboBox.Content.SynchronizeDropDownWidth)
-        //{
-        //    DropDownWidth = Size.Width;
-        //}
-
         base.OnPaint(e);
         Paint?.Invoke(this, e!);
     }
@@ -2774,6 +2768,9 @@ public class KryptonComboBox : VisualControlBase,
     {
         // Let base class raise events
         base.OnResize(e);
+
+        // Keep the native drop-down width aligned when DropDownWidth has not been set explicitly.
+        SynchronizeNativeDropDownWidth();
 
         // We must have a layout calculation
         ForceControlLayout();
@@ -3424,10 +3421,26 @@ public class KryptonComboBox : VisualControlBase,
 
     private void OnComboBoxDropDown(object? sender, EventArgs e)
     {
+        // Ensure the list uses the current control width when DropDownWidth is still tracking.
+        SynchronizeNativeDropDownWidth();
+
         _comboBox.Dropped = true;
         _hoverIndex = -1;
         Refresh();
         OnDropDown(e);
+    }
+
+    /// <summary>
+    /// Updates the inner ComboBox drop-down width to match this control when <see cref="DropDownWidth"/>
+    /// has not been assigned explicitly (WinForms-compatible tracking).
+    /// </summary>
+    private void SynchronizeNativeDropDownWidth()
+    {
+        _comboBox.DropDownWidth = _dropDownWidthSet switch
+        {
+            false => Width,
+            _ => _comboBox.DropDownWidth
+        };
     }
 
     private void OnComboBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);


### PR DESCRIPTION
Keep the native drop-down width aligned with the control width when DropDownWidth has not been explicitly set, including during resizing and drop-down display. Document the fix for #4425.